### PR TITLE
Improve WebGL2 support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
         "prefer-rest-params": 0,
         "prefer-spread": 0,
         "space-before-function-paren": ["error", "never"],
-        "prefer-destructuring": 0
+        "prefer-destructuring": 0,
+        "no-buffer-constructor": 0
     }
 }

--- a/examples/MultiSampledRenderbuffers.html
+++ b/examples/MultiSampledRenderbuffers.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <title>Hilo3d MultiSampled Renderbuffers Demo</title>
+    <link rel="stylesheet" type="text/css" href="./example.css" />
+    <style>
+      #info0 {
+        position: absolute;
+        left: 5%;
+        top: 10%;
+        color: #fff;
+      }
+
+      #info1 {
+        position: absolute;
+        left: 55%;
+        top: 10%;
+        color: #fff;
+      }
+
+      #info2 {
+        position: absolute;
+        left: 5%;
+        top: 60%;
+        color: #fff;
+      }
+
+      #info3 {
+        position: absolute;
+        left: 55%;
+        top: 60%;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container"></div>
+    <div id="info0">no samples</div>
+    <div id="info1">0 samples</div>
+    <div id="info2">2 samples</div>
+    <div id="info3">4 samples</div>
+    <script src="../build/Hilo3d.js"></script>
+    <script src="./js/stats.js"></script>
+    <script src="./js/OrbitControls.js"></script>
+    <script src="./js/init.js"></script>
+    <script>
+      renderer.preferWebGL2 = true;
+      ticker.targetFPS = 1;
+      renderer.clearColor = new Hilo3d.Color(.9, .6, .3);
+
+      var sphereGeometry = new Hilo3d.PlaneGeometry();
+      var material = new Hilo3d.BasicMaterial({
+        lightType: "NONE",
+        diffuse: new Hilo3d.Color(1, 1, 1),
+        wireframe: true,
+      });
+
+      camera.lookAt(new Hilo3d.Vector3(0, 0, 0));
+
+      var sceneNode = new Hilo3d.Node();
+      const mesh = new Hilo3d.Mesh({
+        material: material,
+        geometry: sphereGeometry,
+        x: 0,
+        y: 0,
+        z: 0,
+        rotationZ: 30,
+        onUpdate: function () {
+          this.rotationZ += 6.7;
+        },
+      }).setScale(1.4);
+      sceneNode.addChild(mesh);
+
+      var framebufferWidth = renderer.width / 32;
+      var framebufferHeight = renderer.height / 32;
+
+      var framebuffers = [0, 2, 4].map(samples => {
+        var multiSampledFramebuffer = new Hilo3d.Framebuffer(renderer, {
+          width: framebufferWidth,
+          height: framebufferHeight,
+          colorAttachmentInfos: [
+            {
+              attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_RENDERBUFFER,
+              internalFormat: Hilo3d.constants.RGBA8,
+              samples,
+            },
+          ],
+          depthStencilAttachmentInfo: {
+            attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_RENDERBUFFER,
+            internalFormat: Hilo3d.constants.DEPTH_COMPONENT24,
+            attachment: Hilo3d.constants.DEPTH_ATTACHMENT,
+            samples,
+          },
+        });
+
+        var copyFramebuffer = new Hilo3d.Framebuffer(renderer, {
+          width: framebufferWidth,
+          height: framebufferHeight,
+          colorAttachmentInfos: [
+            {
+              attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+            },
+          ],
+        });
+
+        return {
+          multiSampledFramebuffer,
+          copyFramebuffer,
+        };
+      });
+
+      var singleFramebuffer = new Hilo3d.Framebuffer(renderer, {
+        width: framebufferWidth,
+        height: framebufferHeight,
+        colorAttachmentInfos:[{
+          attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+        }]
+      });
+
+      stage.onUpdate = function () {
+        const preWidth = renderer.width;
+        const preHeight = renderer.height;
+
+        sceneNode.traverseUpdate();
+        renderer.width = framebufferWidth;
+        renderer.height = framebufferHeight;
+        renderer.viewport(0, 0, framebufferWidth, framebufferHeight);
+
+        framebuffers.forEach(framebuffer => {
+          const {
+            multiSampledFramebuffer,
+            copyFramebuffer,
+          } = framebuffer;
+
+          multiSampledFramebuffer.bind();
+          stage.renderer.render(sceneNode, camera);
+
+          copyFramebuffer.copyFramebuffer(multiSampledFramebuffer);
+        });
+
+        singleFramebuffer.bind();
+        stage.renderer.render(sceneNode, camera);
+
+        renderer.state.bindSystemFramebuffer();
+        renderer.width = preWidth;
+        renderer.height = preHeight;
+        renderer.viewport();
+      };
+
+      renderer.on("afterRender", () => {
+        singleFramebuffer.render(.025, .025, .45, .45);
+        framebuffers[0].copyFramebuffer.render(.525, .025, .45, .45);
+        framebuffers[1].copyFramebuffer.render(.025, .525, .45, .45);
+        framebuffers[2].copyFramebuffer.render(.525, .525, .45, .45);
+      });
+    </script>
+  </body>
+</html>

