### PR TITLE
fix(webgpu): stabilize uploads on iOS WebKit

### DIFF
--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -163,6 +163,21 @@ map；每个 Renderer 同时只允许一个 pending storage-buffer readback，�
 writer 重新初始化”。GPU 写入只在有效 submission 后提交内容分歧，后续相同 CPU
 bytes 仍会重新上传，避免 CPU shadow 错误掩盖 GPU 修改。
 
+WebGPU 常规 buffer/texture upload 使用可复用 mapped staging arena。Apple mobile WebKit 的 mapped
+upload 路径存在呈现稳定性问题，因此仅该平台在任何 command-buffer 工作开始前分别改用
+`GPUQueue.writeBuffer` 和 `GPUQueue.writeTexture`。源数据先复制到复用的零偏移 scratch，以保持 frame
+arena 子视图和 texture row
+layout 的字节范围；每个在途 submission 保留独立的高水位 scratch 槽位，fence 完成后才回收，避免后续 UBO、顶点或 cubemap 写入覆盖较早的数据。一旦开始编码 copy、mipmap、render 或 compute 命令，后续写入仍回到 staging
+copy，保留严格的命令顺序。
+
+这是 Apple mobile WebKit 实现兼容路径，不是 WebGPU 标准限制；规范同时定义了
+[immediate queue writes](https://gpuweb.github.io/gpuweb/#copies) 和 mapped `COPY_SRC` staging
+buffer。相关 WebKit 报告包括 iOS 26 的
+[整 canvas 闪烁](https://bugs.webkit.org/show_bug.cgi?id=301627) 和 mapped upload
+[状态处理差异](https://bugs.webkit.org/show_bug.cgi?id=293062)。前者报告在 iOS
+26.4 已修复，但 Hilo3D 在 iOS
+26.5.2 仍复现 upload 数据陈旧或归零，因此不将两者视为已确认的同一根因。
+
 `StorageGraphicsShader` 是独立的 WebGPU-only graphics source contract：vertex/fragment 仍由受控 GLSL
 ES 3.10 storage subset 经统一预处理和 Naga 转为 WGSL，不接受手写 graphics WGSL；首版只允许 readonly
 storage。其 Material/Scene texture reflection 仍保留 2D-array/3D/cube 与 sint/uint 类型表达，但

--- a/src/render/rhi/backends/webgpu/WebGPUCommands.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUCommands.ts
@@ -78,6 +78,8 @@ export function resetWebGPUFrameDiagnostics(target?: RHIFrameDiagnostics): RHIFr
 export interface WebGPUFrameReferences {
     readonly objects: (WebGPUDestroyableObject | null)[];
     count: number;
+    readonly directUploadSources: Uint8Array[];
+    directUploadSourceCount: number;
 }
 
 function validationFailure(
@@ -155,6 +157,7 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
     #contextState: RHICommandContextState = 'open';
     #activePass: WebGPURenderPass | WebGPUComputePass | null = null;
     #externalImageUploadPhase = true;
+    #directUploadPhase: boolean;
     readonly #retainedReferences: WebGPUFrameReferences;
     readonly #uploadAllocation: WebGPUUploadAllocation = { buffer: null, offset: 0 };
 
@@ -167,6 +170,7 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
         super(queue.owner, descriptor.label ?? 'WebGPU frame context');
         this.#nativeEncoder = nativeEncoder;
         this.#retainedReferences = retainedReferences;
+        this.#directUploadPhase = queue.owner.directUploadWorkaround;
         this.frameId = this.id;
         this.diagnostics = resetWebGPUFrameDiagnostics(descriptor.diagnostics);
     }
@@ -191,6 +195,21 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
         validateRHIWriteBuffer(this.owner, destination, destinationOffset, data, dataOffset, size);
         const writeSize = size ?? data.byteLength - dataOffset;
         const nativeDestination = webGPUBuffer(this.owner, destination, 'destination');
+        if (this.#directUploadPhase) {
+            const source = this.queue.sourceBytes(data);
+            const snapshot = this.directUploadSnapshot(source, dataOffset, writeSize);
+            this.queue.nativeHandle.writeBuffer(
+                nativeDestination.nativeHandle,
+                destinationOffset,
+                snapshot.buffer,
+                0,
+                writeSize
+            );
+            this.retain(nativeDestination);
+            this.#externalImageUploadPhase = false;
+            this.recordNativeCommand();
+            return;
+        }
         this.queue.stageUpload(
             data,
             dataOffset,
@@ -210,6 +229,23 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
             writeSize
         );
         this.recordNativeCommand();
+    }
+
+    private directUploadSnapshot(
+        source: Uint8Array,
+        sourceOffset: number,
+        byteLength: number
+    ): Uint8Array {
+        const index = this.#retainedReferences.directUploadSourceCount++;
+        let snapshot = this.#retainedReferences.directUploadSources[index];
+        if (snapshot === undefined || snapshot.byteLength < byteLength) {
+            snapshot = new Uint8Array(byteLength);
+            this.#retainedReferences.directUploadSources[index] = snapshot;
+            this.diagnostics.frameArenaGrowths++;
+            this.diagnostics.transientAllocations++;
+        }
+        snapshot.set(source.subarray(sourceOffset, sourceOffset + byteLength), 0);
+        return snapshot;
     }
 
     writeTexture(
@@ -260,28 +296,12 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
                 }
             }
         }
