### PR TITLE
fix: improve WebGPU examples and diagnostics

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,10 @@ npx playwright install chromium
 npm run validate
 ```
 
-Use `npm run dev` for engine development and `npm run examples:dev` for the example gallery.
+Use `npm run dev` for engine development and `npm run examples:dev` for the example gallery. Use
+`npm run examples:serve` to serve the gallery on port 4173 for both localhost and the local network;
+it opens `/examples/index.html` with WebGPU selected by default. Pass `?backend=webgl2` explicitly
+when testing the WebGL 2 lane.
 
 ## Required quality checks
 

--- a/documentation/ENGINEERING_MODERNIZATION.md
+++ b/documentation/ENGINEERING_MODERNIZATION.md
@@ -31,7 +31,7 @@
   合并资源已就绪的多 pass，并以 submission 内 UBO
   revision 快照保证阴影与多相机数据不会互相覆盖。Shader variant 使用有界结构化 hash 与精确碰撞校验。
 - Vite 负责库与多页面示例构建，Vitest Browser
-  Mode 在真实 Chromium 环境中运行单元测试；Playwright 从示例目录自动收集 81 个 HTML：78 个执行 WebGL
+  Mode 在真实 Chromium 环境中运行单元测试；Playwright 从示例目录自动收集 82 个 HTML：79 个执行 WebGL
   2 + WebGPU，WebXR 明确 WebGL
   2-only，两个 compute/GPU-driven 页面明确 WebGPU-only，并对适用后端执行确定性视觉、交互、后处理与拾取门禁；真实 WebGPU
   adapter/device/pipeline fixture 作为额外的深度验收，而不是 WebGPU 唯一覆盖。
@@ -58,7 +58,7 @@
 | 类型发布 | 手工维护的 namespace/CommonJS 声明                      | `tsc` 从源码 emit，声明 rollup 后由 Bundler/NodeNext 消费配置校验       |
 | API 契约 | JSDoc 静态产物，与源码和包入口脱节                      | TypeDoc 零警告文档 + API Extractor 签名基线                             |
 | 单元测试 | 旧断言、旧 mock、浏览器错误不一定失败                   | Vitest 原生 `expect`/`vi`，Chromium Browser Mode，错误门禁与 V8 覆盖率  |
-| UI 测试  | 少量代表页面 smoke test                                 | 81 个 HTML 自动清单；78 个双后端，WebXR 单页与两个 compute 页明确单后端 |
+| UI 测试  | 少量代表页面 smoke test                                 | 82 个 HTML 自动清单；79 个双后端，WebXR 单页与两个 compute 页明确单后端 |
 | 视觉测试 | 截图比较为空实现                                        | 两个后端共用确定场景、readback 断言、截图基线与像素差异阈值             |
 | 示例     | 旧全局变量、vendor 脚本、远程运行时资源                 | 严格 TS 多页面应用，本地 npm 依赖与本地静态资产                         |
 | 渲染 ABI | WebGL 1/2 分支、GLSL 1.00 转译与逐项 uniform            | portable raster GLSL→Naga→WGSL；受控 Direct WGSL compute 与 storage ABI |
@@ -120,7 +120,7 @@ semantic、glTF、动画状态、纹理来源等动态结构均有明确的 inte
 - 删除 AMC 专有扩展；相关演示资产转换为标准 glTF。
 - WebXR 使用标准 WebXR 类型与浏览器 API；当前呈现层是 `XRWebGLLayer`，因此 `webxr.html`
   被明确声明为 WebGL 2-only。它暂不计入 WebGPU 上线门槛，也不会先请求 WebGPU、失败后再回退 WebGL
-  2；其余 78 个 HTML 示例均进入双后端门禁。
+  2；其余 79 个 HTML（包括两个画廊入口）均进入双后端门禁。
 - 资源观测统一为 `renderer.resourceManager.getDiagnostics(rootNode?)`
   返回的后端中立快照，包括已跟踪 mesh/resource、当前使用、待销毁数量和 frame 状态。会读取 WebGL 私有 cache 并产生日志副作用的
   `logGLResource()` 已从公共入口和源码删除。
@@ -757,13 +757,13 @@ Restored 事件顺序正确、选中的 `RenderTarget`
 identity 不变、已释放 texture 能重新上传，恢复后实际 draw/queue/readback 成功，且恢复前后 scene
 pixel 逐字节完全相等并区别于 clear color。
 
-### 81 个 HTML 的后端适用矩阵
+### 82 个 HTML 的后端适用矩阵
 
 Playwright 递归扫描 `examples/`
-自动生成页面清单，不维护容易漏项的手工白名单。当前清单固定为 81 个 HTML：其中 78 个页面分别以
+自动生成页面清单，不维护容易漏项的手工白名单。当前清单固定为 82 个 HTML：其中 79 个页面分别以
 `?backend=webgl2` 和 `?backend=webgpu` 运行；`webxr.html` 因浏览器 WebXR 当前使用 `XRWebGLLayer`
 而只运行 WebGL 2；`compute_gpu_driven.html` 与 `compute_particles.html`
-因公开能力明确 WebGPU-only 而只运行 WebGPU，共形成 159 个 page/backend 组合。三个单后端页面都是创建前的显式产品边界，不是初始化失败后的 runtime
+因公开能力明确 WebGPU-only 而只运行 WebGPU，共形成 161 个 page/backend 组合。三个单后端页面都是创建前的显式产品边界，不是初始化失败后的 runtime
 fallback。
 
 每个组合都必须通过以下检查：
@@ -801,7 +801,7 @@ target 做两次显式 readback，断言彩色像素、pointer 坐标、输出 h
 draw/submit；普通示例门禁因此不再重复加载同一重型 ray-march 页面。这个唯一例外仍在两个后端保留 GPU
 health、页面、网络、console、DevTools graphics 与终态稳定帧门禁，并由
 `DEDICATED_RELEASE_TEST_EXAMPLE_PATHS`
-契约锁定；通用门禁与专用门禁合计仍覆盖完整的 159 个 page/backend 组合。由于该 ray-march 交互在 GitHub
+契约锁定；通用门禁与专用门禁合计仍覆盖完整的 161 个 page/backend 组合。由于该 ray-march 交互在 GitHub
 hosted runner 上成本过高，GitHub
 Actions 明确跳过这一个专用用例；本地与发布前完整 Playwright 门禁仍会执行它。
 
@@ -917,7 +917,7 @@ npm run validate
 
 `validate` 按顺序执行：清理生成物、旧 JavaScript/旧工具配置门禁、格式检查、typed
 lint、全部 TypeScript project
-references、浏览器单测与覆盖率、库构建、两类 ESM 类型消费、81 个 HTML 后端适用矩阵（78 个双后端、WebXR 显式 WebGL
+references、浏览器单测与覆盖率、库构建、两类 ESM 类型消费、82 个 HTML 后端适用矩阵（79 个双后端、WebXR 显式 WebGL
 2-only、两个 compute/GPU-driven 页面显式 WebGPU-only）、双后端交互、WebGPU 深度运行时、双后端视觉回归、全部示例构建、TypeDoc 验证、API 签名比较、npm 包契约验证和 pack 文件检查。任一步失败都会阻止 CI 与发布。
 
 其中 shader 静态门禁会扫描 `src/shader/` 和示例中的 shader 源码：禁止 GLSL 1.00
@@ -942,7 +942,7 @@ corpus 与真实 WebGPU pipeline 互为补充。
 - [x] 公共声明从源码生成，API 文档与 API report 同源。
 - [x] 单一 ESM 入口、类型、source map、package exports 与真实 tarball 一致。
 - [x] 浏览器单测执行完整源码覆盖率门禁，阈值面向 `src/**/*.ts`，不排除 renderer 或 WebGPU 核心目录。
-- [x] 自动清单包含 81 个 HTML；78 个通过 WebGL 2 + WebGPU，WebXR 显式 WebGL
+- [x] 自动清单包含 82 个 HTML；79 个通过 WebGL 2 + WebGPU，WebXR 显式 WebGL
       2-only，两个 compute/GPU-driven 页面显式 WebGPU-only；适用组合都经过页面、请求、控制台与 GPU 错误门禁。
 - [x] 同一确定 PBR 场景和关键交互在两个后端都有 readback/截图或行为断言；WebGPU 不只依赖独立 fixture。
 - [x] `Stage.create()` 默认用无 device/resource 分配的 adapter probe 实现 WebGPU-first `auto`；显式

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -385,7 +385,10 @@ revision 判断是否复用。执行时只顺序读取已准备好的 Pipeline�
 共享层还维护 Buffer、Texture、Shader、Pipeline、BindGroup、Uniform Binding、RenderTarget 和 Shadow
 Atlas 等缓存；compute/storage 路径另有 `StorageBufferResourceCache`、compute pipeline/sampler
 cache、storage graphics/GPU-driven pipeline cache 和复用的 dispatch/draw
-state。后端再维护与原生 API 相关的 Vertex Input、Framebuffer 和状态缓存。诊断计数器统一记录 Cache
+state。后端再维护与原生 API 相关的 Vertex
+Input、Framebuffer 和状态缓存；WebGPU 持久/瞬态 Texture 的默认全资源 native Texture
+View 也按 Texture 复用，同时仍为每次 RHI `createView()` 返回独立逻辑对象。`frame` 生命周期的 Surface
+Texture View 不跨帧复用，因为 `present()` 后对应 Canvas Texture 已失效。诊断计数器统一记录 Cache
 Hit/Miss、Pipeline/BindGroup/Vertex Buffer Switch、Native State Call 和 Transient
 Allocation，并分别公开 indirect draw、dispatch、精确 direct workgroup、buffer clear、compute
 pipeline/bind-group switch；indirect dispatch 不从 CPU 猜测 workgroup 数。

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+            name="description"
+            content="Open the Hilo3D example gallery with WebGPU selected by default."
+        />
+        <title>Hilo3D Examples</title>
+    </head>
+    <body>
+        <p>Opening the Hilo3D example gallery…</p>
+        <script type="module" src="./index.ts"></script>
+    </body>
+</html>

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,0 +1,4 @@
+const gallery = new URL('./list.html', location.href);
+gallery.search = location.search;
+gallery.hash = location.hash;
+location.replace(gallery.href);

--- a/examples/shared/backend.test.ts
+++ b/examples/shared/backend.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExampleBackend } from './backend';
+
+describe('example backend selection', () => {
+    it('defaults missing or empty selections to WebGPU', () => {
+        expect(resolveExampleBackend('https://example.test/examples/index.html')).toBe('webgpu');
+        expect(resolveExampleBackend('https://example.test/examples/index.html?backend=')).toBe(
+            'webgpu'
+        );
+    });
+
+    it('preserves explicit portable backend selections', () => {
+        expect(
+            resolveExampleBackend('https://example.test/examples/index.html?backend=webgpu')
+        ).toBe('webgpu');
+        expect(
+            resolveExampleBackend('https://example.test/examples/index.html?backend=webgl2')
+        ).toBe('webgl2');
+    });
+
+    it('rejects unsupported backend selections', () => {
+        expect(() =>
+            resolveExampleBackend('https://example.test/examples/index.html?backend=webgl')
+        ).toThrow('Unsupported example backend "webgl"');
+    });
+});

--- a/examples/shared/backend.ts
+++ b/examples/shared/backend.ts
@@ -1,9 +1,9 @@
 export type ExampleBackend = 'webgl2' | 'webgpu';
 
-/** Resolve an explicitly selected example backend without silent fallback. */
+/** Resolve the selected example backend, defaulting to WebGPU without silent fallback. */
 export function resolveExampleBackend(url: string | URL = location.href): ExampleBackend {
     const value = new URL(url, location.href).searchParams.get('backend');
-    if (value === null || value === '' || value === 'webgl2') return 'webgl2';
-    if (value === 'webgpu') return 'webgpu';
+    if (value === null || value === '' || value === 'webgpu') return 'webgpu';
+    if (value === 'webgl2') return 'webgl2';
     throw new TypeError(`Unsupported example backend "${value}"; expected "webgl2" or "webgpu".`);
 }

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -230,7 +230,7 @@ function createEntry(path: string): ExampleCatalogEntry {
 export function createExampleCatalog(paths: readonly string[]): readonly ExampleCatalogEntry[] {
     return Object.freeze(
         paths
-            .filter(path => path !== 'list.html')
+            .filter(path => path !== 'index.html' && path !== 'list.html')
             .map(createEntry)
             .sort((left, right) => {
                 const categoryDifference =

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean:build": "rimraf .cache/types .cache/tsconfig.lib.tsbuildinfo dist",
     "dev": "vite --host 0.0.0.0",
     "examples:dev": "vite --config vite.examples.config.ts --host 0.0.0.0",
-    "examples:serve": "vite --config vite.examples.config.ts --host 127.0.0.1 --port 4173 --strictPort",
+    "examples:serve": "vite --config vite.examples.config.ts --host 0.0.0.0 --port 4173 --strictPort --open /examples/index.html",
     "examples:build": "vite build --config vite.examples.config.ts",
     "examples:test": "npm run test:ui",
     "build": "npm run clean:build && npm run build:js && npm run build:types",

--- a/src/render/rhi/backends/webgpu/WebGPUResources.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUResources.ts
@@ -24,6 +24,19 @@ import { WebGPUDestroyableObject, WebGPUResource } from './WebGPUBase';
 import { nativeWebGPUTextureViewDescriptor } from './WebGPUDescriptors';
 import type { WebGPUDevice } from './WebGPUDevice';
 
+function isDefaultTextureViewDescriptor(descriptor: Readonly<RHITextureViewDescriptor>): boolean {
+    return (
+        descriptor.label === undefined &&
+        descriptor.format === undefined &&
+        descriptor.dimension === undefined &&
+        descriptor.aspect === undefined &&
+        descriptor.baseMipLevel === undefined &&
+        descriptor.mipLevelCount === undefined &&
+        descriptor.baseArrayLayer === undefined &&
+        descriptor.arrayLayerCount === undefined
+    );
+}
+
 export class WebGPUBuffer
     extends WebGPUResource<RHINormalizedBufferDescriptor>
     implements RHIBuffer
@@ -126,6 +139,7 @@ export class WebGPUTexture
     readonly usage: number;
     readonly #nativeHandle: GPUTexture;
     readonly #ownsNativeAllocation: boolean;
+    #defaultNativeView: GPUTextureView | null = null;
 
     constructor(
         owner: WebGPUDevice,
@@ -161,14 +175,27 @@ export class WebGPUTexture
     createView(descriptor: RHITextureViewDescriptor = {}): WebGPUTextureView {
         this.owner.assertUsable(this, 'texture');
         const normalized = normalizeRHITextureViewDescriptor(this, descriptor);
+        const cacheDefault =
+            this.lifetime !== 'frame' && isDefaultTextureViewDescriptor(descriptor);
+        if (cacheDefault && this.#defaultNativeView !== null) {
+            return new WebGPUTextureView(
+                this.owner,
+                this.#defaultNativeView,
+                this,
+                normalized,
+                false
+            );
+        }
         const nativeView = this.#nativeHandle.createView(
             nativeWebGPUTextureViewDescriptor(normalized)
         );
-        return new WebGPUTextureView(this.owner, nativeView, this, normalized);
+        if (cacheDefault) this.#defaultNativeView = nativeView;
+        return new WebGPUTextureView(this.owner, nativeView, this, normalized, true);
     }
 
     protected override releaseNative(): void {
         this.owner.mipmapGenerator.release(this);
+        this.#defaultNativeView = null;
         if (this.#ownsNativeAllocation) this.#nativeHandle.destroy();
     }
 }
@@ -185,9 +212,15 @@ export class WebGPUTextureView extends WebGPUDestroyableObject implements RHITex
         owner: WebGPUDevice,
         nativeHandle: GPUTextureView,
         texture: WebGPUTexture,
-        descriptor: Readonly<RHINormalizedTextureViewDescriptor>
+        descriptor: Readonly<RHINormalizedTextureViewDescriptor>,
+        recordsNativeCreation = true
     ) {
-        super(owner, descriptor.label, 'textureView', 'creation-only');
+        super(
+            owner,
+            descriptor.label,
+            recordsNativeCreation ? 'textureView' : null,
+            recordsNativeCreation ? 'creation-only' : null
+        );
         this.#nativeHandle = nativeHandle;
         this.texture = texture;
         this.descriptor = descriptor;

--- a/test/spec/rhi/portable/WebGPUBackend.test.ts
+++ b/test/spec/rhi/portable/WebGPUBackend.test.ts
@@ -510,6 +510,45 @@ function createTriangleResources(device: WebGPUDevice) {
 }
 
 describe('WebGPU RHI native backend', () => {
+    it('reuses a persistent default native texture view without sharing logical lifetime', () => {
+        const harness = createNativeHarness();
+        const diagnostics = new RendererDiagnostics();
+        const device = new WebGPUDevice(harness.device, diagnostics);
+        const persistent = device.createTexture({
+            label: 'persistent view source',
+            size: { width: 4, height: 4 },
+            format: 'rgba8unorm',
+            usage: RHITextureUsage.RENDER_ATTACHMENT
+        });
+
+        const first = persistent.createView();
+        const second = persistent.createView();
+        expect(first).not.toBe(second);
+        expect(first.id).not.toBe(second.id);
+        expect(first.nativeHandle).toBe(second.nativeHandle);
+        expect(harness.textureViewDescriptors).toHaveLength(1);
+
+        first.destroy();
+        expect(second.destroyed).toBe(false);
+
+        persistent.createView({ label: 'diagnostic view' });
+        expect(harness.textureViewDescriptors).toHaveLength(2);
+
+        const frame = device.createTexture({
+            label: 'frame view source',
+            lifetime: 'frame',
+            size: { width: 4, height: 4 },
+            format: 'rgba8unorm',
+            usage: RHITextureUsage.RENDER_ATTACHMENT
+        });
+        frame.createView();
+        frame.createView();
+        expect(harness.textureViewDescriptors).toHaveLength(4);
+        expect(diagnostics.snapshot().nativeObjects.textureView.created).toBe(4);
+
+        device.destroy();
+    });
+
     it('maps per-vertex and instanced matrix columns into native WebGPU vertex layouts', () => {
         const harness = createNativeHarness();
         const device = new WebGPUDevice(harness.device);

--- a/test/ui/example-paths.contract.ts
+++ b/test/ui/example-paths.contract.ts
@@ -59,11 +59,11 @@ describe('example release matrix contract', () => {
     it('discovers every HTML entry recursively with no hand-maintained gallery omissions', () => {
         expect(examplePaths).toEqual(independentlyDiscoverHtml());
         expect(new Set(examplePaths).size).toBe(examplePaths.length);
-        expect(examplePaths).toHaveLength(81);
+        expect(examplePaths).toHaveLength(82);
     });
 
-    it('expands 81 pages into the complete 159-case backend matrix', () => {
-        expect(exampleCases).toHaveLength(159);
+    it('expands 82 pages into the complete 161-case backend matrix', () => {
+        expect(exampleCases).toHaveLength(161);
         expect(new Set(exampleCases.map(item => `${item.path}:${item.backend}`)).size).toBe(
             exampleCases.length
         );
@@ -87,7 +87,7 @@ describe('example release matrix contract', () => {
         expect(catalog).toHaveLength(80);
         expect(new Set(catalog.map(entry => entry.id)).size).toBe(catalog.length);
         expect(new Set(catalog.map(entry => entry.path))).toEqual(
-            new Set(examplePaths.filter(path => path !== 'list.html'))
+            new Set(examplePaths.filter(path => path !== 'index.html' && path !== 'list.html'))
         );
         expect(new Set(catalog.map(entry => entry.category))).toEqual(
             new Set(EXAMPLE_CATEGORIES.map(category => category.id))
@@ -135,7 +135,7 @@ describe('example release matrix contract', () => {
         const dedicatedCases = DEDICATED_RELEASE_TEST_EXAMPLE_PATHS.flatMap(path =>
             backendsForExample(path).map(backend => ({ path, backend }))
         );
-        expect(genericCases).toHaveLength(157);
+        expect(genericCases).toHaveLength(159);
         expect(
             [...genericCases, ...dedicatedCases].map(item => `${item.path}:${item.backend}`).sort()
         ).toEqual(exampleCases.map(item => `${item.path}:${item.backend}`).sort());

--- a/test/ui/examples.spec.ts
+++ b/test/ui/examples.spec.ts
@@ -327,6 +327,16 @@ async function assertObservableRender(
         .toBeGreaterThan(0);
 }
 
+test('canonical examples index opens the WebGPU gallery by default', async ({ page }) => {
+    await page.goto('/examples/index.html', { waitUntil: 'networkidle' });
+    await expect(page).toHaveURL(/\/examples\/list\.html#\w+$/u);
+    await expect(page.locator('#backendSelect')).toHaveValue('webgpu');
+    await expect(page.locator('#exampleFrame')).toHaveAttribute(
+        'src',
+        /[?&]backend=webgpu(?:&|$)/u
+    );
+});
+
 for (const backend of ['webgl2', 'webgpu'] as const) {
     test(`example gallery discovers every ${backend} page @${backend}`, async ({ page }) => {
         await page.goto(`/examples/list.html?backend=${backend}`, { waitUntil: 'networkidle' });


### PR DESCRIPTION
## Summary

- cache each WebGPU texture's native default view so diagnostics count stable GPU objects instead of transient wrapper views
- add `/examples/index.html` as the canonical gallery entry and default examples to WebGPU while preserving explicit WebGL 2 selection
- expose `examples:serve` on localhost and the local network, keep a strict port, and open the canonical entry automatically
- update release-matrix contracts, focused tests, contributor guidance, and rendering/engineering documentation

## Root cause

`createTextureView()` created and tracked a fresh native default view every time diagnostics or bindings requested one, so a small scene could report thousands of texture views. Separately, the examples launcher was loopback-only, did not auto-open the gallery, had no canonical `examples/index.html`, and treated WebGL 2 as the implicit backend.

## Impact

The `geometry_box` resource panel now reports stable texture-view data. Developers can run one command, open the gallery locally or from another device on the LAN, and exercise WebGPU by default; WebGL 2 remains available through `?backend=webgl2`.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:modernity`
- `npm run examples:build`
- targeted Vitest coverage for WebGPU texture-view caching and example backend selection
- `npm run test:ui:contract` (11 passed)
- `npx playwright test test/ui/examples.spec.ts --project=chromium --grep "canonical examples index"` (1 passed)
- manual browser verification for default WebGPU and explicit WebGL 2 routes

Full `npm run validate` and the complete dual-backend Playwright matrix were not run locally.
