### PR TITLE
fix: Fix the bug of raycast mesh with wrong hit point

### DIFF
--- a/src/core/Mesh.js
+++ b/src/core/Mesh.js
@@ -96,7 +96,7 @@ const Mesh = Class.create(/** @lends Mesh.prototype */ {
             const res = geometry.raycast(tempRay, material.side, sort);
             if (res) {
                 res.forEach((point) => {
-                    point.transformMat4(worldMatrix);
+                    point.transformMat4(this.matrix);
                 });
 
                 return res;


### PR DESCRIPTION

可以在raycast_node.html的49行后加入以下代码验证：

var geometry = new Hilo3d.SphereGeometry();
                var sphere = new Hilo3d.Mesh({
                    geometry: geometry,
                    material:
                     new Hilo3d.BasicMaterial({
                        lightType:'NONE',
                        diffuse: new Hilo3d.Color(Math.random(), Math.random(), Math.random())
                    }),                    
                    x: hitResult[0].point.x,
                    y: hitResult[0].point.y,
                    z: hitResult[0].point.z
                });

验证出hit point的位置是在Mesh出计算乘Local Matrix的。望合并