-        this.queue.stageUpload(
-            repacked,
-            0,
-            stagingSize,
-            this.diagnostics,
-            this.#uploadAllocation,
-            Math.max(4, bytesPerBlock)
-        );
-        const staging = this.#uploadAllocation.buffer;
-        if (staging === null) throw new Error('WebGPU upload arena did not return a buffer');
         const concreteDestination = webGPUTexture(
             this.owner,
             destination.texture,
             'destination.texture'
         );
         this.retain(concreteDestination);
-        this.closeExternalImageUploadPhase();
-        const nativeSource = this.queue.textureUploadSource;
-        nativeSource.buffer = staging;
-        nativeSource.offset = this.#uploadAllocation.offset;
-        nativeSource.bytesPerRow = stagingBytesPerRow;
-        nativeSource.rowsPerImage = blockRows;
         const nativeOrigin = this.queue.textureUploadOrigin;
         nativeOrigin.x = destination.origin?.x ?? 0;
         nativeOrigin.y = destination.origin?.y ?? 0;
@@ -294,6 +314,38 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
         nativeExtent.width = Math.ceil(width / block.blockWidth) * block.blockWidth;
         nativeExtent.height = Math.ceil(height / block.blockHeight) * block.blockHeight;
         nativeExtent.depthOrArrayLayers = depth;
+        if (this.#directUploadPhase) {
+            const snapshot = this.directUploadSnapshot(repacked, 0, stagingSize);
+            this.queue.nativeHandle.writeTexture(
+                nativeDestination,
+                snapshot.buffer,
+                {
+                    offset: 0,
+                    bytesPerRow: stagingBytesPerRow,
+                    rowsPerImage: blockRows
+                },
+                nativeExtent
+            );
+            this.#externalImageUploadPhase = false;
+            this.recordNativeCommand();
+            return;
+        }
+        this.queue.stageUpload(
+            repacked,
+            0,
+            stagingSize,
+            this.diagnostics,
+            this.#uploadAllocation,
+            Math.max(4, bytesPerBlock)
+        );
+        const staging = this.#uploadAllocation.buffer;
+        if (staging === null) throw new Error('WebGPU upload arena did not return a buffer');
+        this.closeExternalImageUploadPhase();
+        const nativeSource = this.queue.textureUploadSource;
+        nativeSource.buffer = staging;
+        nativeSource.offset = this.#uploadAllocation.offset;
+        nativeSource.bytesPerRow = stagingBytesPerRow;
+        nativeSource.rowsPerImage = blockRows;
         this.#nativeEncoder.copyBufferToTexture(nativeSource, nativeDestination, nativeExtent);
         this.recordNativeCommand();
     }
@@ -607,6 +659,7 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
 
     private closeExternalImageUploadPhase(): void {
         this.#externalImageUploadPhase = false;
+        this.#directUploadPhase = false;
     }
 
     private assertOpen(): void {

--- a/src/render/rhi/backends/webgpu/WebGPUDevice.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUDevice.ts
@@ -94,6 +94,16 @@ function webGPUAdapterIsFallback(adapter: GPUAdapter): boolean {
     );
 }
 
