### PR TITLE
fix(examples): improve mobile PBR layouts

### DIFF
--- a/examples/gltf_material_extensions.ts
+++ b/examples/gltf_material_extensions.ts
@@ -149,12 +149,28 @@ const { stage, renderer, directionLight, ambientLight } = await createExampleCon
 });
 
 presentationRoot.addTo(stage);
-presentationRoot.x = 0.85;
 renderer.clearColor.set(0.003, 0.005, 0.016, 1);
 directionLight.amount = 1.45;
 directionLight.color.set(1, 0.93, 0.86, 1);
 directionLight.direction.set(-0.7, -1, -0.48);
 ambientLight.amount = 0.15;
+
+function layoutPresentation(): void {
+    const width = window.innerWidth;
+    if (width <= 560) {
+        presentationRoot.setScale(0.62);
+        presentationRoot.setPosition(0.3, -0.72, 0);
+    } else if (width <= 900) {
+        presentationRoot.setScale(0.8);
+        presentationRoot.setPosition(0.5, -0.25, 0);
+    } else {
+        presentationRoot.setScale(1);
+        presentationRoot.setPosition(0.85, 0, 0);
+    }
+}
+
+layoutPresentation();
+window.addEventListener('resize', layoutPresentation);
 
 const environment = await loadEnvironmentMaps();
 addEnvironmentSkybox(stage, environment.skyboxMap);