--- a/examples/depthTexture.html
+++ b/examples/depthTexture.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>Hilo3d Depth Texture Demo</title>
+    <link rel="stylesheet" type="text/css" href="./example.css">
+</head>
+<body>
+    <div id="container"></div>
+    <script src="../build/Hilo3d.js"></script>
+    <script src="./js/stats.js"></script>
+    <script src="./js/OrbitControls.js"></script>
+    <script src="./js/init.js"></script>
+    <script>
+        Hilo3d.extensions.use('WEBGL_depth_texture');
+        var boxGeometry = new Hilo3d.BoxGeometry();
+        boxGeometry.setAllRectUV([[0, 1], [1, 1], [1, 0], [0, 0]]);
+        var material = new Hilo3d.BasicMaterial({
+          lightType: 'NONE',
+        });
+
+        var depthNode = new Hilo3d.Node({
+          onUpdate: function() {
+            this.rotationY += 0.5;
+            this.rotationX += 0.5;
+          }
+        });
+        for(let i = 0;i < 20;i ++) {
+          depthNode.addChild(new Hilo3d.Mesh({
+            material: material,
+            geometry: boxGeometry,
+            x: (Math.random() * 2 - 1) * 5,
+            y: (Math.random() * 2 - 1) * 5,
+            z: (Math.random() * 2 - 1) * 5,
+            rotationX: Math.random() * 360,
+            rotationY: Math.random() * 360,
+            rotationZ: Math.random() * 360,
+            onUpdate: function() {
+              this.rotationY += 0.5;
+              this.rotationX += 0.5;
+            }
+          })).setScale(.1);
+        };
+
+        stage.onUpdate = function() {
+          framebuffer.bind();
+          depthNode.onUpdate();
+          stage.renderer.render(depthNode, camera);
+          framebuffer.unbind();
+        }
+
+        var framebuffer = new Hilo3d.Framebuffer(renderer, {
+          attachment: Hilo3d.constants.DEPTH_ATTACHMENT,
+          format: Hilo3d.constants.DEPTH_COMPONENT,
+          internalFormat: Hilo3d.constants.DEPTH_COMPONENT16,
+          type: Hilo3d.constants.UNSIGNED_SHORT,
+          needRenderbuffer: false,
+        });
+
+        renderer.on('afterRender', () => {
+          framebuffer.render();
+        })
+        
+    </script>
+</body>
+</html>

--- a/examples/depthTexture.html
+++ b/examples/depthTexture.html
@@ -51,15 +51,18 @@
         }
 
         var framebuffer = new Hilo3d.Framebuffer(renderer, {
-          attachment: Hilo3d.constants.DEPTH_ATTACHMENT,
-          format: Hilo3d.constants.DEPTH_COMPONENT,
-          internalFormat: Hilo3d.constants.DEPTH_COMPONENT16,
-          type: Hilo3d.constants.UNSIGNED_SHORT,
-          needRenderbuffer: false,
+          colorAttachmentInfos: [],
+          depthStencilAttachmentInfo: {
+            attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+            attachment: Hilo3d.constants.DEPTH_ATTACHMENT,
+            format: Hilo3d.constants.DEPTH_COMPONENT,
+            internalFormat: Hilo3d.constants.DEPTH_COMPONENT16,
+            type: Hilo3d.constants.UNSIGNED_SHORT,
+          }
         });
 
         renderer.on('afterRender', () => {
-          framebuffer.render();
+          framebuffer.render(0, 0, 1, 1, null, framebuffer.depthStencilAttachmentInfo.texture);
         })
         
     </script>