+function requiresAppleMobileDirectUploadWorkaround(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const userAgent = navigator.userAgent;
+    if (!userAgent.includes('AppleWebKit')) return false;
+    return (
+        /(?:iPad|iPhone|iPod)/u.test(userAgent) ||
+        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+    );
+}
+
 /** Concrete RHI device: all native API access remains inside this backend directory. */
 export class WebGPUDevice implements RHIDevice, WebGPUObjectOwner {
     readonly id = allocateRHIDeviceId();
@@ -106,6 +116,11 @@ export class WebGPUDevice implements RHIDevice, WebGPUObjectOwner {
     readonly framebufferCacheMetrics = new RHICacheCounter();
     readonly framebufferCache: WebGPUFramebufferCache;
     readonly mipmapGenerator: WebGPUMipmapGenerator;
+    /**
+     * @internal Apple mobile WebKit buffer and texture uploads use the direct queue path as an
+     * implementation workaround, not as a WebGPU portability requirement.
+     */
+    readonly directUploadWorkaround: boolean;
     label: string;
     #generation = 1;
     #destroyed = false;
@@ -129,6 +144,7 @@ export class WebGPUDevice implements RHIDevice, WebGPUObjectOwner {
         this.label = nativeHandle.label;
         this.#lostSignal = createWebGPUDeferred<RHIDeviceLostInfo>();
         this.lost = this.#lostSignal.promise;
+        this.directUploadWorkaround = requiresAppleMobileDirectUploadWorkaround();
         this.graphicsQueue = new WebGPUQueue(this, nativeHandle.queue);
         this.framebufferCache = new WebGPUFramebufferCache(this, this.framebufferCacheMetrics);
         this.mipmapGenerator = new WebGPUMipmapGenerator(this, mipmapShaderArtifacts);

--- a/src/render/rhi/backends/webgpu/WebGPUQueue.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUQueue.ts
@@ -627,6 +627,7 @@ export class WebGPUQueue extends WebGPUObject implements RHIQueue {
             index += 1;
         }
         references.count = 0;
+        references.directUploadSourceCount = 0;
         this.#freeFrameReferences[this.#freeFrameReferenceCount] = references;
         this.#freeFrameReferenceCount += 1;
     }
@@ -695,7 +696,14 @@ export class WebGPUQueue extends WebGPUObject implements RHIQueue {
     }
 
     private acquireFrameReferences(): WebGPUFrameReferences {
-        if (this.#freeFrameReferenceCount === 0) return { objects: [], count: 0 };
+        if (this.#freeFrameReferenceCount === 0) {
+            return {
+                objects: [],
+                count: 0,
+                directUploadSources: [],
+                directUploadSourceCount: 0
+            };
+        }
         this.#freeFrameReferenceCount -= 1;
         const index = this.#freeFrameReferenceCount;
         const references = this.#freeFrameReferences[index];

--- a/test/spec/rhi/portable/WebGPUBackend.test.ts
+++ b/test/spec/rhi/portable/WebGPUBackend.test.ts
@@ -77,6 +77,12 @@ interface NativeHarness {
         readonly dataOffset: number;
         readonly size: number | undefined;
     }[];
+    readonly textureWrites: readonly {
+        readonly destination: GPUTexture;
+        readonly data: AllowSharedBufferSource;
+        readonly dataLayout: GPUTexelCopyBufferLayout;
+        readonly size: GPUExtent3D;
+    }[];
     readonly surfaceConfigurations: GPUCanvasConfiguration[];
     readonly textureCopyExtents: GPUExtent3D[];
     readonly textureCopySources: GPUTexelCopyBufferInfo[];
@@ -112,6 +118,12 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
         readonly data: AllowSharedBufferSource;
         readonly dataOffset: number;
         readonly size: number | undefined;
+    }[] = [];
+    const textureWrites: {
+        readonly destination: GPUTexture;
+        readonly data: AllowSharedBufferSource;
+        readonly dataLayout: GPUTexelCopyBufferLayout;
+        readonly size: GPUExtent3D;
     }[] = [];
     const surfaceConfigurations: GPUCanvasConfiguration[] = [];
     const textureCopyExtents: GPUExtent3D[] = [];
@@ -319,6 +331,25 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
                 `queue.writeBuffer:${destination.label}@${String(destinationOffset)}:${String(byteLength)}`
             );
         },
+        writeTexture: (
+            destination: GPUTexelCopyTextureInfo,
+            data: AllowSharedBufferSource,
+            dataLayout: GPUTexelCopyBufferLayout,
+            size: GPUExtent3D
+        ) => {
+            textureWrites.push({
+                destination: destination.texture,
+                data,
+                dataLayout: { ...dataLayout },
+                size: {
+                    width: extentNumber(size, 'width', 1),
+                    height: extentNumber(size, 'height', 1),
+                    depthOrArrayLayers: extentNumber(size, 'depthOrArrayLayers', 1)
+                }
+            });
+            const origin = destination.origin as GPUOrigin3DDict | undefined;
+            log.push(`queue.writeTexture:${destination.texture.label}@${String(origin?.z ?? 0)}`);
+        },
         copyExternalImageToTexture: (
             source: GPUCopyExternalImageSourceInfo,
             destination: GPUCopyExternalImageDestInfo,
@@ -442,6 +473,7 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
         renderPassDescriptors,
         renderPassCalls,
         bufferWrites,
+        textureWrites,
         surfaceConfigurations,
         textureCopyExtents,
         textureCopySources,
@@ -1320,6 +1352,118 @@ describe('WebGPU RHI native backend', () => {
         ).toHaveLength(1);
 
         device.destroy();
+    });
+
+    it('normalizes Apple mobile direct uploads and preserves later command order', () => {
+        vi.stubGlobal('navigator', {
+            userAgent:
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) AppleWebKit/605.1.15',
+            platform: 'iPhone',
+            maxTouchPoints: 5
+        });
+        try {
+            const harness = createNativeHarness();
+            const device = new WebGPUDevice(harness.device);
+            const source = device.createBuffer({
+                label: 'direct source',
+                size: 4,
+                usage: RHIBufferUsage.COPY_SRC,
+                initialData: new Uint8Array([9, 9, 9, 9])
+            });
+            const uniform = device.createBuffer({
+                label: 'direct uniform destination',
+                size: 12,
+                usage: RHIBufferUsage.COPY_DST | RHIBufferUsage.UNIFORM
+            });
+            const vertex = device.createBuffer({
+                label: 'direct vertex destination',
+                size: 4,
+                usage: RHIBufferUsage.COPY_DST | RHIBufferUsage.VERTEX
+            });
+            const cube = device.createTexture({
+                label: 'direct cube destination',
+                size: { width: 2, height: 2, depthOrArrayLayers: 6 },
+                viewDimension: 'cube',
+                format: 'rgba8unorm',
+                usage: RHITextureUsage.COPY_DST | RHITextureUsage.TEXTURE_BINDING
+            });
+            const arena = new Uint8Array([90, 91, 92, 93, 1, 2, 3, 4, 5, 6, 7, 8]);
+            const textureArena = new Uint8Array([
+                90, 91, 92, 93, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+            ]);
+            harness.log.length = 0;
+
+            const frame = device.graphicsQueue.beginFrame();
+            frame.writeBuffer(uniform, 0, arena.subarray(4, 8));
+            frame.writeBuffer(vertex, 0, arena.subarray(8, 12));
+            frame.writeTexture(
+                { texture: cube, origin: { z: 2 } },
+                textureArena,
+                { offset: 4, bytesPerRow: 8, rowsPerImage: 2 },
+                { width: 2, height: 2 }
+            );
+            frame.copyBufferToBuffer(source, 0, uniform, 4, 4);
+            frame.writeBuffer(uniform, 8, new Uint8Array([10, 11, 12, 13]));
+            frame.writeTexture(
+                { texture: cube, origin: { z: 3 } },
+                new Uint8Array(16),
+                { bytesPerRow: 8, rowsPerImage: 2 },
+                { width: 2, height: 2 }
+            );
+            device.graphicsQueue.endFrame(frame);
+
+            expect(harness.bufferWrites).toHaveLength(2);
+            for (const write of harness.bufferWrites) {
+                expect(write.data).toBeInstanceOf(ArrayBuffer);
+                expect(write.dataOffset).toBe(0);
+                expect(write.size).toBe(4);
+            }
+            expect(harness.bufferWrites[0]?.data).not.toBe(harness.bufferWrites[1]?.data);
+            expect(harness.textureWrites).toHaveLength(1);
+            const textureWrite = harness.textureWrites[0];
+            expect(textureWrite?.destination.label).toBe('direct cube destination');
+            expect(textureWrite?.data).toBeInstanceOf(ArrayBuffer);
+            expect(textureWrite?.dataLayout).toEqual({
+                offset: 0,
+                bytesPerRow: 256,
+                rowsPerImage: 2
+            });
+            expect(textureWrite?.size).toEqual({
+                width: 2,
+                height: 2,
+                depthOrArrayLayers: 1
+            });
+            const textureBytes = new Uint8Array(textureWrite?.data as ArrayBuffer);
+            expect([...textureBytes.subarray(0, 8)]).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+            expect([...textureBytes.subarray(256, 264)]).toEqual([9, 10, 11, 12, 13, 14, 15, 16]);
+            expect(harness.log).toContain('queue.writeBuffer:direct uniform destination@0:4');
+            expect(harness.log).toContain('queue.writeBuffer:direct vertex destination@0:4');
+            expect(harness.log).toContain('queue.writeTexture:direct cube destination@2');
+            const encodedCopy = harness.log.indexOf(
+                'encoder.copyBufferToBuffer:direct source->direct uniform destination'
+            );
+            const stagedWrite = harness.log.indexOf(
+                'encoder.copyBufferToBuffer:WebGPU upload arena->direct uniform destination'
+            );
+            expect(encodedCopy).toBeGreaterThan(
+                harness.log.indexOf('queue.writeBuffer:direct vertex destination@0:4')
+            );
+            expect(stagedWrite).toBeGreaterThan(encodedCopy);
+            expect(
+                harness.log.indexOf(
+                    'encoder.copyBufferToTexture:WebGPU upload arena->direct cube destination'
+                )
+            ).toBeGreaterThan(stagedWrite);
+            expect(harness.log.indexOf('queue.submit')).toBeGreaterThan(stagedWrite);
+            expect([...harness.getBufferBytesForHandle(uniform.nativeHandle)]).toEqual([
+                1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0
+            ]);
+
+            harness.resolveWork();
+            device.destroy();
+        } finally {
+            vi.unstubAllGlobals();
+        }
     });
 
     it('stages a cross-realm ArrayBuffer without same-realm identity assumptions', () => {


### PR DESCRIPTION
## What

- route early-frame buffer and texture uploads through `GPUQueue.writeBuffer` / `GPUQueue.writeTexture` on Apple mobile WebKit only
- retain reusable zero-offset upload snapshots until the submission fence completes
- keep later uploads on the existing staging-copy path after encoded GPU work starts, preserving queue/command ordering
- add portable backend coverage for buffer writes, cubemap texture uploads, row repacking, source lifetime, and the staging fallback
- document the platform scope, standards status, and related upstream WebKit reports

## Why

On an iPhone 17 Pro Max running iOS 26.5.2, WebGPU examples showed full-canvas flicker, frozen-looking interaction, black geometry, and missing diffuse IBL. The same examples were correct with WebGL2, while ShaderToy's continuous animation remained correct.

Device testing narrowed the failures to mapped staging uploads: direct buffer queue writes fixed the flicker/interaction symptoms, and direct texture queue writes fixed cubemap/IBL data that otherwise sampled as zero. The workaround is backend-local and gated to Apple mobile WebKit; desktop and other WebGPU implementations retain the reusable mapped staging arena.

This is an implementation compatibility workaround, not a WebGPU portability rule. The WebGPU specification defines both immediate queue writes and mapped `COPY_SRC` staging buffers. Related upstream evidence includes:

- WebKit #301627: iOS 26 full-canvas WebGPU flicker. It was reported fixed in iOS 26.4, so the iOS 26.5.2 Hilo3D reproduction is not assumed to have the same root cause: https://bugs.webkit.org/show_bug.cgi?id=301627
- WebKit #293062: mapped upload / `copyBufferToTexture` state handling differed from the specification: https://bugs.webkit.org/show_bug.cgi?id=293062
- WebGPU copy/upload model: https://gpuweb.github.io/gpuweb/#copies

## Impact

The direct path is limited to iPhone/iPad/iPod WebKit, including iPadOS desktop-mode UA detection. It allocates only when a reusable per-submission scratch slot must grow and recycles slots after the fence.

A local desktop A/B showed why the workaround remains scoped: upload-heavy CPU time was about 13% slower with the direct path forced globally, while representative lighting and scene-churn cases were within 1%. This local benchmark is directional only and is not enrolled baseline evidence.

## Validation

- manual iPhone 17 Pro Max / iOS 26.5.2 WebGPU verification: affected examples render and interact correctly, including diffuse environment lighting
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run api:check`
- `npm run docs:check`
- targeted `WebGPUBackend.test.ts` (37 tests)
- `npm run test:rhi` (211 tests)
- `npm run test:render:architecture` (132 tests)
- `npm run test:webgpu` (13 Playwright tests)
- `git diff --check`

Not run: full `npm run validate`, an automated physical-iOS lane, or the enrolled cross-commit performance baseline protocol.