### PR TITLE
Add portable Hilo3D game development skill

### DIFF
--- a/.agents/skills/build-hilo3d-games/SKILL.md
+++ b/.agents/skills/build-hilo3d-games/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: build-hilo3d-games
+description:
+    Build, extend, debug, and optimize browser games with the published ESM package hilo3d 2.0.0 or
+    its current alpha prerelease. Use for standalone TypeScript/Vite game projects involving Hilo3D
+    2D sprites, atlas animation, Canvas text, 3D scenes, PBR materials, glTF assets, cameras,
+    lighting, input, picking, physics integration, hybrid 2D UI over 3D worlds, WebGPU/WebGL2
+    backend selection, rendering performance, or game architecture. Also use to scaffold a complete
+    runnable 2D, 3D, or hybrid Hilo3D game without cloning the Hilo3D repository.
+---
+
+# Build Hilo3D Games
+
+Build standalone browser games against the Hilo3D 2.0.0 release line. Do not require a Hilo3D source
+checkout. Prefer strict TypeScript, native ESM, Vite, reusable resources, and a small playable
+vertical slice before expanding content.
+
+## Work from the 2.0.0 contract
+
+- Resolve the dependency from the official npm registry: use exact `2.0.0` when published; otherwise
+  use the highest exact `2.0.0-alpha.N`. Never substitute a 1.x, beta, or release candidate.
+- Keep the generated exact version and package lock. Change it only when the user requests a version
+  or after verifying compatibility with a newer 2.0.0 release.
+- Use Node.js 22.22.2 or newer for the bundled starter.
+- Import public API only from `hilo3d`.
+- Treat installed declarations at `node_modules/hilo3d/dist/Hilo3d.d.ts` as the final local source
+  of truth when a signature is uncertain.
+- Never copy private engine internals, generated documentation, or repository-relative examples into
+  a consumer game.
+- Use only the public rendering backends `webgpu` and `webgl2`; use `backend: 'auto'` by default.
+
+## Choose the game shape
+
+Select one primary shape before writing code:
+
+- **2D**: `Camera2D`, `Sprite`, `SpriteFrame`, `Text2D`, layers, and pointer events.
+- **3D**: `PerspectiveCamera`, `Mesh`, geometry, PBR materials, lights, glTF, and optional physics.
+- **Hybrid**: one 3D world camera plus a higher-priority `Camera2D` HUD in the same `Stage`.
+
+If starting from nothing, run:
+
+```sh
+node <skill-root>/scripts/create-hilo3d-game.mjs \
+  --type 2d \
+  --name my-game \
+  --output ./my-game
+cd my-game
+npm install
+npm run dev
+```
+
+Valid types are `2d`, `3d`, and `hybrid`. The generator refuses to overwrite a non-empty output
+directory. Its default `auto` version lookup prefers stable `2.0.0` and otherwise selects the latest
+numbered alpha. Pass `--hilo-version 2.0.0-alpha.1` only to reproduce or test that exact release.
+Read [Starter generator](references/starter-generator.md) when scaffolding or adapting the starter.
+
+## Follow the implementation workflow
+
+1. Define the smallest playable loop: player action, world response, success/failure feedback, and
+   restart.
+2. Scaffold or inspect the existing application. Preserve its framework and build conventions when
+   it is already a valid modern ESM project.
+3. Create all stages asynchronously with `await Stage.create(...)`.
+4. Separate input state, simulation, presentation, and lifecycle cleanup.
+5. Register simulation tickables before `stage` so state updates before rendering.
+6. Load or generate assets before exposing gameplay. Surface load failures; do not silently render
+   missing content.
+7. Make resize behavior explicit for the Stage and every active camera.
+8. Add interaction only for objects that need it, and enable only the necessary DOM event types.
+9. Reuse geometry, materials, textures, atlas frames, and scratch math objects in steady-state code.
+10. Validate type safety, production build, both applicable graphics backends, interaction, resize,
+    pause/resume, and teardown.
+
+## Avoid high-frequency mistakes
+
+- Hilo3D event listeners receive the base `DispatchEvent` type. Narrow optional pointer fields with
+  runtime checks before reading `stageX`, `stageY`, `hitPoint`, or propagation helpers.
+- Pass render-target operations in target-first order:
+  `renderer.renderToTarget(target, scene, camera)`.
+- Keep gameplay state authoritative outside render callbacks. Update simulation before ticking
+  `stage`.
+- Show initialization and required-asset failures in the page, not only in the developer console.
+- Keep generated games independent from this skill after scaffolding; runtime code and build scripts
+  must depend only on published packages and application-owned assets.
+
+## Respect core API rules
+
+Use this baseline:
+
+```ts
+import * as Hilo3d from 'hilo3d';
+
+const camera = new Hilo3d.PerspectiveCamera({
+    aspect: innerWidth / innerHeight,
+    near: 0.1,
+    far: 200,
+    z: 6
+});
+
+const stage = await Hilo3d.Stage.create({
+    backend: 'auto',
+    container: document.querySelector<HTMLElement>('#app')!,
+    camera,
+    width: innerWidth,
+    height: innerHeight,
+    pixelRatio: Math.min(devicePixelRatio || 1, 2)
+});
+
+const ticker = new Hilo3d.Ticker(60);
+ticker.addTick(stage);
+ticker.start();
+```
+
+Keep these invariants:
+
+- `Stage` and `Renderer` are created only through their asynchronous `create()` factories.
+- `auto` prefers WebGPU and falls back to WebGL2 only during capability selection. Explicit `webgpu`
+  failure must remain visible.
+- `Ticker` deltas are milliseconds. Convert with `dt / 1000` for units-per-second movement.
+- Clamp long deltas after tab suspension and use a fixed step for deterministic physics.
+- `Node` rotations are degrees. Do not feed radians into `rotationX/Y/Z`.
+- Update `PerspectiveCamera.aspect` or call `Camera2D.resize()` whenever the Stage size changes.
+- Call `stage.destroy()` and remove application-owned DOM listeners during teardown.
+
+Read [Public API](references/public-api.md) for the practical interface map and
+[Game architecture](references/game-architecture.md) for state, loop, input, collision, lifecycle,
+and testing patterns.
+
+## Route to focused guidance
+
+- Read [2D games](references/2d-games.md) for sprite atlases, animation, UI text, batching, layers,
+  pointer events, and pixel-space layout.
+- Read [3D games](references/3d-games.md) for meshes, materials, lighting, shadows, glTF, animation,
+  environment assets, and `cannon-es` physics.
+- Read [Rendering and performance](references/rendering-performance.md) for camera composition,
+  backend policy, draw-call control, transparency, shaders, render targets, diagnostics, and
+  WebGPU-only compute.
+
+Load only the references needed for the current task. Do not read every reference by default.
+
+## Build a real game, not a rendering demo
+
+Every generated game should have:
+
+- a clear objective and immediate player agency;
+- start, playing, paused, won, or lost states as appropriate;
+- readable feedback through motion, color, text, or sound hooks;
+- keyboard and pointer/touch behavior suitable for its controls;
+- deterministic restart without reloading the page;
+- responsive layout and capped device pixel ratio;
+- no per-frame object churn in hot paths;
+- explicit cleanup;
+- a concise control hint visible in the game.
+
+Use DOM overlays only for accessibility-heavy menus, forms, and settings. Use `Text2D` and sprites
+for in-world or canvas-composited HUD elements that should participate in Hilo3D camera/layer
+composition.
+
+## Verify completion
+
+Run the narrowest available equivalents of:
+
+```sh
+npm run typecheck
+npm run build
+```
+
+Then test:
+
+1. the default `auto` backend;
+2. explicit `?backend=webgl2` and `?backend=webgpu` selection when the app supports query routing;
+3. first load with an empty cache;
+4. resize and high-DPI behavior;
+5. keyboard plus pointer/touch controls;
+6. pause, resume, restart, win/loss, and teardown;
+7. missing or failed assets;
+8. sustained play without increasing draw calls, listeners, or resource counts.
+
+Do not claim a backend passed unless it was actually exercised. If WebGPU is unavailable, report
+that limitation and still test WebGL2.

--- a/.agents/skills/build-hilo3d-games/agents/openai.yaml
+++ b/.agents/skills/build-hilo3d-games/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: 'Hilo3D Game Development'
+  short_description: 'Build 2D, 3D, and hybrid games with Hilo3D 2.0'
+  default_prompt:
+    'Use $build-hilo3d-games to create and verify a complete 2D, 3D, or hybrid browser game with
+    Hilo3D 2.0.0.'

--- a/.agents/skills/build-hilo3d-games/assets/starter/index.html
+++ b/.agents/skills/build-hilo3d-games/assets/starter/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="theme-color" content="#071022" />
+        <title>Hilo3D Game</title>
+    </head>
+    <body>
+        <main id="app" aria-label="Hilo3D game">
+            <div id="loading" role="status">Loading Hilo3D…</div>
+        </main>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/.agents/skills/build-hilo3d-games/assets/starter/package.json
+++ b/.agents/skills/build-hilo3d-games/assets/starter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "__PROJECT_NAME__",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.22.2"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "npm run typecheck && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hilo3d": "__HILO3D_VERSION__"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/.agents/skills/build-hilo3d-games/assets/starter/src/startup.ts
+++ b/.agents/skills/build-hilo3d-games/assets/starter/src/startup.ts
@@ -1,0 +1,9 @@
+export function reportStartupFailure(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    const loading = document.querySelector<HTMLElement>('#loading');
+    if (loading) {
+        loading.setAttribute('role', 'alert');
+        loading.textContent = `Unable to start the game: ${message}`;
+    }
+    console.error('Unable to start the Hilo3D game.', error);
+}