--- a/examples/drawBuffers.html
+++ b/examples/drawBuffers.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>Hilo3d Draw Buffers Demo</title>
+    <link rel="stylesheet" type="text/css" href="./example.css">
+</head>
+<body>
+    <div id="container"></div>
+    <script src="../build/Hilo3d.js"></script>
+    <script src="./js/stats.js"></script>
+    <script src="./js/OrbitControls.js"></script>
+    <script src="./js/init.js"></script>
+    <script>
+        var boxGeometry = new Hilo3d.BoxGeometry();
+        boxGeometry.setAllRectUV([[0, 1], [1, 1], [1, 0], [0, 0]]);
+        var material = new Hilo3d.ShaderMaterial({
+          shaderCacheId: 'HiloDrawBuffers',
+          shaderName: 'HiloDrawBuffers',
+          lightType: 'PBR',
+          vs: Hilo3d.Shader.shaders['basic.vert'],
+          fs: `
+            ${Hilo3d.Shader.shaders['chunk/extensions.frag']}
+            ${Hilo3d.Shader.shaders['chunk/precision.frag']}
+            #ifdef HILO_IS_WEBGL2
+              layout(location = 1) out highp vec4 hilo_FragData1;
+              layout(location = 2) out highp vec4 hilo_FragData2;
+              layout(location = 3) out highp vec4 hilo_FragData3;
+            #endif
+
+            uniform sampler2D u_diffuse;
+
+            varying vec2 v_texcoord0;
+            varying vec3 v_normal;
+            varying vec3 v_fragPos;
+
+            void main() {
+              vec3 diffuse = texture2D(u_diffuse, v_texcoord0).rgb;
+              gl_FragData[0] = vec4(diffuse, 1.0);
+              gl_FragData[1] = vec4(v_normal, 1.0);
+              gl_FragData[2] = vec4(v_fragPos, 1.0);
+              gl_FragData[3] = vec4(dot(v_normal, vec3(0.0, 0.0, 1.0)), 0.0, 0.0, 1.0);
+            }
+          `,
+          uniforms: {
+            u_diffuse: 'DIFFUSE'
+          },
+          diffuse: new Hilo3d.LazyTexture({
+            src: '//gw.alicdn.com/imgextra/i3/O1CN01sTOdgW1CgslZ8CrFJ_!!6000000000111-2-tps-512-512.png'
+          }),
+          getCustomRenderOption:function() {
+            return {
+              HILO_HAS_TEXCOORD0: 1,
+            }
+          },
+          enableDrawBuffers: true,
+        });
+
+        var sceneNode = new Hilo3d.Node({
+          onUpdate: function() {
+            this.rotationY += 0.5;
+            this.rotationX += 0.5;
+          }
+        });
+        for(let i = 0;i < 20;i ++) {
+          sceneNode.addChild(new Hilo3d.Mesh({
+            material: material,
+            geometry: boxGeometry,
+            x: (Math.random() * 2 - 1) * 5,
+            y: (Math.random() * 2 - 1) * 5,
+            z: (Math.random() * 2 - 1) * 5,
+            rotationX: Math.random() * 360,
+            rotationY: Math.random() * 360,
+            rotationZ: Math.random() * 360,
+            onUpdate: function() {
+              this.rotationY -= 1;
+              this.rotationZ += 1;
+            }
+          })).setScale(.2);
+        };
+
+        stage.onUpdate = function() {
+          framebuffer.bind();
+          sceneNode.traverseUpdate();
+          stage.renderer.render(sceneNode, camera);
+          framebuffer.unbind();
+        }
+
+        var framebuffer = new Hilo3d.Framebuffer(renderer, {
+          colorAttachmentInfos: [{
+            attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+          }, {
+            attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+          }, {
+            attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+          }, {
+            attachmentType: Hilo3d.Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+          }]
+        });
+
+        renderer.on('afterRender', () => {
+          framebuffer.render(0, 0, 0.5, 0.5, null, framebuffer.colorAttachmentInfos[0].texture);
+          framebuffer.render(0.5, 0, 0.5, 0.5, null, framebuffer.colorAttachmentInfos[1].texture);
+          framebuffer.render(0, 0.5, 0.5, 0.5, null, framebuffer.colorAttachmentInfos[2].texture);
+          framebuffer.render(0.5, 0.5, 0.5, 0.5, null, framebuffer.colorAttachmentInfos[3].texture);
+        });        
+    </script>
+</body>
+</html>

--- a/examples/uniformBufferObject.html
+++ b/examples/uniformBufferObject.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>Hilo3d Uniform Buffer Object</title>
+    <link rel="stylesheet" type="text/css" href="./example.css">
+</head>
+<body>
+<div id="container"></div>
+<script src="../build/Hilo3d.js"></script>
+<script src="./js/stats.js"></script>
+<script src="./js/OrbitControls.js"></script>
+<script src="./js/init.js"></script>
+<script>
+    renderer.clearColor = new Hilo3d.Color(0, 0, 0, 1);
+    renderer.preferWebGL2 = true;
+    var container = new Hilo3d.Node();
+    var geometry = new Hilo3d.SphereGeometry({
+        radius: 1,
+        heightSegments: 32,
+        widthSegments: 64,
+    })
+    var modelUniformBuffer = new Hilo3d.UniformBuffer(new Float32Array(16));
+    var materialUniformBuffer = new Hilo3d.UniformBuffer(new Float32Array(8));
+
+    var mesh = new Hilo3d.Mesh({
+        rotationX:90,
+        time:0,
+        geometry: geometry,
+        material: new Hilo3d.ShaderMaterial({
+            shaderCacheId: "UVAnimation",
+            getCustomRenderOption(option){
+                option.CUSTOM_OPTION = 1;
+                return option;
+            },
+            needBasicUnifroms: false,
+            needBasicAttributes: false,
+            diffuse: new Hilo3d.LazyTexture({
+                src: '//gw.alicdn.com/tfs/TB1Q8dQSVXXXXciXVXXXXXXXXXX-512-512.jpg'
+            }),
+            mixTexture:new Hilo3d.LazyTexture({
+                src: '//gw.alicdn.com/tfs/TB1T1wEizTpK1RjSZKPXXa3UpXa-512-512.png'
+            }),
+            uniforms:{
+                u_diffuse:'DIFFUSE',
+                u_mixTexture:{
+                    get(mesh, material, programInfo) {
+                        return Hilo3d.semantic.handlerTexture(material.mixTexture, programInfo.textureIndex);
+                    }
+                },
+            },
+            uniformBlocks: {
+                MaterialBlock: materialUniformBuffer,
+                ModelBlock: modelUniformBuffer,
+            },
+            attributes:{
+                a_position: 'POSITION',
+                a_texcoord0:'TEXCOORD_0'
+            },
+            fs:`
+                precision HILO_MAX_FRAGMENT_PRECISION float;
+
+                varying vec2 v_texcoord0;
+
+                uniform sampler2D u_diffuse;
+                uniform sampler2D u_mixTexture;
+
+                layout(std140)  uniform MaterialBlock {
+                  vec4 color;
+                  float u_time;
+                };
+
+                void main(void) {
+                    float uOffset = sin(u_time * 0.0005);
+                    float vOffset = cos(u_time * 0.0003);
+                    vec4 diffuse = texture2D(u_diffuse, vec2(v_texcoord0.x + uOffset, v_texcoord0.y + vOffset));    
+                    vec4 mixTexture = texture2D(u_mixTexture, v_texcoord0);    
+                    gl_FragColor = mix(vec4(diffuse.r, diffuse.g, color.b, 1), mixTexture, 0.05);
+                }
+            `,
+            vs:`
+                precision HILO_MAX_VERTEX_PRECISION float;
+
+                attribute vec3 a_position;
+                attribute vec2 a_texcoord0;
+
+                layout(std140) uniform ModelBlock {
+                  uniform mat4 u_modelViewProjectionMatrix;
+                };
+
+                varying vec2 v_texcoord0;
+
+                void main(void) {
+                    vec4 pos = vec4(a_position, 1.0);
+                    gl_Position = u_modelViewProjectionMatrix * pos;
+                    v_texcoord0 = a_texcoord0;
+                }
+            `
+        }),
+        onUpdate(dt){
+            this.time += dt;
+            Hilo3d.semantic.init(renderer, {}, stage.camera, renderer.lightManager, renderer.fog);
+
+            materialUniformBuffer.data.set([1, 0, Math.sin(this.time * 0.001) * 0.5 + 0.5, 1], 0);
+            materialUniformBuffer.data[4] = this.time;
+            materialUniformBuffer.isDirty = true;
+
+            modelUniformBuffer.data.set(Hilo3d.semantic.MODELVIEWPROJECTION.get(this), 0);
+            modelUniformBuffer.isDirty = true;
+        }
+    });
+
+    container.addChild(mesh);
+    stage.addChild(container);
+
+    // stage.renderer.initContext();
+    // var material = mesh.material;
+    
+    // // 编译
+    // var shader = Hilo3d.Shader.getCustomShader(material.vs, material.fs, '', material.shaderCacheId);
+    // shader.alwaysUse = true;
+    // var program = Hilo3d.Program.getProgram(, Hilo3d.Shader.renderer.state);
+    // program.alwaysUse = true;
+
+    // // 删除
+    // var shader = Hilo3d.Shader.cache.get(material.shaderCacheId);
+    // var program = Hilo3d.Program.cache.get(shader.id);
+    // shader.destroy();
+    // program.destroy();
+</script>
+</body>
+</html>

