### PR TITLE
fix(rendering): correct WebGL2 shadow atlas orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
   storage rows, pointer input, and readback. Apply it to Bloom, Color Uber, graph present,
   transmission, ShaderToy, Life Game, the compute particle field, the compute path tracer, and
   built-in material/environment sampling so WebGL 2 and WebGPU retain the same Y orientation.
+- Keep shared Shadow Atlas rectangles in positive top-left coordinates and convert light-space UVs
+  through the portable render-target helper. WebGL 2 no longer samples a vertically mirrored depth
+  atlas that made moving shadows appear to rotate opposite their casters.
 - Correct `SpriteFrame`'s top-left atlas-row offset for `flipY` textures on both backends. Full
   textures were unaffected, but subframes previously selected the vertically opposite source row,
   swapping nine-slice top/bottom pieces and requiring reversed character-direction maps. Use a

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -397,18 +397,21 @@ pass，不创建这些原生对象。
 - fullscreen quad 自身仍以 bottom-left geometry UV 表达，因此 scene/render-target
   sampling 使用不同的
   `hiloRenderTargetUV()`；不能在 vertex、fragment、present 和单个 effect 中重复翻转。
+- Shadow Atlas 的 rect 始终以 top-left 正向 scale/offset 保存；light-space
+  projection 在映射进 rect 前通过同一个 `hiloRenderTargetUV()` 转成 backend-native render-target
+  sampler 坐标。不能把 WebGPU 所需的 V 翻转预先写进共享 LightBlock，否则 WebGL 2 会再次翻转投影。
 - `gl_FragCoord` 是 backend-native 输入。需要 ShaderToy 式 bottom-left screen
   coordinate 时必须把 attachment size 传给
   `hiloBottomLeftFragCoord()`。不依赖方向的随机 dither 可以继续直接使用 native fragment position。
 - compute/storage image 的 row 0 是顶部；compute presenter 只在 storage-row 到 fullscreen native
   UV 的边界转换一次。CPU readback 仍返回 top-to-bottom rows。
 
-这套合同覆盖 ShaderToy、Life Game、Bloom/Color Uber、opaque scene texture transmission、compute
-particles、compute path tracer、普通 glTF 材质与 cube IBL。方向性 fixture 同时验证 WebGL
-2/WebGPU 的 render-target copy、managed 2D texture 和 cube-face
-top/bottom 结果，避免某个 example 修正后另一个路径再次反向。
+这套合同覆盖 ShaderToy、Life Game、Bloom/Color Uber、opaque scene texture transmission、Shadow
+Atlas、compute particles、compute path tracer、普通 glTF 材质与 cube
+IBL。方向性 fixture 同时验证 WebGL 2/WebGPU 的 render-target copy、managed 2D texture、cube-face
+top/bottom 和不对称投影阴影，避免某个 example 修正后另一个路径再次反向。
 
-相关代码：[`portableCoordinates.glsl`](../src/shader/method/portableCoordinates.glsl)、[`uv.frag`](../src/shader/chunk/uv.frag)、[`textureEnvMap.glsl`](../src/shader/method/textureEnvMap.glsl)、[`fullscreen-orientation.ts`](../test/ui/fixtures/fullscreen-orientation.ts)。
+相关代码：[`portableCoordinates.glsl`](../src/shader/method/portableCoordinates.glsl)、[`uv.frag`](../src/shader/chunk/uv.frag)、[`textureEnvMap.glsl`](../src/shader/method/textureEnvMap.glsl)、[`fullscreen-orientation.ts`](../test/ui/fixtures/fullscreen-orientation.ts)、[`shadow-orientation.ts`](../test/ui/fixtures/shadow-orientation.ts)。
 
 ## 4. WebGPU / WebGL 2 双后端如何实现同一合同
 

--- a/src/render/renderer/ShadowAtlasSceneAdapter.ts
+++ b/src/render/renderer/ShadowAtlasSceneAdapter.ts
@@ -76,7 +76,7 @@ export interface ShadowAtlasSceneSlice {
     readonly maxBias: number;
     readonly near: number;
     readonly far: number;
-    /** `[scaleX, scaleY, offsetX, offsetY]`; Y is flipped into the top-left atlas. */
+    /** Top-left atlas rectangle encoded as `[scaleX, scaleY, offsetX, offsetY]`. */
     readonly atlasRect: Float32Array;
 }
 