--- a/examples/list.css
+++ b/examples/list.css
@@ -589,6 +589,28 @@ select:focus-visible {
 }
 
 @media (max-width: 620px) {
+    .galleryHeader {
+        gap: 8px;
+        padding-inline: 10px;
+    }
+
+    .brand {
+        gap: 8px;
+    }
+
+    .brandTitle {
+        font-size: 15px;
+        line-height: 1.05;
+    }
+
+    .siteLinks {
+        display: none;
+    }
+
+    .headerActions {
+        gap: 6px;
+    }
+
     .viewerToolbar {
         min-height: 60px;
         padding: 9px 12px;
@@ -610,7 +632,8 @@ select:focus-visible {
     }
 
     .backendControl select {
-        min-width: 100px;
+        min-width: 96px;
+        padding-inline: 9px 26px;
     }
 }
 

--- a/examples/pbr2.ts
+++ b/examples/pbr2.ts
@@ -123,9 +123,12 @@ for (const button of familyButtons) {
 
 function layoutMaterialGrid(): void {
     const width = window.innerWidth;
-    if (width <= 820) {
+    if (width <= 560) {
+        materialRoot.setScale(0.48);
+        materialRoot.setPosition(0.85, -0.82, 0);
+    } else if (width <= 820) {
         materialRoot.setScale(0.62);
-        materialRoot.setPosition(1.35, -0.18, 0);
+        materialRoot.setPosition(1.05, -0.24, 0);
     } else if (width <= 1200) {
         materialRoot.setScale(0.8);
         materialRoot.setPosition(1.85, 0.05, 0);

--- a/examples/pbr_lab.css
+++ b/examples/pbr_lab.css
@@ -253,9 +253,9 @@ body[data-material-family='ceramic'] .familySwatch {
 
 @media (max-width: 820px) {
     .labPanel {
-        top: 14px;
-        left: 14px;
-        width: min(280px, calc(100vw - 28px));
+        top: 12px;
+        left: 12px;
+        width: calc(100vw - 24px);
         padding: 18px;
         border-radius: 17px;
     }
@@ -277,5 +277,28 @@ body[data-material-family='ceramic'] .familySwatch {
     .axisLabel,
     .labHint {
         display: none;
+    }
+
+    .hilo3dStats {
+        display: none !important;
+    }
+}
+
+@media (max-width: 560px) {
+    .labPanel {
+        padding: 16px;
+    }
+
+    .labPanel h1 {
+        font-size: 28px;
+    }
+
+    .familyControls {
+        gap: 6px;
+        margin-top: 13px;
+    }
+
+    .familyControls button {
+        min-height: 36px;
     }
 }

--- a/examples/pbr_layered_materials.ts
+++ b/examples/pbr_layered_materials.ts
@@ -84,12 +84,28 @@ const { stage, renderer, directionLight, ambientLight } = await createExampleCon
 });
 
 galleryRoot.addTo(stage);
-galleryRoot.x = 0.7;
 renderer.clearColor.set(0.003, 0.006, 0.018, 1);
 directionLight.amount = 1.8;
 directionLight.color.set(1, 0.82, 0.65, 1);
 directionLight.direction.set(-0.65, -1, -0.4);
 ambientLight.amount = 0.08;
+
+function layoutGallery(): void {
+    const width = window.innerWidth;
+    if (width <= 560) {
+        galleryRoot.setScale(0.52);
+        galleryRoot.setPosition(0.25, -0.08, 0);
+    } else if (width <= 900) {
+        galleryRoot.setScale(0.72);
+        galleryRoot.setPosition(0.35, 0, 0);
+    } else {
+        galleryRoot.setScale(1);
+        galleryRoot.setPosition(0.7, 0, 0);
+    }
+}
+
+layoutGallery();
+window.addEventListener('resize', layoutGallery);
 
 const environment = await loadEnvironmentMaps();
 addEnvironmentSkybox(stage, environment.skyboxMap);

--- a/examples/pbr_showcase.css
+++ b/examples/pbr_showcase.css
@@ -257,9 +257,9 @@ body {
 
 @media (max-width: 900px) {
     .showcasePanel {
-        top: 14px;
-        left: 14px;
-        width: min(360px, calc(100vw - 28px));
+        top: 12px;
+        left: 12px;
+        width: calc(100vw - 24px);
         padding: 17px;
         border-radius: 17px;
     }
@@ -273,9 +273,9 @@ body {
     }
 
     .featureCards {
-        right: 14px;
-        bottom: 14px;
-        left: 14px;
+        right: 12px;
+        bottom: max(12px, env(safe-area-inset-bottom));
+        left: 12px;
         grid-template-columns: repeat(3, 1fr);
     }
 
@@ -301,7 +301,24 @@ body {
     }
 
     .assetSwitcher {
+        display: flex;
         margin-top: 13px;
+        margin-right: -17px;
+        margin-left: -17px;
+        overflow-x: auto;
+        padding: 0 17px 4px;
+        scroll-padding-inline: 17px;
+        scroll-snap-type: x proximity;
+        scrollbar-color: rgba(142, 184, 255, 0.35) transparent;
+        scrollbar-width: thin;
+    }
+
+    .assetButton {
+        min-width: max-content;
+        min-height: 36px;
+        flex: 0 0 auto;
+        padding-inline: 14px;
+        scroll-snap-align: start;
     }
 
     .assetMeta {
@@ -315,10 +332,16 @@ body {
     }
 
     .featureCards {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(3, minmax(210px, 78vw));
+        overflow-x: auto;
+        padding: 0 2px 4px;
+        scroll-padding-inline: 2px;
+        scroll-snap-type: x proximity;
+        scrollbar-color: rgba(142, 184, 255, 0.35) transparent;
+        scrollbar-width: thin;
     }
 
-    .featureCard:not(:first-child) {
-        display: none;
+    .featureCard {
+        scroll-snap-align: start;
     }
 }

--- a/test/ui/examples.spec.ts
+++ b/test/ui/examples.spec.ts
@@ -337,6 +337,62 @@ test('canonical examples index opens the WebGPU gallery by default', async ({ pa
     );
 });
 
+test('PBR showcase controls remain usable at phone width', async ({ page }) => {
+    await page.setViewportSize({ width: 344, height: 728 });
+    await page.route('**/*.ts', route =>
+        route.fulfill({
+            contentType: 'application/javascript',
+            body: ''
+        })
+    );
+
+    await page.goto('/examples/list.html', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('.siteLinks')).toHaveCSS('display', 'none');
+    const brandBounds = await page.locator('.brand').boundingBox();
+    const backendBounds = await page.locator('.backendControl').boundingBox();
+    if (!brandBounds || !backendBounds) throw new Error('Mobile gallery header is not visible');
+    expect(brandBounds.x + brandBounds.width).toBeLessThanOrEqual(backendBounds.x);
+    expect(backendBounds.x + backendBounds.width).toBeLessThanOrEqual(344);
+
+    await page.goto('/examples/pbr2.html', { waitUntil: 'domcontentloaded' });
+    await page.locator('body').evaluate(body => {
+        const stats = document.createElement('div');
+        stats.className = 'hilo3dStats';
+        body.append(stats);
+    });
+    await expect(page.locator('.hilo3dStats')).toHaveCSS('display', 'none');
+    const labPanelBounds = await page.locator('.labPanel').boundingBox();
+    if (!labPanelBounds) throw new Error('Mobile PBR lab panel is not visible');
+    expect(labPanelBounds.x).toBeGreaterThanOrEqual(0);
+    expect(labPanelBounds.x + labPanelBounds.width).toBeLessThanOrEqual(344);
+
+    await page.goto('/examples/pbr_layered_materials.html', {
+        waitUntil: 'domcontentloaded'
+    });
+    const featureCardLayout = await page.locator('.featureCards').evaluate(element => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        visibleCards: [...element.children].filter(
+            child => getComputedStyle(child).display !== 'none'
+        ).length
+    }));
+    expect(featureCardLayout.scrollWidth).toBeGreaterThan(featureCardLayout.clientWidth);
+    expect(featureCardLayout.visibleCards).toBe(3);
+
+    await page.goto('/examples/gltf_material_extensions.html', {
+        waitUntil: 'domcontentloaded'
+    });
+    const assetSwitcherLayout = await page.locator('.assetSwitcher').evaluate(element => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        visibleButtons: [...element.children].filter(
+            child => getComputedStyle(child).display !== 'none'
+        ).length
+    }));
+    expect(assetSwitcherLayout.scrollWidth).toBeGreaterThan(assetSwitcherLayout.clientWidth);
+    expect(assetSwitcherLayout.visibleButtons).toBe(7);
+});
+
 for (const backend of ['webgl2', 'webgpu'] as const) {
     test(`example gallery discovers every ${backend} page @${backend}`, async ({ page }) => {
         await page.goto(`/examples/list.html?backend=${backend}`, { waitUntil: 'networkidle' });


### PR DESCRIPTION
## Summary

- compact the gallery header at phone widths so navigation and backend selection do not overlap
- resize and reframe the PBR Material Lab, Layered PBR Studio, and Khronos material gallery scenes for portrait viewports
- keep every material and asset control reachable through touch-friendly horizontal scrollers
- hide the Material Lab performance HUD on narrow screens
- add a 344×728 mobile layout regression contract

## Root cause

The three showcases only reduced their DOM panels at narrow breakpoints. Their 3D presentation roots still used desktop framing, the Material Lab diagnostics remained visible, and two mobile control layouts either consumed most of the canvas or hid controls entirely. The shared gallery header also retained secondary site links after switching to its compact layout.

## User impact

Phone-sized viewports now show complete scene compositions without controls or diagnostics obscuring the main content. All material toggles and all seven Khronos asset choices remain accessible.

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:ui:contract`
- `npx playwright test test/ui/examples.spec.ts --project=chromium --grep 'PBR showcase controls remain usable at phone width'`
- `npx playwright test test/ui/examples.spec.ts test/ui/runtime-parity.spec.ts --project=chromium --grep 'pbr2\.html renders through webgpu|Layered PBR studio toggles material lobes on webgpu|Khronos material gallery switches layered glTF assets on webgpu'`
- manual WebGPU visual verification at 344×728 and 390×844 viewports