--- a/src/Hilo3d.js
+++ b/src/Hilo3d.js
@@ -23,6 +23,7 @@ export { default as Camera } from './camera/Camera';
 export { default as PerspectiveCamera } from './camera/PerspectiveCamera';
 export { default as OrthographicCamera } from './camera/OrthographicCamera';
 export { default as Buffer } from './renderer/Buffer';
+export { default as UniformBuffer } from './renderer/UniformBuffer';
 export { default as capabilities } from './renderer/capabilities';
 export { default as extensions } from './renderer/extensions';
 export { default as Framebuffer } from './renderer/Framebuffer';

--- a/src/material/Material.js
+++ b/src/material/Material.js
@@ -490,6 +490,13 @@ const Material = Class.create(/** @lends Material.prototype */ {
     enableTextureLod: false,
 
     /**
+    * 是否开启 drawBuffers
+    * @default false
+    * @type {Boolean}
+    */
+    enableDrawBuffers: false,
+
+    /**
      * 是否需要加基础 uniforms
      * @type {Boolean}
      * @default true
@@ -682,6 +689,10 @@ const Material = Class.create(/** @lends Material.prototype */ {
 
         if (capabilities.SHADER_TEXTURE_LOD && this.enableTextureLod) {
             option.USE_SHADER_TEXTURE_LOD = 1;
+        }
+
+        if (capabilities.DRAW_BUFFERS && this.enableDrawBuffers) {
+            option.USE_DRAW_BUFFERS = 1;
         }
 
         const textureOption = this._textureOption.reset(option);

--- a/src/renderer/Framebuffer.js
+++ b/src/renderer/Framebuffer.js
@@ -15,12 +15,16 @@ import {
 } from '../utils/util';
 
 import constants from '../constants';
+import extensions from './extensions';
+import capabilities from './capabilities';
 
 const {
+    FRAMEBUFFER,
     TEXTURE_2D,
     RGBA,
     UNSIGNED_BYTE,
     COLOR_ATTACHMENT0,
+    DEPTH_STENCIL_ATTACHMENT,
     DEPTH_STENCIL,
     DEPTH_TEST,
     CULL_FACE,
@@ -31,12 +35,27 @@ const {
 
 const cache = new Cache();
 
+const defaultAttachmentOptions = {
+    framebufferTarget: FRAMEBUFFER,
+    attachment: COLOR_ATTACHMENT0,
+    target: TEXTURE_2D,
+    format: RGBA,
+    internalFormat: RGBA,
+    type: UNSIGNED_BYTE,
+    minFilter: NEAREST,
+    magFilter: NEAREST,
+    wrapS: CLAMP_TO_EDGE,
+    wrapT: CLAMP_TO_EDGE,
+};
+
 /**
  * 帧缓冲
  * @class
  */
 const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
     Statics: {
+        ATTACHMENT_TYPE_TEXTURE: 'TEXTURE',
+        ATTACHMENT_TYPE_RENDERBUFFER: 'RENDERBUFFER',
         /**
          * 缓存
          * @readOnly
@@ -67,7 +86,7 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
             cache.each((framebuffer) => {
                 framebuffer.destroy();
             });
-        }
+        },
     },
 
     /**
@@ -90,59 +109,66 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
     bufferInternalFormat: DEPTH_STENCIL,
 
     /**
+     * framebufferTarget
+     * @type {GLenum}
+     * @default gl.FRAMEBUFFER
+     */
+    framebufferTarget: defaultAttachmentOptions.framebufferTarget,
+
+    /**
      * texture target
      * @type {GLenum}
      * @default gl.TEXTURE_2D
      */
-    target: TEXTURE_2D,
+    target: defaultAttachmentOptions.target,
 
     /**
      * texture format
      * @type {GLenum}
      * @default gl.RGBA
      */
-    format: RGBA,
+    format: defaultAttachmentOptions.format,
 
     /**
      * texture internalFormat
      * @type {GLenum}
      * @default gl.RGBA
      */
-    internalFormat: RGBA,
+    internalFormat: defaultAttachmentOptions.internalFormat,
 
     /**
      * texture type
      * @type {GLenum}
      * @default gl.UNSIGNED_BYTE
      */
-    type: UNSIGNED_BYTE,
+    type: defaultAttachmentOptions.type,
     /**
      * texture minFilter
      * @type {GLenum}
      * @default gl.NEAREST
      */
-    minFilter: NEAREST,
+    minFilter: defaultAttachmentOptions.minFilter,
 
     /**
      * texture magFilter
      * @type {GLenum}
      * @default gl.NEAREST
      */
-    magFilter: NEAREST,
+    magFilter: defaultAttachmentOptions.magFilter,
 
     /**
      * texture wrapS
      * @type {GLenum}
      * @default gl.CLAMP_TO_EDGE
      */
-    wrapS: CLAMP_TO_EDGE,
+    wrapS: defaultAttachmentOptions.wrapS,
 
     /**
      * texture wrapS
      * @type {GLenum}
      * @default gl.CLAMP_TO_EDGE
      */
-    wrapT: CLAMP_TO_EDGE,
+    wrapT: defaultAttachmentOptions.wrapT,
 
     /**
      * texture data
@@ -156,7 +182,7 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
      * @type {GLenum}
      * @default gl.COLOR_ATTACHMENT0
      */
-    attachment: COLOR_ATTACHMENT0,
+    attachment: defaultAttachmentOptions.attachment,
 
     /**
      * 是否需要renderbuffer
@@ -199,6 +225,18 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
 
     _isInit: false,
 
+    /**
+     * colorAttachmentInfos
+     * @type {AttachmentInfo[]}
+     */
+    colorAttachmentInfos: undefined,
+
+    /**
+     * depthStencilAttachmentInfo
+     * @type {AttachmentInfo}
+     */
+    depthStencilAttachmentInfo: undefined,
+
 
     /**
      * @constructs
@@ -216,6 +254,35 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
 
         if (!this.height) {
             this.height = renderer.height;
+        }
+
+        if (this.colorAttachmentInfos === undefined) {
+            this.colorAttachmentInfos = [{
+                attachmentType: Framebuffer.ATTACHMENT_TYPE_TEXTURE,
+                framebufferTarget: this.framebufferTarget,
+                target: this.target,
+                format: this.format,
+                internalFormat: this.internalFormat,
+                type: this.type,
+                minFilter: this.minFilter,
+                magFilter: this.magFilter,
+                wrapS: this.wrapS,
+                wrapT: this.wrapT,
+                data: this.data,
+                width: this.width,
+                height: this.height,
+            }];
+        }
+
+        if (this.depthStencilAttachmentInfo === undefined && this.needRenderbuffer) {
+            this.depthStencilAttachmentInfo = {
+                attachmentType: Framebuffer.ATTACHMENT_TYPE_RENDERBUFFER,
+                framebufferTarget: this.framebufferTarget,
+                attachment: DEPTH_STENCIL_ATTACHMENT,
+                internalFormat: DEPTH_STENCIL,
+                width: this.width,
+                height: this.height,
+            };
         }
 
         cache.add(this.id, this);
@@ -245,17 +312,92 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
          */
         this.framebuffer = gl.createFramebuffer();
         this.bind();
-        if (this.needRenderbuffer) {
-            this.renderbuffer = this.createRenderbuffer();
-        }
 
-        this.texture = this.createTexture();
+        this._createAttachments();
 
         if (!this.isComplete()) {
             log.warn('Framebuffer is not complete => ' + gl.checkFramebufferStatus(gl.FRAMEBUFFER));
         }
 
         this.unbind();
+    },
+    _createAttachments() {
+        const { colorAttachmentInfos, depthStencilAttachmentInfo } = this;
+        const drawBuffers = [];
+        if (colorAttachmentInfos) {
+            colorAttachmentInfos.forEach((attachmentInfo, index) => {
+                const attachment = COLOR_ATTACHMENT0 + index;
+                switch (attachmentInfo.attachmentType) {
+                    case Framebuffer.ATTACHMENT_TYPE_RENDERBUFFER:
+                        this._createFramebufferAttachment(attachmentInfo, attachment);
+                        break;
+                    case Framebuffer.ATTACHMENT_TYPE_TEXTURE:
+                    default:
+                        this._createTextureAttachment(attachmentInfo, attachment);
+                        break;
+                }
+
+                drawBuffers.push(attachment);
+            });
+        }
+
+        if (depthStencilAttachmentInfo) {
+            const attachment = depthStencilAttachmentInfo.attachment;
+            switch (depthStencilAttachmentInfo.attachmentType) {
+                case Framebuffer.ATTACHMENT_TYPE_RENDERBUFFER:
+                    this._createRenderbufferAttachment(depthStencilAttachmentInfo, attachment);
+                    break;
+                case Framebuffer.ATTACHMENT_TYPE_TEXTURE:
+                default:
+                    this._createTextureAttachment(depthStencilAttachmentInfo, attachment);
+                    break;
+            }
+        }
+
+        if (drawBuffers.length > 1 && capabilities.DRAW_BUFFERS) {
+            extensions.drawBuffers.drawBuffers(drawBuffers);
+        }
+    },
+    _createTextureAttachment(attachmentInfo, attachment) {
+        const state = this.state;
+        const gl = state.gl;
+
+        const textureOptions = Object.assign({}, defaultAttachmentOptions, attachmentInfo);
+        const texture = new Texture({
+            minFilter: textureOptions.minFilter,
+            magFilter: textureOptions.magFilter,
+            internalFormat: textureOptions.internalFormat,
+            format: textureOptions.format,
+            type: textureOptions.type,
+            width: textureOptions.width || this.width,
+            height: textureOptions.height || this.height,
+            image: textureOptions.data,
+            wrapS: textureOptions.wrapS,
+            wrapT: textureOptions.wrapT
+        });
+
+        const glTexture = texture.getGLTexture(state);
+        gl.framebufferTexture2D(textureOptions.framebufferTarget, attachment, textureOptions.target, glTexture, 0);
+        attachmentInfo.texture = texture;
+
+        if (attachment === COLOR_ATTACHMENT0) {
+            this.texture = texture;
+        }
+        return texture;
+    },
+    _createRenderbufferAttachment(attachmentInfo, attachment) {
+        const {
+            gl,
+            width,
+            height
+        } = this;
+        const renderbuffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+        gl.renderbufferStorage(gl.RENDERBUFFER, attachmentInfo.internalFormat, width, height);
+        gl.framebufferRenderbuffer(attachmentInfo.framebufferTarget, attachment, gl.RENDERBUFFER, renderbuffer);
+        attachmentInfo.renderbuffer = renderbuffer;
+
+        return renderbuffer;
     },
     /**
      * framebuffer 是否完成
@@ -304,12 +446,22 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
      * @param  {Number} [height=1]
      * @param  {Color} [clearColor=null]
      */
-    render(x = 0, y = 0, width = 1, height = 1, clearColor) {
+    render(x = 0, y = 0, width = 1, height = 1, clearColor = null, texture = null) {
         if (this._isInit) {
             const {
                 gl,
-                state
+                state,
+                colorAttachmentInfos,
             } = this;
+
+            if (!texture) {
+                if (colorAttachmentInfos[0]) {
+                    texture = colorAttachmentInfos[0].texture;
+                } else {
+                    return;
+                }
+            }
+
             state.disable(DEPTH_TEST);
             state.disable(CULL_FACE);
 
@@ -340,52 +492,9 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
             }
 
             state.activeTexture(gl.TEXTURE0);
-            state.bindTexture(gl.TEXTURE_2D, this.texture.getGLTexture(state));
+            state.bindTexture(gl.TEXTURE_2D, texture.getGLTexture(state));
             vao.draw();
         }
-    },
-    /**
-     * 生成 Renderbuffer
-     * @private
-     * @return {WebGLRenderbuffer}
-     */
-    createRenderbuffer() {
-        const {
-            gl,
-            width,
-            height
-        } = this;
-        const renderbuffer = gl.createRenderbuffer();
-        gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
-        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
-        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, renderbuffer);
-        return renderbuffer;
-    },
-    /**
-     * 生成纹理
-     * @private
-     * @return {Texture}
-     */
-    createTexture() {
-        const state = this.state;
-        const gl = state.gl;
-        const texture = new Texture({
-            minFilter: this.minFilter,
-            magFilter: this.magFilter,
-            internalFormat: this.internalFormat,
-            format: this.format,
-            type: this.type,
-            width: this.width,
-            height: this.height,
-            image: this.data,
-            wrapS: this.wrapS,
-            wrapT: this.wrapT
-        });
-
-        const glTexture = texture.getGLTexture(state);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, this.attachment, this.target, glTexture, 0);
-
-        return texture;
     },
     /**
      * resize
@@ -454,17 +563,47 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
                 this.framebuffer = null;
             }
 
-            if (this.renderbuffer) {
-                gl.deleteRenderbuffer(this.renderbuffer);
-                this.renderbuffer = null;
+            if (this.colorAttachmentInfos) {
+                this.colorAttachmentInfos.forEach((attachmentInfo) => {
+                    const { texture, renderbuffer } = attachmentInfo;
+                    if (texture) {
+                        texture.destroy();
+                    } else if (renderbuffer) {
+                        gl.deleteRenderbuffer(this.renderbuffer);
+                    }
+                });
             }
 
-            if (this.texture) {
-                this.texture.destroy();
-                this.texture = null;
+            if (this.depthStencilAttachmentInfo) {
+                const { texture, renderbuffer } = this.depthStencilAttachmentInfo;
+                if (texture) {
+                    texture.destroy();
+                } else if (renderbuffer) {
+                    gl.deleteRenderbuffer();
+                }
             }
         }
     }
 });
 
 export default Framebuffer;
+
+/**
+ * @typedef {object} AttachmentInfo
+ * @property {'TEXTURE'|'RENDERBUFFER'} attachmentType
+ * @property {GLenum} framebufferTarget
+ * @property {GLenum} attachment
+ * @property {GLenum} target
+ * @property {GLenum} internalFormat
+ * @property {GLenum} format
+ * @property {GLenum} type
+ * @property {GLenum} minFilter
+ * @property {GLenum} magFilter
+ * @property {GLenum} wrapS
+ * @property {GLenum} wrapT
+ * @property {Number} width
+ * @property {Number} height
+ * @property {TypedArray} data
+ * @property {Texture} texture
+ * @property {WebGLRenderbuffer} renderbuffer
+ */

--- a/src/renderer/Framebuffer.js
+++ b/src/renderer/Framebuffer.js
@@ -272,8 +272,6 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
                 wrapS: this.wrapS,
                 wrapT: this.wrapT,
                 data: this.data,
-                width: this.width,
-                height: this.height,
             }];
         }
 
