### PR TITLE
fix(tooling): handle quoted CSS data URLs in link validation

### DIFF
--- a/scripts/check-site-links.ts
+++ b/scripts/check-site-links.ts
@@ -1,15 +1,14 @@
 import { opendir, readFile, stat } from 'node:fs/promises';
 import { dirname, relative, resolve, sep } from 'node:path';
+import { extractSiteReferences, type SiteFileType } from './site-link-references';
 
 const projectRoot = resolve(import.meta.dirname, '..');
 const siteDirectory = resolve(projectRoot, 'site');
 const externalReferencePattern = /^(?:[a-z][a-z\d+.-]*:|\/\/)/i;
-const htmlReferencePattern = /\b(?:href|src|poster)=["']([^"']+)["']/g;
-const cssReferencePattern = /url\(\s*(["']?)([^"')]+)\1\s*\)/g;
 
 interface SiteFile {
     path: string;
-    type: 'css' | 'html';
+    type: SiteFileType;
 }
 
 interface LinkIssue {
@@ -52,21 +51,13 @@ async function resolveTarget(reference: string, sourcePath: string): Promise<str
     return target;
 }
 
-function extractReferences(file: SiteFile, contents: string): string[] {
-    const pattern = file.type === 'html' ? htmlReferencePattern : cssReferencePattern;
-    return [...contents.matchAll(pattern)].map(match => {
-        const valueIndex = file.type === 'html' ? 1 : 2;
-        return (match[valueIndex] ?? '').replaceAll('&amp;', '&').trim();
-    });
-}
-
 const siteFiles = await collectSiteFiles(siteDirectory);
 const issues: LinkIssue[] = [];
 let checkedReferences = 0;
 
 for (const file of siteFiles) {
     const contents = await readFile(file.path, 'utf8');
-    for (const reference of extractReferences(file, contents)) {
+    for (const reference of extractSiteReferences(file.type, contents)) {
         if (!reference || reference.startsWith('#') || externalReferencePattern.test(reference)) {
             continue;
         }

--- a/scripts/site-link-references.ts
+++ b/scripts/site-link-references.ts
@@ -1,0 +1,16 @@
+const htmlReferencePattern = /\b(?:href|src|poster)=["']([^"']+)["']/g;
+const cssReferencePattern = /url\(\s*(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|([^"')]+))\s*\)/g;
+
+export type SiteFileType = 'css' | 'html';
+
+/** Extract link-like references without interpreting nested syntax inside quoted CSS URLs. */
+export function extractSiteReferences(fileType: SiteFileType, contents: string): string[] {
+    const matches =
+        fileType === 'html'
+            ? [...contents.matchAll(htmlReferencePattern)].map(match => match[1] ?? '')
+            : [...contents.matchAll(cssReferencePattern)].map(
+                  match => match[1] ?? match[2] ?? match[3] ?? ''
+              );
+
+    return matches.map(reference => reference.replaceAll('&amp;', '&').trim());
+}

--- a/test/spec/tooling/SiteLinkReferences.test.ts
+++ b/test/spec/tooling/SiteLinkReferences.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { extractSiteReferences } from '../../../scripts/site-link-references';
+
+describe('extractSiteReferences', () => {
+    it('keeps nested SVG fragment references inside a quoted data URL', () => {
+        const reference =
+            "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E" +
+            "%3Cfilter id='n'/%3E%3Crect filter='url(%23n)'/%3E%3C/svg%3E";
+
+        expect(
+            extractSiteReferences('css', `.grain { background-image: url("${reference}"); }`)
+        ).toEqual([reference]);
+    });
+
+    it('extracts quoted and unquoted local CSS references', () => {
+        expect(
+            extractSiteReferences(
+                'css',
+                [
+                    '.icon { background: url("./icon.svg#mark"); }',
+                    ".font { src: url('../fonts/font.woff2?#iefix'); }",
+                    '.texture { background: url(images/grid.png); }'
+                ].join('\n')
+            )
+        ).toEqual(['./icon.svg#mark', '../fonts/font.woff2?#iefix', 'images/grid.png']);
+    });
+
+    it('extracts HTML references and decodes ampersand entities', () => {
+        expect(
+            extractSiteReferences(
+                'html',
+                '<a href="./guide.html?lang=en&amp;mode=full"><img src="./cover.png"></a>'
+            )
+        ).toEqual(['./guide.html?lang=en&mode=full', './cover.png']);
+    });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,6 +12,7 @@
     "examples/shared/catalog.ts",
     "test/**/*.ts",
     "scripts/npm-pack-result.ts",
+    "scripts/site-link-references.ts",
     "scripts/shader-modernity.ts",
     "scripts/performance/**/*.ts"
   ],


### PR DESCRIPTION
## Summary

- parse quoted CSS `url(...)` values without treating nested syntax as separate links
- keep the site link checker focused on the complete data URL
- add regression coverage for SVG data URLs containing fragment references

## Root cause

The CSS reference regex stopped at quotes inside a double-quoted SVG data URL. It then matched the nested `url(%23n)` filter reference as if it were a standalone local asset, causing the Pages workflow to report `assets/bloom-*.css -> %23n` as missing.

## Validation

- `npm run test:unit -- test/spec/tooling/SiteLinkReferences.test.ts`
- `npm run site:build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
