### PR TITLE
Add WebGL2 support

### DIFF
--- a/examples/js/init.js
+++ b/examples/js/init.js
@@ -14,6 +14,9 @@ if (!window.notInit) {
         width: innerWidth,
         height: innerHeight,
         preferWebGL2: location.search.indexOf('webgl2') > -1,
+        antialias: false,
+        alpha: false,
+        useLogDepth: false,
     });
 
     window.onresize = function(){

--- a/examples/js/init.js
+++ b/examples/js/init.js
@@ -12,7 +12,8 @@ if (!window.notInit) {
         camera: camera,
         clearColor: new Hilo3d.Color(0.4, 0.4, 0.4),
         width: innerWidth,
-        height: innerHeight
+        height: innerHeight,
+        preferWebGL2: location.search.indexOf('webgl2') > -1,
     });
 
     window.onresize = function(){
@@ -46,6 +47,7 @@ if (!window.notInit) {
     ['init', 'initFailed'].forEach(function(eventName){
         stage.renderer.on(eventName, function(e){
             console.log(e.type, e);
+            console.log('Stage use ' + (renderer.isWebGL2 ? 'WebGL2' : 'WebGL1'));
         });
     });
 

--- a/examples/sRGB.html
+++ b/examples/sRGB.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>Hilo3d sRGB Demo</title>
+    <link rel="stylesheet" type="text/css" href="./example.css">
+</head>
+<body>
+    <div id="container"></div>
+    <script src="../build/Hilo3d.js"></script>
+    <script src="./js/stats.js"></script>
+    <script src="./js/OrbitControls.js"></script>
+    <script src="./js/init.js"></script>
+    <script>
+        var planeGeometry = new Hilo3d.PlaneGeometry();
+
+        var sRGBPlane = new Hilo3d.Mesh({
+            geometry:planeGeometry,
+            material: new Hilo3d.BasicMaterial({
+                lightType: 'NONE',
+                diffuse:new Hilo3d.LazyTexture({
+                    src:'//gw.alicdn.com/imgextra/i2/O1CN015YnrkX1jp17VWipnN_!!6000000004596-2-tps-512-512.png',
+                    format: Hilo3d.constants.RGBA,
+                    internalFormat: Hilo3d.constants.SRGB8_ALPHA8,
+                    flipY: true,
+                    minFilter: Hilo3d.constants.NEAREST,
+                    magFilter: Hilo3d.constants.NEAREST,
+                }),
+            }),
+            x: -1,
+        });
+        stage.addChild(sRGBPlane);
+
+        var linearPlane = new Hilo3d.Mesh({
+            geometry:planeGeometry,
+            material: new Hilo3d.BasicMaterial({
+                lightType: 'NONE',
+                diffuse:new Hilo3d.LazyTexture({
+                    src:'//gw.alicdn.com/imgextra/i3/O1CN01sTOdgW1CgslZ8CrFJ_!!6000000000111-2-tps-512-512.png',
+                    flipY: true,
+                    minFilter: Hilo3d.constants.NEAREST,
+                    magFilter: Hilo3d.constants.NEAREST,
+                }),
+            }),
+            x: 1
+        });
+        stage.addChild(linearPlane);
+    </script>
+</body>
+</html>

--- a/examples/ssao.html
+++ b/examples/ssao.html
@@ -109,17 +109,17 @@
                 for(int i = 0; i < 32; ++i)
                 {
                     // 获取样本位置
-                    vec3 sample = TBN * u_kernel[i]; // 切线->观察空间
-                    sample = fragPos + sample * u_radius; 
+                    vec3 samplePos = TBN * u_kernel[i]; // 切线->观察空间
+                    samplePos = fragPos + samplePos * u_radius; 
 
-                    vec4 offset = vec4(sample, 1.0);
+                    vec4 offset = vec4(samplePos, 1.0);
                     offset = u_projection * offset; // 观察->裁剪空间
                     offset.xyz /= offset.w; // 透视划分
                     offset.xyz = offset.xyz * 0.5 + 0.5; // 变换到0.0 - 1.0的值域
                     
                     float sampleDepth = -texture2D(u_depth, offset.xy).x;
                     float rangeCheck = smoothstep(0.0, 1.0, u_radius / abs(fragPos.z - sampleDepth));
-                    occlusion += (sampleDepth >= sample.z ? 1.0 : 0.0) * rangeCheck;    
+                    occlusion += (sampleDepth >= samplePos.z ? 1.0 : 0.0) * rangeCheck;    
                 }
                 occlusion = 1.0 - (occlusion / 32.0);
                 gl_FragColor = vec4(vec3(occlusion), 1.0);

--- a/examples/textureLod.html
+++ b/examples/textureLod.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>Hilo3d Texture Lod Demo</title>
+    <link rel="stylesheet" type="text/css" href="./example.css">
+</head>
+<body>
+<div id="container"></div>
+<script src="../build/Hilo3d.js"></script>
+<script src="./js/stats.js"></script>
+<script src="./js/OrbitControls.js"></script>
+<script src="./js/init.js"></script>
+<script>
+    renderer.clearColor = new Hilo3d.Color(0, 0, 0, 1);
+    var container = new Hilo3d.Node();
+    var geometry = new Hilo3d.SphereGeometry({
+        radius: 1,
+        heightSegments: 32,
+        widthSegments: 64,
+    })
+    var mesh = new Hilo3d.Mesh({
+        time:0,
+        geometry: geometry,
+        material: new Hilo3d.ShaderMaterial({
+            shaderCacheId: "UVAnimation",
+            needBasicUnifroms: false,
+            needBasicAttributes: false,
+            side: Hilo3d.constants.BACK,
+            enableTextureLod: true,
+            diffuse: new Hilo3d.LazyTexture({
+                src: 'https://gw.alicdn.com/tfs/TB1zONZJHH1gK0jSZFwXXc7aXXa-4000-2000.jpg',
+                minFilter: Hilo3d.constants.LINEAR_MIPMAP_LINEAR,
+            }),
+            uniforms:{
+                u_diffuse:'DIFFUSE',
+                u_modelViewProjectionMatrix:'MODELVIEWPROJECTION',
+                u_time:{
+                    get:function(mesh, material, programInfo){
+                        return mesh.time;
+                    }
+                },
+            },
+            attributes:{
+                a_position: 'POSITION',
+                a_texcoord0:'TEXCOORD_0'
+            },
+            fs:`
+                precision HILO_MAX_FRAGMENT_PRECISION float;
+                ${Hilo3d.Shader.shaders['chunk/extensions.frag']}
+                varying vec2 v_texcoord0;
+                uniform sampler2D u_diffuse;
+                uniform float u_time;
+                                
+                void main(void) {
+                    float uOffset = cos(u_time * 0.0001) + .5;
+                    float level = (sin(u_time * 0.0013) * 0.5 + 0.5) * 9.;
+                    vec4 diffuse = texture2DLodEXT(u_diffuse, vec2(v_texcoord0.x + uOffset, v_texcoord0.y), level);    
+                    gl_FragColor = diffuse;
+                }
+            `,
+            vs:`
+                precision HILO_MAX_VERTEX_PRECISION float;
+                attribute vec3 a_position;
+                attribute vec2 a_texcoord0;
+                uniform mat4 u_modelViewProjectionMatrix;
+                varying vec2 v_texcoord0;
+
+                void main(void) {
+                    vec4 pos = vec4(a_position, 1.0);
+                    gl_Position = u_modelViewProjectionMatrix * pos;
+                    v_texcoord0 = a_texcoord0;
+                }
+            `
+        }),
+        onUpdate(dt){
+            this.time += dt;
+        }
+    });
+
+    container.addChild(mesh);
+    stage.addChild(container);
+</script>
+</body>
+</html>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,5 @@
 import * as webgl from './webgl';
+import * as webgl2 from './webgl2';
 import * as webglExtensions from './webglExtensions';
 import * as Hilo from './Hilo';
 
@@ -11,8 +12,9 @@ import * as Hilo from './Hilo';
 const constants = {
     webgl,
     webglExtensions,
+    webgl2,
     Hilo
 };
-Object.assign(constants, webgl, webglExtensions, Hilo);
+Object.assign(constants, webgl, webglExtensions, webgl2, Hilo);
 
 export default constants;

--- a/src/constants/webgl2.js
+++ b/src/constants/webgl2.js
@@ -1,0 +1,1327 @@
+// See https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants#additional_constants_defined_webgl_2
+
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const READ_BUFFER = 0x0C02;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNPACK_ROW_LENGTH = 0x0CF2;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNPACK_SKIP_ROWS = 0x0CF3;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNPACK_SKIP_PIXELS = 0x0CF4;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PACK_ROW_LENGTH = 0x0D02;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PACK_SKIP_ROWS = 0x0D03;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PACK_SKIP_PIXELS = 0x0D04;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_BINDING_3D = 0x806A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNPACK_SKIP_IMAGES = 0x806D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNPACK_IMAGE_HEIGHT = 0x806E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_3D_TEXTURE_SIZE = 0x8073;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_ELEMENTS_VERTICES = 0x80E8;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_ELEMENTS_INDICES = 0x80E9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_TEXTURE_LOD_BIAS = 0x84FD;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_FRAGMENT_UNIFORM_COMPONENTS = 0x8B49;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_VERTEX_UNIFORM_COMPONENTS = 0x8B4A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_ARRAY_TEXTURE_LAYERS = 0x88FF;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MIN_PROGRAM_TEXEL_OFFSET = 0x8904;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_PROGRAM_TEXEL_OFFSET = 0x8905;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_VARYING_COMPONENTS = 0x8B4B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAGMENT_SHADER_DERIVATIVE_HINT = 0x8B8B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RASTERIZER_DISCARD = 0x8C89;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const VERTEX_ARRAY_BINDING = 0x85B5;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_VERTEX_OUTPUT_COMPONENTS = 0x9122;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_FRAGMENT_INPUT_COMPONENTS = 0x9125;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_SERVER_WAIT_TIMEOUT = 0x9111;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_ELEMENT_INDEX = 0x8D6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RED = 0x1903;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB8 = 0x8051;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA8 = 0x8058;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB10_A2 = 0x8059;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_3D = 0x806F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_WRAP_R = 0x8072;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_MIN_LOD = 0x813A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_MAX_LOD = 0x813B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_BASE_LEVEL = 0x813C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_MAX_LEVEL = 0x813D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_COMPARE_MODE = 0x884C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_COMPARE_FUNC = 0x884D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SRGB = 0x8C40;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SRGB8 = 0x8C41;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SRGB8_ALPHA8 = 0x8C43;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COMPARE_REF_TO_TEXTURE = 0x884E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA32F = 0x8814;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB32F = 0x8815;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA16F = 0x881A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB16F = 0x881B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_2D_ARRAY = 0x8C1A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_BINDING_2D_ARRAY = 0x8C1D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R11F_G11F_B10F = 0x8C3A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB9_E5 = 0x8C3D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA32UI = 0x8D70;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB32UI = 0x8D71;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA16UI = 0x8D76;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB16UI = 0x8D77;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA8UI = 0x8D7C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB8UI = 0x8D7D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA32I = 0x8D82;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB32I = 0x8D83;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA16I = 0x8D88;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB16I = 0x8D89;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA8I = 0x8D8E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB8I = 0x8D8F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RED_INTEGER = 0x8D94;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB_INTEGER = 0x8D98;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA_INTEGER = 0x8D99;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R8 = 0x8229;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG8 = 0x822B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R16F = 0x822D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R32F = 0x822E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG16F = 0x822F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG32F = 0x8230;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R8I = 0x8231;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R8UI = 0x8232;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R16I = 0x8233;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R16UI = 0x8234;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R32I = 0x8235;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R32UI = 0x8236;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG8I = 0x8237;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG8UI = 0x8238;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG16I = 0x8239;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG16UI = 0x823A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG32I = 0x823B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG32UI = 0x823C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const R8_SNORM = 0x8F94;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG8_SNORM = 0x8F95;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB8_SNORM = 0x8F96;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGBA8_SNORM = 0x8F97;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RGB10_A2UI = 0x906F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_IMMUTABLE_FORMAT = 0x912F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TEXTURE_IMMUTABLE_LEVELS = 0x82D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_2_10_10_10_REV = 0x8368;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_10F_11F_11F_REV = 0x8C3B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_5_9_9_9_REV = 0x8C3E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_32_UNSIGNED_INT_24_8_REV = 0x8DAD;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_24_8 = 0x84FA;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const HALF_FLOAT = 0x140B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG = 0x8227;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RG_INTEGER = 0x8228;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INT_2_10_10_10_REV = 0x8D9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const URRENT_QUERY = 0x8865;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const QUERY_RESULT = 0x8866;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const QUERY_RESULT_AVAILABLE = 0x8867;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const ANY_SAMPLES_PASSED = 0x8C2F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const ANY_SAMPLES_PASSED_CONSERVATIVE = 0x8D6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_DRAW_BUFFERS = 0x8824;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER0 = 0x8825;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER1 = 0x8826;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER2 = 0x8827;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER3 = 0x8828;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER4 = 0x8829;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER5 = 0x882A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER6 = 0x882B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER7 = 0x882C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER8 = 0x882D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER9 = 0x882E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER10 = 0x882F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER11 = 0x8830;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER12 = 0x8831;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER13 = 0x8832;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER14 = 0x8833;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_BUFFER15 = 0x8834;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_COLOR_ATTACHMENTS = 0x8CDF;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT1 = 0x8CE1;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT2 = 0x8CE2;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT3 = 0x8CE3;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT4 = 0x8CE4;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT5 = 0x8CE5;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT6 = 0x8CE6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT7 = 0x8CE7;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT8 = 0x8CE8;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT9 = 0x8CE9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT10 = 0x8CEA;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT11 = 0x8CEB;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT12 = 0x8CEC;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT13 = 0x8CED;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT14 = 0x8CEE;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR_ATTACHMENT15 = 0x8CE;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SAMPLER_3D = 0x8B5F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SAMPLER_2D_SHADOW = 0x8B62;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SAMPLER_2D_ARRAY = 0x8DC1;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SAMPLER_2D_ARRAY_SHADOW = 0x8DC4;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SAMPLER_CUBE_SHADOW = 0x8DC5;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INT_SAMPLER_2D = 0x8DCA;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INT_SAMPLER_3D = 0x8DCB;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INT_SAMPLER_CUBE = 0x8DCC;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INT_SAMPLER_2D_ARRAY = 0x8DCF;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_SAMPLER_2D = 0x8DD2;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_SAMPLER_3D = 0x8DD3;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_SAMPLER_CUBE = 0x8DD4;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_SAMPLER_2D_ARRAY = 0x8DD7;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_SAMPLES = 0x8D57;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SAMPLER_BINDING = 0x891;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PIXEL_PACK_BUFFER = 0x88EB;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PIXEL_UNPACK_BUFFER = 0x88EC;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PIXEL_PACK_BUFFER_BINDING = 0x88ED;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const PIXEL_UNPACK_BUFFER_BINDING = 0x88EF;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COPY_READ_BUFFER = 0x8F36;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COPY_WRITE_BUFFER = 0x8F37;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COPY_READ_BUFFER_BINDING = 0x8F36;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COPY_WRITE_BUFFER_BINDING = 0x8F3;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_MAT2x3 = 0x8B65; // eslint-disable-line
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_MAT2x4 = 0x8B66; // eslint-disable-line
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_MAT3x2 = 0x8B67; // eslint-disable-line
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_MAT3x4 = 0x8B68; // eslint-disable-line
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_MAT4x2 = 0x8B69; // eslint-disable-line
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FLOAT_MAT4x3 = 0x8B6A; // eslint-disable-line
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_VEC2 = 0x8DC6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_VEC3 = 0x8DC7;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_INT_VEC4 = 0x8DC8;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNED_NORMALIZED = 0x8C17;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SIGNED_NORMALIZED = 0x8F9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const VERTEX_ATTRIB_ARRAY_INTEGER = 0x88FD;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_BUFFER_MODE = 0x8C7F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS = 0x8C80;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_VARYINGS = 0x8C83;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_BUFFER_START = 0x8C84;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_BUFFER_SIZE = 0x8C85;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN = 0x8C88;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS = 0x8C8A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS = 0x8C8B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INTERLEAVED_ATTRIBS = 0x8C8C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SEPARATE_ATTRIBS = 0x8C8D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_BUFFER = 0x8C8E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_BUFFER_BINDING = 0x8C8F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK = 0x8E22;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_PAUSED = 0x8E23;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_ACTIVE = 0x8E24;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TRANSFORM_FEEDBACK_BINDING = 0x8E2;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING = 0x8210;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE = 0x8211;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_RED_SIZE = 0x8212;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_GREEN_SIZE = 0x8213;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_BLUE_SIZE = 0x8214;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE = 0x8215;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE = 0x8216;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE = 0x8217;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_DEFAULT = 0x8218;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH_STENCIL_ATTACHMENT = 0x821A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH_STENCIL = 0x84F9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH24_STENCIL8 = 0x88F0;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_FRAMEBUFFER_BINDING = 0x8CA6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const READ_FRAMEBUFFER = 0x8CA8;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DRAW_FRAMEBUFFER = 0x8CA9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const READ_FRAMEBUFFER_BINDING = 0x8CAA;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const RENDERBUFFER_SAMPLES = 0x8CAB;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER = 0x8CD4;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const FRAMEBUFFER_INCOMPLETE_MULTISAMPLE = 0x8D5;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BUFFER = 0x8A11;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BUFFER_BINDING = 0x8A28;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BUFFER_START = 0x8A29;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BUFFER_SIZE = 0x8A2A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_VERTEX_UNIFORM_BLOCKS = 0x8A2B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_FRAGMENT_UNIFORM_BLOCKS = 0x8A2D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_COMBINED_UNIFORM_BLOCKS = 0x8A2E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_UNIFORM_BUFFER_BINDINGS = 0x8A2F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_UNIFORM_BLOCK_SIZE = 0x8A30;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS = 0x8A31;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS = 0x8A33;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BUFFER_OFFSET_ALIGNMENT = 0x8A34;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const ACTIVE_UNIFORM_BLOCKS = 0x8A36;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_TYPE = 0x8A37;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_SIZE = 0x8A38;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_INDEX = 0x8A3A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_OFFSET = 0x8A3B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_ARRAY_STRIDE = 0x8A3C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_MATRIX_STRIDE = 0x8A3D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_IS_ROW_MAJOR = 0x8A3E;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_BINDING = 0x8A3F;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_DATA_SIZE = 0x8A40;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_ACTIVE_UNIFORMS = 0x8A42;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES = 0x8A43;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER = 0x8A44;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER = 0x8A4;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const OBJECT_TYPE = 0x9112;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SYNC_CONDITION = 0x9113;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SYNC_STATUS = 0x9114;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SYNC_FLAGS = 0x9115;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SYNC_FENCE = 0x9116;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SYNC_GPU_COMMANDS_COMPLETE = 0x9117;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const UNSIGNALED = 0x9118;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SIGNALED = 0x9119;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const ALREADY_SIGNALED = 0x911A;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TIMEOUT_EXPIRED = 0x911B;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const CONDITION_SATISFIED = 0x911C;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const WAIT_FAILED = 0x911D;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const SYNC_FLUSH_COMMANDS_BIT = 0x0000000;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const COLOR = 0x1800;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH = 0x1801;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const STENCIL = 0x1802;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MIN = 0x8007;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX = 0x8008;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH_COMPONENT24 = 0x81A6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const STREAM_READ = 0x88E1;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const STREAM_COPY = 0x88E2;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const STATIC_READ = 0x88E5;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const STATIC_COPY = 0x88E6;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DYNAMIC_READ = 0x88E9;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DYNAMIC_COPY = 0x88EA;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH_COMPONENT32F = 0x8CAC;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const DEPTH32F_STENCIL8 = 0x8CAD;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const INVALID_INDEX = 0xFFFFFFF;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const TIMEOUT_IGNO = RED - 1;
+/**
+ * @memberOf constants
+ * @type {glEnum}
+ */
+export const MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x924;

--- a/src/constants/webglExtensions.js
+++ b/src/constants/webglExtensions.js
@@ -1,412 +1,494 @@
 // modified from https://github.com/06wj/gl-extensions-constants/blob/master/index.js
 
 /**
+ * Describes the frequency divisor used for instanced rendering.
  * @memberOf constants
  * @type {GLenum}
  */
-export const VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE; //  Describes the frequency divisor used for instanced rendering.
+export const VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
 /**
+ * Passed to getParameter to get the vendor string of the graphics driver.
  * @memberOf constants
  * @type {GLenum}
  */
-export const UNMASKED_VENDOR_WEBGL = 0x9245; //  Passed to getParameter to get the vendor string of the graphics driver.
+export const UNMASKED_VENDOR_WEBGL = 0x9245;
 /**
+ * Passed to getParameter to get the renderer string of the graphics driver.
  * @memberOf constants
  * @type {GLenum}
  */
-export const UNMASKED_RENDERER_WEBGL = 0x9246; //  Passed to getParameter to get the renderer string of the graphics driver.
+export const UNMASKED_RENDERER_WEBGL = 0x9246;
 /**
+ * Returns the maximum available anisotropy.
  * @memberOf constants
  * @type {GLenum}
  */
-export const MAX_TEXTURE_MAX_ANISOTROPY_EXT = 0x84FF; //  Returns the maximum available anisotropy.
+export const MAX_TEXTURE_MAX_ANISOTROPY_EXT = 0x84FF;
 /**
+ * Passed to texParameter to set the desired maximum anisotropy for a texture.
  * @memberOf constants
  * @type {GLenum}
  */
-export const TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE; //  Passed to texParameter to set the desired maximum anisotropy for a texture.
+export const TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE;
 /**
+ * A DXT1-compressed image in an RGB image format.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83F0; //  A DXT1-compressed image in an RGB image format.
+export const COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83F0;
 /**
+ * A DXT1-compressed image in an RGB image format with a simple on/off alpha value.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_S3TC_DXT1_EXT = 0x83F1; //  A DXT1-compressed image in an RGB image format with a simple on/off alpha value.
+export const COMPRESSED_RGBA_S3TC_DXT1_EXT = 0x83F1;
 /**
+ * A DXT3-compressed image in an RGBA image format. Compared to a 32-bit RGBA texture, it offers 4:1 compression.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_S3TC_DXT3_EXT = 0x83F2; //  A DXT3-compressed image in an RGBA image format. Compared to a 32-bit RGBA texture, it offers 4:1 compression.
+export const COMPRESSED_RGBA_S3TC_DXT3_EXT = 0x83F2;
 /**
+ * A DXT5-compressed image in an RGBA image format. It also provides a 4:1 compression, but differs to the DXT3 compression in how the alpha compression is done.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83F3; //  A DXT5-compressed image in an RGBA image format. It also provides a 4:1 compression, but differs to the DXT3 compression in how the alpha compression is done.
+export const COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83F3;
 /**
+ * One-channel (red) unsigned format compression.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_R11_EAC = 0x9270; //  One-channel (red) unsigned format compression.
+export const COMPRESSED_R11_EAC = 0x9270;
 /**
+ * One-channel (red) signed format compression.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_SIGNED_R11_EAC = 0x9271; //  One-channel (red) signed format compression.
+export const COMPRESSED_SIGNED_R11_EAC = 0x9271;
 /**
+ * Two-channel (red and green) unsigned format compression.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RG11_EAC = 0x9272; //  Two-channel (red and green) unsigned format compression.
+export const COMPRESSED_RG11_EAC = 0x9272;
 /**
+ * Two-channel (red and green) signed format compression.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_SIGNED_RG11_EAC = 0x9273; //  Two-channel (red and green) signed format compression.
+export const COMPRESSED_SIGNED_RG11_EAC = 0x9273;
 /**
+ * Compresses RBG8 data with no alpha channel.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB8_ETC2 = 0x9274; //  Compresses RBG8 data with no alpha channel.
+export const COMPRESSED_RGB8_ETC2 = 0x9274;
 /**
+ * Compresses RGBA8 data. The RGB part is encoded the same as RGB_ETC2, but the alpha part is encoded separately.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA8_ETC2_EAC = 0x9275; //  Compresses RGBA8 data. The RGB part is encoded the same as RGB_ETC2, but the alpha part is encoded separately.
+export const COMPRESSED_RGBA8_ETC2_EAC = 0x9275;
 /**
+ * Compresses sRBG8 data with no alpha channel.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_SRGB8_ETC2 = 0x9276; //  Compresses sRBG8 data with no alpha channel.
+export const COMPRESSED_SRGB8_ETC2 = 0x9276;
 /**
+ * Compresses sRGBA8 data. The sRGB part is encoded the same as SRGB_ETC2, but the alpha part is encoded separately.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = 0x9277; //  Compresses sRGBA8 data. The sRGB part is encoded the same as SRGB_ETC2, but the alpha part is encoded separately.
+export const COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = 0x9277;
 /**
+ * Similar to RGB8_ETC, but with ability to punch through the alpha channel, which means to make it completely opaque or transparent.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9278; //  Similar to RGB8_ETC, but with ability to punch through the alpha channel, which means to make it completely opaque or transparent.
+export const COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9278;
 /**
+ * Similar to SRGB8_ETC, but with ability to punch through the alpha channel, which means to make it completely opaque or transparent.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9279; //  Similar to SRGB8_ETC, but with ability to punch through the alpha channel, which means to make it completely opaque or transparent.
+export const COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9279;
 /**
+ * RGB compression in 4-bit mode. One block for each 4×4 pixels.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8C00; //  RGB compression in 4-bit mode. One block for each 4×4 pixels.
+export const COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8C00;
 /**
+ * RGBA compression in 4-bit mode. One block for each 4×4 pixels.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_PVRTC_4BPPV1_IMG = 0x8C02; //  RGBA compression in 4-bit mode. One block for each 4×4 pixels.
+export const COMPRESSED_RGBA_PVRTC_4BPPV1_IMG = 0x8C02;
 /**
+ * RGB compression in 2-bit mode. One block for each 8×4 pixels.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB_PVRTC_2BPPV1_IMG = 0x8C01; //  RGB compression in 2-bit mode. One block for each 8×4 pixels.
+export const COMPRESSED_RGB_PVRTC_2BPPV1_IMG = 0x8C01;
 /**
+ * RGBA compression in 2-bit mode. One block for each 8×4 pixe
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_PVRTC_2BPPV1_IMG = 0x8C03; //  RGBA compression in 2-bit mode. One block for each 8×4 pixe
+export const COMPRESSED_RGBA_PVRTC_2BPPV1_IMG = 0x8C03;
 /**
+ * Compresses 24-bit RGB data with no alpha channel.
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB_ETC1_WEBGL = 0x8D64; //  Compresses 24-bit RGB data with no alpha channel.
-/**
+export const COMPRESSED_RGB_ETC1_WEBGL = 0x8D64;
+export const /**
+ *
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGB_ATC_WEBGL = 0x8C92; //  Compresses RGB textures with no alpha channel.
+    _WEBGL = 0x8C92; //  Compresses RGB textures with no alpha channel.
 /**
+ * Compresses RGBA textures using explicit alpha encoding (useful when alpha transitions are sharp).
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL = 0x8C92; //  Compresses RGBA textures using explicit alpha encoding (useful when alpha transitions are sharp).
+export const COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL = 0x8C92;
 /**
+ * Compresses RGBA textures using interpolated alpha encoding (useful when alpha transitions are gradient).
  * @memberOf constants
  * @type {GLenum}
  */
-export const COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL = 0x87EE; //  Compresses RGBA textures using interpolated alpha encoding (useful when alpha transitions are gradient).
+export const COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL = 0x87EE;
 /**
+ * Unsigned integer type for 24-bit depth texture data.
  * @memberOf constants
  * @type {GLenum}
  */
-export const UNSIGNED_INT_24_8_WEBGL = 0x84FA; //  Unsigned integer type for 24-bit depth texture data.
+export const UNSIGNED_INT_24_8_WEBGL = 0x84FA;
 /**
+ * Half floating-point type (16-bit).
  * @memberOf constants
  * @type {GLenum}
  */
-export const HALF_FLOAT_OES = 0x8D61; //  Half floating-point type (16-bit).
+export const HALF_FLOAT_OES = 0x8D61;
 /**
+ * RGBA 32-bit floating-point color-renderable format.
  * @memberOf constants
  * @type {GLenum}
  */
-export const RGBA32F_EXT = 0x8814; //  RGBA 32-bit floating-point color-renderable format.
+export const RGBA32F_EXT = 0x8814;
 /**
+ * RGB 32-bit floating-point color-renderable format.
  * @memberOf constants
  * @type {GLenum}
  */
-export const RGB32F_EXT = 0x8815; //  RGB 32-bit floating-point color-renderable format.
+export const RGB32F_EXT = 0x8815;
 /**
+ * Returns the type of the color-renderable format of the attachment.
  * @memberOf constants
  * @type {GLenum}
  */
-export const FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211; //
+export const FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
 /**
+ * Unsigned normalized integer type.
  * @memberOf constants
  * @type {GLenum}
  */
-export const UNSIGNED_NORMALIZED_EXT = 0x8C17; //
+export const UNSIGNED_NORMALIZED_EXT = 0x8C17;
 /**
+ * Produces the minimum color components of the source and destination colors.
  * @memberOf constants
  * @type {GLenum}
  */
-export const MIN_EXT = 0x8007; //  Produces the minimum color components of the source and destination colors.
+export const MIN_EXT = 0x8007;
 /**
+ * Produces the maximum color components of the source and destination colors.
  * @memberOf constants
  * @type {GLenum}
  */
-export const MAX_EXT = 0x8008; //  Produces the maximum color components of the source and destination colors.
+export const MAX_EXT = 0x8008;
 /**
+ * Unsized sRGB format that leaves the precision up to the driver.
  * @memberOf constants
  * @type {GLenum}
  */
-export const SRGB_EXT = 0x8C40; //  Unsized sRGB format that leaves the precision up to the driver.
+export const SRGB_EXT = 0x8C40;
 /**
+ * Unsized sRGB format with unsized alpha component.
  * @memberOf constants
  * @type {GLenum}
  */
-export const SRGB_ALPHA_EXT = 0x8C42; //  Unsized sRGB format with unsized alpha component.
+export const SRGB_ALPHA_EXT = 0x8C42;
 /**
+ * Sized (8-bit) sRGB and alpha formats.
  * @memberOf constants
  * @type {GLenum}
  */
-export const SRGB8_ALPHA8_EXT = 0x8C43; //  Sized (8-bit) sRGB and alpha formats.
+export const SRGB8_ALPHA8_EXT = 0x8C43;
 /**
+ * Returns the framebuffer color encoding.
  * @memberOf constants
  * @type {GLenum}
  */
-export const FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT = 0x8210; //  Returns the framebuffer color encoding.
+export const FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT = 0x8210;
 /**
+ * Indicates the accuracy of the derivative calculation for the GLSL built-in functions: dFdx, dFdy, and fwidth.
  * @memberOf constants
  * @type {GLenum}
  */
-export const FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B; //  Indicates the accuracy of the derivative calculation for the GLSL built-in functions: dFdx, dFdy, and fwidth.
+export const FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT0_WEBGL = 0x8CE0; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT0_WEBGL = 0x8CE0;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT1_WEBGL = 0x8CE1; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT1_WEBGL = 0x8CE1;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT2_WEBGL = 0x8CE2; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT2_WEBGL = 0x8CE2;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT3_WEBGL = 0x8CE3; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT3_WEBGL = 0x8CE3;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT4_WEBGL = 0x8CE4; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT4_WEBGL = 0x8CE4;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT5_WEBGL = 0x8CE5; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT5_WEBGL = 0x8CE5;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT6_WEBGL = 0x8CE6; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT6_WEBGL = 0x8CE6;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT7_WEBGL = 0x8CE7; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT7_WEBGL = 0x8CE7;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT8_WEBGL = 0x8CE8; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT8_WEBGL = 0x8CE8;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT9_WEBGL = 0x8CE9; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT9_WEBGL = 0x8CE9;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT10_WEBGL = 0x8CEA; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT10_WEBGL = 0x8CEA;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT11_WEBGL = 0x8CEB; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT11_WEBGL = 0x8CEB;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT12_WEBGL = 0x8CEC; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT12_WEBGL = 0x8CEC;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT13_WEBGL = 0x8CED; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT13_WEBGL = 0x8CED;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT14_WEBGL = 0x8CEE; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT14_WEBGL = 0x8CEE;
 /**
+ * Framebuffer color attachment point
  * @memberOf constants
  * @type {GLenum}
  */
-export const COLOR_ATTACHMENT15_WEBGL = 0x8CEF; //  Framebuffer color attachment point
+export const COLOR_ATTACHMENT15_WEBGL = 0x8CEF;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER0_WEBGL = 0x8825; //  Draw buffer
+export const DRAW_BUFFER0_WEBGL = 0x8825;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER1_WEBGL = 0x8826; //  Draw buffer
+export const DRAW_BUFFER1_WEBGL = 0x8826;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER2_WEBGL = 0x8827; //  Draw buffer
+export const DRAW_BUFFER2_WEBGL = 0x8827;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER3_WEBGL = 0x8828; //  Draw buffer
+export const DRAW_BUFFER3_WEBGL = 0x8828;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER4_WEBGL = 0x8829; //  Draw buffer
+export const DRAW_BUFFER4_WEBGL = 0x8829;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER5_WEBGL = 0x882A; //  Draw buffer
+export const DRAW_BUFFER5_WEBGL = 0x882A;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER6_WEBGL = 0x882B; //  Draw buffer
+export const DRAW_BUFFER6_WEBGL = 0x882B;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER7_WEBGL = 0x882C; //  Draw buffer
+export const DRAW_BUFFER7_WEBGL = 0x882C;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER8_WEBGL = 0x882D; //  Draw buffer
+export const DRAW_BUFFER8_WEBGL = 0x882D;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER9_WEBGL = 0x882E; //  Draw buffer
+export const DRAW_BUFFER9_WEBGL = 0x882E;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER10_WEBGL = 0x882F; //  Draw buffer
+export const DRAW_BUFFER10_WEBGL = 0x882F;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER11_WEBGL = 0x8830; //  Draw buffer
+export const DRAW_BUFFER11_WEBGL = 0x8830;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER12_WEBGL = 0x8831; //  Draw buffer
+export const DRAW_BUFFER12_WEBGL = 0x8831;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER13_WEBGL = 0x8832; //  Draw buffer
+export const DRAW_BUFFER13_WEBGL = 0x8832;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER14_WEBGL = 0x8833; //  Draw buffer
+export const DRAW_BUFFER14_WEBGL = 0x8833;
 /**
+ * Draw buffer
  * @memberOf constants
  * @type {GLenum}
  */
-export const DRAW_BUFFER15_WEBGL = 0x8834; //  Draw buffer
+export const DRAW_BUFFER15_WEBGL = 0x8834;
 /**
+ * Maximum number of framebuffer color attachment points
  * @memberOf constants
  * @type {GLenum}
  */
-export const MAX_COLOR_ATTACHMENTS_WEBGL = 0x8CDF; //  Maximum number of framebuffer color attachment points
+export const MAX_COLOR_ATTACHMENTS_WEBGL = 0x8CDF;
 /**
+ * Maximum number of draw buffers
  * @memberOf constants
  * @type {GLenum}
  */
-export const MAX_DRAW_BUFFERS_WEBGL = 0x8824; //  Maximum number of draw buffers
+export const MAX_DRAW_BUFFERS_WEBGL = 0x8824;
 /**
+ * The bound vertex array object (VAO).
  * @memberOf constants
  * @type {GLenum}
  */
-export const VERTEX_ARRAY_BINDING_OES = 0x85B5; //  The bound vertex array object (VAO).
+export const VERTEX_ARRAY_BINDING_OES = 0x85B5;
 /**
+ * The number of bits used to hold the query result for the given target.
  * @memberOf constants
  * @type {GLenum}
  */
-export const QUERY_COUNTER_BITS_EXT = 0x8864; //  The number of bits used to hold the query result for the given target.
+export const QUERY_COUNTER_BITS_EXT = 0x8864;
 /**
+ * The currently active query.
  * @memberOf constants
  * @type {GLenum}
  */
-export const CURRENT_QUERY_EXT = 0x8865; //  The currently active query.
+export const CURRENT_QUERY_EXT = 0x8865;
 /**
+ * The query result.
  * @memberOf constants
  * @type {GLenum}
  */
-export const QUERY_RESULT_EXT = 0x8866; //  The query result.
+export const QUERY_RESULT_EXT = 0x8866;
 /**
+ * A Boolean indicating whether or not a query result is available.
  * @memberOf constants
  * @type {GLenum}
  */
-export const QUERY_RESULT_AVAILABLE_EXT = 0x8867; //  A Boolean indicating whether or not a query result is available.
+export const QUERY_RESULT_AVAILABLE_EXT = 0x8867;
 /**
+ * Elapsed time (in nanoseconds).
  * @memberOf constants
  * @type {GLenum}
  */
-export const TIME_ELAPSED_EXT = 0x88BF; //  Elapsed time (in nanoseconds).
+export const TIME_ELAPSED_EXT = 0x88BF;
 /**
+ * The current time.
  * @memberOf constants
  * @type {GLenum}
  */
-export const TIMESTAMP_EXT = 0x8E28; //  The current time.
+export const TIMESTAMP_EXT = 0x8E28;
 /**
+ * A Boolean indicating whether or not the GPU performed any disjoint operation.
  * @memberOf constants
  * @type {GLenum}
  */
-export const GPU_DISJOINT_EXT = 0x8FBB; //  A Boolean indicating whether or not the GPU performed any disjoint operation.
+export const GPU_DISJOINT_EXT = 0x8FBB;

--- a/src/core/Stage.js
+++ b/src/core/Stage.js
@@ -91,6 +91,7 @@ const Stage = Class.create(/** @lends Stage.prototype */ {
      * @param {number} [params.height=innerHeight] stage的高，默认网页高度
      * @param {number} [params.pixelRatio=根据设备自动判断] 像素密度。
      * @param {Color} [params.clearColor=new Color(1, 1, 1, 1)] 背景色。
+     * @param {boolean} [params.preferWebGL2=false] 是否优先使用 WebGL2
      * @param {boolean} [params.useFramebuffer=false] 是否使用Framebuffer，有后处理需求时需要。
      * @param {Object} [params.framebufferOption={}] framebufferOption Framebuffer的配置，useFramebuffer为true时生效。
      * @param {boolean} [params.useLogDepth=false] 是否使用对数深度，处理深度冲突。

--- a/src/material/Material.js
+++ b/src/material/Material.js
@@ -3,6 +3,7 @@ import math from '../math/math';
 import semantic from './semantic';
 import log from '../utils/log';
 import constants from '../constants';
+import capabilities from '../renderer/capabilities';
 
 const {
     LEQUAL,
@@ -482,6 +483,13 @@ const Material = Class.create(/** @lends Material.prototype */ {
     exposure: 1,
 
     /**
+     * 是否开启 texture lod
+     * @default false
+     * @type {Boolean}
+     */
+    enableTextureLod: false,
+
+    /**
      * 是否需要加基础 uniforms
      * @type {Boolean}
      * @default true
@@ -670,6 +678,10 @@ const Material = Class.create(/** @lends Material.prototype */ {
 
         if (this.premultiplyAlpha) {
             option.PREMULTIPLY_ALPHA = 1;
+        }
+
+        if (capabilities.SHADER_TEXTURE_LOD && this.enableTextureLod) {
+            option.USE_SHADER_TEXTURE_LOD = 1;
         }
 
         const textureOption = this._textureOption.reset(option);

--- a/src/renderer/Program.js
+++ b/src/renderer/Program.js
@@ -303,7 +303,7 @@ const Program = Class.create(/** @lends Program.prototype */ {
                 if (instancedExtension) {
                     divisor = (d = 1) => {
                         each((location) => {
-                            instancedExtension.vertexAttribDivisorANGLE(location, d);
+                            instancedExtension.vertexAttribDivisor(location, d);
                         });
                     };
                 }

--- a/src/renderer/Program.js
+++ b/src/renderer/Program.js
@@ -286,7 +286,7 @@ const Program = Class.create(/** @lends Program.prototype */ {
 
             if (instancedExtension) {
                 divisor = (d = 1) => {
-                    instancedExtension.vertexAttribDivisorANGLE(location, d);
+                    instancedExtension.vertexAttribDivisor(location, d);
                 };
             }
 

--- a/src/renderer/VertexArrayObject.js
+++ b/src/renderer/VertexArrayObject.js
@@ -71,7 +71,7 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
          */
         bindSystemVao() {
             if (extensions.vao) {
-                extensions.vao.bindVertexArrayOES(null);
+                extensions.vao.bindVertexArray(null);
             }
 
             currentVao = null;
@@ -134,8 +134,9 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
     constructor(gl, id, params) {
         this.gl = gl;
         this.id = id;
-        this.vaoExtension = extensions.vao;
+
         this.instancedExtension = extensions.instanced;
+        this.vaoExtension = extensions.vao;
 
         Object.assign(this, params);
 
@@ -148,7 +149,7 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
         }
 
         if (this.useVao) {
-            this.vao = this.vaoExtension.createVertexArrayOES();
+            this.vao = this.vaoExtension.createVertexArray();
         }
 
         this.attributes = [];
@@ -161,7 +162,7 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
     bind() {
         if (currentVao !== this) {
             if (this.useVao) {
-                this.vaoExtension.bindVertexArrayOES(this.vao);
+                this.vaoExtension.bindVertexArray(this.vao);
             } else {
                 this.bindSystemVao();
             }
@@ -218,7 +219,7 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
      */
     unbind() {
         if (this.useVao) {
-            this.vaoExtension.bindVertexArrayOES(null);
+            this.vaoExtension.bindVertexArray(null);
         }
         currentVao = null;
     },
@@ -265,9 +266,9 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
         } = this;
         if (this.useInstanced) {
             if (this.indexBuffer) {
-                this.instancedExtension.drawElementsInstancedANGLE(mode, this.vertexCount, gl.UNSIGNED_SHORT, 0, primcount);
+                this.instancedExtension.drawElementsInstanced(mode, this.vertexCount, gl.UNSIGNED_SHORT, 0, primcount);
             } else {
-                this.instancedExtension.drawArraysInstancedANGLE(mode, 0, this.getVertexCount(), primcount);
+                this.instancedExtension.drawArraysInstanced(mode, 0, this.getVertexCount(), primcount);
             }
         }
     },
@@ -417,7 +418,7 @@ const VertexArrayObject = Class.create(/** @lends VertexArrayObject.prototype */
         this.instancedExtension = null;
 
         if (this.useVao) {
-            this.vaoExtension.deleteVertexArrayOES(this.vao);
+            this.vaoExtension.deleteVertexArray(this.vao);
             this.vao = null;
             this.vaoExtension = null;
         }

--- a/src/renderer/WebGLRenderer.js
+++ b/src/renderer/WebGLRenderer.js
@@ -254,6 +254,20 @@ const WebGLRenderer = Class.create(/** @lends WebGLRenderer.prototype */ {
     _isContextLost: false,
 
     /**
+     * 是否是 WebGL2
+     * @type {Boolean}
+     * @default false
+     */
+    isWebGL2: false,
+
+    /**
+     * 是否优先使用 WebGL2
+     * @type {Boolean}
+     * @default false
+     */
+    preferWebGL2: false,
+
+    /**
      * @constructs
      * @param  {Object} [params] 初始化参数，所有params都会复制到实例上
      */
@@ -422,7 +436,22 @@ const WebGLRenderer = Class.create(/** @lends WebGLRenderer.prototype */ {
             contextAttributes.gameMode = true;
         }
 
-        let gl = this.gl = this.domElement.getContext('webgl', contextAttributes);
+        if (this.preferWebGL2) {
+            try {
+                this.gl = this.domElement.getContext('webgl2', contextAttributes);
+                this.isWebGL2 = true;
+            } catch (e) {
+                this.isWebGL2 = false;
+                this.gl = null;
+            }
+        }
+
+        if (!this.gl) {
+            this.gl = this.domElement.getContext('webgl', contextAttributes);
+            this.isWebGL2 = false;
+        }
+
+        let gl = this.gl;
 
         // HILO_DEBUG_START
         gl = this.gl = WebGLDebugUtils.makeDebugContext(gl, (err, funcName) => {
@@ -448,10 +477,6 @@ const WebGLRenderer = Class.create(/** @lends WebGLRenderer.prototype */ {
         }
 
         this.renderList.useInstanced = this.useInstanced;
-
-        if (!extensions.vao) {
-            this.useVao = false;
-        }
 
         if (this.useFramebuffer) {
             /**

--- a/src/renderer/WebGLState.js
+++ b/src/renderer/WebGLState.js
@@ -1,4 +1,5 @@
 import Class from '../core/Class';
+import { isWebGL2 } from '../utils/util';
 
 /**
  * WebGL 状态管理，减少 api 调用
@@ -25,6 +26,13 @@ const WebGLState = Class.create(/** @lends WebGLState.prototype */ {
     systemFramebuffer: null,
 
     /**
+    * 是否是 WebGL2
+    * @default false
+    * @type {Boolean}
+    */
+    isWebGL2: false,
+
+    /**
      * @constructs
      * @param  {WebGLRenderingContext} gl
      */
@@ -34,6 +42,7 @@ const WebGLState = Class.create(/** @lends WebGLState.prototype */ {
          * @type {WebGLRenderingContext}
          */
         this.gl = gl;
+        this.isWebGL2 = isWebGL2(gl);
         this.reset();
     },
     /**

--- a/src/renderer/capabilities.js
+++ b/src/renderer/capabilities.js
@@ -136,7 +136,7 @@ const capabilities = {
 
         this.VERTEX_TEXTURE_FLOAT = !!extensions.texFloat && this.MAX_VERTEX_TEXTURE_IMAGE_UNITS > 0;
         this.FRAGMENT_TEXTURE_FLOAT = !!extensions.texFloat;
-        this.EXT_FRAG_DEPTH = !!extensions.fragDepth;
+        this.FRAG_DEPTH = !!extensions.fragDepth;
 
         this.SHADER_TEXTURE_LOD = !!extensions.shaderTextureLod;
 

--- a/src/renderer/capabilities.js
+++ b/src/renderer/capabilities.js
@@ -1,4 +1,7 @@
 import extensions from './extensions';
+import {
+    isWebGL2
+} from '../utils/util';
 
 /**
  * WebGL 能力
@@ -6,6 +9,10 @@ import extensions from './extensions';
  * @type {Object}
  */
 const capabilities = {
+    /**
+     * 是否是 WebGL2
+     */
+    isWebGL2: false,
     /**
      * 最大纹理数量
      * @type {Number}
@@ -104,6 +111,7 @@ const capabilities = {
      */
     init(gl) {
         this.gl = gl;
+        this.isWebGL2 = isWebGL2(gl);
         const arr = [
             'MAX_RENDERBUFFER_SIZE',
             'MAX_COMBINED_TEXTURE_IMAGE_UNITS',
@@ -128,7 +136,7 @@ const capabilities = {
 
         this.VERTEX_TEXTURE_FLOAT = !!extensions.texFloat && this.MAX_VERTEX_TEXTURE_IMAGE_UNITS > 0;
         this.FRAGMENT_TEXTURE_FLOAT = !!extensions.texFloat;
-        this.EXT_FRAG_DEPTH = extensions.get('EXT_frag_depth');
+        this.EXT_FRAG_DEPTH = !!extensions.fragDepth;
 
         this.SHADER_TEXTURE_LOD = !!extensions.shaderTextureLod;
 

--- a/src/renderer/extensions.js
+++ b/src/renderer/extensions.js
@@ -13,9 +13,8 @@ import {
 const WebGL2DefaultSupportExtensions = {
     OES_texture_float: {
         name: 'OES_texture_float',
-        isWebGL2: true,
     },
-    EXT_FRAG_DEPTH: {
+    EXT_frag_depth: {
         name: 'EXT_frag_depth',
     },
     OES_element_index_uint: {
@@ -62,6 +61,12 @@ const extensions = {
      * @type {OESTextureFloat}
      */
     texFloat: undefined,
+
+    /**
+     * EXT_frag_depth扩展
+     * @type {EXTFragDepth}
+     */
+    fragDepth: undefined,
 
     /**
      * WEBGL_lose_context扩展
@@ -205,6 +210,10 @@ export default extensions;
 
 /**
  * @typedef {any} OESTextureFloat
+ */
+
+/**
+ * @typedef {any} EXTFragDepth
  */
 
 /**

--- a/src/renderer/extensions.js
+++ b/src/renderer/extensions.js
@@ -23,6 +23,9 @@ const WebGL2DefaultSupportExtensions = {
     EXT_shader_texture_lod: {
         name: 'EXT_shader_texture_lod',
     },
+    EXT_sRGB: {
+        name: 'EXT_sRGB',
+    },
 };
 
 const WebGLPolyfillExtensions = {
@@ -79,6 +82,12 @@ const extensions = {
      * @type {EXTTextureFilterAnisotropic}
      */
     textureFilterAnisotropic: undefined,
+
+    /**
+     * EXT_sRGB
+     * @type {EXT_sRGB}
+     */
+    sRGB: undefined,
 
     _usedExtensions: {},
     _disabledExtensions: {},
@@ -198,6 +207,7 @@ extensions.use('EXT_frag_depth', 'fragDepth');
 extensions.use('EXT_texture_filter_anisotropic', 'textureFilterAnisotropic');
 extensions.use('WEBGL_lose_context', 'loseContext');
 extensions.use('EXT_color_buffer_float', 'colorBufferFloat');
+extensions.use('EXT_sRGB', 'sRGB');
 
 export default extensions;
 
@@ -223,4 +233,8 @@ export default extensions;
 
 /**
  * @typedef {any} EXTTextureFilterAnisotropic
+ */
+
+/**
+ * @typedef {any} EXT_sRGB
  */

--- a/src/renderer/extensions.js
+++ b/src/renderer/extensions.js
@@ -197,6 +197,7 @@ extensions.use('EXT_shader_texture_lod', 'shaderTextureLod');
 extensions.use('EXT_frag_depth', 'fragDepth');
 extensions.use('EXT_texture_filter_anisotropic', 'textureFilterAnisotropic');
 extensions.use('WEBGL_lose_context', 'loseContext');
+extensions.use('EXT_color_buffer_float', 'colorBufferFloat');
 
 export default extensions;
 

--- a/src/renderer/extensions/InstancedArraysExtension.js
+++ b/src/renderer/extensions/InstancedArraysExtension.js
@@ -1,18 +1,18 @@
 export class WebGL1InstancedArraysExtension {
     constructor(instancedArraysExtension) {
-        this._instancedArraysExtension = instancedArraysExtension;
+        this._ext = instancedArraysExtension;
     }
 
     drawArraysInstanced(mode, first, count, instanceCount) {
-        this._instancedArraysExtension.drawArraysInstancedANGLE(mode, first, count, instanceCount);
+        this._ext.drawArraysInstancedANGLE(mode, first, count, instanceCount);
     }
 
     drawElementsInstanced(mode, count, type, offset, instanceCount) {
-        this._instancedArraysExtension.drawElementsInstancedANGLE(mode, count, type, offset, instanceCount);
+        this._ext.drawElementsInstancedANGLE(mode, count, type, offset, instanceCount);
     }
 
     vertexAttribDivisor(index, divisor) {
-        this._instancedArraysExtension.vertexAttribDivisorANGLE(index, divisor);
+        this._ext.vertexAttribDivisorANGLE(index, divisor);
     }
 }
 

--- a/src/renderer/extensions/InstancedArraysExtension.js
+++ b/src/renderer/extensions/InstancedArraysExtension.js
@@ -1,0 +1,35 @@
+export class WebGL1InstancedArraysExtension {
+    constructor(instancedArraysExtension) {
+        this._instancedArraysExtension = instancedArraysExtension;
+    }
+
+    drawArraysInstanced(mode, first, count, instanceCount) {
+        this._instancedArraysExtension.drawArraysInstancedANGLE(mode, first, count, instanceCount);
+    }
+
+    drawElementsInstanced(mode, count, type, offset, instanceCount) {
+        this._instancedArraysExtension.drawElementsInstancedANGLE(mode, count, type, offset, instanceCount);
+    }
+
+    vertexAttribDivisor(index, divisor) {
+        this._instancedArraysExtension.vertexAttribDivisorANGLE(index, divisor);
+    }
+}
+
+export class WebGL2InstancedArraysExtension {
+    constructor(gl) {
+        this._gl = gl;
+    }
+
+    drawArraysInstanced(mode, first, count, instanceCount) {
+        this._gl.drawArraysInstanced(mode, first, count, instanceCount);
+    }
+
+    drawElementsInstanced(mode, count, type, offset, instanceCount) {
+        this._gl.drawElementsInstanced(mode, count, type, offset, instanceCount);
+    }
+
+    vertexAttribDivisor(index, divisor) {
+        this._gl.vertexAttribDivisor(index, divisor);
+    }
+}

--- a/src/renderer/extensions/VertexArrayObjectExtension.js
+++ b/src/renderer/extensions/VertexArrayObjectExtension.js
@@ -1,22 +1,22 @@
 export class WebGL1VertexArrayObjectExtension {
     constructor(vaoExtension) {
-        this._vaoExtension = vaoExtension;
+        this._ext = vaoExtension;
     }
 
     createVertexArray(vertexArray) {
-        return this._vaoExtension.createVertexArrayOES(vertexArray);
+        return this._ext.createVertexArrayOES(vertexArray);
     }
 
     deleteVertexArray(vertexArray) {
-        this._vaoExtension.deleteVertexArrayOES(vertexArray);
+        this._ext.deleteVertexArrayOES(vertexArray);
     }
 
     isVertexArray(vertexArray) {
-        return this._vaoExtension.isVertexArrayOES(vertexArray);
+        return this._ext.isVertexArrayOES(vertexArray);
     }
 
     bindVertexArray(vertexArray) {
-        this._vaoExtension.bindVertexArrayOES(vertexArray);
+        this._ext.bindVertexArrayOES(vertexArray);
     }
 }
 

--- a/src/renderer/extensions/VertexArrayObjectExtension.js
+++ b/src/renderer/extensions/VertexArrayObjectExtension.js
@@ -1,0 +1,43 @@
+export class WebGL1VertexArrayObjectExtension {
+    constructor(vaoExtension) {
+        this._vaoExtension = vaoExtension;
+    }
+
+    createVertexArray(vertexArray) {
+        return this._vaoExtension.createVertexArrayOES(vertexArray);
+    }
+
+    deleteVertexArray(vertexArray) {
+        this._vaoExtension.deleteVertexArrayOES(vertexArray);
+    }
+
+    isVertexArray(vertexArray) {
+        return this._vaoExtension.isVertexArrayOES(vertexArray);
+    }
+
+    bindVertexArray(vertexArray) {
+        this._vaoExtension.bindVertexArrayOES(vertexArray);
+    }
+}
+
+export class WebGL2VertexArrayObjectExtension {
+    constructor(gl) {
+        this._gl = gl;
+    }
+
+    createVertexArray(vertexArray) {
+        return this._gl.createVertexArray(vertexArray);
+    }
+
+    deleteVertexArray(vertexArray) {
+        this._gl.deleteVertexArray(vertexArray);
+    }
+
+    isVertexArray(vertexArray) {
+        return this._gl.isVertexArray(vertexArray);
+    }
+
+    bindVertexArray(vertexArray) {
+        this._gl.bindVertexArray(vertexArray);
+    }
+}

--- a/src/shader/Shader.js
+++ b/src/shader/Shader.js
@@ -197,8 +197,8 @@ const Shader = Class.create(/** @lends Shader.prototype */ {
 
                 if (useLogDepth) {
                     headers.USE_LOG_DEPTH = 1;
-                    if (capabilities.EXT_FRAG_DEPTH) {
-                        headers.USE_EXT_FRAG_DEPTH = 1;
+                    if (capabilities.FRAG_DEPTH) {
+                        headers.USE_FRAG_DEPTH = 1;
                     }
                 }
 

--- a/src/shader/chunk/GLSL300Define.frag
+++ b/src/shader/chunk/GLSL300Define.frag
@@ -1,0 +1,10 @@
+#version 300 es
+#define HILO_IS_WEBGL2
+#define varying in
+#define texture2D texture
+#define textureCube texture
+#define texture2DLodEXT textureLod
+#define textureCubeLodEXT textureLod
+#define gl_FragColor fragColor
+#define gl_FragDepthEXT gl_FragDepth
+layout(location = 0) out highp vec4 fragColor;

--- a/src/shader/chunk/GLSL300Define.vert
+++ b/src/shader/chunk/GLSL300Define.vert
@@ -1,0 +1,8 @@
+#version 300 es
+#define HILO_IS_WEBGL2
+#define attribute in
+#define varying out
+#define texture2D texture
+#define textureCube texture
+#define texture2DLodEXT textureLod
+#define textureCubeLodEXT textureLod

--- a/src/shader/chunk/extensions.frag
+++ b/src/shader/chunk/extensions.frag
@@ -1,7 +1,9 @@
-#ifdef HILO_USE_SHADER_TEXTURE_LOD
-    #extension GL_EXT_shader_texture_lod: enable
-#endif
+#ifndef HILO_IS_WEBGL2
+    #ifdef HILO_USE_SHADER_TEXTURE_LOD
+        #extension GL_EXT_shader_texture_lod: enable
+    #endif
 
-#ifdef HILO_USE_EXT_FRAG_DEPTH
-    #extension GL_EXT_frag_depth: enable
+    #ifdef HILO_USE_FRAG_DEPTH
+        #extension GL_EXT_frag_depth: enable
+    #endif
 #endif

--- a/src/shader/chunk/logDepth.frag
+++ b/src/shader/chunk/logDepth.frag
@@ -1,4 +1,4 @@
-#if defined(HILO_USE_LOG_DEPTH) && defined(HILO_USE_EXT_FRAG_DEPTH)
+#if defined(HILO_USE_LOG_DEPTH) && defined(HILO_USE_FRAG_DEPTH)
     uniform float u_logDepth;
     varying float v_fragDepth;
 #endif

--- a/src/shader/chunk/logDepth.vert
+++ b/src/shader/chunk/logDepth.vert
@@ -1,5 +1,5 @@
 #ifdef HILO_USE_LOG_DEPTH
-    #ifdef HILO_USE_EXT_FRAG_DEPTH
+    #ifdef HILO_USE_FRAG_DEPTH
         varying float v_fragDepth;
     #else
         uniform float u_logDepth;

--- a/src/shader/chunk/logDepth_main.frag
+++ b/src/shader/chunk/logDepth_main.frag
@@ -1,3 +1,3 @@
-#if defined(HILO_USE_LOG_DEPTH) && defined(HILO_USE_EXT_FRAG_DEPTH)
+#if defined(HILO_USE_LOG_DEPTH) && defined(HILO_USE_FRAG_DEPTH)
     gl_FragDepthEXT = log2( v_fragDepth ) * u_logDepth * 0.5;
 #endif

--- a/src/shader/chunk/logDepth_main.vert
+++ b/src/shader/chunk/logDepth_main.vert
@@ -1,5 +1,5 @@
 #ifdef HILO_USE_LOG_DEPTH
-    #ifdef HILO_USE_EXT_FRAG_DEPTH
+    #ifdef HILO_USE_FRAG_DEPTH
         v_fragDepth = 1.0 + gl_Position.w;
     #else
         gl_Position.z = log2( max( 1e-6, gl_Position.w + 1.0 ) ) * u_logDepth - 1.0;

--- a/src/shader/method/textureEnvMap.glsl
+++ b/src/shader/method/textureEnvMap.glsl
@@ -1,27 +1,27 @@
-vec4 textureEnvMap(sampler2D texture, vec3 position){
-    return texture2D(texture, vec2(atan(position.x, position.z) * HILO_INVERSE_PI * 0.5+0.5,  acos(position.y) * HILO_INVERSE_PI));
+vec4 textureEnvMap(sampler2D uTexture, vec3 position){
+    return texture2D(uTexture, vec2(atan(position.x, position.z) * HILO_INVERSE_PI * 0.5+0.5,  acos(position.y) * HILO_INVERSE_PI));
 }
 
-vec4 textureEnvMap(samplerCube texture, vec3 position){
-    return textureCube(texture, position);
+vec4 textureEnvMap(samplerCube uTexture, vec3 position){
+    return textureCube(uTexture, position);
 }
 
-vec4 textureEnvMapIncludeMipmapsLod(sampler2D texture, vec3 position, float lod){
+vec4 textureEnvMapIncludeMipmapsLod(sampler2D uTexture, vec3 position, float lod){
     lod = floor(lod);
     vec2 uv = vec2(atan(position.x, position.z) * HILO_INVERSE_PI * 0.5+0.5,  acos(position.y) * HILO_INVERSE_PI);
 
     float scale = pow(2.0, lod);
 
-    return texture2D(texture, vec2(uv.x / scale, (uv.y / scale / 2.0) + 1.0 - 1.0/pow(2.0, lod)));
+    return texture2D(uTexture, vec2(uv.x / scale, (uv.y / scale / 2.0) + 1.0 - 1.0/pow(2.0, lod)));
 }
 
 #ifdef HILO_USE_SHADER_TEXTURE_LOD
-    vec4 textureEnvMapLod(sampler2D texture, vec3 position, float lod){
-        return texture2DLodEXT(texture, vec2(atan(position.x, position.z) * HILO_INVERSE_PI * 0.5+0.5,  acos(position.y) * HILO_INVERSE_PI), lod);
+    vec4 textureEnvMapLod(sampler2D uTexture, vec3 position, float lod){
+        return texture2DLodEXT(uTexture, vec2(atan(position.x, position.z) * HILO_INVERSE_PI * 0.5+0.5,  acos(position.y) * HILO_INVERSE_PI), lod);
     }
 
-    vec4 textureEnvMapLod(samplerCube texture, vec3 position, float lod){
-        return textureCubeLodEXT(texture, position, lod);
+    vec4 textureEnvMapLod(samplerCube uTexture, vec3 position, float lod){
+        return textureCubeLodEXT(uTexture, position, lod);
     }
 #endif
 

--- a/src/texture/Texture.js
+++ b/src/texture/Texture.js
@@ -458,7 +458,7 @@ const Texture = Class.create(/** @lends Texture.prototype */ {
     },
     /**
      * 修复 WebGL & WebGL2 internalFormat
-     * @param {WebGLState} state 
+     * @param {WebGLState} state
      * @returns {number} internalFormat
      */
     _fixInternalFormat(state, type, format, internalFormat) {

--- a/src/texture/Texture.js
+++ b/src/texture/Texture.js
@@ -441,14 +441,17 @@ const Texture = Class.create(/** @lends Texture.prototype */ {
         const gl = state.gl;
         const type = this.type;
         const format = this.format;
-        const internalFormat = this._fixInternalFormat(state, type, format);
+        let internalFormat = this.internalFormat;
 
         if (this.compressed) {
             gl.compressedTexImage2D(target, level, internalFormat, width, height, this.border, image);
-        } else if (image && image.width !== undefined) {
-            gl.texImage2D(target, level, internalFormat, format, this.type, image);
         } else {
-            gl.texImage2D(target, level, internalFormat, width, height, this.border, format, this.type, image);
+            internalFormat = this._fixInternalFormat(state, type, format, internalFormat);
+            if (image && image.width !== undefined) {
+                gl.texImage2D(target, level, internalFormat, format, this.type, image);
+            } else {
+                gl.texImage2D(target, level, internalFormat, width, height, this.border, format, this.type, image);
+            }
         }
 
         return this;
@@ -458,8 +461,7 @@ const Texture = Class.create(/** @lends Texture.prototype */ {
      * @param {WebGLState} state 
      * @returns {number} internalFormat
      */
-    _fixInternalFormat(state, type, format) {
-        let internalFormat = this.internalFormat;
+    _fixInternalFormat(state, type, format, internalFormat) {
         if (state.isWebGL2 && type === FLOAT) {
             if (format === RGBA) {
                 internalFormat = RGBA32F;
@@ -512,9 +514,11 @@ const Texture = Class.create(/** @lends Texture.prototype */ {
             const useRepeat = this.useRepeat;
 
             if (this.image && !this.image.length) {
-                const needPowerOfTwo = useRepeat || useMipmap;
-                const sizeResult = this.getSupportSize(this.image, needPowerOfTwo);
-                this.image = this.resizeImg(this.image, sizeResult.width, sizeResult.height);
+                if (!state.isWebGL2) {
+                    const needPowerOfTwo = useRepeat || useMipmap;
+                    const sizeResult = this.getSupportSize(this.image, needPowerOfTwo);
+                    this.image = this.resizeImg(this.image, sizeResult.width, sizeResult.height);
+                }
                 this.width = this.image.width;
                 this.height = this.image.height;
             }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -368,6 +368,16 @@ function hasOwnProperty(obj, name) {
     return Object.prototype.hasOwnProperty.call(obj, name);
 }
 
+/**
+ * 是否是 WebGL2
+ * @memberOf util
+ * @param  {any}  gl
+ * @return {boolean}
+ */
+function isWebGL2(gl) {
+    return typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
+}
+
 
 export {
     each,
@@ -387,5 +397,6 @@ export {
     isArrayLike,
     getElementRect,
     serialRun,
-    hasOwnProperty
+    hasOwnProperty,
+    isWebGL2,
 };

--- a/test/spec/renderer/extensions.test.js
+++ b/test/spec/renderer/extensions.test.js
@@ -4,8 +4,8 @@ describe('extensions', () => {
     it('init', () => {
         extensions.init(testEnv.gl);
 
-        extensions.instanced.should.equal(testEnv.gl.getExtension('ANGLE_instanced_arrays'));
-        extensions.vao.should.equal(testEnv.gl.getExtension('OES_vertex_array_object'));
+        extensions.instanced._ext.should.equal(testEnv.gl.getExtension('ANGLE_instanced_arrays'));
+        extensions.vao._ext.should.equal(testEnv.gl.getExtension('OES_vertex_array_object'));
         extensions.texFloat.should.equal(testEnv.gl.getExtension('OES_texture_float'));
         extensions.loseContext.should.equal(testEnv.gl.getExtension('WEBGL_lose_context'));
         extensions.uintIndices.should.equal(testEnv.gl.getExtension('OES_element_index_uint'));


### PR DESCRIPTION
## P0
- [x] Vertex Array Objects
- [x] Non-Power of 2 Texture Support
- [x] Standard Derivatives
- [x] Instanced Drawing
- [x] UNSIGNED_INT indices
- [x] Setting gl_FragDepth
- [x] Direct texture LOD access
- [x] Texture access in vertex shaders
- [x] Floating point textures
- [x] Floating Point Framebuffer Attachments
- [x] [WebGL2 constants](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants#additional_constants_defined_webgl_2)
- [x] GLSL 300
- [x] Hilo3d capabilities
- [x] Hilo3d extensions

## P1
- [ ] 3D Textures
- [ ] Texture arrays
- [ ] Common compressed textures
- [x] sRGB support to textures and framebuffer objects
- [ ] Multi-Sampled renderbuffers
- [ ] Uniform Buffer Objects
- [ ] Integer textures, attributes and math
- [ ] Transform feedback
- [ ] Samplers
- [ ] Depth Textures
- [ ] Blend Equation MIN / MAX
- [ ] Multiple Draw Buffers
- [ ] Occlusion Queries

## References
* https://webgl2fundamentals.org/webgl/lessons/webgl2-whats-new.html
* https://webgl2fundamentals.org/webgl/lessons/webgl1-to-webgl2.html