@@ -283,8 +281,6 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
                 framebufferTarget: this.framebufferTarget,
                 attachment: DEPTH_STENCIL_ATTACHMENT,
                 internalFormat: DEPTH_STENCIL,
-                width: this.width,
-                height: this.height,
             };
         }
 
@@ -372,8 +368,8 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
             internalFormat: textureOptions.internalFormat,
             format: textureOptions.format,
             type: textureOptions.type,
-            width: textureOptions.width || this.width,
-            height: textureOptions.height || this.height,
+            width: this.width,
+            height: this.height,
             image: textureOptions.data,
             wrapS: textureOptions.wrapS,
             wrapT: textureOptions.wrapT
@@ -614,20 +610,24 @@ const Framebuffer = Class.create(/** @lends Framebuffer.prototype */ {
             if (this.colorAttachmentInfos) {
                 this.colorAttachmentInfos.forEach((attachmentInfo) => {
                     const { texture, renderbuffer } = attachmentInfo;
+                    attachmentInfo.texture = null;
+                    attachmentInfo.renderbuffer = null;
                     if (texture) {
                         texture.destroy();
                     } else if (renderbuffer) {
-                        gl.deleteRenderbuffer(this.renderbuffer);
+                        gl.deleteRenderbuffer(renderbuffer);
                     }
                 });
             }
 
             if (this.depthStencilAttachmentInfo) {
                 const { texture, renderbuffer } = this.depthStencilAttachmentInfo;
+                this.depthStencilAttachmentInfo.texture = null;
+                this.depthStencilAttachmentInfo.renderbuffer = null;
                 if (texture) {
                     texture.destroy();
                 } else if (renderbuffer) {
-                    gl.deleteRenderbuffer();
+                    gl.deleteRenderbuffer(renderbuffer);
                 }
             }
         }
@@ -650,8 +650,6 @@ export default Framebuffer;
  * @property {GLenum} magFilter
  * @property {GLenum} wrapS
  * @property {GLenum} wrapT
- * @property {Number} width
- * @property {Number} height
  * @property {TypedArray} data
  * @property {Texture} texture
  * @property {WebGLRenderbuffer} renderbuffer

--- a/src/renderer/UniformBuffer.js
+++ b/src/renderer/UniformBuffer.js
@@ -1,0 +1,86 @@
+import Class from '../core/Class';
+import Buffer from './Buffer';
+
+/**
+ * Uniform Buffer Object
+ * @class
+ */
+const UniformBuffer = Class.create(/** @lends UniformBuffer.prototype */ {
+    /**
+     * @default Buffer
+     * @type {String}
+     */
+    className: 'UniformBuffer',
+
+    /**
+     * @default true
+     * @type {Boolean}
+     */
+    isUniformBuffer: true,
+
+    /**
+     * is dirty
+     * @type {Boolean}
+     * @default false
+    */
+    isDirty: false,
+
+    /**
+     * data
+     * @type {TypedArray|ArrayBuffer}
+     * @default null
+     */
+    data: {
+        get() {
+            return this._data;
+        },
+        set(data) {
+            this._data = data;
+            this.isDirty = true;
+        }
+    },
+
+    /**
+     * data
+     * @type {TypedArray|ArrayBuffer}
+     * @default null
+     * @private
+     */
+    _data: null,
+
+    /**
+     * @type {Buffer}
+     * @default null
+     * @private
+     */
+    _buffer: null,
+
+    /**
+     * @constructs
+     */
+    constructor(data) {
+        this.data = data;
+    },
+
+    getBuffer(gl) {
+        if (!this._buffer) {
+            this._buffer = new Buffer(gl, gl.UNIFORM_BUFFER, null, gl.DYNAMIC_DRAW);
+        }
+
+        if (this.isDirty) {
+            this._buffer.bufferData(this.data);
+            this.isDirty = false;
+        }
+        return this._buffer;
+    },
+
+    destroy() {
+        if (this._buffer) {
+            this._buffer.destroy();
+            this._buffer = null;
+        }
+        this.isDirty = true;
+    },
+});
+
+export default UniformBuffer;

--- a/src/renderer/WebGLRenderer.js
+++ b/src/renderer/WebGLRenderer.js
@@ -617,6 +617,17 @@ const WebGLRenderer = Class.create(/** @lends WebGLRenderer.prototype */ {
      */
     setupUniforms(program, mesh, useInstanced, force) {
         const material = this.forceMaterial || mesh.material;
+
+        if (this.isWebGL2) {
+            const uniformBlocks = material.uniformBlocks;
+            for (let name in program.uniformBlocks) {
+                const uniformBlock = uniformBlocks[name];
+                if (uniformBlock) {
+                    program[name] = uniformBlock;
+                }
+            }
+        }
+
         for (let name in program.uniforms) {
             const uniformInfo = material.getUniformInfo(name);
             const programUniformInfo = program.uniforms[name];

--- a/src/renderer/capabilities.js
+++ b/src/renderer/capabilities.js
@@ -139,6 +139,7 @@ const capabilities = {
         this.FRAG_DEPTH = !!extensions.fragDepth;
 
         this.SHADER_TEXTURE_LOD = !!extensions.shaderTextureLod;
+        this.DRAW_BUFFERS = !!extensions.drawBuffers;
 
         if (extensions.textureFilterAnisotropic) {
             this.MAX_TEXTURE_MAX_ANISOTROPY = gl.getParameter(extensions.textureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT);

--- a/src/renderer/extensions.js
+++ b/src/renderer/extensions.js
@@ -7,6 +7,10 @@ import {
 } from './extensions/InstancedArraysExtension';
 
 import {
+    WebGL1DrawBuffersExtension, WebGL2DrawBuffersExtension,
+} from './extensions/drawBuffersExtension';
+
+import {
     isWebGL2
 } from '../utils/util';
 
@@ -37,14 +41,18 @@ const WebGLPolyfillExtensions = {
     ANGLE_instanced_arrays: {
         WebGL1: WebGL1InstancedArraysExtension,
         WebGL2: WebGL2InstancedArraysExtension,
-    }
+    },
+    WEBGL_draw_buffers: {
+        WebGL1: WebGL1DrawBuffersExtension,
+        WebGL2: WebGL2DrawBuffersExtension,
+    },
 };
 
 /**
  * WebGL 扩展
  * @namespace extensions
  * @type {Object}
- * @description WebGL 扩展管理，默认开启的扩展有：ANGLE_instanced_arrays, OES_vertex_array_object, OES_texture_float, OES_element_index_uint, EXT_shader_texture_lod, EXT_texture_filter_anisotropic, WEBGL_lose_context
+ * @description WebGL 扩展管理，默认开启的扩展有：ANGLE_instanced_arrays, OES_vertex_array_object, OES_texture_float, OES_element_index_uint, EXT_shader_texture_lod, EXT_texture_filter_anisotropic, WEBGL_lose_context, WEBGL_draw_buffers
  */
 const extensions = {
     /**
@@ -58,6 +66,12 @@ const extensions = {
      * @type {OESVertexArrayObject}
      */
     vao: undefined,
+
+    /**
+     * WEBGL_draw_buffers扩展
+     * @type {WEBGLDrawBuffers}
+     */
+    drawBuffers: undefined,
 
     /**
      * OES_texture_float扩展
@@ -208,6 +222,7 @@ extensions.use('EXT_texture_filter_anisotropic', 'textureFilterAnisotropic');
 extensions.use('WEBGL_lose_context', 'loseContext');
 extensions.use('EXT_color_buffer_float', 'colorBufferFloat');
 extensions.use('EXT_sRGB', 'sRGB');
+extensions.use('WEBGL_draw_buffers', 'drawBuffers');
 
 export default extensions;
 
@@ -237,4 +252,8 @@ export default extensions;
 
 /**
  * @typedef {any} EXT_sRGB
+ */
+
+/**
+ * @typedef {any} WEBGLDrawBuffers
  */

--- a/src/renderer/extensions/drawBuffersExtension.js
+++ b/src/renderer/extensions/drawBuffersExtension.js
@@ -1,0 +1,19 @@
+export class WebGL1DrawBuffersExtension {
+    constructor(drawBuffersExtension) {
+        this._ext = drawBuffersExtension;
+    }
+
+    drawBuffers(buffers) {
+        this._ext.drawBuffersWEBGL(buffers);
+    }
+}
+
+export class WebGL2DrawBuffersExtension {
+    constructor(gl) {
+        this._gl = gl;
+    }
+
+    drawBuffers(buffers) {
+        this._gl.drawBuffers(buffers);
+    }
+}

--- a/src/shader/chunk/extensions.frag
+++ b/src/shader/chunk/extensions.frag
@@ -6,4 +6,8 @@
     #ifdef HILO_USE_FRAG_DEPTH
         #extension GL_EXT_frag_depth: enable
     #endif
+
+    #ifdef HILO_USE_DRAW_BUFFERS
+        #extension GL_EXT_draw_buffers: enable
+    #endif
 #endif


### PR DESCRIPTION
## Unsupported features
###  P1
- [x] Common compressed textures
- [x] sRGB support to textures and framebuffer objects
- [x] Multi-Sampled renderbuffers
- [x] Depth Textures
- [x] Multiple Draw Buffers
- [x] Uniform Buffer Objects

### P2
- [ ] 3D Textures
- [ ] Texture arrays
- [ ] Integer textures, attributes and math
- [ ] Blend Equation MIN / MAX
- [ ] Samplers
- [ ] Occlusion Queries
- [ ] Transform feedback






## References
* https://webgl2fundamentals.org/webgl/lessons/webgl2-whats-new.html
* https://webgl2fundamentals.org/webgl/lessons/webgl1-to-webgl2.html
* #40 