@@ -946,9 +946,9 @@ export class ShadowAtlasSceneAdapter {
         for (const slice of atlas.slices) {
             const offset = slice.sliceIndex * 4;
             this.#stageLightBlock.atlasRects[offset] = slice.uvRect.width;
-            this.#stageLightBlock.atlasRects[offset + 1] = -slice.uvRect.height;
+            this.#stageLightBlock.atlasRects[offset + 1] = slice.uvRect.height;
             this.#stageLightBlock.atlasRects[offset + 2] = slice.uvRect.x;
-            this.#stageLightBlock.atlasRects[offset + 3] = slice.uvRect.y + slice.uvRect.height;
+            this.#stageLightBlock.atlasRects[offset + 3] = slice.uvRect.y;
         }
     }
 

--- a/src/shader/method/getShadow.glsl
+++ b/src/shader/method/getShadow.glsl
@@ -1,3 +1,5 @@
+#include "./portableCoordinates.glsl"
+
 bool isOutOfRange(vec2 pos) {
     if (pos.x < 0.0 || pos.x > 1.0 || pos.y < 0.0 || pos.y > 1.0) {
         return true;
@@ -18,7 +20,7 @@ float getShadowAtlas(int sliceIndex, float bias, vec3 fragPos, mat4 lightSpaceMa
         return 1.0;
     }
     vec4 atlasRect = u_shadowAtlasRects[sliceIndex];
-    vec2 atlasUV = atlasRect.zw + projection.xy * atlasRect.xy;
+    vec2 atlasUV = atlasRect.zw + hiloRenderTargetUV(projection.xy) * atlasRect.xy;
     vec2 texel = u_shadowAtlasSize.zw;
     vec2 rectEnd = atlasRect.zw + atlasRect.xy;
     vec2 rectMin = min(atlasRect.zw, rectEnd) + texel * 0.5;

--- a/test/spec/renderer/ShadowAtlasSceneAdapter.test.ts
+++ b/test/spec/renderer/ShadowAtlasSceneAdapter.test.ts
@@ -149,7 +149,8 @@ describe.each([
         expectNumbers(result.lightBlock.directionalBiases.subarray(0, 2), [0.002, 0.04]);
         expectNumbers(result.lightBlock.spotBiases.subarray(0, 2), [0.003, 0.06]);
         expectNumbers(result.lightBlock.pointCameraPlanes.subarray(0, 2), [0.25, 25]);
-        expectNumbers(result.slices[0]?.atlasRect ?? [], [1 / 3, -1 / 3, 0, 1 / 3]);
+        expectNumbers(result.slices[0]?.atlasRect ?? [], [1 / 3, 1 / 3, 0, 0]);
+        expectNumbers(result.slices[7]?.atlasRect ?? [], [1 / 3, 1 / 3, 1 / 3, 2 / 3]);
         expect(
             result.slices.every(slice =>
                 Array.from(slice.lightSpaceMatrix.elements).every(value => Number.isFinite(value))

--- a/test/ui/fixtures/shadow-orientation.html
+++ b/test/ui/fixtures/shadow-orientation.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Hilo3d shadow atlas orientation fixture</title>
+        <style>
+            html,
+            body,
+            #stage {
+                width: 96px;
+                height: 96px;
+                margin: 0;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="stage"></div>
+        <script type="module" src="./shadow-orientation.ts"></script>
+    </body>
+</html>

--- a/test/ui/fixtures/shadow-orientation.ts
+++ b/test/ui/fixtures/shadow-orientation.ts
@@ -1,0 +1,183 @@
+import * as Hilo3d from '../../../src/Hilo3d';
+
+const SIZE = 96;
+const requestedBackend = new URL(location.href).searchParams.get('backend');
+if (requestedBackend !== 'webgl2' && requestedBackend !== 'webgpu') {
+    throw new TypeError('Shadow orientation fixture requires backend=webgl2 or backend=webgpu');
+}
+const backend: Hilo3d.RendererBackend = requestedBackend;
+const container = document.querySelector<HTMLElement>('#stage');
+if (!container) throw new Error('Shadow orientation fixture container is missing');
+
+const camera = new Hilo3d.OrthographicCamera({
+    left: -3,
+    right: 3,
+    bottom: -3,
+    top: 3,
+    near: 0.1,
+    far: 20,
+    x: 0,
+    y: 8,
+    z: 0
+});
+camera.up.set(0, 0, -1);
+camera.lookAt(new Hilo3d.Vector3(0, 0, 0));
+
+const stage = await Hilo3d.Stage.create<Hilo3d.RendererBackend>({
+    backend,
+    container,
+    camera,
+    width: SIZE,
+    height: SIZE,
+    pixelRatio: 1,
+    antialias: false,
+    clearColor: new Hilo3d.Color(1, 1, 1)
+});
+
+new Hilo3d.Mesh({
+    rotationX: -90,
+    geometry: new Hilo3d.PlaneGeometry(),
+    material: new Hilo3d.BasicMaterial({
+        lightType: 'LAMBERT',
+        diffuse: new Hilo3d.Color(0.85, 0.85, 0.85),
+        castShadows: false,
+        receiveShadows: true
+    })
+})
+    .setScale(6)
+    .addTo(stage);
+
+new Hilo3d.Mesh({
+    x: -0.9,
+    y: 0.8,
+    z: 0.45,
+    geometry: new Hilo3d.BoxGeometry({ width: 0.8, height: 1.6, depth: 0.6 }),
+    material: new Hilo3d.BasicMaterial({
+        lightType: 'LAMBERT',
+        diffuse: new Hilo3d.Color(0.85, 0.85, 0.85)
+    })
+}).addTo(stage);
+
+new Hilo3d.Mesh({
+    x: 1.25,
+    y: 0.5,
+    z: -0.8,
+    geometry: new Hilo3d.SphereGeometry({
+        radius: 0.5,
+        heightSegments: 24,
+        widthSegments: 32
+    }),
+    material: new Hilo3d.BasicMaterial({
+        lightType: 'LAMBERT',
+        diffuse: new Hilo3d.Color(0.85, 0.85, 0.85)
+    })
+}).addTo(stage);
+
+stage.addChild(
+    new Hilo3d.AmbientLight({
+        color: new Hilo3d.Color(1, 1, 1),
+        amount: 0.22
+    })
+);
+stage.addChild(
+    new Hilo3d.DirectionalLight({
+        color: new Hilo3d.Color(1, 1, 1),
+        amount: 0.9,
+        direction: new Hilo3d.Vector3(-1, -2, -0.5),
+        shadow: {
+            width: 512,
+            height: 512,
+            minBias: 0.001,
+            maxBias: 0.01,
+            cameraInfo: {
+                left: -4,
+                right: 4,
+                bottom: -4,
+                top: 4,
+                near: 0.1,
+                far: 20,
+                x: 5,
+                y: 8,
+                z: 3
+            }
+        }
+    })
+);
+
+const target = stage.renderer.createRenderTarget({
+    width: SIZE,
+    height: SIZE,
+    sampleCount: 1,
+    colorAttachments: [
+        {
+            format: 'rgba8unorm',
+            clearValue: { r: 1, g: 1, b: 1, a: 1 }
+        }
+    ],
+    depthStencilAttachment: { format: 'depth24plus' },
+    label: 'Shadow atlas orientation diagnostics'
+});
+
+stage.renderer.renderToTarget(target, stage, camera);
+const readback = await target.readColorAttachment();
+
+function summarizeDarkPixels(threshold: number): {
+    readonly threshold: number;
+    readonly count: number;
+    readonly centroid: readonly [number, number] | null;
+    readonly bounds: readonly [number, number, number, number] | null;
+} {
+    let count = 0;
+    let sumX = 0;
+    let sumY = 0;
+    let minimumX = SIZE;
+    let minimumY = SIZE;
+    let maximumX = -1;
+    let maximumY = -1;
+    for (let y = 0; y < SIZE; y += 1) {
+        for (let x = 0; x < SIZE; x += 1) {
+            const offset = (y * SIZE + x) * 4;
+            const luminance =
+                ((readback.data[offset] ?? 0) +
+                    (readback.data[offset + 1] ?? 0) +
+                    (readback.data[offset + 2] ?? 0)) /
+                3;
+            if (luminance >= threshold) continue;
+            count++;
+            sumX += x;
+            sumY += y;
+            if (x < minimumX) minimumX = x;
+            if (y < minimumY) minimumY = y;
+            if (x > maximumX) maximumX = x;
+            if (y > maximumY) maximumY = y;
+        }
+    }
+    return {
+        threshold,
+        count,
+        centroid: count === 0 ? null : [sumX / count, sumY / count],
+        bounds: count === 0 ? null : [minimumX, minimumY, maximumX, maximumY]
+    };
+}
+
+const summaries = [40, 80, 120, 160].map(summarizeDarkPixels);
+window.__HILO3D_SHADOW_ORIENTATION_RESULT__ = {
+    backend,
+    summaries
+};
+document.body.dataset['shadowOrientationComplete'] = 'true';
+document.body.dataset['shadowOrientationResult'] = JSON.stringify({ backend, summaries });
+
+declare global {
+    interface Window {
+        __HILO3D_SHADOW_ORIENTATION_RESULT__?: {
+            readonly backend: Hilo3d.RendererBackend;
+            readonly summaries: readonly {
+                readonly threshold: number;
+                readonly count: number;
+                readonly centroid: readonly [number, number] | null;
+                readonly bounds: readonly [number, number, number, number] | null;
+            }[];
+        };
+    }
+}

--- a/test/ui/post-processing.spec.ts
+++ b/test/ui/post-processing.spec.ts
@@ -95,6 +95,49 @@ for (const backend of backends) {
         }
     });
 
+    test(`shadow atlas preserves projected row orientation on ${backend} @${backend}`, async ({
+        page
+    }) => {
+        await installRenderHealthProbe(page);
+        const failures = await installPageFailureMonitor(page);
+        try {
+            await page.goto(`/test/ui/fixtures/shadow-orientation.html?backend=${backend}`, {
+                waitUntil: 'networkidle'
+            });
+            await expect(page.locator('body')).toHaveAttribute(
+                'data-shadow-orientation-complete',
+                'true'
+            );
+            const result = await page.evaluate(() => {
+                const diagnostics = window.__HILO3D_SHADOW_ORIENTATION_RESULT__;
+                if (!diagnostics) throw new Error('Shadow orientation diagnostics are unavailable');
+                return {
+                    backend: diagnostics.backend,
+                    summary: diagnostics.summaries.find(entry => entry.threshold === 80)
+                };
+            });
+
+            expect(result.backend).toBe(backend);
+            expect(result.summary?.count).toBeGreaterThan(250);
+            expect(result.summary?.centroid?.[0]).toBeGreaterThan(30);
+            expect(result.summary?.centroid?.[0]).toBeLessThan(45);
+            expect(result.summary?.centroid?.[1]).toBeGreaterThan(38);
+            expect(result.summary?.centroid?.[1]).toBeLessThan(48);
+            expect(result.summary?.bounds?.[0]).toBeLessThan(20);
+            expect(result.summary?.bounds?.[2]).toBeGreaterThan(65);
+            await assertFinalGraphicsHealth(
+                page,
+                backend,
+                `shadow atlas orientation graphics errors on ${backend}`
+            );
+
+            await page.goto('about:blank');
+            failures.assertEmpty(`shadow atlas orientation failures on ${backend}`);
+        } finally {
+            await failures.dispose();
+        }
+    });
+
     test(`life-game ping-pong accepts public texture updates through ${backend} @${backend}`, async ({
         page
     }) => {


### PR DESCRIPTION
## Summary

- store shared Shadow Atlas rectangles as positive top-left scale/offset values
- convert light-space projection UVs through the portable render-target coordinate helper
- add an asymmetric box+sphere shadow readback fixture for WebGL2 and WebGPU
- document the Shadow Atlas coordinate contract and changelog entry

## Root cause

The shared LightBlock pre-flipped the Shadow Atlas V scale for WebGPU, then the fragment shader sampled that pre-flipped coordinate directly on both backends. WebGL2 already uses bottom-left render-target sampling in this path, so its depth atlas was vertically mirrored and moving shadows appeared to rotate opposite their casters. Other managed-texture, fullscreen render-target, upload, and readback paths already use their portable coordinate helpers; this was isolated to Shadow Atlas mapping.

## Impact

WebGL2 directional, spot, and point shadows now use the same projected orientation as WebGPU without changing global viewport/scissor behavior or adding a backend branch to the shared renderer.

## Validation

- `npx vitest run test/spec/renderer/ShadowAtlasSceneAdapter.test.ts test/spec/renderer/GlslToWgsl.test.ts test/spec/renderer/ShadowAtlasPipelineIntegration.test.ts` — 74 passed
- `npm run typecheck`
- `npm run lint`
- `npm run test:render:architecture` — 130 passed
- `npm run test:rhi` — 209 passed
- targeted shadow Playwright check — 2 passed
- `npm run test:ui:webgl2` — 84 passed
- `npm run test:ui:webgpu` — 86 passed
- `npm run test:webgpu` — 13 passed
- `npm run format:check`
- `npm run docs:check`

The new regression fixture was also verified against the old mapping: WebGL2's dark-region centroid moved to the opposite side while WebGPU remained correct, so the fixture fails on the original bug and passes on the fix.