### PR TITLE
fix(examples): resolve environment assets in production

### DIFF
--- a/examples/shared/defaultEnvironment.ts
+++ b/examples/shared/defaultEnvironment.ts
@@ -1,11 +1,27 @@
 import * as Hilo3d from '../../src/Hilo3d';
 
-const ASSET_DIRECTORY = '../image/environment/ferndale-studio-03';
+const ENVIRONMENT_ASSET_URLS = {
+    'diffuse.rgbd': new URL('../image/environment/ferndale-studio-03/diffuse.rgbd', import.meta.url)
+        .href,
+    'specular.rgbd': new URL(
+        '../image/environment/ferndale-studio-03/specular.rgbd',
+        import.meta.url
+    ).href,
+    'right.jpg': new URL('../image/environment/ferndale-studio-03/right.jpg', import.meta.url).href,
+    'left.jpg': new URL('../image/environment/ferndale-studio-03/left.jpg', import.meta.url).href,
+    'top.jpg': new URL('../image/environment/ferndale-studio-03/top.jpg', import.meta.url).href,
+    'bottom.jpg': new URL('../image/environment/ferndale-studio-03/bottom.jpg', import.meta.url)
+        .href,
+    'front.jpg': new URL('../image/environment/ferndale-studio-03/front.jpg', import.meta.url).href,
+    'back.jpg': new URL('../image/environment/ferndale-studio-03/back.jpg', import.meta.url).href
+} as const;
 const RGBD_MAGIC = 'H3DRGBD1';
 const HEADER_BYTES = 16;
 
-function assetUrl(name: string): string {
-    return new URL(`${ASSET_DIRECTORY}/${name}`, import.meta.url).href;
+type EnvironmentAssetName = keyof typeof ENVIRONMENT_ASSET_URLS;
+
+function assetUrl(name: EnvironmentAssetName): string {
+    return ENVIRONMENT_ASSET_URLS[name];
 }
 
 function expectedPayloadBytes(faceSize: number, levelCount: number): number {
@@ -17,7 +33,9 @@ function expectedPayloadBytes(faceSize: number, levelCount: number): number {
     return bytes;
 }
 
-async function loadRGBDCube(name: string): Promise<Hilo3d.CubeTexture> {
+async function loadRGBDCube(
+    name: Extract<EnvironmentAssetName, `${string}.rgbd`>
+): Promise<Hilo3d.CubeTexture> {
     const url = assetUrl(name);
     const response = await fetch(url);
     if (!response.ok) {
@@ -99,15 +117,14 @@ export async function loadDefaultEnvironmentMaps(): Promise<{
 }
 
 export function loadDefaultSkyboxMap(): Promise<Hilo3d.CubeTexture> {
-    const faceUrl = (name: string): string => assetUrl(`${name}.jpg`);
     return new Hilo3d.CubeTextureLoader().load({
         images: [
-            faceUrl('right'),
-            faceUrl('left'),
-            faceUrl('top'),
-            faceUrl('bottom'),
-            faceUrl('front'),
-            faceUrl('back')
+            assetUrl('right.jpg'),
+            assetUrl('left.jpg'),
+            assetUrl('top.jpg'),
+            assetUrl('bottom.jpg'),
+            assetUrl('front.jpg'),
+            assetUrl('back.jpg')
         ],
         internalFormat: Hilo3d.constants.SRGB8,
         format: Hilo3d.constants.RGB,

--- a/test/ui/example-paths.contract.ts
+++ b/test/ui/example-paths.contract.ts
@@ -161,10 +161,11 @@ describe('example release matrix contract', () => {
             'environment',
             'ferndale-studio-03'
         );
+        const normalizedEnvironmentSource = environmentSource.replaceAll(/\s+/gu, '');
         expect(initializationSource).toContain('loadDefaultEnvironmentMaps()');
         expect(initializationSource).toContain('loadDefaultSkyboxMap()');
         expect(environmentSource).toContain("const RGBD_MAGIC = 'H3DRGBD1'");
-        for (const asset of [
+        const runtimeEnvironmentAssets = [
             'diffuse.rgbd',
             'specular.rgbd',
             'right.jpg',
@@ -172,11 +173,16 @@ describe('example release matrix contract', () => {
             'top.jpg',
             'bottom.jpg',
             'front.jpg',
-            'back.jpg',
-            'README.md'
-        ]) {
+            'back.jpg'
+        ];
+        for (const asset of runtimeEnvironmentAssets) {
             expect(existsSync(join(environmentDirectory, asset)), asset).toBe(true);
+            expect(normalizedEnvironmentSource, asset).toContain(
+                `newURL('../image/environment/ferndale-studio-03/${asset}',import.meta.url)`
+            );
         }
+        expect(existsSync(join(environmentDirectory, 'README.md'))).toBe(true);
+        expect(environmentSource).not.toContain('ASSET_DIRECTORY');
         expect(`${initializationSource}\n${environmentSource}`).not.toMatch(
             /bakedDiffuse_|(?:^|[/_"'])p[xyz]\.jpg|(?:^|[/_"'])n[xyz]\.jpg/u
         );


### PR DESCRIPTION
## Summary

- replace dynamically composed default-environment paths with explicit Vite-analyzable asset URLs
- preserve the existing RGBD and skybox loading behavior while emitting deployable hashed assets
- extend the example release contract to require static URLs for every runtime environment asset

## Root cause

`defaultEnvironment.ts` built the asset path from a separate directory constant and a runtime filename. Vite could not statically analyze that expression, so the production chunk retained `../image/environment/...`. Because the shared chunk is deployed under `/assets/`, the browser requested `/image/environment/...` instead of the files deployed under `/examples/image/...`, causing the GitHub Pages 404.

## Impact

The Quick Start and other examples using the shared default environment can load their diffuse/specular RGBD maps and skybox faces from a production GitHub Pages build.

## Validation

- `npm run test:ui:contract -- test/ui/example-paths.contract.ts`
- `npm run examples:build`
- verified the production `init-*.js` no longer contains the source-relative environment directory and that hashed diffuse/specular RGBD assets are emitted
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`