--- a/.agents/skills/build-hilo3d-games/assets/starter/src/style.css
+++ b/.agents/skills/build-hilo3d-games/assets/starter/src/style.css
@@ -1,0 +1,60 @@
+:root {
+    color: #f7fbff;
+    background: #071022;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+}
+
+body {
+    background: radial-gradient(circle at 50% 15%, rgb(26 62 112 / 55%), transparent 38%), #071022;
+}
+
+canvas {
+    display: block;
+    touch-action: none;
+}
+
+#loading,
+.game-overlay {
+    position: fixed;
+    z-index: 10;
+    left: 50%;
+    top: 24px;
+    transform: translateX(-50%);
+    border: 1px solid rgb(167 222 255 / 35%);
+    border-radius: 999px;
+    padding: 10px 16px;
+    color: #eaf8ff;
+    background: rgb(5 15 35 / 78%);
+    box-shadow: 0 12px 40px rgb(0 0 0 / 25%);
+    backdrop-filter: blur(12px);
+    font-size: 13px;
+    letter-spacing: 0.03em;
+    text-align: center;
+    user-select: none;
+}
+
+.game-overlay strong {
+    color: #ffe18c;
+}

--- a/.agents/skills/build-hilo3d-games/assets/starter/src/vite-env.d.ts
+++ b/.agents/skills/build-hilo3d-games/assets/starter/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/.agents/skills/build-hilo3d-games/assets/starter/tsconfig.json
+++ b/.agents/skills/build-hilo3d-games/assets/starter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/.agents/skills/build-hilo3d-games/assets/starter/variants/main-2d.ts
+++ b/.agents/skills/build-hilo3d-games/assets/starter/variants/main-2d.ts
@@ -1,0 +1,292 @@
+import * as Hilo3d from 'hilo3d';
+import './style.css';
+import { reportStartupFailure } from './startup';
+
+type GameState = 'playing' | 'won';
+
+async function main(): Promise<void> {
+    const app = document.querySelector<HTMLElement>('#app');
+    if (!app) throw new Error('The game requires #app.');
+
+    function backendFromUrl(): Hilo3d.StageBackend {
+        const value = new URL(location.href).searchParams.get('backend');
+        return value === 'webgl2' || value === 'webgpu' ? value : 'auto';
+    }
+
+    function createAtlas(): Hilo3d.Texture<HTMLCanvasElement> {
+        const canvas = document.createElement('canvas');
+        canvas.width = 192;
+        canvas.height = 64;
+        const context = canvas.getContext('2d');
+        if (!context) throw new Error('Canvas 2D is required to create the starter atlas.');
+
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        context.fillStyle = '#66e1ff';
+        context.beginPath();
+        context.roundRect(10, 10, 44, 44, 12);
+        context.fill();
+        context.fillStyle = '#09213d';
+        context.fillRect(23, 21, 6, 12);
+        context.fillRect(37, 21, 6, 12);
+
+        context.translate(96, 32);
+        context.fillStyle = '#ffe07a';
+        context.beginPath();
+        for (let point = 0; point < 10; point += 1) {
+            const radius = point % 2 === 0 ? 23 : 10;
+            const angle = -Math.PI / 2 + (point * Math.PI) / 5;
+            context.lineTo(Math.cos(angle) * radius, Math.sin(angle) * radius);
+        }
+        context.closePath();
+        context.fill();
+        context.resetTransform();
+
+        context.strokeStyle = '#ff7096';
+        context.lineWidth = 7;
+        context.beginPath();
+        context.arc(160, 32, 18, 0, Math.PI * 2);
+        context.stroke();
+
+        return new Hilo3d.Texture({
+            image: canvas,
+            flipY: true,
+            premultiplyAlpha: true,
+            minFilter: Hilo3d.constants.webgl.LINEAR,
+            magFilter: Hilo3d.constants.webgl.LINEAR,
+            wrapS: Hilo3d.constants.webgl.CLAMP_TO_EDGE,
+            wrapT: Hilo3d.constants.webgl.CLAMP_TO_EDGE,
+            name: 'Starter2DAtlas'
+        });
+    }
+
+    const camera = new Hilo3d.Camera2D({
+        width: innerWidth,
+        height: innerHeight
+    });
+    const stage = await Hilo3d.Stage.create({
+        backend: backendFromUrl(),
+        container: app,
+        camera,
+        width: innerWidth,
+        height: innerHeight,
+        pixelRatio: Math.min(devicePixelRatio || 1, 2),
+        antialias: true,
+        useInstanced: true,
+        clearColor: new Hilo3d.Color(0.025, 0.055, 0.12)
+    });
+
+    const atlas = createAtlas();
+    const playerFrame = new Hilo3d.SpriteFrame({
+        texture: atlas,
+        x: 0,
+        y: 0,
+        width: 64,
+        height: 64
+    });
+    const starFrame = new Hilo3d.SpriteFrame({
+        texture: atlas,
+        x: 64,
+        y: 0,
+        width: 64,
+        height: 64
+    });
+    const ringFrame = new Hilo3d.SpriteFrame({
+        texture: atlas,
+        x: 128,
+        y: 0,
+        width: 64,
+        height: 64
+    });
+
+    const player = new Hilo3d.Sprite({
+        frame: playerFrame,
+        width: 56,
+        height: 56,
+        useHandCursor: true
+    }).addTo(stage);
+
+    const star = new Hilo3d.Sprite({
+        frame: starFrame,
+        width: 48,
+        height: 48,
+        useHandCursor: true
+    }).addTo(stage);
+
+    const exitRing = new Hilo3d.Sprite({
+        frame: ringFrame,
+        width: 72,
+        height: 72,
+        pointerEnabled: false,
+        visible: false
+    }).addTo(stage);
+
+    const scoreLabel = new Hilo3d.Text2D({
+        text: 'STARS 0 / 5',
+        style: {
+            font: '700 22px system-ui, sans-serif',
+            fillStyle: '#ffffff',
+            strokeStyle: '#071022',
+            strokeWidth: 5,
+            padding: 8,
+            resolution: 2,
+            textAlign: 'center'
+        },
+        anchorX: 0.5
+    }).addTo(stage);
+
+    const hintLabel = new Hilo3d.Text2D({
+        text: 'WASD / ARROWS TO MOVE • TAP THE STAR • R TO RESTART',
+        style: {
+            font: '650 12px system-ui, sans-serif',
+            fillStyle: '#9cecff',
+            strokeStyle: '#071022',
+            strokeWidth: 4,
+            padding: 6,
+            resolution: 2,
+            textAlign: 'center'
+        },
+        anchorX: 0.5
+    }).addTo(stage);
+
+    const starPositions = [
+        [0.2, 0.3],
+        [0.78, 0.28],
+        [0.72, 0.72],
+        [0.28, 0.76],
+        [0.5, 0.46]
+    ] as const;
+    const keys = new Set<string>();
+    let state: GameState = 'playing';
+    let score = 0;
+
+    function placeStar(): void {
+        const position = starPositions[score % starPositions.length];
+        if (!position) throw new Error('Starter star positions are incomplete.');
+        star.setPosition(stage.width * position[0], stage.height * position[1], 10);
+    }
+
+    function restart(): void {
+        state = 'playing';
+        score = 0;
+        exitRing.visible = false;
+        star.visible = true;
+        player.setPosition(stage.width * 0.5, stage.height * 0.68, 20);
+        scoreLabel.setText('STARS 0 / 5');
+        hintLabel.setText('WASD / ARROWS TO MOVE • TAP THE STAR • R TO RESTART');
+        placeStar();
+    }
+
+    function collectStar(): void {
+        if (state !== 'playing') return;
+        score += 1;
+        scoreLabel.setText(`STARS ${String(score)} / 5`);
+        if (score >= 5) {
+            state = 'won';
+            star.visible = false;
+            exitRing.visible = true;
+            exitRing.setPosition(player.x, player.y, 5);
+            hintLabel.setText('YOU FOUND THE CONSTELLATION • PRESS R TO PLAY AGAIN');
+            return;
+        }
+        placeStar();
+    }
+
+    function overlaps(left: Hilo3d.Sprite, right: Hilo3d.Sprite): boolean {
+        return (
+            Math.abs(left.x - right.x) * 2 < left.width + right.width &&
+            Math.abs(left.y - right.y) * 2 < left.height + right.height
+        );
+    }
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+        keys.add(event.code);
+        if (event.code === 'KeyR') restart();
+        if (event.code.startsWith('Arrow')) event.preventDefault();
+    };
+    const onKeyUp = (event: KeyboardEvent): void => {
+        keys.delete(event.code);
+    };
+    const onBlur = (): void => {
+        keys.clear();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+
+    star.on('click', collectStar);
+    player.on('click', () => {
+        player.tint.set(0.75, 1, 1, 1);
+    });
+    stage.enableDOMEvent('click');
+
+    const game: Hilo3d.Tickable = {
+        tick(dtMilliseconds): void {
+            const dt = Math.min(dtMilliseconds, 50) / 1000;
+            star.rotationZ += dt * 90;
+            exitRing.rotationZ -= dt * 70;
+            if (state !== 'playing') return;
+
+            let directionX =
+                Number(keys.has('KeyD') || keys.has('ArrowRight')) -
+                Number(keys.has('KeyA') || keys.has('ArrowLeft'));
+            let directionY =
+                Number(keys.has('KeyS') || keys.has('ArrowDown')) -
+                Number(keys.has('KeyW') || keys.has('ArrowUp'));
+            const length = Math.hypot(directionX, directionY);
+            if (length > 0) {
+                directionX /= length;
+                directionY /= length;
+            }
+
+            const speed = 260;
+            player.x = Math.max(28, Math.min(stage.width - 28, player.x + directionX * speed * dt));
+            player.y = Math.max(
+                86,
+                Math.min(stage.height - 56, player.y + directionY * speed * dt)
+            );
+            player.rotationZ += directionX * dt * 70;
+            if (overlaps(player, star)) collectStar();
+        }
+    };
+
+    function resize(): void {
+        const width = Math.max(1, innerWidth);
+        const height = Math.max(1, innerHeight);
+        stage.resize(width, height, Math.min(devicePixelRatio || 1, 2));
+        camera.resize(width, height);
+        scoreLabel.setPosition(width * 0.5, 18, 30);
+        hintLabel.setPosition(width * 0.5, height - 36, 30);
+        if (player.x === 0 && player.y === 0) restart();
+        else {
+            player.x = Math.min(player.x, width - 28);
+            player.y = Math.min(player.y, height - 56);
+            placeStar();
+        }
+    }
+
+    window.addEventListener('resize', resize);
+    resize();
+
+    const ticker = new Hilo3d.Ticker(60);
+    ticker.addTick(game);
+    ticker.addTick(stage);
+    ticker.start();
+    document.querySelector('#loading')?.remove();
+    console.info(`Hilo3D 2D starter uses ${stage.renderer.backend}`);
+
+    let destroyed = false;
+    function destroy(): void {
+        if (destroyed) return;
+        destroyed = true;
+        ticker.stop();
+        window.removeEventListener('keydown', onKeyDown);
+        window.removeEventListener('keyup', onKeyUp);
+        window.removeEventListener('blur', onBlur);
+        window.removeEventListener('resize', resize);
+        stage.destroy();
+    }
+    window.addEventListener('beforeunload', destroy, { once: true });
+}
+
+void main().catch(reportStartupFailure);

--- a/.agents/skills/build-hilo3d-games/assets/starter/variants/main-3d.ts
+++ b/.agents/skills/build-hilo3d-games/assets/starter/variants/main-3d.ts
@@ -1,0 +1,229 @@
+import * as Hilo3d from 'hilo3d';
+import './style.css';
+import { reportStartupFailure } from './startup';
+
+type GameState = 'playing' | 'won';
+
+async function main(): Promise<void> {
+    const app = document.querySelector<HTMLElement>('#app');
+    if (!app) throw new Error('The game requires #app.');
+
+    function backendFromUrl(): Hilo3d.StageBackend {
+        const value = new URL(location.href).searchParams.get('backend');
+        return value === 'webgl2' || value === 'webgpu' ? value : 'auto';
+    }
+
+    const camera = new Hilo3d.PerspectiveCamera({
+        fov: 50,
+        aspect: innerWidth / innerHeight,
+        near: 0.1,
+        far: 100,
+        x: 0,
+        y: 5,
+        z: 8
+    });
+    const stage = await Hilo3d.Stage.create({
+        backend: backendFromUrl(),
+        container: app,
+        camera,
+        width: innerWidth,
+        height: innerHeight,
+        pixelRatio: Math.min(devicePixelRatio || 1, 2),
+        antialias: true,
+        clearColor: new Hilo3d.Color(0.018, 0.035, 0.085)
+    });
+
+    new Hilo3d.AmbientLight({
+        color: new Hilo3d.Color(0.42, 0.55, 0.9),
+        amount: 0.75
+    }).addTo(stage);
+    new Hilo3d.DirectionalLight({
+        color: new Hilo3d.Color(1, 0.88, 0.68),
+        amount: 4,
+        direction: new Hilo3d.Vector3(-1, -1.4, -0.8)
+    }).addTo(stage);
+
+    new Hilo3d.Mesh({
+        geometry: new Hilo3d.PlaneGeometry({ width: 18, height: 18 }),
+        material: new Hilo3d.PBRMaterial({
+            baseColor: new Hilo3d.Color(0.05, 0.12, 0.2),
+            metallic: 0.05,
+            roughness: 0.85,
+            receiveShadows: true
+        }),
+        rotationX: -90
+    }).addTo(stage);
+
+    const player = new Hilo3d.Mesh({
+        geometry: new Hilo3d.BoxGeometry({ width: 0.8, height: 0.8, depth: 0.8 }),
+        material: new Hilo3d.PBRMaterial({
+            baseColor: new Hilo3d.Color(0.12, 0.78, 1),
+            metallic: 0.3,
+            roughness: 0.28,
+            emission: new Hilo3d.Color(0.01, 0.12, 0.2)
+        }),
+        y: 0.4,
+        useHandCursor: true
+    }).addTo(stage);
+
+    const beacon = new Hilo3d.Mesh({
+        geometry: new Hilo3d.SphereGeometry({
+            radius: 0.55,
+            widthSegments: 32,
+            heightSegments: 16
+        }),
+        material: new Hilo3d.PBRMaterial({
+            baseColor: new Hilo3d.Color(1, 0.68, 0.18),
+            metallic: 0.15,
+            roughness: 0.22,
+            emission: new Hilo3d.Color(0.35, 0.08, 0.01)
+        }),
+        x: 4.3,
+        y: 0.65,
+        z: -4.2,
+        useHandCursor: true
+    }).addTo(stage);
+
+    const obstacleGeometry = new Hilo3d.BoxGeometry({ width: 1.2, height: 1.2, depth: 1.2 });
+    const obstacleMaterial = new Hilo3d.PBRMaterial({
+        baseColor: new Hilo3d.Color(0.48, 0.18, 0.72),
+        metallic: 0.15,
+        roughness: 0.55
+    });
+    const obstaclePositions = [
+        [-2.5, -1],
+        [-0.2, -2.7],
+        [2, -1.2],
+        [2.8, 2.4],
+        [-2.2, 2.9]
+    ] as const;
+    const obstacles = obstaclePositions.map(([x, z]) =>
+        new Hilo3d.Mesh({
+            geometry: obstacleGeometry,
+            material: obstacleMaterial,
+            x,
+            y: 0.6,
+            z
+        }).addTo(stage)
+    );
+
+    const overlay = document.createElement('div');
+    overlay.className = 'game-overlay';
+    overlay.innerHTML =
+        '<strong>BEACON RUN</strong> · WASD / ARROWS TO MOVE · TAP THE BEACON · R TO RESTART';
+    document.body.appendChild(overlay);
+
+    const keys = new Set<string>();
+    let state: GameState = 'playing';
+
+    function restart(): void {
+        state = 'playing';
+        player.setPosition(0, 0.4, 3.8);
+        overlay.innerHTML =
+            '<strong>BEACON RUN</strong> · WASD / ARROWS TO MOVE · TAP THE BEACON · R TO RESTART';
+    }
+
+    function win(): void {
+        if (state === 'won') return;
+        state = 'won';
+        overlay.innerHTML = '<strong>BEACON REACHED</strong> · PRESS R TO PLAY AGAIN';
+    }
+
+    function collides(x: number, z: number): boolean {
+        for (const obstacle of obstacles) {
+            if (Math.abs(x - obstacle.x) < 1 && Math.abs(z - obstacle.z) < 1) return true;
+        }
+        return false;
+    }
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+        keys.add(event.code);
+        if (event.code === 'KeyR') restart();
+        if (event.code.startsWith('Arrow')) event.preventDefault();
+    };
+    const onKeyUp = (event: KeyboardEvent): void => {
+        keys.delete(event.code);
+    };
+    const onBlur = (): void => {
+        keys.clear();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+
+    beacon.on('click', () => {
+        if (state !== 'playing') return;
+        player.setPosition(beacon.x, player.y, beacon.z);
+        win();
+    });
+    stage.enableDOMEvent('click');
+
+    const game: Hilo3d.Tickable = {
+        tick(dtMilliseconds): void {
+            const dt = Math.min(dtMilliseconds, 50) / 1000;
+            beacon.rotationY += dt * 80;
+            beacon.y = 0.65 + Math.sin(performance.now() * 0.0025) * 0.12;
+
+            if (state === 'playing') {
+                let directionX =
+                    Number(keys.has('KeyD') || keys.has('ArrowRight')) -
+                    Number(keys.has('KeyA') || keys.has('ArrowLeft'));
+                let directionZ =
+                    Number(keys.has('KeyS') || keys.has('ArrowDown')) -
+                    Number(keys.has('KeyW') || keys.has('ArrowUp'));
+                const length = Math.hypot(directionX, directionZ);
+                if (length > 0) {
+                    directionX /= length;
+                    directionZ /= length;
+                }
+                const speed = 4.5;
+                const nextX = Math.max(-7.5, Math.min(7.5, player.x + directionX * speed * dt));
+                const nextZ = Math.max(-7.5, Math.min(7.5, player.z + directionZ * speed * dt));
+                if (!collides(nextX, player.z)) player.x = nextX;
+                if (!collides(player.x, nextZ)) player.z = nextZ;
+                player.rotationY -= directionX * dt * 130;
+                player.rotationX += directionZ * dt * 90;
+
+                if (Math.hypot(player.x - beacon.x, player.z - beacon.z) < 0.85) win();
+            }
+
+            const blend = 1 - Math.exp(-6 * dt);
+            camera.x += (player.x - camera.x) * blend;
+            camera.z += (player.z + 8 - camera.z) * blend;
+            camera.lookAt(player);
+        }
+    };
+
+    function resize(): void {
+        const width = Math.max(1, innerWidth);
+        const height = Math.max(1, innerHeight);
+        stage.resize(width, height, Math.min(devicePixelRatio || 1, 2));
+        camera.aspect = width / height;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+    restart();
+
+    const ticker = new Hilo3d.Ticker(60);
+    ticker.addTick(game);
+    ticker.addTick(stage);
+    ticker.start();
+    document.querySelector('#loading')?.remove();
+    console.info(`Hilo3D 3D starter uses ${stage.renderer.backend}`);
+
+    let destroyed = false;
+    function destroy(): void {
+        if (destroyed) return;
+        destroyed = true;
+        ticker.stop();
+        window.removeEventListener('keydown', onKeyDown);
+        window.removeEventListener('keyup', onKeyUp);
+        window.removeEventListener('blur', onBlur);
+        window.removeEventListener('resize', resize);
+        overlay.remove();
+        stage.destroy();
+    }
+    window.addEventListener('beforeunload', destroy, { once: true });
+}
+
+void main().catch(reportStartupFailure);

--- a/.agents/skills/build-hilo3d-games/assets/starter/variants/main-hybrid.ts
+++ b/.agents/skills/build-hilo3d-games/assets/starter/variants/main-hybrid.ts
@@ -1,0 +1,273 @@
+import * as Hilo3d from 'hilo3d';
+import './style.css';
+import { reportStartupFailure } from './startup';
+
+const WORLD_LAYER = 1;
+type GameState = 'playing' | 'won';
+
+async function main(): Promise<void> {
+    const app = document.querySelector<HTMLElement>('#app');
+    if (!app) throw new Error('The game requires #app.');
+
+    function backendFromUrl(): Hilo3d.StageBackend {
+        const value = new URL(location.href).searchParams.get('backend');
+        return value === 'webgl2' || value === 'webgpu' ? value : 'auto';
+    }
+
+    const worldCamera = new Hilo3d.PerspectiveCamera({
+        fov: 52,
+        aspect: innerWidth / innerHeight,
+        near: 0.1,
+        far: 100,
+        visibility: WORLD_LAYER,
+        priority: 0,
+        clearColor: true,
+        x: 0,
+        y: 4.8,
+        z: 8
+    });
+    const uiCamera = new Hilo3d.Camera2D({
+        width: innerWidth,
+        height: innerHeight,
+        visibility: Hilo3d.DEFAULT_2D_LAYER,
+        priority: 100,
+        clearColor: false
+    });
+    const stage = await Hilo3d.Stage.create({
+        backend: backendFromUrl(),
+        container: app,
+        cameras: [worldCamera, uiCamera],
+        width: innerWidth,
+        height: innerHeight,
+        pixelRatio: Math.min(devicePixelRatio || 1, 2),
+        antialias: true,
+        clearColor: new Hilo3d.Color(0.012, 0.025, 0.07)
+    });
+
+    new Hilo3d.AmbientLight({
+        layer: WORLD_LAYER,
+        color: new Hilo3d.Color(0.32, 0.5, 0.9),
+        amount: 0.8
+    }).addTo(stage);
+    new Hilo3d.DirectionalLight({
+        layer: WORLD_LAYER,
+        color: new Hilo3d.Color(1, 0.86, 0.62),
+        amount: 4.5,
+        direction: new Hilo3d.Vector3(-1, -1.3, -0.7)
+    }).addTo(stage);
+
+    new Hilo3d.Mesh({
+        layer: WORLD_LAYER,
+        geometry: new Hilo3d.PlaneGeometry({ width: 20, height: 20 }),
+        material: new Hilo3d.PBRMaterial({
+            baseColor: new Hilo3d.Color(0.035, 0.1, 0.16),
+            roughness: 0.9
+        }),
+        rotationX: -90
+    }).addTo(stage);
+
+    const player = new Hilo3d.Mesh({
+        layer: WORLD_LAYER,
+        geometry: new Hilo3d.SphereGeometry({
+            radius: 0.48,
+            widthSegments: 28,
+            heightSegments: 16
+        }),
+        material: new Hilo3d.PBRMaterial({
+            baseColor: new Hilo3d.Color(0.14, 0.82, 1),
+            metallic: 0.4,
+            roughness: 0.22,
+            emission: new Hilo3d.Color(0.01, 0.1, 0.2)
+        }),
+        y: 0.5
+    }).addTo(stage);
+
+    const shardGeometry = new Hilo3d.BoxGeometry({ width: 0.5, height: 0.8, depth: 0.5 });
+    const shardMaterial = new Hilo3d.PBRMaterial({
+        baseColor: new Hilo3d.Color(1, 0.58, 0.16),
+        metallic: 0.3,
+        roughness: 0.2,
+        emission: new Hilo3d.Color(0.28, 0.05, 0)
+    });
+    const shardPositions = [
+        [-3.6, -2.4],
+        [3.8, -2.8],
+        [3.1, 3],
+        [-3.2, 2.8]
+    ] as const;
+    const shards = shardPositions.map(([x, z]) =>
+        new Hilo3d.Mesh({
+            layer: WORLD_LAYER,
+            geometry: shardGeometry,
+            material: shardMaterial,
+            x,
+            y: 0.55,
+            z,
+            useHandCursor: true
+        }).addTo(stage)
+    );
+
+    const title = new Hilo3d.Text2D({
+        text: 'SHARD SEEKER',
+        style: {
+            font: '800 28px system-ui, sans-serif',
+            fillStyle: '#ffffff',
+            strokeStyle: '#071022',
+            strokeWidth: 6,
+            padding: 8,
+            resolution: 2,
+            textAlign: 'center'
+        },
+        anchorX: 0.5
+    }).addTo(stage);
+    const scoreLabel = new Hilo3d.Text2D({
+        text: 'SHARDS 0 / 4',
+        style: {
+            font: '700 17px ui-monospace, monospace',
+            fillStyle: '#ffd98a',
+            strokeStyle: '#071022',
+            strokeWidth: 5,
+            padding: 7,
+            resolution: 2,
+            textAlign: 'center'
+        },
+        anchorX: 0.5
+    }).addTo(stage);
+    const resetButton = new Hilo3d.Text2D({
+        text: 'WASD / ARROWS • TAP SHARDS • R TO RESET',
+        style: {
+            font: '700 12px system-ui, sans-serif',
+            fillStyle: '#8eeaff',
+            strokeStyle: '#071022',
+            strokeWidth: 5,
+            padding: 8,
+            resolution: 2,
+            textAlign: 'center'
+        },
+        anchorX: 0.5,
+        anchorY: 0.5,
+        useHandCursor: true
+    }).addTo(stage);
+    if (title.material) title.material.renderOrder = 100;
+    if (scoreLabel.material) scoreLabel.material.renderOrder = 100;
+    if (resetButton.material) resetButton.material.renderOrder = 110;
+
+    const keys = new Set<string>();
+    const collected = new Set<Hilo3d.Mesh>();
+    let state: GameState = 'playing';
+
+    function collect(shard: Hilo3d.Mesh): void {
+        if (state !== 'playing' || collected.has(shard)) return;
+        collected.add(shard);
+        shard.visible = false;
+        scoreLabel.setText(`SHARDS ${String(collected.size)} / ${String(shards.length)}`);
+        if (collected.size === shards.length) {
+            state = 'won';
+            title.setText('CONSTELLATION COMPLETE');
+            resetButton.setText('TAP HERE OR PRESS R TO PLAY AGAIN');
+        }
+    }
+
+    function restart(): void {
+        state = 'playing';
+        collected.clear();
+        for (const shard of shards) shard.visible = true;
+        player.setPosition(0, 0.5, 0);
+        title.setText('SHARD SEEKER');
+        scoreLabel.setText(`SHARDS 0 / ${String(shards.length)}`);
+        resetButton.setText('WASD / ARROWS • TAP SHARDS • R TO RESET');
+    }
+
+    for (const shard of shards) {
+        shard.on('click', () => collect(shard));
+    }
+    resetButton.on('click', restart);
+    stage.enableDOMEvent('click');
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+        keys.add(event.code);
+        if (event.code === 'KeyR') restart();
+        if (event.code.startsWith('Arrow')) event.preventDefault();
+    };
+    const onKeyUp = (event: KeyboardEvent): void => {
+        keys.delete(event.code);
+    };
+    const onBlur = (): void => {
+        keys.clear();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+
+    const game: Hilo3d.Tickable = {
+        tick(dtMilliseconds): void {
+            const dt = Math.min(dtMilliseconds, 50) / 1000;
+            for (let index = 0; index < shards.length; index += 1) {
+                const shard = shards[index];
+                if (!shard || !shard.visible) continue;
+                shard.rotationY += dt * (70 + index * 12);
+                shard.rotationX += dt * 35;
+                if (Math.hypot(player.x - shard.x, player.z - shard.z) < 0.85) collect(shard);
+            }
+
+            if (state === 'playing') {
+                let directionX =
+                    Number(keys.has('KeyD') || keys.has('ArrowRight')) -
+                    Number(keys.has('KeyA') || keys.has('ArrowLeft'));
+                let directionZ =
+                    Number(keys.has('KeyS') || keys.has('ArrowDown')) -
+                    Number(keys.has('KeyW') || keys.has('ArrowUp'));
+                const length = Math.hypot(directionX, directionZ);
+                if (length > 0) {
+                    directionX /= length;
+                    directionZ /= length;
+                }
+                player.x = Math.max(-8.5, Math.min(8.5, player.x + directionX * 4.8 * dt));
+                player.z = Math.max(-8.5, Math.min(8.5, player.z + directionZ * 4.8 * dt));
+                player.rotationZ -= directionX * dt * 140;
+                player.rotationX += directionZ * dt * 140;
+            }
+
+            const blend = 1 - Math.exp(-7 * dt);
+            worldCamera.x += (player.x - worldCamera.x) * blend;
+            worldCamera.z += (player.z + 8 - worldCamera.z) * blend;
+            worldCamera.lookAt(player);
+        }
+    };
+
+    function resize(): void {
+        const width = Math.max(1, innerWidth);
+        const height = Math.max(1, innerHeight);
+        stage.resize(width, height, Math.min(devicePixelRatio || 1, 2));
+        worldCamera.aspect = width / height;
+        uiCamera.resize(width, height);
+        title.setPosition(width * 0.5, 18, 40);
+        scoreLabel.setPosition(width * 0.5, 64, 40);
+        resetButton.setPosition(width * 0.5, height - 34, 40);
+    }
+    window.addEventListener('resize', resize);
+    resize();
+    restart();
+
+    const ticker = new Hilo3d.Ticker(60);
+    ticker.addTick(game);
+    ticker.addTick(stage);
+    ticker.start();
+    document.querySelector('#loading')?.remove();
+    console.info(`Hilo3D hybrid starter uses ${stage.renderer.backend}`);
+
+    let destroyed = false;
+    function destroy(): void {
+        if (destroyed) return;
+        destroyed = true;
+        ticker.stop();
+        window.removeEventListener('keydown', onKeyDown);
+        window.removeEventListener('keyup', onKeyUp);
+        window.removeEventListener('blur', onBlur);
+        window.removeEventListener('resize', resize);
+        stage.destroy();
+    }
+    window.addEventListener('beforeunload', destroy, { once: true });
+}
+
+void main().catch(reportStartupFailure);

--- a/.agents/skills/build-hilo3d-games/references/2d-games.md
+++ b/.agents/skills/build-hilo3d-games/references/2d-games.md
@@ -1,0 +1,225 @@
+# Build 2D games
+
+## Contents
+
+- [Use the 2D coordinate contract](#use-the-2d-coordinate-contract)
+- [Build sprites from textures and atlas frames](#build-sprites-from-textures-and-atlas-frames)
+- [Preserve batching](#preserve-batching)
+- [Use Text2D for dynamic labels](#use-text2d-for-dynamic-labels)
+- [Add pointer interaction](#add-pointer-interaction)
+- [Use simple collision shapes](#use-simple-collision-shapes)
+- [Compose a 2D background, 3D world, and HUD](#compose-a-2d-background-3d-world-and-hud)
+- [Design a complete 2D vertical slice](#design-a-complete-2d-vertical-slice)
+
+## Use the 2D coordinate contract
+
+`Camera2D` projects logical game pixels with:
+
+- origin at the top-left;
+- positive X to the right;
+- positive Y downward;
+- default visibility `DEFAULT_2D_LAYER`;
+- default priority `100`;
+- color preserved from lower-priority cameras.
+
+Create a 2D-only Stage:
+
+```ts
+const camera = new Hilo3d.Camera2D({ width, height });
+const stage = await Hilo3d.Stage.create({
+    backend: 'auto',
+    container,
+    camera,
+    width,
+    height,
+    useInstanced: true
+});
+```
+
+On resize, update both:
+
+```ts
+stage.resize(width, height, Math.min(devicePixelRatio || 1, 2));
+camera.resize(width, height);
+```
+
+## Build sprites from textures and atlas frames
+
+For a full texture:
+
+```ts
+const sprite = new Hilo3d.Sprite({
+    texture,
+    x: 200,
+    y: 160,
+    width: 64,
+    height: 64,
+    anchorX: 0.5,
+    anchorY: 0.5,
+    tint: new Hilo3d.Color(1, 1, 1, 1)
+}).addTo(stage);
+```
+
+For an atlas:
+
+```ts
+const frames = [
+    new Hilo3d.SpriteFrame({
+        texture: atlas,
+        x: 0,
+        y: 0,
+        width: 64,
+        height: 64,
+        duration: 90
+    }),
+    new Hilo3d.SpriteFrame({
+        texture: atlas,
+        x: 64,
+        y: 0,
+        width: 64,
+        height: 64,
+        duration: 90
+    })
+];
+
+const player = new Hilo3d.Sprite({
+    frames,
+    frameRate: 12,
+    loop: true,
+    autoPlay: true
+});
+```
+
+Control animation with `play()`, `pause()`, `stop()`, and `gotoFrame(index)`. Listen for
+`framechange`, `loop`, and `complete` when game logic needs animation events.
+
+Frame coordinates use top-left source pixels. `SpriteFrame` accounts for the texture `flipY` policy;
+do not manually invert atlas rows.
+
+## Preserve batching
+
+Default Sprites use one shared quad and opt into portable instancing. Sprites batch when they share
+the same geometry and `SpriteMaterial` identity. The default material cache shares a material per
+texture.
+
+Do:
+
+- place many frames on one atlas;
+- let Sprites using the same texture use the default material;
+- update transforms, tint, size, and UV frame in place;
+- keep decorative non-interactive sprites `pointerEnabled: false`.
+
+Avoid:
+
+- one texture per tiny sprite;
+- one custom material per sprite;
+- rebuilding Geometry or Sprite every animation frame;
+- changing material identity merely to change tint;
+- thousands of dynamic `Text2D` labels.
+
+Portable sprite draws are split at 128 instances. Large scenes can still batch efficiently across
+multiple draws.
+
+Transparent objects within one instance batch preserve collection order rather than receiving a
+global per-sprite depth sort. Use a small number of shared materials with distinct `renderOrder`
+values for intentional layers. This splits batches, so use only as much ordering as required.
+
+## Use Text2D for dynamic labels
+
+```ts
+const score = new Hilo3d.Text2D({
+    text: 'SCORE 000',
+    style: {
+        font: '700 24px system-ui, sans-serif',
+        fillStyle: '#ffffff',
+        strokeStyle: '#10152b',
+        strokeWidth: 4,
+        padding: 6,
+        resolution: 2,
+        textAlign: 'center'
+    },
+    anchorX: 0.5
+}).addTo(stage);
+
+score.setText('SCORE 120');
+score.setStyle({ fillStyle: '#ffe082' });
+```
+
+`Text2D` rerasterizes only after `setText()` or `setStyle()`. It preserves its Canvas, Texture,
+material, and pipeline identity. Each label still owns a texture and draw item.
+
+Use:
+
+- `Text2D` for scores, timers, prompts, and low-frequency labels;
+- a font atlas and normal Sprites for large amounts of mostly static glyphs;
+- DOM for accessible forms, long text, and screen-reader navigation.
+
+## Add pointer interaction
+
+```ts
+button.on('click', event => {
+    if ('stopPropagation' in event && typeof event.stopPropagation === 'function') {
+        event.stopPropagation();
+    }
+    activateButton();
+});
+stage.enableDOMEvent('click');
+```
+
+For drag:
+
+```ts
+stage.enableDOMEvent(['pointerdown', 'pointermove', 'pointerup', 'pointercancel']);
+```
+
+Sprites use their actual width, height, anchor, and world transform for CPU hit tests.
+Higher-priority cameras receive pointer hits first. Layer filtering for picking matches rendering.
+
+Set `useHandCursor: true` only for clickable objects. Disable picking on backgrounds and particle
+decorations.
+
+## Use simple collision shapes
+
+For centered sprites:
+
+```ts
+function overlaps(a: Hilo3d.Sprite, b: Hilo3d.Sprite): boolean {
+    return (
+        Math.abs(a.x - b.x) * 2 < a.width * Math.abs(a.scaleX) + b.width * Math.abs(b.scaleX) &&
+        Math.abs(a.y - b.y) * 2 < a.height * Math.abs(a.scaleY) + b.height * Math.abs(b.scaleY)
+    );
+}
+```
+
+Adjust for anchors if they differ from `0.5`. For many moving objects, use a uniform grid or spatial
+hash instead of testing every pair.
+
+## Compose a 2D background, 3D world, and HUD
+
+Use distinct layer bits:
+
+```ts
+const WORLD_LAYER = 1;
+const BACKGROUND_LAYER = 1 << 2;
+const UI_LAYER = Hilo3d.DEFAULT_2D_LAYER;
+```
+
+Create cameras with increasing priorities. The background camera clears color, the world and UI
+cameras normally preserve it. See [Rendering and performance](rendering-performance.md) for the full
+hybrid pattern.
+
+## Design a complete 2D vertical slice
+
+Include:
+
+- one controllable Sprite;
+- one collectible, obstacle, target, or enemy;
+- collision feedback;
+- a Text2D score or state label;
+- keyboard and pointer/touch controls;
+- an explicit restart path;
+- responsive layout;
+- shared atlas resources.
+
+The bundled `2d` starter demonstrates this without external assets by generating one Canvas atlas at
+runtime.

--- a/.agents/skills/build-hilo3d-games/references/3d-games.md
+++ b/.agents/skills/build-hilo3d-games/references/3d-games.md
@@ -1,0 +1,230 @@
+# Build 3D games
+
+## Contents
+
+- [Create a world with visible scale](#create-a-world-with-visible-scale)
+- [Reuse geometry and materials](#reuse-geometry-and-materials)
+- [Choose materials intentionally](#choose-materials-intentionally)
+- [Add shadows sparingly](#add-shadows-sparingly)
+- [Load glTF assets](#load-gltf-assets)
+- [Drive character and camera movement](#drive-character-and-camera-movement)
+- [Use picking for world interaction](#use-picking-for-world-interaction)
+- [Integrate physics with cannon-es](#integrate-physics-with-cannon-es)
+- [Design a complete 3D vertical slice](#design-a-complete-3d-vertical-slice)
+
+## Create a world with visible scale
+
+Start with a camera, at least one lit object, ambient fill, and a key light:
+
+```ts
+const camera = new Hilo3d.PerspectiveCamera({
+    fov: 50,
+    aspect: width / height,
+    near: 0.1,
+    far: 200,
+    z: 7
+});
+
+const stage = await Hilo3d.Stage.create({
+    backend: 'auto',
+    container,
+    camera,
+    width,
+    height,
+    antialias: true,
+    clearColor: new Hilo3d.Color(0.025, 0.035, 0.075)
+});
+
+new Hilo3d.AmbientLight({
+    color: new Hilo3d.Color(0.45, 0.55, 0.8),
+    amount: 0.65
+}).addTo(stage);
+
+new Hilo3d.DirectionalLight({
+    color: new Hilo3d.Color(1, 0.9, 0.72),
+    amount: 4,
+    direction: new Hilo3d.Vector3(-1, -1.2, -0.6)
+}).addTo(stage);
+```
+
+Use consistent world units. A practical default is one unit per meter for physics and character
+movement.
+
+## Reuse geometry and materials
+
+```ts
+const obstacleGeometry = new Hilo3d.BoxGeometry({ width: 1, height: 1, depth: 1 });
+const obstacleMaterial = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.15, 0.6, 0.95),
+    metallic: 0.15,
+    roughness: 0.5
+});
+
+for (const position of obstaclePositions) {
+    new Hilo3d.Mesh({
+        geometry: obstacleGeometry,
+        material: obstacleMaterial,
+        x: position.x,
+        y: position.y,
+        z: position.z
+    }).addTo(stage);
+}
+```
+
+Set `useInstanced: true` when many meshes share geometry and material and do not require independent
+render state. Keep a conservative object count before adding occlusion or elaborate level streaming.
+
+## Choose materials intentionally
+
+Use `PBRMaterial` for:
+
+- glTF-aligned assets;
+- metal, plastic, stone, wood, painted surfaces;
+- image-based lighting and physically meaningful roughness.
+
+Use `BasicMaterial` with `lightType: 'NONE'` for:
+
+- debug shapes;
+- flat collectibles and effects;
+- stylized unlit surfaces;
+- UI-like 3D markers.
+
+Avoid using transparency when alpha cutout is sufficient. For foliage or fences, prefer
+`alphaCutoff` so depth writing and sorting remain stable. For real transparency, use explicit
+`renderOrder` only when depth sorting is insufficient.
+
+## Add shadows sparingly
+
+```ts
+const sun = new Hilo3d.DirectionalLight({
+    amount: 4,
+    direction: new Hilo3d.Vector3(-1, -1, -0.5),
+    shadow: {
+        width: 1024,
+        height: 1024,
+        minBias: 0.0005,
+        maxBias: 0.003
+    }
+});
+```
+
+Enable `castShadows` and `receiveShadows` only on relevant materials. One high-quality key shadow
+usually gives better performance and visual consistency than many shadow-casting lights.
+
+## Load glTF assets
+
+```ts
+const loader = new Hilo3d.GLTFLoader();
+const model = await loader.load({
+    src: new URL('./assets/level.glb', import.meta.url).href
+});
+await model.ready;
+
+model.node.setScale(1);
+model.node.addTo(stage);
+model.anim?.play();
+```
+
+Treat `model.ready` as part of required asset readiness. Inspect `model.resourceErrors` when using
+optional error-tolerant loading.
+
+Prefer `.glb` for a single deployable asset and standard glTF PBR textures. Compress textures only
+when target backend/device support is considered. Keep a fallback for required content.
+
+Use `model.bounds` or `model.node.getBounds()` to frame imported content. Do not assume authoring
+units or object origin.
+
+## Drive character and camera movement
+
+Convert input to an intent vector, normalize diagonals, then multiply by units per second:
+
+```ts
+const move = new Hilo3d.Vector3();
+
+function updatePlayer(dtMilliseconds: number): void {
+    const dt = Math.min(dtMilliseconds, 50) / 1000;
+    move.set(
+        Number(keys.has('KeyD')) - Number(keys.has('KeyA')),
+        0,
+        Number(keys.has('KeyS')) - Number(keys.has('KeyW'))
+    );
+    if (move.length() > 0) move.normalize();
+    player.x += move.x * PLAYER_SPEED * dt;
+    player.z += move.z * PLAYER_SPEED * dt;
+}
+```
+
+Use an explicit camera rig:
+
+```ts
+const cameraRig = new Hilo3d.Node().addTo(stage);
+camera.addTo(cameraRig);
+```
+
+For follow cameras, smooth toward a target position with a frame-rate-independent factor:
+
+```ts
+const blend = 1 - Math.exp(-8 * dtSeconds);
+cameraRig.x += (player.x - cameraRig.x) * blend;
+cameraRig.z += (player.z - cameraRig.z) * blend;
+```
+
+## Use picking for world interaction
+
+Enable only needed events:
+
+```ts
+stage.enableDOMEvent('click');
+interactable.on('click', event => {
+    if (!('hitPoint' in event) || !(event.hitPoint instanceof Hilo3d.Vector3)) return;
+    const point = event.hitPoint;
+    select(interactable, point);
+});
+```
+
+For aiming or editor-like tools, call `stage.getMeshResultAtPoint(x, y, true)` with Stage logical
+coordinates. Use `Ray` and `Mesh.raycast()` for explicit ray tests.
+
+## Integrate physics with cannon-es
+
+Hilo3D does not hide physics behind render objects. Keep one mapping from Mesh to physics Body:
+
+```ts
+import * as CANNON from 'cannon-es';
+
+const world = new CANNON.World({
+    gravity: new CANNON.Vec3(0, -9.8, 0)
+});
+
+const body = new CANNON.Body({
+    mass: 1,
+    shape: new CANNON.Box(new CANNON.Vec3(0.5, 0.5, 0.5))
+});
+world.addBody(body);
+```
+
+Fixed-step the world and copy transforms into the Mesh before Stage rendering:
+
+```ts
+world.step(1 / 60, Math.min(dtMilliseconds, 100) / 1000, 3);
+mesh.position.set(body.position.x, body.position.y, body.position.z);
+mesh.quaternion.set(body.quaternion.x, body.quaternion.y, body.quaternion.z, body.quaternion.w);
+```
+
+Use simple collision shapes and remove bodies when entities despawn. Avoid allocating vectors in the
+synchronization loop.
+
+## Design a complete 3D vertical slice
+
+Include:
+
+- a controllable or automatically animated player object;
+- obstacles, targets, or collectibles;
+- camera movement;
+- a win/loss or score condition;
+- visible lighting and material response;
+- collision or picking;
+- a restart path;
+- a 2D or DOM control hint.
+
+The bundled `3d` starter uses only generated primitives, so it runs before art assets exist.

--- a/.agents/skills/build-hilo3d-games/references/game-architecture.md
+++ b/.agents/skills/build-hilo3d-games/references/game-architecture.md
@@ -1,0 +1,234 @@
+# Game architecture
+
+## Contents
+
+- [Organize by ownership](#organize-by-ownership)
+- [Model game states explicitly](#model-game-states-explicitly)
+- [Use one scheduler](#use-one-scheduler)
+- [Record input state](#record-input-state)
+- [Keep collision appropriate to the game](#keep-collision-appropriate-to-the-game)
+- [Load before play](#load-before-play)
+- [Resize deliberately](#resize-deliberately)
+- [Pause correctly](#pause-correctly)
+- [Tear down completely](#tear-down-completely)
+- [Test gameplay logic separately](#test-gameplay-logic-separately)
+
+## Organize by ownership
+
+Keep four boundaries:
+
+1. **Input** records buttons, axes, pointer positions, and one-shot actions.
+2. **Simulation** owns authoritative game state, movement, collision, score, and rules.
+3. **Presentation** maps state to Hilo3D nodes, materials, text, particles, and cameras.
+4. **Lifecycle** owns loading, start/pause/resume/restart, resize, listeners, and teardown.
+
+For a prototype, these may be classes in one file. Split them once each boundary has independent
+state or tests.
+
+## Model game states explicitly
+
+Use a union instead of scattered booleans:
+
+```ts
+type GameState = 'loading' | 'ready' | 'playing' | 'paused' | 'won' | 'lost';
+```
+
+Centralize transitions:
+
+```ts
+function setState(next: GameState): void {
+    state = next;
+    pauseLabel.visible = next === 'paused';
+}
+```
+
+Restart by resetting state and existing objects. Do not reload the page or create a second Stage.
+
+## Use one scheduler
+
+Register tickables in dependency order:
+
+```ts
+const ticker = new Hilo3d.Ticker(60);
+ticker.addTick(inputSystem);
+ticker.addTick(simulation);
+ticker.addTick(presentation);
+ticker.addTick(Hilo3d.Tween);
+ticker.addTick(Hilo3d.Animation);
+ticker.addTick(stage);
+```
+
+`dt` is milliseconds. Clamp it:
+
+```ts
+tick(dt: number): void {
+    const seconds = Math.min(dt, 50) / 1000;
+    player.x += velocityX * seconds;
+}
+```
+
+For physics or deterministic rules, use a fixed-step accumulator:
+
+```ts
+const STEP = 1 / 60;
+let accumulator = 0;
+
+function update(dtMilliseconds: number): void {
+    accumulator = Math.min(accumulator + dtMilliseconds / 1000, 0.25);
+    while (accumulator >= STEP) {
+        simulate(STEP);
+        accumulator -= STEP;
+    }
+}
+```
+
+Render once after the fixed steps. Do not tie game speed to the monitor refresh rate.
+
+## Record input state
+
+Use DOM listeners to record input, not to mutate the world in unrelated callbacks:
+
+```ts
+const keys = new Set<string>();
+
+const onKeyDown = (event: KeyboardEvent): void => {
+    keys.add(event.code);
+};
+const onKeyUp = (event: KeyboardEvent): void => {
+    keys.delete(event.code);
+};
+
+window.addEventListener('keydown', onKeyDown);
+window.addEventListener('keyup', onKeyUp);
+```
+
+Read `keys` in the simulation tick. Use `event.code` for physical controls. Prevent browser
+scrolling only for keys the focused game actually consumes.
+
+For Hilo3D object picking:
+
+```ts
+button.on('click', () => activate());
+stage.enableDOMEvent('click');
+```
+
+For drag controls enable `pointerdown`, `pointermove`, `pointerup`, and `pointercancel`. Capture
+only the information the simulation needs. Disable unused event types to avoid unnecessary picking.
+
+`StagePointerEvent.stageX` and `stageY` are logical Stage pixels. They map directly to the default
+top-left `Camera2D` layout. Narrow the event before reading them:
+
+```ts
+sprite.on('pointerdown', event => {
+    if (
+        'stageX' in event &&
+        typeof event.stageX === 'number' &&
+        'stageY' in event &&
+        typeof event.stageY === 'number'
+    ) {
+        dragTarget.set(event.stageX, event.stageY);
+    }
+});
+```
+
+For a 3D surface, use `event.hitPoint` from a picked Mesh or
+`stage.getMeshResultAtPoint(stageX, stageY, true)`. A screen coordinate alone does not identify a
+unique 3D world position; intersect the camera ray with the intended plane or collision geometry.
+
+## Keep collision appropriate to the game
+
+- 2D arcade: axis-aligned boxes, circles, grids, or spatial hashes.
+- Simple 3D: spheres, AABBs, rays, and Hilo3D picking.
+- Dynamic rigid bodies: integrate a physics library such as `cannon-es`.
+
+Separate collision shape from render geometry. Approximate complex art with stable simple shapes.
+Use layer or category masks to skip impossible pairs.
+
+## Load before play
+
+Represent asset loading as a state. Load independent assets concurrently:
+
+```ts
+const [playerTexture, levelModel] = await Promise.all([
+    new Hilo3d.TextureLoader().load({ src: playerUrl, flipY: true }),
+    new Hilo3d.GLTFLoader().load({ src: levelUrl })
+]);
+await levelModel.ready;
+```
+
+Surface meaningful errors. A missing required player or level asset should block play. Optional
+cosmetics may use an intentional fallback.
+
+Avoid third-party CDNs for runtime assets when a project can ship them locally.
+
+## Resize deliberately
+
+```ts
+function resize(): void {
+    const width = Math.max(1, window.innerWidth);
+    const height = Math.max(1, window.innerHeight);
+    stage.resize(width, height, Math.min(devicePixelRatio || 1, 2));
+    perspectiveCamera.aspect = width / height;
+    uiCamera.resize(width, height);
+    layoutHud(width, height);
+}
+```
+
+Register one resize listener and call it once after scene creation. Recalculate layout from logical
+Stage dimensions, not backing-buffer pixels.
+
+## Pause correctly
+
+Choose one of two policies:
+
+- Pause simulation but keep rendering menus and UI.
+- Pause the ticker completely when nothing needs to animate.
+
+For the first policy, leave Stage ticking and skip only gameplay simulation. Reset transient input
+when focus is lost:
+
+```ts
+window.addEventListener('blur', () => {
+    keys.clear();
+    state = 'paused';
+});
+```
+
+## Tear down completely
+
+One owner should dispose the application:
+
+```ts
+function destroy(): void {
+    ticker.stop();
+    window.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('keyup', onKeyUp);
+    window.removeEventListener('resize', resize);
+    stage.destroy();
+}
+```
+
+`stage.destroy()` disables DOM event types registered through `stage.enableDOMEvent(...)`, clears
+Hilo3D node listeners in the Stage tree, destroys the renderer, and releases owned rendering
+resources. The application must still remove listeners it registered directly on `window`,
+`document`, the canvas, audio objects, gamepads, or other external owners. Do not destroy textures
+or materials still shared by live objects.
+
+## Test gameplay logic separately
+
+Keep simulation functions free of DOM and GPU dependencies where practical. Unit-test:
+
+- movement and clamping;
+- collision and damage;
+- scoring and state transitions;
+- fixed-step behavior;
+- restart determinism.
+
+Browser-test:
+
+- asset loading and first frame;
+- input routing and picking;
+- backend selection;
+- resize and device pixel ratio;
+- pause/resume after focus loss;
+- WebGL2/WebGPU parity where supported.

--- a/.agents/skills/build-hilo3d-games/references/public-api.md
+++ b/.agents/skills/build-hilo3d-games/references/public-api.md
@@ -1,0 +1,302 @@
+# Hilo3D 2.0.0 public API
+
+This is a task-oriented map, not a replacement for the installed declarations. When exact types
+matter, inspect `node_modules/hilo3d/dist/Hilo3d.d.ts`.
+
+## Contents
+
+- [Imports and initialization](#imports-and-initialization)
+- [Scene graph](#scene-graph)
+- [Stage and cameras](#stage-and-cameras)
+- [Loop and time](#loop-and-time)
+- [Geometry](#geometry)
+- [Materials](#materials)
+- [Lights](#lights)
+- [Textures and loaders](#textures-and-loaders)
+- [2D](#2d)
+- [Math](#math)
+- [Renderer-level features](#renderer-level-features)
+
+## Imports and initialization
+
+Use the package root:
+
+```ts
+import * as Hilo3d from 'hilo3d';
+```
+
+The package is ESM-only. Create rendering entry points asynchronously:
+
+```ts
+const stage = await Hilo3d.Stage.create({
+    backend: 'auto',
+    container,
+    width,
+    height,
+    camera
+});
+
+const renderer = await Hilo3d.Renderer.create({
+    backend: 'webgl2',
+    domElement: canvas
+});
+```
+
+Prefer `Stage` for games because it owns the scene root, cameras, renderer, DOM picking, update
+traversal, resize, and teardown.
+
+## Scene graph
+
+`Node` is the base of scene objects.
+
+Common constructor fields:
+
+- identity and data: `name`, `userData`;
+- transform: `x`, `y`, `z`, `scaleX/Y/Z`, `rotationX/Y/Z`, `pivotX/Y/Z`;
+- behavior: `visible`, `layer`, `pointerEnabled`, `pointerChildren`, `useHandCursor`, `onUpdate`;
+- hierarchy: `parent`.
+
+Common methods:
+
+```ts
+parent.addChild(child);
+parent.removeChild(child);
+child.addTo(parent);
+child.removeFromParent();
+child.setPosition(x, y, z);
+child.setScale(uniformScale);
+child.setRotation(xDegrees, yDegrees, zDegrees);
+child.lookAt(target);
+child.on(type, listener);
+child.off(type, listener);
+```
+
+Use `Node` containers to group transforms and game entities. Share render resources across many
+`Mesh` or `Sprite` instances.
+
+`Mesh` combines a `Geometry` and `Material`:
+
+```ts
+const mesh = new Hilo3d.Mesh({
+    geometry,
+    material,
+    useInstanced: false,
+    frustumTest: true,
+    layer: 1
+});
+```
+
+Destroy a standalone mesh with a renderer:
+
+```ts
+mesh.destroy(stage.renderer, true);
+```
+
+The second argument destroys its textures. Use it only when those textures are not shared.
+Destroying the whole `Stage` is the normal application teardown.
+
+## Stage and cameras
+
+Useful Stage options include:
+
+- `backend: 'auto' | 'webgl2' | 'webgpu'`;
+- `container` or `canvas`;
+- `camera` for one camera or `cameras` for a composition;
+- `width`, `height`, `pixelRatio`;
+- `clearColor`, `alpha`, `depth`, `stencil`, `antialias`;
+- `useInstanced`, `useLogDepth`, `gameMode`.
+
+Useful methods:
+
+```ts
+stage.tick(dtMilliseconds);
+stage.resize(width, height, pixelRatio?);
+stage.setCameras(cameras);
+stage.addCamera(camera);
+stage.removeCamera(camera);
+stage.enableDOMEvent(['pointerdown', 'pointermove', 'pointerup']);
+stage.getMeshResultAtPoint(x, y, true);
+stage.releaseGPUResources();
+stage.destroy();
+```
+
+Camera fields shared by 2D and 3D:
+
+- `visibility`: layer bit mask;
+- `priority`: lower values render first;
+- `clearColor`, `clearDepth`, `clearStencil`.
+
+Create 3D cameras with:
+
+```ts
+const camera = new Hilo3d.PerspectiveCamera({
+    fov: 50,
+    aspect: width / height,
+    near: 0.1,
+    far: 200,
+    z: 6
+});
+```
+
+Create pixel-space 2D cameras with:
+
+```ts
+const camera = new Hilo3d.Camera2D({
+    width,
+    height,
+    priority: 100,
+    visibility: Hilo3d.DEFAULT_2D_LAYER,
+    clearColor: false
+});
+```
+
+`Camera2D` uses a top-left origin, right-growing X, and down-growing Y. Call
+`camera.resize(width, height)` after Stage resize.
+
+## Loop and time
+
+`Ticker` dispatches millisecond deltas:
+
+```ts
+const ticker = new Hilo3d.Ticker(60);
+ticker.addTick(gameSimulation);
+ticker.addTick(Hilo3d.Tween);
+ticker.addTick(Hilo3d.Animation);
+ticker.addTick(stage);
+ticker.start();
+```
+
+Other useful methods are `removeTick`, `pause`, `resume`, `stop`, `nextTick`, `timeout`, and
+`interval`. `pause()` suppresses callbacks without discarding the loop; `stop()` cancels it.
+
+## Geometry
+
+Built-in geometry:
+
+```ts
+new Hilo3d.BoxGeometry({ width: 1, height: 1, depth: 1 });
+new Hilo3d.SphereGeometry({ radius: 0.5, widthSegments: 32, heightSegments: 16 });
+new Hilo3d.PlaneGeometry({ width: 2, height: 2 });
+```
+
+Use `Geometry` and `GeometryData` for custom attributes and indices. Reuse one geometry for objects
+with the same topology. Do not recreate geometry during animation.
+
+## Materials
+
+Use `PBRMaterial` for physically based 3D:
+
+```ts
+const material = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.2, 0.65, 1),
+    metallic: 0.2,
+    roughness: 0.55,
+    castShadows: true,
+    receiveShadows: true
+});
+```
+
+Important PBR inputs include `baseColorMap`, `metallicRoughnessMap`, `normalMap`, `occlusionMap`,
+`emission`, `emissionFactor`, `diffuseEnvMap`, `specularEnvMap`, `brdfLUT`, and clearcoat fields.
+
+Use `BasicMaterial` for unlit, Lambert, Phong, or Blinn-Phong rendering:
+
+```ts
+new Hilo3d.BasicMaterial({
+    lightType: 'NONE',
+    diffuse: new Hilo3d.Color(1, 0.4, 0.1),
+    transparent: true
+});
+```
+
+Material controls include `renderOrder`, `transparent`, `transparency`, `alphaCutoff`, `depthTest`,
+`depthMask`, `cullFace`, `side`, `blend`, `castShadows`, and `receiveShadows`.
+
+Use `ShaderMaterial` only when built-in materials cannot express the effect. Portable raster shaders
+use GLSL ES 3.00 and registered std140 uniform blocks; classic numeric uniforms are not a portable
+extension point.
+
+## Lights
+
+Common lights:
+
+```ts
+new Hilo3d.AmbientLight({ color, amount: 0.5 });
+new Hilo3d.DirectionalLight({ color, amount: 3, direction });
+new Hilo3d.PointLight({ color, amount: 5, range: 12 });
+new Hilo3d.SpotLight({ color, amount: 8, range: 20 });
+new Hilo3d.AreaLight({ color, amount: 2 });
+```
+
+Directional, point, and spot lights support shadow configuration. Shadows consume passes and texture
+memory; add them selectively.
+
+## Textures and loaders
+
+Load an image as a texture:
+
+```ts
+const texture = await new Hilo3d.TextureLoader().load({
+    src: new URL('./assets/player.png', import.meta.url).href,
+    flipY: true
+});
+```
+
+Or load the image and configure the texture explicitly:
+
+```ts
+const image = await new Hilo3d.BasicLoader().loadImg(url);
+const texture = new Hilo3d.Texture({
+    image,
+    flipY: true,
+    premultiplyAlpha: true,
+    minFilter: Hilo3d.constants.webgl.LINEAR,
+    magFilter: Hilo3d.constants.webgl.LINEAR
+});
+```
+
+Other public loaders include `GLTFLoader`, `HDRLoader`, `KTXLoader`, `CubeTextureLoader`,
+`LoadQueue`, and `Loader`.
+
+Load glTF:
+
+```ts
+const model = await new Hilo3d.GLTFLoader().load({ src: modelUrl });
+await model.ready;
+model.node.addTo(stage);
+model.anim?.play();
+```
+
+The result exposes `node`, `scene`, `meshes`, `cameras`, `lights`, `textures`, `materials`, optional
+`anim` and `bounds`, `ready`, and `resourceErrors`.
+
+## 2D
+
+Core 2D types are `Camera2D`, `Sprite`, `SpriteFrame`, `SpriteMaterial`, and `Text2D`. See
+[2D games](2d-games.md) for complete patterns.
+
+## Math
+
+Common public math types include `Color`, `Vector2`, `Vector3`, `Vector4`, `Euler`, `Quaternion`,
+`Matrix3`, `Matrix4`, `Ray`, `Plane`, `Sphere`, and `Frustum`.
+
+Reuse temporary math instances inside hot loops:
+
+```ts
+const velocity = new Hilo3d.Vector3();
+const target = new Hilo3d.Vector3();
+```
+
+## Renderer-level features
+
+The Stage exposes `stage.renderer`. Public renderer features include:
+
+- `backend`, `renderInfo`, and `resourceManager.getDiagnostics(...)`;
+- `renderFrame(...)` for application-owned multi-pass work;
+- `createRenderTarget(...)` and `createStorageBuffer(...)`;
+- `renderToTarget(...)`, `present(...)`, and `waitForIdle()`;
+- checked native extensions through `getExtension(...)`;
+- `releaseGPUResources()` and `destroy()`.
+
+Stay at Stage/scene level unless the game genuinely needs render targets, post-processing, readback,
+compute, storage buffers, or custom pipeline orchestration.

--- a/.agents/skills/build-hilo3d-games/references/rendering-performance.md
+++ b/.agents/skills/build-hilo3d-games/references/rendering-performance.md
@@ -1,0 +1,205 @@
+# Rendering and performance
+
+## Contents
+
+- [Backend policy](#backend-policy)
+- [Compose 3D and 2D in one Stage](#compose-3d-and-2d-in-one-stage)
+- [Control draw calls](#control-draw-calls)
+- [Manage transparency](#manage-transparency)
+- [Use render targets and post-processing only when needed](#use-render-targets-and-post-processing-only-when-needed)
+- [Portable custom shaders](#portable-custom-shaders)
+- [WebGPU-only compute](#webgpu-only-compute)
+- [Texture and asset performance](#texture-and-asset-performance)
+- [Diagnose rendering problems](#diagnose-rendering-problems)
+
+## Backend policy
+
+Default to:
+
+```ts
+backend: 'auto';
+```
+
+`auto` probes WebGPU capability first and selects WebGL2 when unavailable. Once WebGPU is selected,
+later initialization, shader, pipeline, or resource errors remain visible; they are not fallback
+signals.
+
+Use explicit `webgpu` when the feature genuinely requires compute, storage resources, indirect
+drawing, or another WebGPU-only capability. Use explicit `webgl2` for compatibility testing or
+WebGL2-only canvas behavior.
+
+For a development query:
+
+```ts
+function backendFromUrl(): Hilo3d.StageBackend {
+    const backend = new URL(location.href).searchParams.get('backend');
+    return backend === 'webgpu' || backend === 'webgl2' ? backend : 'auto';
+}
+```
+
+## Compose 3D and 2D in one Stage
+
+Use layers and camera priorities:
+
+```ts
+const WORLD_LAYER = 1;
+const worldCamera = new Hilo3d.PerspectiveCamera({
+    aspect: width / height,
+    visibility: WORLD_LAYER,
+    priority: 0,
+    clearColor: true,
+    z: 6
+});
+const uiCamera = new Hilo3d.Camera2D({
+    width,
+    height,
+    visibility: Hilo3d.DEFAULT_2D_LAYER,
+    priority: 100,
+    clearColor: false
+});
+
+const stage = await Hilo3d.Stage.create({
+    cameras: [worldCamera, uiCamera],
+    width,
+    height
+});
+```
+
+The collection predicate is:
+
+```ts
+(camera.visibility & node.layer) !== 0;
+```
+
+Normal 3D nodes default to layer bit 0 (`1`). Sprites and Text2D default to bit 1
+(`DEFAULT_2D_LAYER`). Set lights to the world layer so the UI is not considered part of 3D lighting.
+
+Later cameras normally clear depth/stencil while loading prior color. Preserve prior depth only when
+a real effect needs it; multi-camera preservation can force single-sample attachments.
+
+## Control draw calls
+
+Prioritize:
+
+1. reuse geometry and material identity;
+2. atlas 2D art;
+3. use instancing for repeated meshes or sprites;
+4. reduce material variants and transparency layers;
+5. keep lights and shadow casters bounded;
+6. cull or pool offscreen and inactive entities;
+7. update existing typed arrays and objects.
+
+Do not create new `Color`, `Vector`, arrays, descriptors, materials, or geometries inside per-frame
+loops without a measured reason.
+
+Track steady-state behavior with:
+
+```ts
+const info = stage.renderer.renderInfo;
+const diagnostics = stage.renderer.resourceManager.getDiagnostics(stage);
+console.log(info, diagnostics);
+```
+
+Use diagnostics during development, not as a per-frame production HUD.
+
+## Manage transparency
+
+Transparent objects require ordering and often cost overdraw. Prefer:
+
+- opaque rendering when possible;
+- alpha cutoff for hard-edged sprites, leaves, and fences;
+- fewer large transparent layers;
+- explicit `renderOrder` for semantic UI layers;
+- premultiplied alpha textures and matching material policy.
+
+Do not use `renderOrder` to hide incorrect depth or blend configuration.
+
+## Use render targets and post-processing only when needed
+
+For offscreen rendering:
+
+```ts
+const target = renderer.createRenderTarget({
+    width: renderer.width,
+    height: renderer.height
+});
+renderer.renderToTarget(target, scene, camera);
+```
+
+Resize persistent targets with the viewport and call `target.destroy()` during teardown. Compose
+multiple renderer operations inside `renderer.renderFrame(...)` when they belong to one application
+frame.
+
+Stay with the default Stage path for ordinary games. Custom render pipelines, readback, multiple
+targets, and post-processing add lifecycle and validation responsibilities.
+
+## Portable custom shaders
+
+Portable raster shader source is GLSL ES 3.00. Use:
+
+- `in`/`out`;
+- `texture()`;
+- explicit fragment outputs;
+- std140 uniform blocks for numeric data;
+- samplers outside blocks.
+
+Do not add hand-authored parallel WGSL for portable raster effects. WebGPU translation is handled by
+Hilo3D.
+
+Use `ShaderMaterial` for deliberate custom effects. Prefer built-in PBR or Basic materials for
+common surface work so batching, shadows, semantics, and backend parity remain reliable.
+
+## WebGPU-only compute
+
+`ComputeShader`, `ComputeKernel`, storage buffers, compute passes, storage-aware raster, and
+GPU-driven draws are advanced WebGPU-only features. Before choosing them:
+
+- prove a CPU or portable raster solution is insufficient;
+- request `backend: 'webgpu'` or explicit required features;
+- provide a clear unsupported-device result;
+- keep gameplay correctness independent from decorative compute when possible;
+- validate on real WebGPU, not only type checks.
+
+Do not simulate missing WebGPU compute through an unrelated hidden fallback and call it equivalent.
+
+## Texture and asset performance
+
+- Use power-of-two atlases when mipmapping and repeat behavior benefit from them.
+- Set filters and wrapping intentionally.
+- Use `premultiplyAlpha: true` for compatible translucent sprite art.
+- Cap large texture dimensions for mobile-class devices.
+- Prefer glTF/GLB for 3D scene delivery.
+- Load independent assets concurrently and release unused resources.
+- Avoid changing texture dimensions or sources every frame.
+- Use `Text2D` for low-frequency label changes, not per-particle text.
+
+## Diagnose rendering problems
+
+When the canvas is blank:
+
+1. await Stage creation and asset readiness;
+2. inspect console errors instead of swallowing them;
+3. verify camera position, near/far planes, and object scale;
+4. confirm `(camera.visibility & node.layer) !== 0`;
+5. confirm a material and geometry exist;
+6. add ambient plus directional light for PBR;
+7. test a known unlit BasicMaterial;
+8. inspect backend selection and renderer diagnostics;
+9. test explicit WebGL2 and WebGPU separately.
+
+When picking fails:
+
+1. enable the exact DOM event;
+2. verify `pointerEnabled`;
+3. verify camera layer visibility;
+4. update Stage DOM viewport after layout changes;
+5. confirm no higher-priority camera intercepts the hit.
+
+When performance degrades:
+
+1. compare draw and resource counts before and after;
+2. look for per-frame allocations or resource creation;
+3. count unique materials and textures;
+4. inspect transparency and shadow passes;
+5. check device pixel ratio and canvas size;
+6. profile CPU simulation separately from GPU rendering.

--- a/.agents/skills/build-hilo3d-games/references/starter-generator.md
+++ b/.agents/skills/build-hilo3d-games/references/starter-generator.md
@@ -1,0 +1,67 @@
+# Starter generator
+
+Use `scripts/create-hilo3d-game.mjs` to create a standalone strict TypeScript and Vite project. The
+generated project queries published Hilo3D versions, prefers exact `2.0.0`, and otherwise uses the
+highest exact `2.0.0-alpha.N`. It does not read from a Hilo3D repository checkout.
+
+## Commands
+
+```sh
+node <skill-root>/scripts/create-hilo3d-game.mjs \
+  --type 3d \
+  --name crystal-runner \
+  --output ./crystal-runner
+```
+
+Options:
+
+| Option           | Required | Values                                              |
+| ---------------- | -------- | --------------------------------------------------- |
+| `--type`         | Yes      | `2d`, `3d`, or `hybrid`                             |
+| `--name`         | Yes      | npm-compatible project name                         |
+| `--output`       | Yes      | New or empty destination directory                  |
+| `--hilo-version` | No       | `auto` (default), `2.0.0`, or exact `2.0.0-alpha.N` |
+| `--registry`     | No       | Registry URL for automatic version lookup           |
+
+In `auto` mode, the generator queries `https://registry.npmjs.org/`. It uses stable `2.0.0` as soon
+as that version exists; before then it selects the numbered alpha with the highest numeric suffix.
+It deliberately ignores 1.x, beta, and release-candidate versions. Use `--registry` for a compatible
+private or mirrored registry, or `--hilo-version` to skip lookup and pin an exact known release.
+
+The generator copies the shared starter files, selects one variant as `src/main.ts`, and omits the
+unused variant sources. It refuses a non-empty destination so it cannot silently overwrite user
+work. It also warns when invoked with Node.js older than 22.22.2; upgrade Node before installing
+dependencies or running the generated game. Startup failures replace the loading status with a
+visible error while preserving the full exception in the developer console.
+
+After generation:
+
+```sh
+cd <output>
+npm install
+npm run dev
+```
+
+Useful scripts:
+
+```sh
+npm run typecheck
+npm run build
+npm run preview
+```
+
+## Adaptation rules
+
+- Preserve the generated exact version until compatibility with another Hilo3D release is verified.
+- Keep `src/main.ts` small while prototyping; split into `game/`, `systems/`, `entities/`, `ui/`,
+  and `assets/` when features become independently testable.
+- Replace generated Canvas textures with local assets using `TextureLoader`, `BasicLoader`, or
+  `GLTFLoader`.
+- Keep URL construction relative to modules:
+
+```ts
+const url = new URL('./assets/player.png', import.meta.url).href;
+```
+
+- Do not use remote CDN imports or global `Hilo3d` variables.
+- Keep one owner for the ticker, resize listener, input listeners, and Stage teardown.

--- a/.agents/skills/build-hilo3d-games/scripts/create-hilo3d-game.mjs
+++ b/.agents/skills/build-hilo3d-games/scripts/create-hilo3d-game.mjs
@@ -115,7 +115,7 @@ async function resolveHiloVersion(requested, registry) {
     try {
         ({ stdout } = await execFileAsync(
             process.platform === 'win32' ? 'npm.cmd' : 'npm',
-            ['view', 'hilo3d', 'versions', '--json', `--registry=${registry}`],
+            ['view', 'hilo3d', 'versions', '--json', '--tag=latest', `--registry=${registry}`],
             { maxBuffer: 1024 * 1024 }
         ));
     } catch (error) {

--- a/.agents/skills/build-hilo3d-games/scripts/create-hilo3d-game.mjs
+++ b/.agents/skills/build-hilo3d-games/scripts/create-hilo3d-game.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import { copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const SKILL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const STARTER_ROOT = join(SKILL_ROOT, 'assets', 'starter');
+const VALID_TYPES = new Set(['2d', '3d', 'hybrid']);
+const PROJECT_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+const MAXIMUM_PROJECT_NAME_LENGTH = 214;
+const MINIMUM_NODE_VERSION = [22, 22, 2];
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+const HILO_STABLE_VERSION = '2.0.0';
+const HILO_ALPHA_PATTERN = /^2\.0\.0-alpha\.(\d+)$/u;
+const execFileAsync = promisify(execFile);
+
+function usage() {
+    return `Create a standalone Hilo3D 2.0.0 game.
+
+Usage:
+  node create-hilo3d-game.mjs --type <2d|3d|hybrid> --name <name> --output <directory> [options]
+
+Options:
+  --hilo-version <version|auto>  Exact 2.0.0/2.0.0-alpha.N, or stable-first lookup (default: auto)
+  --registry <url>               Registry used for automatic lookup (default: npmjs.org)
+
+Example:
+  node create-hilo3d-game.mjs --type hybrid --name orbit-quest --output ./orbit-quest
+`;
+}
+
+function parseArguments(argv) {
+    const options = {};
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+        if (argument === '--help' || argument === '-h') return { help: true };
+        if (
+            argument !== '--type' &&
+            argument !== '--name' &&
+            argument !== '--output' &&
+            argument !== '--hilo-version' &&
+            argument !== '--registry'
+        ) {
+            throw new Error(`Unknown argument: ${argument}\n\n${usage()}`);
+        }
+        const value = argv[index + 1];
+        if (!value || value.startsWith('--')) {
+            throw new Error(`Missing value for ${argument}\n\n${usage()}`);
+        }
+        options[argument.slice(2)] = value;
+        index += 1;
+    }
+    return options;
+}
+
+function compareVersionParts(left, right) {
+    for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+        const difference = (left[index] ?? 0) - (right[index] ?? 0);
+        if (difference !== 0) return difference;
+    }
+    return 0;
+}
+
+function warnForUnsupportedNode() {
+    const current = process.versions.node.split('.').map(Number);
+    if (compareVersionParts(current, MINIMUM_NODE_VERSION) < 0) {
+        process.stderr.write(
+            `Warning: generated Hilo3D projects require Node.js 22.22.2 or newer; current Node is ${process.versions.node}.\n`
+        );
+    }
+}
+
+function validateRegistry(value) {
+    try {
+        const url = new URL(value);
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') throw new Error();
+        return url.href;
+    } catch {
+        throw new Error('--registry must be an absolute HTTP or HTTPS URL');
+    }
+}
+
+function selectPublishedHiloVersion(versions) {
+    if (versions.includes(HILO_STABLE_VERSION)) return HILO_STABLE_VERSION;
+
+    const alphas = versions
+        .map(version => {
+            const match = HILO_ALPHA_PATTERN.exec(version);
+            return match ? { number: Number(match[1]), version } : undefined;
+        })
+        .filter(candidate => candidate !== undefined)
+        .sort((left, right) => right.number - left.number);
+
+    if (alphas[0]) return alphas[0].version;
+    throw new Error(
+        'No compatible hilo3d release is published: expected 2.0.0 or 2.0.0-alpha.N. ' +
+            'Use --hilo-version with an exact prerelease only when it is available from your registry.'
+    );
+}
+
+async function resolveHiloVersion(requested, registry) {
+    if (requested && requested !== 'auto') {
+        if (requested !== HILO_STABLE_VERSION && !HILO_ALPHA_PATTERN.test(requested)) {
+            throw new Error(
+                '--hilo-version must be auto, 2.0.0, or an exact 2.0.0-alpha.N version'
+            );
+        }
+        return requested;
+    }
+
+    let stdout;
+    try {
+        ({ stdout } = await execFileAsync(
+            process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            ['view', 'hilo3d', 'versions', '--json', `--registry=${registry}`],
+            { maxBuffer: 1024 * 1024 }
+        ));
+    } catch (error) {
+        const detail =
+            error && typeof error === 'object' && 'stderr' in error
+                ? String(error.stderr).trim()
+                : '';
+        throw new Error(
+            `Could not query published hilo3d versions from ${registry}.` +
+                (detail ? `\n${detail}` : '') +
+                '\nRetry online or pass --hilo-version with an exact published version.'
+        );
+    }
+
+    let result;
+    try {
+        result = JSON.parse(stdout);
+    } catch {
+        throw new Error(`Registry ${registry} returned invalid JSON for hilo3d versions`);
+    }
+    const versions = Array.isArray(result) ? result : [result];
+    return selectPublishedHiloVersion(versions.filter(value => typeof value === 'string'));
+}
+
+async function directoryExists(path) {
+    try {
+        return (await stat(path)).isDirectory();
+    } catch (error) {
+        if (error && typeof error === 'object' && error.code === 'ENOENT') return false;
+        throw error;
+    }
+}
+
+async function requireEmptyDestination(output) {
+    if (!(await directoryExists(output))) {
+        await mkdir(output, { recursive: true });
+        return;
+    }
+    const entries = await readdir(output);
+    if (entries.length > 0) {
+        throw new Error(`Output directory is not empty: ${output}`);
+    }
+}
+
+async function copy(relativeSource, output, relativeDestination = relativeSource) {
+    const source = join(STARTER_ROOT, relativeSource);
+    const destination = join(output, relativeDestination);
+    await mkdir(dirname(destination), { recursive: true });
+    await copyFile(source, destination);
+}
+
+async function generate(options) {
+    warnForUnsupportedNode();
+    const type = options.type;
+    const name = options.name;
+    const outputValue = options.output;
+    const registry = validateRegistry(options.registry ?? DEFAULT_REGISTRY);
+
+    if (!type || !VALID_TYPES.has(type)) {
+        throw new Error(`--type must be one of: ${[...VALID_TYPES].join(', ')}`);
+    }
+    if (!name || name.length > MAXIMUM_PROJECT_NAME_LENGTH || !PROJECT_NAME_PATTERN.test(name)) {
+        throw new Error(
+            `--name must be a lowercase npm-compatible package name no longer than ${String(MAXIMUM_PROJECT_NAME_LENGTH)} characters`
+        );
+    }
+    if (!outputValue) throw new Error('--output is required');
+
+    const hiloVersion = await resolveHiloVersion(options['hilo-version'], registry);
+    const output = resolve(process.cwd(), outputValue);
+    await requireEmptyDestination(output);
+
+    await Promise.all([
+        copy('index.html', output),
+        copy('tsconfig.json', output),
+        copy('src/style.css', output),
+        copy('src/startup.ts', output),
+        copy('src/vite-env.d.ts', output),
+        copy(`variants/main-${type}.ts`, output, 'src/main.ts')
+    ]);
+
+    const packageTemplate = await readFile(join(STARTER_ROOT, 'package.json'), 'utf8');
+    const packageJson = packageTemplate
+        .replaceAll('__PROJECT_NAME__', name)
+        .replaceAll('__HILO3D_VERSION__', hiloVersion);
+    await writeFile(join(output, 'package.json'), packageJson, 'utf8');
+
+    process.stdout.write(`Created ${type} Hilo3D game with hilo3d@${hiloVersion} at ${output}
+
+Next:
+  cd ${JSON.stringify(output)}
+  npm install
+  npm run dev
+`);
+}
+
+try {
+    const options = parseArguments(process.argv.slice(2));
+    if (options.help) process.stdout.write(usage());
+    else await generate(options);
+} catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    process.exitCode = 1;
+}

--- a/.claude/skills/build-hilo3d-games
+++ b/.claude/skills/build-hilo3d-games
@@ -1,0 +1,1 @@
+../../.agents/skills/build-hilo3d-games

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - Add a portable `build-hilo3d-games` Agent Skill with strict TypeScript/Vite starters for 2D, 3D,
   and hybrid games, stable-first `2.0.0` dependency resolution, focused public-API references, and
   repository checks that keep bundled examples and version-selection behavior valid.
+- Separate the full release gate from npm's publish lifecycle: `npm run release:check` retains the
+  complete validation matrix, while `prepublishOnly` performs only fast deterministic checks before
+  `prepack` builds the tarball, avoiding repeated browser suites and expired publish OTPs.
+- Make the releasable-texture example deterministic by always installing a replacement CPU image
+  before marking the texture for upload, removing a random page error from the WebGL2/WebGPU UI
+  release gate.
 - Add a shared 2D frontend with atlas-backed `Sprite`, `SpriteFrame` sequence animation,
   Canvas-2D-backed `Text2D`, pixel-space `Camera2D`, actual-size sprite pointer hit tests, and
   automatic portable instance batches capped at 128 sprites per draw. Sprite raster uses one GLSL ES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.0.0-alpha.1 (2026-07-25)
 
 ### Breaking changes
 
@@ -17,6 +17,9 @@
 
 ### Changes
 
+- Add a portable `build-hilo3d-games` Agent Skill with strict TypeScript/Vite starters for 2D, 3D,
+  and hybrid games, stable-first `2.0.0` dependency resolution, focused public-API references, and
+  repository checks that keep bundled examples and version-selection behavior valid.
 - Add a shared 2D frontend with atlas-backed `Sprite`, `SpriteFrame` sequence animation,
   Canvas-2D-backed `Text2D`, pixel-space `Camera2D`, actual-size sprite pointer hit tests, and
   automatic portable instance batches capped at 128 sprites per draw. Sprite raster uses one GLSL ES
@@ -132,7 +135,7 @@
   buffer-range validation paths static, removing draw-count-amplified hot-path allocations without
   weakening the backend validation contract.
 
-# 2.0.0 (2026-07-14)
+## Earlier 2.0.0 development baseline (2026-07-14)
 
 ### Breaking changes
 

--- a/documentation/ENGINEERING_MODERNIZATION.md
+++ b/documentation/ENGINEERING_MODERNIZATION.md
@@ -1,6 +1,6 @@
 # Hilo3d 现代前端工程改造记录
 
-状态：已完成 · 目标版本：2.0.0 · 最后核验：2026-07-18
+状态：已完成 · 目标版本：2.0.0 · 最后核验：2026-07-25
 
 范围：源码、示例、测试、构建、类型声明、API 文档、站点、npm 包、CI 与发布流程
 
@@ -36,8 +36,11 @@
   2-only，三个 compute/GPU-driven/path-tracing 页面明确 WebGPU-only，并对适用后端执行确定性视觉、交互、后处理与拾取门禁；真实 WebGPU
   adapter/device/pipeline fixture 作为额外的深度验收，而不是 WebGPU 唯一覆盖。
 - 类型声明、TypeDoc API 页面和 API Extractor 签名报告全部从同一份已检查源码生成。
-- npm 发布物按真实 tarball 校验，而不是只检查仓库内文件；本地/发布使用 `npm run validate`
-  执行完整双后端浏览器矩阵。默认 hosted
+- npm 发布物按真实 tarball 校验，而不是只检查仓库内文件；CI 与候选版本使用
+  `npm run validate`（或等价别名
+  `npm run release:check`）执行完整双后端浏览器矩阵。npm发布生命周期只执行快速、确定性的
+  `publish:check`，再由 `prepack`
+  构建 tarball，避免在 OTP 已生成后重新运行高成本浏览器矩阵。默认 hosted
   CI 把等价的 portable 门禁拆成预检、coverage、RHI、包/API/文档和四个隔离的 WebGL 2
   presentation/UI/视觉分片；WebGPU native/offscreen RHI 保持独立进程，non-evidence portable
   benchmark smoke 则由按性能路径、定时或手动触发的独立工作流执行。
@@ -898,8 +901,8 @@ job 验证。
 WebGPU 由独立 RHI job 中的 native/offscreen SwiftShader
 lane 验证 adapter、device、pipeline、draw、submit、readback 与 backend contract。GitHub hosted
 Linux 不稳定的 WebGPU canvas presentation 不作为虚假的合并门禁；完整双后端页面/视觉矩阵仍由本地
-`npm run validate` 与手动 physical-GPU workflow 负责。串行的 `npm run validate:ci`
-保留为 hosted 门禁的本地复现入口，过期任务由 concurrency 自动取消。
+`npm run validate`、`npm run release:check` 与手动 physical-GPU workflow 负责。串行的
+`npm run validate:ci` 保留为 hosted 门禁的本地复现入口，过期任务由 concurrency 自动取消。
 
 Portable RHI benchmark smoke 只以单 draw 生产场景验证 fixture、allocation
 profiler、readback 和当前 RHI 路径。它不属于普通合并门禁；独立 workflow 仅在 benchmark/performance 路径变化、每日定时或手动触发时运行 WebGL
@@ -992,6 +995,24 @@ corpus 与真实 WebGPU pipeline 互为补充。
       uniform 有自动测试。
 - [x] 旧构建、测试、文档生成和运行时 vendor 链路已删除。
 - [x] CI 只验证固定的最低 Node 22.22.2 档位，发布前复用同一完整门禁。
+
+## npm 发布生命周期
+
+完整候选版本验收与实际 npm 上传分成两个阶段：
+
+```sh
+npm run release:check
+npm publish --tag next --access public --otp=<current-otp>
+```
+
+`release:check` 是完整 `validate`
+的显式别名，仍执行全部单元、覆盖率、RHI、浏览器、视觉、文档、API 和包消费门禁。它应在 CI 通过的提交上、生成发布 OTP 之前完成。
+
+`npm publish` 的 `prepublishOnly` 只运行 `publish:check`：现代性门禁与 Hilo3D Skill 回归。随后
+`prepack` 从当前源码重新构建 JS、source
+map 和声明。这个轻量生命周期不会重复 coverage 或 Playwright 矩阵，也不替代
+`release:check`；它只防止上传阶段重新引入明显的源码、Skill 或构建错误。正式版使用对应的稳定 dist-tag，2.0.0
+prerelease 使用 `next`，不得让 prerelease 覆盖 `latest`。
 
 ## 后续维护规则
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -5,6 +5,7 @@ import tseslint from 'typescript-eslint';
 
 export default defineConfig(
     globalIgnores([
+        '.agents/skills/**/assets/**',
         '.cache/**',
         'coverage/**',
         'dist/**',

--- a/examples/texture_image_release.ts
+++ b/examples/texture_image_release.ts
@@ -72,9 +72,7 @@ setInterval(function () {
             if (!(img instanceof HTMLImageElement)) {
                 throw new TypeError('Replacement texture request did not return an image');
             }
-            if (Math.random() < 0.5) {
-                texture.image = img;
-            }
+            texture.image = img;
             texture.needUpdate = true;
         })
         .catch((error: unknown) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilo3d",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilo3d",
-      "version": "2.0.0",
+      "version": "2.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.4.4",

--- a/package.json
+++ b/package.json
@@ -81,10 +81,12 @@
     "site:build:built": "npm run docs:build:built && npm run examples:build && jiti scripts/build-site.ts && npm run site:check:links",
     "site:check:links": "jiti scripts/check-site-links.ts",
     "pack:check": "npm pack --dry-run --ignore-scripts",
+    "publish:check": "npm run check:modernity && npm run test:skill",
+    "release:check": "npm run validate",
     "validate": "npm run clean && npm run check:modernity && npm run format:check && npm run lint && npm run typecheck && npm run test:skill && npm run test:coverage && npm run test:rhi && npm run test:rhi-benchmark-contract && npm run build && npm run test:types && npm run test:browser && npm run examples:build && npm run docs:check:built && npm run api:check:built && npm run test:package:built && npm run pack:check",
     "validate:ci": "npm run clean && npm run check:modernity && npm run format:check && npm run lint && npm run typecheck:ci && npm run test:skill && npm run test:rhi-benchmark-contract && npm run test:coverage && npm run test:rhi && npm run build && npm run test:types && npm run test:browser:ci && npm run examples:build && npm run docs:check:built && npm run api:check:built && npm run test:package:built && npm run pack:check",
     "prepack": "npm run build",
-    "prepublishOnly": "npm run validate"
+    "prepublishOnly": "npm run publish:check"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilo3d",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "A TypeScript-first 3D engine with explicit WebGL 2 and WebGPU backends.",
   "type": "module",
   "types": "./dist/Hilo3d.d.ts",
@@ -41,6 +41,7 @@
     "format:check": "prettier --check .",
     "test": "npm run test:unit",
     "test:unit": "vitest run",
+    "test:skill": "jiti scripts/check-hilo3d-skill.ts",
     "test:rhi": "vitest run --config vitest.rhi.config.ts test/spec/rhi/portable && vitest run --config vitest.rhi-native.config.ts test/spec/rhi/portable/WebGPUBackend.native.test.ts",
     "test:rhi-benchmark-contract": "vitest run --config test/performance/vitest.config.ts",
     "test:rhi-benchmark-smoke": "jiti scripts/performance/smoke-rhi-production-fixture.ts",
@@ -80,8 +81,8 @@
     "site:build:built": "npm run docs:build:built && npm run examples:build && jiti scripts/build-site.ts && npm run site:check:links",
     "site:check:links": "jiti scripts/check-site-links.ts",
     "pack:check": "npm pack --dry-run --ignore-scripts",
-    "validate": "npm run clean && npm run check:modernity && npm run format:check && npm run lint && npm run typecheck && npm run test:coverage && npm run test:rhi && npm run test:rhi-benchmark-contract && npm run build && npm run test:types && npm run test:browser && npm run examples:build && npm run docs:check:built && npm run api:check:built && npm run test:package:built && npm run pack:check",
-    "validate:ci": "npm run clean && npm run check:modernity && npm run format:check && npm run lint && npm run typecheck:ci && npm run test:rhi-benchmark-contract && npm run test:coverage && npm run test:rhi && npm run build && npm run test:types && npm run test:browser:ci && npm run examples:build && npm run docs:check:built && npm run api:check:built && npm run test:package:built && npm run pack:check",
+    "validate": "npm run clean && npm run check:modernity && npm run format:check && npm run lint && npm run typecheck && npm run test:skill && npm run test:coverage && npm run test:rhi && npm run test:rhi-benchmark-contract && npm run build && npm run test:types && npm run test:browser && npm run examples:build && npm run docs:check:built && npm run api:check:built && npm run test:package:built && npm run pack:check",
+    "validate:ci": "npm run clean && npm run check:modernity && npm run format:check && npm run lint && npm run typecheck:ci && npm run test:skill && npm run test:rhi-benchmark-contract && npm run test:coverage && npm run test:rhi && npm run build && npm run test:types && npm run test:browser:ci && npm run examples:build && npm run docs:check:built && npm run api:check:built && npm run test:package:built && npm run pack:check",
     "prepack": "npm run build",
     "prepublishOnly": "npm run validate"
   },
@@ -103,6 +104,10 @@
     "url": "https://github.com/hiloteam/Hilo3d/issues"
   },
   "homepage": "https://hilo3d.js.org",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "engines": {
     "node": ">=22.22.2"
   },

--- a/scripts/check-hilo3d-skill.ts
+++ b/scripts/check-hilo3d-skill.ts
@@ -26,7 +26,9 @@ function localRegistryEnvironment(cache: string): NodeJS.ProcessEnv {
         no_proxy: '127.0.0.1,localhost',
         npm_config_cache: cache,
         npm_config_https_proxy: '',
-        npm_config_proxy: ''
+        npm_config_proxy: '',
+        // `npm publish --tag next` exports this into prepublishOnly scripts.
+        npm_config_tag: 'next'
     };
 }
 

--- a/scripts/check-hilo3d-skill.ts
+++ b/scripts/check-hilo3d-skill.ts
@@ -1,0 +1,417 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+import ts from 'typescript';
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = resolve(import.meta.dirname, '..');
+const skillRoot = join(repositoryRoot, '.agents', 'skills', 'build-hilo3d-games');
+const generator = join(skillRoot, 'scripts', 'create-hilo3d-game.mjs');
+const temporaryDirectories: string[] = [];
+
+interface TestRegistry {
+    close(): Promise<void>;
+    url: string;
+}
+
+function localRegistryEnvironment(cache: string): NodeJS.ProcessEnv {
+    return {
+        ...process.env,
+        NO_PROXY: '127.0.0.1,localhost',
+        no_proxy: '127.0.0.1,localhost',
+        npm_config_cache: cache,
+        npm_config_https_proxy: '',
+        npm_config_proxy: ''
+    };
+}
+
+async function makeTemporaryDirectory(label: string): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), `hilo3d-${label}-`));
+    temporaryDirectories.push(directory);
+    return directory;
+}
+
+async function closeServer(server: Server): Promise<void> {
+    await new Promise<void>((resolveClose, rejectClose) => {
+        server.close(error => {
+            if (error) rejectClose(error);
+            else resolveClose();
+        });
+    });
+}
+
+async function startRegistry(versions: readonly string[]): Promise<TestRegistry> {
+    let registryUrl = '';
+    const server = createServer((request, response) => {
+        if (request.url !== '/hilo3d') {
+            response.writeHead(404, { 'content-type': 'application/json' });
+            response.end(JSON.stringify({ error: 'not_found' }));
+            return;
+        }
+
+        const latest = versions.at(-1) ?? '1.19.1';
+        const packageVersions = Object.fromEntries(
+            versions.map(version => [
+                version,
+                {
+                    name: 'hilo3d',
+                    version,
+                    dist: {
+                        integrity: 'sha512-dGVzdA==',
+                        shasum: '0000000000000000000000000000000000000000',
+                        tarball: `${registryUrl}hilo3d/-/hilo3d-${version}.tgz`
+                    }
+                }
+            ])
+        );
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(
+            JSON.stringify({
+                name: 'hilo3d',
+                'dist-tags': { latest },
+                versions: packageVersions
+            })
+        );
+    });
+
+    await new Promise<void>((resolveListen, rejectListen) => {
+        const reject = (error: Error): void => {
+            rejectListen(error);
+        };
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolveListen();
+        });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        await closeServer(server);
+        throw new Error('The test registry did not expose a TCP address.');
+    }
+    registryUrl = `http://127.0.0.1:${String(address.port)}/`;
+    return {
+        close: () => closeServer(server),
+        url: registryUrl
+    };
+}
+
+async function generate(
+    output: string,
+    registry: string,
+    type: '2d' | '3d' | 'hybrid' = '2d'
+): Promise<void> {
+    const cache = await makeTemporaryDirectory('skill-npm-cache');
+    await execFileAsync(
+        process.execPath,
+        [
+            generator,
+            '--type',
+            type,
+            '--name',
+            `skill-${type}-test`,
+            '--output',
+            output,
+            '--registry',
+            registry
+        ],
+        {
+            cwd: repositoryRoot,
+            env: localRegistryEnvironment(cache)
+        }
+    );
+}
+
+async function walkFiles(directory: string): Promise<string[]> {
+    const entries = await readdir(directory);
+    const files: string[] = [];
+    for (const entry of entries) {
+        const path = join(directory, entry);
+        if ((await stat(path)).isDirectory()) files.push(...(await walkFiles(path)));
+        else files.push(path);
+    }
+    return files;
+}
+
+function parseHilo3dDependency(packageJsonText: string): string {
+    const packageJson: unknown = JSON.parse(packageJsonText);
+    if (
+        typeof packageJson !== 'object' ||
+        packageJson === null ||
+        !('dependencies' in packageJson) ||
+        typeof packageJson.dependencies !== 'object' ||
+        packageJson.dependencies === null ||
+        !('hilo3d' in packageJson.dependencies) ||
+        typeof packageJson.dependencies.hilo3d !== 'string'
+    ) {
+        throw new Error('Generated package.json does not contain a string hilo3d dependency.');
+    }
+    return packageJson.dependencies.hilo3d;
+}
+
+async function checkStructure(): Promise<void> {
+    const files = await walkFiles(skillRoot);
+    const markdownFiles = files.filter(file => file.endsWith('.md'));
+    const skill = await readFile(join(skillRoot, 'SKILL.md'), 'utf8');
+    assert(skill.split('\n').length < 500, 'SKILL.md must stay below 500 lines.');
+    assert.match(skill, /^---\nname: build-hilo3d-games\n/u);
+
+    for (const markdownFile of markdownFiles) {
+        const markdown = await readFile(markdownFile, 'utf8');
+        if (
+            markdownFile.startsWith(join(skillRoot, 'references')) &&
+            markdown.split('\n').length > 100
+        ) {
+            assert(
+                markdown.includes('\n## Contents\n'),
+                `${relative(skillRoot, markdownFile)} needs a table of contents.`
+            );
+        }
+        for (const match of markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/gu)) {
+            const href = match[1];
+            if (!href || href.startsWith('#') || href.startsWith('http')) continue;
+            const fileReference = href.split('#', 1)[0];
+            if (!fileReference) continue;
+            await stat(resolve(dirname(markdownFile), fileReference));
+        }
+    }
+
+    const textFiles = files.filter(file => /\.(?:css|html|json|md|mjs|ts|yaml)$/u.test(file));
+    for (const file of textFiles) {
+        const contents = await readFile(file, 'utf8');
+        const label = relative(skillRoot, file);
+        assert(!contents.includes(repositoryRoot), `${label} contains the checkout path.`);
+        assert(!contents.includes('/Users/'), `${label} contains a user-specific absolute path.`);
+    }
+
+    const openAiMetadata = await readFile(join(skillRoot, 'agents', 'openai.yaml'), 'utf8');
+    assert(openAiMetadata.includes('$build-hilo3d-games'));
+}
+
+async function checkDocumentationContracts(): Promise<void> {
+    const twoDimensional = await readFile(join(skillRoot, 'references', '2d-games.md'), 'utf8');
+    const threeDimensional = await readFile(join(skillRoot, 'references', '3d-games.md'), 'utf8');
+    const rendering = await readFile(
+        join(skillRoot, 'references', 'rendering-performance.md'),
+        'utf8'
+    );
+
+    assert(twoDimensional.includes("typeof event.stopPropagation === 'function'"));
+    assert(threeDimensional.includes('event.hitPoint instanceof Hilo3d.Vector3'));
+    assert(rendering.includes('renderer.renderToTarget(target, scene, camera);'));
+    assert(!rendering.includes('renderer.renderToTarget(scene, camera, target);'));
+}
+
+function checkStrictPublicApiSnippets(): void {
+    const virtualFile = join(repositoryRoot, 'src', '__hilo3d-skill-snippets.ts');
+    const source = `
+import * as Hilo3d from './Hilo3d';
+
+declare const button: Hilo3d.Sprite;
+declare const dragTarget: Hilo3d.Vector2;
+declare const interactable: Hilo3d.Mesh;
+declare const renderer: Hilo3d.Renderer;
+declare const scene: Hilo3d.Node;
+declare const camera: Hilo3d.Camera;
+
+button.on('click', event => {
+    if ('stopPropagation' in event && typeof event.stopPropagation === 'function') {
+        event.stopPropagation();
+    }
+});
+
+button.on('pointerdown', event => {
+    if (
+        'stageX' in event &&
+        typeof event.stageX === 'number' &&
+        'stageY' in event &&
+        typeof event.stageY === 'number'
+    ) {
+        dragTarget.set(event.stageX, event.stageY);
+    }
+});
+
+interactable.on('click', event => {
+    if (!('hitPoint' in event) || !(event.hitPoint instanceof Hilo3d.Vector3)) return;
+    const point = event.hitPoint;
+    void point;
+});
+
+const target = renderer.createRenderTarget({
+    width: renderer.width,
+    height: renderer.height
+});
+renderer.renderToTarget(target, scene, camera);
+target.destroy();
+`;
+    const configPath = join(repositoryRoot, 'tsconfig.lib.json');
+    const config = ts.readConfigFile(configPath, fileName => ts.sys.readFile(fileName));
+    if (config.error) {
+        throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
+    }
+    const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, repositoryRoot);
+    const options: ts.CompilerOptions = {
+        ...parsed.options,
+        noEmit: true
+    };
+    const host = ts.createCompilerHost(options);
+    const defaultFileExists = host.fileExists.bind(host);
+    const defaultGetSourceFile = host.getSourceFile.bind(host);
+    const defaultReadFile = host.readFile.bind(host);
+    host.fileExists = fileName => fileName === virtualFile || defaultFileExists(fileName);
+    host.readFile = fileName => (fileName === virtualFile ? source : defaultReadFile(fileName));
+    host.getSourceFile = (
+        fileName,
+        languageVersionOrOptions,
+        onError,
+        shouldCreateNewSourceFile
+    ) =>
+        fileName === virtualFile
+            ? ts.createSourceFile(fileName, source, languageVersionOrOptions, true)
+            : defaultGetSourceFile(
+                  fileName,
+                  languageVersionOrOptions,
+                  onError,
+                  shouldCreateNewSourceFile
+              );
+
+    const program = ts.createProgram([...parsed.fileNames, virtualFile], options, host);
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+    assert.equal(
+        diagnostics.length,
+        0,
+        ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+            getCanonicalFileName: fileName => fileName,
+            getCurrentDirectory: () => repositoryRoot,
+            getNewLine: () => '\n'
+        })
+    );
+}
+
+async function checkAlphaSelection(): Promise<void> {
+    const registry = await startRegistry([
+        '1.19.1',
+        '2.0.0-alpha.1',
+        '2.0.0-alpha.9',
+        '2.0.0-beta.1',
+        '2.0.0-rc.1'
+    ]);
+    try {
+        const output = join(await makeTemporaryDirectory('skill-alpha'), 'game');
+        await generate(output, registry.url);
+        assert.equal(
+            parseHilo3dDependency(await readFile(join(output, 'package.json'), 'utf8')),
+            '2.0.0-alpha.9'
+        );
+    } finally {
+        await registry.close();
+    }
+}
+
+async function checkStableSelectionAndVariants(): Promise<void> {
+    const registry = await startRegistry(['2.0.0-alpha.99', '2.0.0']);
+    try {
+        for (const type of ['2d', '3d', 'hybrid'] as const) {
+            const output = join(await makeTemporaryDirectory(`skill-${type}`), 'game');
+            await generate(output, registry.url, type);
+            assert.equal(
+                parseHilo3dDependency(await readFile(join(output, 'package.json'), 'utf8')),
+                '2.0.0'
+            );
+            const mainSource = await readFile(join(output, 'src', 'main.ts'), 'utf8');
+            assert(mainSource.includes("import { reportStartupFailure } from './startup';"));
+            await stat(join(output, 'src', 'startup.ts'));
+        }
+    } finally {
+        await registry.close();
+    }
+}
+
+async function checkMissingVersionFailure(): Promise<void> {
+    const registry = await startRegistry(['1.19.1', '2.0.0-beta.1']);
+    try {
+        const output = join(await makeTemporaryDirectory('skill-missing-version'), 'game');
+        const cache = await makeTemporaryDirectory('skill-missing-version-cache');
+        let failure: unknown;
+        try {
+            await execFileAsync(
+                process.execPath,
+                [
+                    generator,
+                    '--type',
+                    '2d',
+                    '--name',
+                    'missing-version-test',
+                    '--output',
+                    output,
+                    '--registry',
+                    registry.url
+                ],
+                {
+                    cwd: repositoryRoot,
+                    env: localRegistryEnvironment(cache)
+                }
+            );
+        } catch (error) {
+            failure = error;
+        }
+        assert(failure && typeof failure === 'object' && 'stderr' in failure);
+        assert(String(failure.stderr).includes('No compatible hilo3d release is published'));
+        await assert.rejects(stat(output), { code: 'ENOENT' });
+    } finally {
+        await registry.close();
+    }
+}
+
+async function checkInvalidProjectNameFailure(): Promise<void> {
+    const output = join(await makeTemporaryDirectory('skill-invalid-name'), 'game');
+    const overlongName = 'a'.repeat(215);
+    let failure: unknown;
+    try {
+        await execFileAsync(
+            process.execPath,
+            [
+                generator,
+                '--type',
+                '2d',
+                '--name',
+                overlongName,
+                '--output',
+                output,
+                '--hilo-version',
+                '2.0.0-alpha.1'
+            ],
+            { cwd: repositoryRoot }
+        );
+    } catch (error) {
+        failure = error;
+    }
+    assert(failure && typeof failure === 'object' && 'stderr' in failure);
+    assert(String(failure.stderr).includes('no longer than 214 characters'));
+    await assert.rejects(stat(output), { code: 'ENOENT' });
+}
+
+async function main(): Promise<void> {
+    try {
+        await checkStructure();
+        await checkDocumentationContracts();
+        checkStrictPublicApiSnippets();
+        await checkAlphaSelection();
+        await checkStableSelectionAndVariants();
+        await checkMissingVersionFailure();
+        await checkInvalidProjectNameFailure();
+        process.stdout.write('Hilo3D skill checks passed.\n');
+    } finally {
+        await Promise.all(
+            temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true }))
+        );
+    }
+}
+
+await main();


### PR DESCRIPTION
## Summary

- add a portable, English `build-hilo3d-games` Agent Skill for Codex, Claude, and compatible skill runners
- bundle strict TypeScript/Vite starters for complete 2D, 3D, and hybrid games, with focused public API and best-practice references
- resolve exact `hilo3d@2.0.0` when available and otherwise the newest numbered `2.0.0-alpha.N`, with an exact-version override
- prepare package metadata for `2.0.0-alpha.1` and add repository regression coverage for the skill

## Validation

- `npm run validate`
- skill quick validation from the official skill-creator tooling
- standalone consumer verification for 2D, 3D, and hybrid starters using a locally packed `hilo3d@2.0.0-alpha.1`: strict TypeScript checks and Vite production builds all passed
- staged credential scan and `git diff --check`

## Notes

- npm publication is intentionally not part of this PR; the maintainer will publish the alpha/release separately
- the registry resolver is stable-first, so consumers automatically use `2.0.0` after it is published and otherwise fall back to the latest compatible alpha
