### PR TITLE
feat(render): implement WebGPU phase 1 graph views and history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Changes
 
+- Add explicit Render Graph texture views for mip, array-layer, dimension, compatible-format, and
+  depth/stencil-aspect access across sampled, storage, attachment, and copy paths. Add
+  renderer-owned double/triple-buffer history textures whose recipes survive device recovery, whose
+  contents invalidate on descriptor or device-generation changes, and whose current/history rotation
+  commits only after a successful submitted writer frame. History recipes initially accept one
+  single-sample 2D color mip/layer so slot validity always means complete initialization.
 - Add camera-relative cascaded shadows for directional lights on the shared WebGL 2/WebGPU shadow
   atlas path. `DirectionalLight.shadow` now supports one to four cascades, practical split
   weighting, a maximum shadow distance, cross-cascade blending, and texel stabilization while
@@ -167,13 +173,14 @@
   forces, boundary physics, GPU-authored indirect arguments, and three particle raster layers stay
   on the public Render Graph/RHI path. Its deterministic test mode drives real pointer input without
   reading particle state back to the CPU.
-- Keep first-release compute textures limited to complete 2D graph resources, with transient
-  write-only storage textures and no persistent storage-texture or layer/mip-view API. Persistent
-  state uses externally owned renderer `StorageBuffer` objects imported per frame; each Renderer
-  accepts one pending storage-buffer readback. `cpu-shadow` recovery restores CPU bytes rather than
-  later GPU mutations, and Direct WGSL `f16` remains fail-closed until the Naga validation path can
-  validate it end to end. Storage-aware graphics retains broader Material/Scene texture reflection,
-  while `GPUDrivenRenderPass` rejects non-2D graph texture bindings before backend execution.
+- Keep storage texture writes write-only and complete for the selected single-mip view; overlapping
+  sampled/write feedback remains invalid. Persistent texture state uses renderer-owned history
+  recipes, while persistent buffer state uses externally owned renderer `StorageBuffer` objects
+  imported per frame; each Renderer accepts one pending storage-buffer readback. `cpu-shadow`
+  recovery restores CPU bytes rather than later GPU mutations, and Direct WGSL `f16` remains
+  fail-closed until the Naga validation path can validate it end to end. Storage-aware graphics
+  retains broader Material/Scene texture reflection, while `GPUDrivenRenderPass` validates explicit
+  graph view dimension, format, and sample type before backend execution.
 - Expose the built-in forward culling results to features, reject feature runtimes shared across
   Renderers, and preserve selected RenderTarget color/depth/stencil clear/load/store operations
   across feature-enabled scene, intermediate-color, and output passes.

--- a/documentation/COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md
+++ b/documentation/COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md
@@ -5,7 +5,7 @@
 >
 > 制定日期：2026-07-17
 >
-> 最近核对：2026-07-25
+> 最近核对：2026-08-01
 >
 > 目标版本：当前 `Unreleased` 版本；具体 semver 由发布评审决定
 >
@@ -29,6 +29,7 @@ matrix 或不可覆盖性能 baseline 不会被写成通过。
 | Scene storage integration            | 已完成   | `SceneRenderPass` group 3 pass-global readonly storage；复用 culling/sorting/material/geometry/UBO，instancing 确定性 direct fallback                               |
 | Forward+/高斯/粒子/光追 example/验收 | 已完成   | 组合页覆盖 depth/Scene storage、高斯与 1024 粒子；独立页覆盖 65,536 GPU body，以及静态水面、光谱焦散、体积散射、引导降噪与稳定 bind-group 的渐进式 HDR path tracing |
 | 公共 API 与 requirements             | 已完成   | 根导出、TSDoc、类型消费、创建前 WebGPU 选择、capability/limit/format 检查和 WebGL 2 fail-closed 同版本交付                                                          |
+| Graph texture subresource/history    | 已完成   | 显式 mip/layer/aspect/dimension view；sampled/storage/attachment/copy 共用 hazard；renderer-owned 2/3-buffer history 按成功 submission 轮换并在恢复后失效           |
 
 `storage-buffer`、`storage-texture`、`compute-pass`、`indirect-draw`
 仍按同一个公开 release 单元维护，但 capability 结果也必须满足实际设备 feature、format 和 limit；“已发布”不会把不兼容设备伪装成支持。
@@ -136,10 +137,13 @@ WGSL core 的 atomics、workgroup memory 和 barriers 可以直接在 `ComputeSh
 - 不把 subgroup、shader-f16、timestamp-query 等可选特性变成 compute 基线要求。
 - 不同时设计通用 GPGPU 框架、粒子系统、物理引擎或节点式 shader 编辑器。
 
-首发还有以下明确边界，它们不是遗漏的 native 能力：
+以下条目描述最初首发边界；其中 graph subresource 与 persistent history 已由后续 F0 工作包解除：
 
-- compute graph texture 只绑定完整 2D subresource；没有 array/cube/3D 或 mip/layer view。
-- storage texture 只支持 transient、write-only、完整覆盖；没有 persistent storage texture。
+- compute graph texture 已可绑定显式 array/cube/3D、mip/layer/aspect
+  view；同一 subresource 的 sampled/write feedback 仍拒绝。
+- storage texture 仍是 write-only、完整覆盖所选单 mip
+  view；跨帧 texture 由显式 usage 的双/三缓冲 history recipe 提供，不开放任意 native persistent
+  texture。
 - `StorageBuffer.read()` 每个 Renderer 同时只允许一个 pending request；应用应串行等待。
 - `SceneRenderPass` storage variant 遇到 instanced batch 时展开为 per-mesh direct draw。
 - 内置 `ForwardRenderPipelineFeature.sampledDepth` 仍关闭；完整 Forward+ 通过自定义 SRP 显式组合。
@@ -444,9 +448,9 @@ binding descriptor 是 Hilo3D 的显式 pipeline ABI，不依赖 WebGPU auto
 layout，也不允许运行时从字符串 map 猜测资源。WGSL source 与 descriptor 不一致时必须在 kernel
 prepare、RHI pipeline creation 或真实 WebGPU validation 中失败，且发生在 RHI frame 开始前。
 
-compute texture ABI 有意比 `StorageGraphicsShader` 的 Material-backed texture
-ABI 窄：graph 当前只解析一个完整 2D texture view，因此 compute sampled/storage
-bindings 不接受 array、cube、3D、integer sample type 或任意 mip/layer 子资源。`unfilterable-float`
+compute texture ABI 直接消费显式 graph texture view：sampled/storage
+bindings 可表达 array、cube、3D、integer sample type 与 mip/layer/aspect 子资源，并在 shader
+reflection、view dimension、sample type 与 format 不匹配时于 prepare 阶段拒绝。`unfilterable-float`
 必须配对 `non-filtering-sampler`，后者要求 nearest filter、`maxAnisotropy: 1`
 且不能带 compare；非法组合在 bind group 创建前失败。 `StorageGraphicsShader`
 类型仍能描述 Material/Scene 的 2D-array/3D/cube 与 sint/uint texture；当 `GPUDrivenRenderPass`
@@ -830,10 +834,12 @@ binding 必须使用 `readWriteBuffer()`，不能谎报为 write 来规避初始
 - 同一 logical buffer 的重叠 range 首版按整 buffer
   hazard 处理，先保证正确性；未来才能增加 range-aware hazard。
 
-storage texture 首版只支持 transient、完整 2D subresource 的 write-only
-binding。要读取旧纹理应绑定独立 sampled texture；同一 subresource sampled/write
-feedback 继续拒绝，不插入隐式 copy。当前没有 persistent storage texture、array/cube/3D 或 mip/layer
-view。
+storage texture 保持 write-only 且完整覆盖所选单 mip view。要读取旧纹理应绑定独立 sampled
+view；同一 subresource sampled/write
+feedback 继续拒绝，不插入隐式 copy。显式 view 可选择 array/cube/3D、mip/layer 和 aspect；跨帧 texture 通过 renderer-owned 双/三缓冲 history
+recipe 导入，并只在有效 submission 后交换 current/history。当前 history
+recipe 限定为单 sample、单 mip、单 layer 的 2D color texture，以保证公开的 slot-level `valid`
+精确表示完整初始化状态。
 
 ### 8.3 Hazard 与拓扑
 
@@ -1433,7 +1439,7 @@ npm run validate
 | GPU 写入无法 device-loss 无损恢复            | 强制公开 `cpu-shadow`/`reinitialize` 策略，不做隐式 readback                                        |
 | CPU shadow 被误解为 GPU checkpoint           | 明确恢复到初始/最后 CPU bytes；GPU mutation 不会被暗中 map 回 CPU                                   |
 | 同 pass read-write 破坏现有 graph invariant  | 只增加 buffer 专用 `readWriteBuffer()`；texture feedback 继续拒绝                                   |
-| Graph texture API 暗示任意 native view       | compute 首发仅完整 2D；storage texture 仅 transient write-only，不提供 persistent/layer/mip view    |
+| Graph texture view 与 history 完整性混淆     | view 显式建模 mip/layer/aspect hazard；history 首版限定完整单 mip 2D color slot                     |
 | Naga `f16` 路径未形成完整验证闭环            | Direct WGSL `f16` 在 pipeline 前 fail-closed，不以 parse-only 冒充支持                              |
 | 并发 readback 复用同一 frame/staging 状态    | 每 Renderer 一次 pending request；并发请求明确拒绝，调用方串行等待                                  |
 | StorageLayout 被误做成 std140/std430 混合    | 以 WGSL host-shareable layout 为唯一 storage 规则，独立于 UniformBuffer                             |

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -1,6 +1,6 @@
 # Hilo3D 现代 WebGPU 渲染缺口与落地路线
 
-> 审计基线：`296a18d`（2026-08-01）。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
+> 审计基线：`296a18d`（2026-08-01）；实施状态更新：2026-08-01，F0 已落地。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
 > 2 功能对等作为路线目标。
 
 ## 结论先行
@@ -13,10 +13,10 @@ Draw、HDR/PBR、设备丢失恢复和严格的帧事务都已经存在。当前
    `GPUDrivenRenderPass` 尚未成为普通场景的规模化路径。
 2. **生产级 Clustered Forward+**：仓库已有 depth → compute tile cull → storage-aware
    scene 的验收闭环，但没有可直接替换固定 LightBlock 的内置 PBR clustered lighting。
-3. **时域渲染框架**：没有 motion vector、projection jitter、history、camera-cut
-   invalidation、TAA/TAAU、动态分辨率和 reactive mask。
-4. **现代资源与几何虚拟化**：没有 mip/array subresource graph view、GPU meshlet/LOD、纹理流送、KTX
-   2/Basis、虚拟纹理或虚拟阴影页系统。
+3. **时域渲染框架**：已有 recovery-aware history owner 与显式 invalidation，但仍没有 motion
+   vector、projection jitter、TAA/TAAU、动态分辨率和 reactive mask。
+4. **现代资源与几何虚拟化**：已有 mip/array/aspect subresource graph view，但仍没有 GPU
+   meshlet/LOD、纹理流送、KTX 2/Basis、虚拟纹理或虚拟阴影页系统。
 
 最值得先做的不是直接复刻 Nanite 或 Lumen，而是完成两条可以并行推进的主线：
 
@@ -180,11 +180,13 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 `P0` 是“现代 WebGPU renderer”定义所需能力；`P1` 是高画质生产 profile；`P2`
 是依赖场景规模、内容管线和长期性能投入的虚拟化能力。
 
+实施状态：**F0 已完成**；后续工作包可把 subresource view 与 history owner 作为现有基础使用。
+
 ## 6. 可落地工作包
 
 ### 6.1 Milestone 0：WebGPU high-end profile 基础
 
-#### F0：Graph subresource 与跨帧资源
+#### F0：Graph subresource 与跨帧资源（已完成）
 
 ![F0：Render Graph 子资源视图与跨帧 History](./images/modern-webgpu-roadmap/render-graph-history.jpg)
 
@@ -192,7 +194,7 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 | ---------------------------------- | ----------------------------------------------------- | ---------------------------------------- | ----------------------------------------- |
 | 多 mip/layer texture、帧成功或失败 | 显式 view、subresource hazard、双/三缓冲 history 交换 | Hi-Z mip 链、稳定 history、可恢复 recipe | resize/device loss/失败 submission 不串帧 |
 
-需要增加：
+已落地：
 
 - graph texture 与 texture view 分离；view 显式表达 mip、array layer 和 aspect；
 - sampled、storage、attachment、copy access 都绑定 view，而不是隐含整张 texture；
@@ -201,8 +203,15 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 - resize、camera cut、format/quality change 和 device loss 的 history invalidation generation；
 - transient texture 同帧 alias 先保留为后续优化，不能阻塞 view 正确性。
 
-完成标准：一张多 mip texture 能在连续 pass 中逐级写入/采样；TAA
-history 能跨帧存活、resize 后失效、device loss 后按 recipe 重建，失败 submission 不交换 history。
+当前 history recipe fail-closed 为单 sample、单 mip、单 layer 的 2D color texture，使公开 `valid`
+与完整初始化严格同义；多 mip/array/volume
+history 要等 subresource-validity 能跨帧持久化后再开放。显式 graph view 本身已经支持 mip、array
+layer、dimension、compatible format 和 depth/stencil aspect。
+
+验收证据：多 mip texture 可在连续 pass 中逐级写入/采样；history 可跨帧存活、descriptor
+revision 后失效、device loss 后按 recipe 重建，失败 record/submission 不交换 current/history。Render
+Graph、SRP、capability、ResourceRegistry、真实 WebGPU storage-view 和 package
+type-consumer 均有自动化覆盖。
 
 #### F1：现代 WebGPU capability 与 GPU timeline
 

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -168,13 +168,18 @@ Compute 不是 `Material`。它使用三个后端中立、不可变的 CPU 配�
   access，在 prepare 阶段解析资源并复用显式 layout/pipeline/bind
   group，在 execute 阶段只发 direct 或 indirect dispatch。
 
-compute binding 覆盖 uniform buffer、readonly/read-write storage buffer、完整 2D sampled
-texture、filtering/non-filtering/comparison sampler 和完整覆盖的 transient write-only 2D storage
-texture。首发 graph texture 不公开 array/cube/3D 或 mip/layer 子资源 view，也没有 persistent storage
-texture；跨帧 GPU 数据使用 renderer-owned `StorageBuffer`。它是公共逻辑资源，CPU 写入走统一 upload
-transaction，异步读取走 graph copy、submission fence 和 staging
-map；每个 Renderer 同时只允许一个 pending storage-buffer readback，调用方应串行等待。`cpu-shadow` 与
-`reinitialize` 恢复策略明确区分“恢复 CPU 快照”和“恢复后必须由完整 GPU
+compute binding 覆盖 uniform buffer、readonly/read-write storage buffer、显式 texture
+view、filtering/non-filtering/comparison sampler 和完整覆盖的 write-only storage texture
+view。`ScriptableRenderGraph.createTextureView()` 可选择 mip、array
+layer、dimension、format 和 depth/stencil
+aspect；sampled、storage、attachment 与 copy 共用这一个 view
+identity。跨帧纹理由 renderer-owned 双/三缓冲 history recipe 管理；当前 history
+recipe 明确限定为单 sample、单 mip、单 layer 的 2D color texture，使任一提交成功的 current
+writer 都能完整初始化下一帧 history。跨帧 buffer 继续使用 renderer-owned
+`StorageBuffer`。后者是公共逻辑资源，CPU 写入走统一 upload transaction，异步读取走 graph
+copy、submission fence 和 staging map；每个 Renderer 同时只允许一个 pending storage-buffer
+readback，调用方应串行等待。`cpu-shadow` 与 `reinitialize`
+恢复策略明确区分“恢复 CPU 快照”和“恢复后必须由完整 GPU
 writer 重新初始化”。GPU 写入只在有效 submission 后提交内容分歧，后续相同 CPU
 bytes 仍会重新上传，避免 CPU shadow 错误掩盖 GPU 修改。
 
@@ -196,8 +201,8 @@ buffer。相关 WebKit 报告包括 iOS 26 的
 `StorageGraphicsShader` 是独立的 WebGPU-only graphics source contract：vertex/fragment 仍由受控 GLSL
 ES 3.10 storage subset 经统一预处理和 Naga 转为 WGSL，不接受手写 graphics WGSL；首版只允许 readonly
 storage。其 Material/Scene texture reflection 仍保留 2D-array/3D/cube 与 sint/uint 类型表达，但
-`GPUDrivenRenderPass` 绑定的 graph texture 当前必须是完整 2D view，非 2D
-descriptor 会在构造/prepare 阶段拒绝。`GPUDrivenRenderPass` 把这种 shader 与普通 `Material`
+`GPUDrivenRenderPass` 绑定显式 graph texture view，并在 shader reflection、view dimension、sample
+type 与 format 不兼容时于 prepare 阶段拒绝。`GPUDrivenRenderPass` 把这种 shader 与普通 `Material`
 的 blend/depth/cull raster state 组合，并支持 vertex pulling、显式 vertex/index buffer、direct
 draw、draw indirect 和 indexed draw indirect。compute、copy 与 raster 都通过同一 graph
 access 建边，不读取 GPU 产生的 count、排序结果或 indirect arguments。
@@ -563,10 +568,15 @@ Renderer 的组合式 Pass，使未来加入新的图优化、调试可视化或
 - `storage-buffer`、`storage-texture`、`compute-pass` 与 `indirect-draw` 是 WebGPU-only
   capability。显式或自动选择 WebGL 2 时不会模拟或静默跳过；pipeline
   requirements 会在创建阶段排除不兼容后端。
-- graph compute texture 首发只表达完整 2D subresource；storage
-  texture 是 transient、write-only、完整覆盖，没有 persistent storage texture、layer/mip
-  view 或 sampled/write feedback。跨帧状态使用外部 renderer-owned `StorageBuffer`，每帧通过
-  `importStorageBuffer()` 导入。
+- graph texture 把物理 texture 与显式 view 分离；mip、array layer、dimension、compatible
+  format 和 depth/stencil aspect 都进入 subresource
+  hazard。不同 subresource 可以在同 pass 使用，重叠的 sampled/write feedback 继续 fail-closed。
+- storage texture binding 仍是 write-only 且必须完整覆盖所选单 mip view；跨帧 texture 使用
+  `acquireHistoryTexture()` 的 renderer-owned 双/三缓冲 recipe；当前 recipe
+  fail-closed 为单 sample、单 mip、单 layer 的 2D color
+  texture。history 只在有效 submission 且 current 确有 writer 时轮换；resize/format/quality
+  revision、显式 invalidation 和 device
+  recovery 都递增 generation 并使旧内容失效。跨帧 buffer 继续通过 `importStorageBuffer()` 导入。
 - 每个 Renderer 同时只处理一个 `StorageBuffer.read()`；并发 readback 会明确拒绝。`cpu-shadow`
   恢复 CPU 快照而不保留 GPU mutation；需要保留或重算 GPU-only 状态时选择合适策略并显式重建。
 - `SceneRenderPass` 已能让普通 renderer list 在 group 3 读取 pass-global storage；命中 instancing

--- a/documentation/SCRIPTABLE_RENDER_PIPELINE_PLAN.md
+++ b/documentation/SCRIPTABLE_RENDER_PIPELINE_PLAN.md
@@ -208,10 +208,12 @@ handle。具体 GPU 对象始终归 Renderer cache/registry 和 RHI device 所�
 
 公开 facade 只表达 SRP 需要的图能力：
 
-- transient texture；
+- transient texture 与显式 mip/layer/aspect/dimension view；
 - 当前 output 与公共 RenderTarget attachment import；
 - pipeline-owned persistent target import；
-- sampled read、color/depth attachment、copy source/destination 和显式依赖；
+- renderer-owned 双/三缓冲 history texture；
+- sampled/storage read-write declaration、color/depth attachment、copy
+  source/destination 和显式依赖；
 - stable pass template；
 - terminal output/side effect 标记。
 
@@ -588,6 +590,13 @@ export interface ScriptableRenderGraph {
   frame 有效提交后 commit，record/compile/prepare/execute 失败时 rollback，且不能释放本帧已 acquire 的 target。
 - persistent resource 在 device/context
   recovery 后按 recipe 原位重建；pipeline 不接收 generation-specific handle。
+- history current 只有在本帧声明 writer 且 submission 有效时才轮换；失败帧回滚 write
+  index。descriptor revision、camera cut/显式 invalidation 与 registry
+  generation 变化都会使旧 history 失效并递增公开 generation。
+- history 首版只接受单 sample、单 mip、单 layer 的 2D color texture，确保 slot-level `valid`
+  与“完整初始化”同义；多 mip/array/volume history 留给后续 subresource-validity 扩展。
+- texture view 的 mip/layer/aspect 进入 graph hazard
+  identity；不同 subresource 可并行，重叠 sampled/storage/attachment/copy access 继续拒绝。
 - transient resource 在 submission 完成后归还池；第一版不宣称同帧 alias。
 - graph handle 不能保存在 runtime 字段中；跨 frame 使用必须抛出 generation error。
 - 同 pass sampled read/write feedback、未初始化读取、非法 discard 后读取和 attachment shape
@@ -1180,10 +1189,11 @@ shell 分配保持 O(callback)；architecture test 证明无镜像 graph。
 
 工作：
 
-- 增加 runtime owner + stable key + recipe 的 persistent target registry；
+- 增加 runtime owner + stable key + recipe 的 persistent target/history registry；
 - descriptor revision 触发事务 resize；
 - 接入 submission tracker、release、destroy、WebGL context loss 和 WebGPU device loss；
-- 覆盖 history ping-pong、多 Renderer factory 复用和 runtime cleanup。
+- 覆盖 history 双/三缓冲、失败 submission 回滚、recovery invalidation、多 Renderer
+  factory 复用和 runtime cleanup。
 
 退出条件：恢复前后逻辑 identity、输出像素和 owner 不变；10,000 帧/资源 churn 有界；失败 resize/rebuild 不留下半提交资源。
 

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -916,7 +916,7 @@ export type ComputeStorageTextureViewDimension = '2d';
 
 // @public
 export interface ComputeTextureBinding {
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
 }
 
 // @public
@@ -1955,7 +1955,7 @@ export interface FullscreenRenderPassOptions {
 export interface FullscreenRenderPassParameters {
     readonly colorAttachments: readonly Readonly<RenderPipelineColorAttachment>[];
     readonly depthStencilAttachment?: Readonly<RenderPipelineDepthStencilAttachment>;
-    readonly inputTextures: readonly RenderGraphTextureHandle[];
+    readonly inputTextures: readonly RenderGraphTextureAccessHandle[];
     readonly scissor?: RendererViewport;
     readonly stencilReference?: number;
     readonly viewport?: RendererViewport;
@@ -5477,12 +5477,23 @@ export type RenderGraphPassHandle = number & {
 const renderGraphPassHandleBrand: unique symbol;
 
 // @public
+export type RenderGraphTextureAccessHandle = RenderGraphTextureHandle | RenderGraphTextureViewHandle;
+
+// @public
 export type RenderGraphTextureHandle = number & {
     readonly [renderGraphTextureHandleBrand]: true;
 };
 
 // @public (undocumented)
 const renderGraphTextureHandleBrand: unique symbol;
+
+// @public
+export type RenderGraphTextureViewHandle = number & {
+    readonly [renderGraphTextureViewHandleBrand]: true;
+};
+
+// @public (undocumented)
+const renderGraphTextureViewHandleBrand: unique symbol;
 
 // @public
 export class RenderInfo {
@@ -5531,7 +5542,7 @@ export interface RenderPipelineBufferDescriptor {
 export interface RenderPipelineCapabilities {
     readonly limits: Readonly<RenderPipelineLimits>;
     supportsCapability(capability: RenderPipelineCapabilityName): boolean;
-    supportsTextureFormat(format: RenderTargetColorFormat | RenderTargetDepthStencilFormat, use: RenderPipelineTextureUse, sampleCount?: RenderTargetSampleCount): boolean;
+    supportsTextureFormat(format: RenderPipelineTextureFormat, use: RenderPipelineTextureUse, sampleCount?: RenderTargetSampleCount): boolean;
 }
 
 // @public
@@ -5541,9 +5552,9 @@ export type RenderPipelineCapabilityName = 'storage-buffer' | 'storage-texture' 
 export interface RenderPipelineColorAttachment {
     readonly clearValue?: RenderTargetColor;
     readonly loadOp: RenderTargetLoadOp;
-    readonly resolveTarget?: RenderGraphTextureHandle;
+    readonly resolveTarget?: RenderGraphTextureAccessHandle;
     readonly storeOp: RenderTargetStoreOp;
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
 }
 
 // @public
@@ -5577,7 +5588,7 @@ export interface RenderPipelineDepthStencilAttachment {
     readonly stencilLoadOp?: RenderTargetLoadOp;
     readonly stencilReadOnly?: boolean;
     readonly stencilStoreOp?: RenderTargetStoreOp;
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
 }
 
 // @public
@@ -5596,6 +5607,22 @@ export interface RenderPipelineFactory {
     create(context: RenderPipelineCreateContext): RenderPipeline | Promise<RenderPipeline>;
     readonly name: string;
     readonly requirements?: Readonly<RenderPipelineRequirements>;
+}
+
+// @public
+export interface RenderPipelineHistoryTextureDescriptor extends RenderPipelineTextureDescriptor {
+    readonly bufferCount?: 2 | 3;
+    readonly label?: string;
+    readonly usage: readonly RenderPipelinePersistentTextureUsage[];
+}
+
+// @public
+export interface RenderPipelineHistoryTextureResources {
+    readonly current: RenderGraphTextureHandle;
+    readonly generation: number;
+    history(index?: number): RenderGraphTextureHandle;
+    readonly historyCount: number;
+    readonly valid: boolean;
 }
 
 // @public
@@ -5662,6 +5689,9 @@ export interface RenderPipelinePersistentTargetDescriptor {
 }
 
 // @public
+export type RenderPipelinePersistentTextureUsage = 'sampled' | 'storage' | 'attachment' | 'copy-source' | 'copy-destination';
+
+// @public
 export interface RenderPipelineRequirements {
     readonly requiredCapabilities?: readonly RenderPipelineCapabilityName[];
     readonly requiredFeatures?: readonly RendererFeatureName[];
@@ -5680,22 +5710,50 @@ export interface RenderPipelineTargetResources {
 }
 
 // @public
+export type RenderPipelineTextureAspect = 'all' | 'stencil-only' | 'depth-only';
+
+// @public
 export interface RenderPipelineTextureDescriptor {
+    readonly depthOrArrayLayers?: number;
+    readonly dimension?: RenderPipelineTextureDimension;
     readonly extent: RenderPipelineExtent;
-    readonly format: RenderTargetColorFormat | RenderTargetDepthStencilFormat;
+    readonly format: RenderPipelineTextureFormat;
     readonly mipLevelCount?: number;
     readonly sampleCount?: RenderTargetSampleCount;
+    readonly viewDimension?: RenderPipelineTextureViewDimension;
+    readonly viewFormats?: readonly RenderPipelineTextureFormat[];
 }
 
 // @public
+export type RenderPipelineTextureDimension = '1d' | '2d' | '3d';
+
+// @public
+export type RenderPipelineTextureFormat = 'r8unorm' | 'r8snorm' | 'r8uint' | 'r8sint' | 'r16uint' | 'r16sint' | 'r16float' | 'rg8unorm' | 'rg8snorm' | 'rg8uint' | 'rg8sint' | 'r32uint' | 'r32sint' | 'r32float' | 'rg16uint' | 'rg16sint' | 'rg16float' | 'rgba8unorm' | 'rgba8unorm-srgb' | 'rgba8snorm' | 'rgba8uint' | 'rgba8sint' | 'bgra8unorm' | 'bgra8unorm-srgb' | 'rgb10a2unorm' | 'rgb10a2uint' | 'rg11b10ufloat' | 'rgb9e5ufloat' | 'rg32uint' | 'rg32sint' | 'rg32float' | 'rgba16uint' | 'rgba16sint' | 'rgba16float' | 'rgba32uint' | 'rgba32sint' | 'rgba32float' | 'stencil8' | 'depth16unorm' | 'depth24plus' | 'depth24plus-stencil8' | 'depth32float' | 'depth32float-stencil8' | 'bc1-rgba-unorm' | 'bc1-rgba-unorm-srgb' | 'bc2-rgba-unorm' | 'bc2-rgba-unorm-srgb' | 'bc3-rgba-unorm' | 'bc3-rgba-unorm-srgb' | 'etc2-rgb8unorm' | 'etc2-rgb8unorm-srgb' | 'etc2-rgb8a1unorm' | 'etc2-rgb8a1unorm-srgb' | 'etc2-rgba8unorm' | 'etc2-rgba8unorm-srgb' | 'eac-r11unorm' | 'eac-r11snorm' | 'eac-rg11unorm' | 'eac-rg11snorm' | 'astc-4x4-unorm' | 'astc-4x4-unorm-srgb';
+
+// @public
 export interface RenderPipelineTextureRequirement {
-    readonly format: RenderTargetColorFormat | RenderTargetDepthStencilFormat;
+    readonly format: RenderPipelineTextureFormat;
     readonly sampleCount?: RenderTargetSampleCount;
     readonly use: RenderPipelineTextureUse;
 }
 
 // @public
 export type RenderPipelineTextureUse = 'sampled' | 'filterable-sampled' | 'color-attachment' | 'depth-stencil-attachment' | 'storage' | 'copy-source' | 'copy-destination';
+
+// @public
+export interface RenderPipelineTextureViewDescriptor {
+    readonly arrayLayerCount?: number;
+    readonly aspect?: RenderPipelineTextureAspect;
+    readonly baseArrayLayer?: number;
+    readonly baseMipLevel?: number;
+    readonly dimension?: RenderPipelineTextureViewDimension;
+    readonly format?: RenderPipelineTextureFormat;
+    readonly label?: string;
+    readonly mipLevelCount?: number;
+}
+
+// @public
+export type RenderPipelineTextureViewDimension = '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
 
 // @public
 export interface RenderTarget {
@@ -5897,7 +5955,7 @@ export class SceneRenderPass implements ScriptableRenderPass<SceneRenderPassPara
 export interface SceneRenderPassParameters {
     readonly colorAttachments: readonly Readonly<RenderPipelineColorAttachment>[];
     readonly depthStencilAttachment?: Readonly<RenderPipelineDepthStencilAttachment>;
-    readonly opaqueTexture?: RenderGraphTextureHandle;
+    readonly opaqueTexture?: RenderGraphTextureAccessHandle;
     readonly rendererList: RendererListHandle;
     readonly scissor?: RendererViewport;
     readonly stencilReference?: number;
@@ -5922,7 +5980,7 @@ export interface SceneStorageShaderVariant {
 export interface ScriptableRenderCommands {
     clearBuffer(buffer: RenderGraphBufferHandle, byteOffset?: number, byteLength?: number): void;
     copyBuffer(source: RenderGraphBufferHandle, destination: RenderGraphBufferHandle): void;
-    copyTexture(source: RenderGraphTextureHandle, destination: RenderGraphTextureHandle): void;
+    copyTexture(source: RenderGraphTextureAccessHandle, destination: RenderGraphTextureAccessHandle): void;
     drawRendererList(list: RendererListHandle): void;
     setScissor(rect: RendererViewport): void;
     setStencilReference(reference: number): void;
@@ -5931,13 +5989,17 @@ export interface ScriptableRenderCommands {
 
 // @public
 export interface ScriptableRenderGraph {
+    acquireHistoryTexture(key: object, descriptor: Readonly<RenderPipelineHistoryTextureDescriptor>): RenderPipelineHistoryTextureResources;
     acquirePersistentTarget(key: object, descriptor: Readonly<RenderPipelinePersistentTargetDescriptor>): RenderPipelineTargetResources;
     addPass<P extends object>(pass: ScriptableRenderPass<P>, parameters: P): RenderGraphPassHandle;
     createBuffer(name: string, descriptor: Readonly<RenderPipelineBufferDescriptor>): RenderGraphBufferHandle;
     createTexture(name: string, descriptor: Readonly<RenderPipelineTextureDescriptor>): RenderGraphTextureHandle;
+    createTextureView(name: string, texture: RenderGraphTextureHandle, descriptor?: Readonly<RenderPipelineTextureViewDescriptor>): RenderGraphTextureViewHandle;
     importOutput(): RenderPipelineOutputResources;
     importRenderTarget(target: RenderTarget): RenderPipelineTargetResources;
     importStorageBuffer(buffer: StorageBuffer): RenderGraphBufferHandle;
+    invalidateHistoryTexture(key: object): boolean;
+    releaseHistoryTexture(key: object): boolean;
     releasePersistentTarget(key: object): boolean;
 }
 
@@ -5953,17 +6015,17 @@ export interface ScriptableRenderPass<P extends object> {
 export interface ScriptableRenderPassBuilder {
     clearBuffer(buffer: RenderGraphBufferHandle, byteOffset?: number, byteLength?: number): void;
     copyBuffer(source: RenderGraphBufferHandle, destination: RenderGraphBufferHandle): void;
-    copyTexture(source: RenderGraphTextureHandle, destination: RenderGraphTextureHandle): void;
+    copyTexture(source: RenderGraphTextureAccessHandle, destination: RenderGraphTextureAccessHandle): void;
     dependsOn(pass: RenderGraphPassHandle): void;
     markSideEffect(): void;
     readBuffer(buffer: RenderGraphBufferHandle, use: RenderGraphBufferReadUse): void;
-    readTexture(texture: RenderGraphTextureHandle): void;
+    readTexture(texture: RenderGraphTextureAccessHandle): void;
     readWriteBuffer(buffer: RenderGraphBufferHandle): void;
     useColorAttachment(options: Readonly<RenderPipelineColorAttachment>): void;
     useDepthStencilAttachment(options: Readonly<RenderPipelineDepthStencilAttachment>): void;
     useRendererList(list: RendererListHandle): void;
     writeBuffer(buffer: RenderGraphBufferHandle, use: RenderGraphBufferWriteUse): void;
-    writeStorageTexture(texture: RenderGraphTextureHandle): void;
+    writeStorageTexture(texture: RenderGraphTextureAccessHandle): void;
 }
 
 // @public
@@ -7517,8 +7579,8 @@ export class TextureCopyPass implements ScriptableRenderPass<TextureCopyPassPara
 
 // @public
 export interface TextureCopyPassParameters {
-    readonly destination: RenderGraphTextureHandle;
-    readonly source: RenderGraphTextureHandle;
+    readonly destination: RenderGraphTextureAccessHandle;
+    readonly source: RenderGraphTextureAccessHandle;
 }
 
 // @public

--- a/src/render/graph/RenderGraphBuilder.ts
+++ b/src/render/graph/RenderGraphBuilder.ts
@@ -20,7 +20,11 @@ import type {
     RGResourceHandle,
     RGResourceNode,
     RGTextureDescriptor,
+    RGTextureAccessHandle,
     RGTextureHandle,
+    RGTextureViewDescriptor,
+    RGTextureViewHandle,
+    RGTextureViewResourceNode,
     RGTextureResourceNode,
     RGBufferWriteUse
 } from './RenderGraphResource';
@@ -124,11 +128,19 @@ type MutableTextureResourceNode = Omit<
     { -readonly [Key in keyof RGTextureResourceNode]: RGTextureResourceNode[Key] },
     'descriptor'
 > & { descriptor: MutableTextureDescriptor };
+type MutableTextureViewDescriptor = {
+    -readonly [Key in keyof RGTextureViewDescriptor]: RGTextureViewDescriptor[Key];
+};
+type MutableTextureViewResourceNode = Omit<
+    { -readonly [Key in keyof RGTextureViewResourceNode]: RGTextureViewResourceNode[Key] },
+    'descriptor'
+> & { descriptor: MutableTextureViewDescriptor };
 type MutableBufferResourceNode = Omit<
     { -readonly [Key in keyof RGBufferResourceNode]: RGBufferResourceNode[Key] },
     'descriptor'
 > & { descriptor: MutableBufferDescriptor };
-type MutableResourceNode = MutableTextureResourceNode | MutableBufferResourceNode;
+type MutableResourceNode =
+    MutableTextureResourceNode | MutableTextureViewResourceNode | MutableBufferResourceNode;
 type MutableDepthStencilAttachmentDeclaration = {
     -readonly [
         Key in keyof RGDepthStencilAttachmentDeclaration
@@ -136,8 +148,8 @@ type MutableDepthStencilAttachmentDeclaration = {
 };
 
 interface MutableColorAttachmentDeclaration extends RGColorAttachmentDeclaration {
-    texture: RGTextureHandle;
-    resolveTarget?: RGTextureHandle;
+    texture: RGTextureAccessHandle;
+    resolveTarget?: RGTextureAccessHandle;
     clearValue?: { r: number; g: number; b: number; a: number };
     loadOp: RGColorAttachmentDeclaration['loadOp'];
     storeOp: RGColorAttachmentDeclaration['storeOp'];
@@ -230,9 +242,11 @@ export class RenderGraphBuilderStorage {
     };
 
     readonly #textureNodePool: MutableTextureResourceNode[] = [];
+    readonly #textureViewNodePool: MutableTextureViewResourceNode[] = [];
     readonly #bufferNodePool: MutableBufferResourceNode[] = [];
     readonly #passNodePool: MutablePassNode[] = [];
     #textureNodeCursor = 0;
+    #textureViewNodeCursor = 0;
     #bufferNodeCursor = 0;
     #passNodeCursor = 0;
     #leased = false;
@@ -241,6 +255,7 @@ export class RenderGraphBuilderStorage {
         if (this.#leased) throw new Error('Render graph builder storage is already leased');
         this.#leased = true;
         this.#textureNodeCursor = 0;
+        this.#textureViewNodeCursor = 0;
         this.#bufferNodeCursor = 0;
         this.#passNodeCursor = 0;
         this.resources.length = 0;
@@ -258,7 +273,8 @@ export class RenderGraphBuilderStorage {
         descriptor: RGTextureDescriptor,
         imported: RHITexture | null,
         provider: RGImportedTextureProvider | null,
-        resourceLifetime: RGTextureResourceNode['resourceLifetime']
+        resourceLifetime: RGTextureResourceNode['resourceLifetime'],
+        initiallyInitialized: boolean
     ): MutableTextureResourceNode {
         let node = this.#textureNodePool[this.#textureNodeCursor];
         if (!node) {
@@ -272,6 +288,7 @@ export class RenderGraphBuilderStorage {
                 provider,
                 resourceLifetime,
                 readFromLastGraphWriter: false,
+                initiallyInitialized,
                 extracted: false
             };
             this.#textureNodePool.push(node);
@@ -285,6 +302,7 @@ export class RenderGraphBuilderStorage {
             node.provider = provider;
             node.resourceLifetime = resourceLifetime;
             node.readFromLastGraphWriter = false;
+            node.initiallyInitialized = initiallyInitialized;
             node.extracted = false;
         }
         this.#textureNodeCursor++;
@@ -336,6 +354,36 @@ export class RenderGraphBuilderStorage {
         return node;
     }
 
+    acquireTextureViewNode(
+        handle: RGTextureViewHandle,
+        name: string,
+        texture: RGTextureHandle,
+        descriptor: RGTextureViewDescriptor
+    ): MutableTextureViewResourceNode {
+        let node = this.#textureViewNodePool[this.#textureViewNodeCursor];
+        if (!node) {
+            node = {
+                kind: 'texture-view',
+                handle,
+                name,
+                texture,
+                descriptor: this.createTextureViewDescriptor(descriptor),
+                extracted: false
+            };
+            this.#textureViewNodePool.push(node);
+            this.recordResourceGrowth();
+        } else {
+            node.handle = handle;
+            node.name = name;
+            node.texture = texture;
+            this.copyTextureViewDescriptor(node.descriptor, descriptor);
+        }
+        this.#textureViewNodeCursor++;
+        this.resources.push(node);
+        this.resourceByHandle.set(handle, node);
+        return node;
+    }
+
     acquirePassNode<P>(
         handle: RGPassHandle,
         index: number,
@@ -361,7 +409,7 @@ export class RenderGraphBuilderStorage {
                 colorAttachments: [],
                 colorAttachmentPool: [],
                 depthStencilAttachment: null,
-                depthStencilStorage: { texture: 0 as RGTextureHandle },
+                depthStencilStorage: { texture: 0 as RGTextureAccessHandle },
                 explicitDependencies: [],
                 dependencySet: new Set(),
                 sideEffect: false
@@ -487,8 +535,10 @@ export class RenderGraphBuilderStorage {
         for (const pass of this.passes) this.clearPassReferences(pass);
         for (const resource of this.resources) {
             resource.name = '';
-            resource.imported = null;
-            resource.provider = null;
+            if (resource.kind !== 'texture-view') {
+                resource.imported = null;
+                resource.provider = null;
+            }
         }
         this.resources.length = 0;
         this.resourceByHandle.clear();
@@ -500,7 +550,9 @@ export class RenderGraphBuilderStorage {
 
     private recordResourceGrowth(): void {
         this.diagnostics.resourceNodeCapacity =
-            this.#textureNodePool.length + this.#bufferNodePool.length;
+            this.#textureNodePool.length +
+            this.#textureViewNodePool.length +
+            this.#bufferNodePool.length;
         this.diagnostics.growthCount++;
     }
 
@@ -548,6 +600,28 @@ export class RenderGraphBuilderStorage {
         };
         this.copyBufferDescriptor(target, descriptor);
         return target;
+    }
+
+    private createTextureViewDescriptor(
+        descriptor: RGTextureViewDescriptor
+    ): MutableTextureViewDescriptor {
+        const target: MutableTextureViewDescriptor = {};
+        this.copyTextureViewDescriptor(target, descriptor);
+        return target;
+    }
+
+    private copyTextureViewDescriptor(
+        target: MutableTextureViewDescriptor,
+        source: RGTextureViewDescriptor
+    ): void {
+        this.copyOptionalProperty(target, source, 'label');
+        this.copyOptionalProperty(target, source, 'format');
+        this.copyOptionalProperty(target, source, 'dimension');
+        this.copyOptionalProperty(target, source, 'aspect');
+        this.copyOptionalProperty(target, source, 'baseMipLevel');
+        this.copyOptionalProperty(target, source, 'mipLevelCount');
+        this.copyOptionalProperty(target, source, 'baseArrayLayer');
+        this.copyOptionalProperty(target, source, 'arrayLayerCount');
     }
 
     private copyBufferDescriptor(
@@ -601,14 +675,14 @@ export class RGPassBuilder {
         private readonly pass: MutablePassNode
     ) {}
 
-    readTexture(handle: RGTextureHandle): RGTextureHandle {
-        this.graph.requireResource(handle, 'texture');
+    readTexture(handle: RGTextureAccessHandle): RGTextureAccessHandle {
+        this.graph.requireTextureAccess(handle);
         this.addRead(handle);
         return handle;
     }
 
-    writeTexture(handle: RGTextureHandle): RGTextureHandle {
-        this.graph.requireResource(handle, 'texture');
+    writeTexture(handle: RGTextureAccessHandle): RGTextureAccessHandle {
+        this.graph.requireTextureAccess(handle);
         this.addWrite(handle);
         return handle;
     }
@@ -651,10 +725,10 @@ export class RGPassBuilder {
     }
 
     useColorAttachment(declaration: RGColorAttachmentDeclaration): void {
-        this.graph.requireResource(declaration.texture, 'texture');
+        this.graph.requireTextureAccess(declaration.texture);
         this.addAttachment(declaration.texture);
         if (declaration.resolveTarget !== undefined) {
-            this.graph.requireResource(declaration.resolveTarget, 'texture');
+            this.graph.requireTextureAccess(declaration.resolveTarget);
             this.addAttachment(declaration.resolveTarget);
         }
         this.graph.acquireColorAttachment(this.pass, declaration);
@@ -668,7 +742,7 @@ export class RGPassBuilder {
                 this.pass.name
             );
         }
-        this.graph.requireResource(declaration.texture, 'texture');
+        this.graph.requireTextureAccess(declaration.texture);
         this.addAttachment(declaration.texture);
         this.graph.setDepthStencilAttachment(this.pass, declaration);
     }
@@ -759,8 +833,21 @@ export class RenderGraphBuilder {
             descriptor,
             null,
             null,
-            'transient'
+            'transient',
+            false
         );
+        return handle;
+    }
+
+    createTextureView(
+        name: string,
+        texture: RGTextureHandle,
+        descriptor: RGTextureViewDescriptor = {}
+    ): RGTextureViewHandle {
+        this.assertOpen();
+        this.requireResource(texture, 'texture');
+        const handle = this.allocateResourceHandle() as RGTextureViewHandle;
+        this.#storage.acquireTextureViewNode(handle, name, texture, descriptor);
         return handle;
     }
 
@@ -780,8 +867,14 @@ export class RenderGraphBuilder {
         return handle;
     }
 
-    importTexture(name: string, texture: RHITexture): RGTextureHandle {
+    importTexture(name: string, texture: RHITexture, initiallyInitialized = true): RGTextureHandle {
         this.assertOpen();
+        if (typeof initiallyInitialized !== 'boolean') {
+            renderGraphFailure(
+                'invalid-descriptor',
+                'imported texture initialization state must be boolean'
+            );
+        }
         const handle = this.allocateResourceHandle() as RGTextureHandle;
         this.#storage.acquireTextureNode(
             handle,
@@ -790,7 +883,8 @@ export class RenderGraphBuilder {
             texture.descriptor,
             texture,
             null,
-            texture.lifetime
+            texture.lifetime,
+            initiallyInitialized
         );
         return handle;
     }
@@ -825,9 +919,16 @@ export class RenderGraphBuilder {
         name: string,
         descriptor: RGTextureDescriptor,
         provider: RGImportedTextureProvider,
-        lifetime: 'persistent' | 'frame' = 'frame'
+        lifetime: 'persistent' | 'frame' = 'frame',
+        initiallyInitialized = true
     ): RGTextureHandle {
         this.assertOpen();
+        if (typeof initiallyInitialized !== 'boolean') {
+            renderGraphFailure(
+                'invalid-descriptor',
+                'imported texture initialization state must be boolean'
+            );
+        }
         const handle = this.allocateResourceHandle() as RGTextureHandle;
         this.#storage.acquireTextureNode(
             handle,
@@ -836,7 +937,8 @@ export class RenderGraphBuilder {
             descriptor,
             null,
             provider,
-            lifetime
+            lifetime,
+            initiallyInitialized
         );
         return handle;
     }
@@ -1046,6 +1148,12 @@ export class RenderGraphBuilder {
     }
 
     /** @internal */
+    requireResource(handle: RGResourceHandle, kind: 'texture'): RGTextureResourceNode;
+    /** @internal */
+    requireResource(handle: RGResourceHandle, kind: 'buffer'): RGBufferResourceNode;
+    /** @internal */
+    requireResource(handle: RGResourceHandle): RGResourceNode;
+    /** @internal */
     requireResource(handle: RGResourceHandle, kind?: 'texture' | 'buffer'): RGResourceNode {
         this.assertOpen();
         const resource = this.#storage.resourceByHandle.get(handle);
@@ -1053,6 +1161,20 @@ export class RenderGraphBuilder {
             renderGraphFailure('invalid-handle', `resource handle ${String(handle)} is invalid`);
         }
         return resource as RGResourceNode;
+    }
+
+    /** @internal */
+    requireTextureAccess(
+        handle: RGTextureAccessHandle
+    ): RGTextureResourceNode | RGTextureViewResourceNode {
+        const resource = this.requireResource(handle);
+        if (resource.kind !== 'texture' && resource.kind !== 'texture-view') {
+            renderGraphFailure(
+                'invalid-handle',
+                `texture access handle ${String(handle)} is invalid`
+            );
+        }
+        return resource;
     }
 
     /** @internal */

--- a/src/render/graph/RenderGraphCompiler.ts
+++ b/src/render/graph/RenderGraphCompiler.ts
@@ -8,12 +8,14 @@ import {
     type RHICapabilities,
     type RHINormalizedBufferDescriptor,
     type RHINormalizedTextureDescriptor,
+    type RHINormalizedTextureViewDescriptor,
     type RHITexture,
     type RHITextureDescriptor
 } from '../rhi/core';
 import {
     normalizeRHIBufferDescriptor,
-    normalizeRHITextureDescriptor
+    normalizeRHITextureDescriptor,
+    normalizeRHITextureViewDescriptorForTextureDescriptor
 } from '../rhi/core/RHIValidation';
 import type { RGPassNode, RenderGraphBuildSnapshot } from './RenderGraphBuilder';
 import type {
@@ -27,7 +29,9 @@ import type {
     RGResourceHandle,
     RGResourceLifetime,
     RGResourceNode,
-    RGTextureHandle
+    RGTextureAccessHandle,
+    RGTextureHandle,
+    RGTextureViewHandle
 } from './RenderGraphResource';
 import { renderGraphFailure } from './RenderGraphValidation';
 
@@ -40,6 +44,7 @@ export interface CompiledRGTextureResource {
     readonly imported: RHITexture | null;
     readonly provider: RGImportedTextureProvider | null;
     readonly readFromLastGraphWriter: boolean;
+    readonly initiallyInitialized: boolean;
     readonly extracted: boolean;
     readonly lifetime: RGResourceLifetime | null;
 }
@@ -57,7 +62,24 @@ export interface CompiledRGBufferResource {
     readonly lifetime: RGResourceLifetime | null;
 }
 
-export type CompiledRGResource = CompiledRGTextureResource | CompiledRGBufferResource;
+export interface CompiledRGTextureViewResource {
+    readonly kind: 'texture-view';
+    readonly handle: RGTextureViewHandle;
+    readonly name: string;
+    readonly origin: 'view';
+    readonly texture: RGTextureHandle;
+    readonly descriptor: Readonly<
+        RHINormalizedTextureViewDescriptor & {
+            readonly lifetime?: never;
+            readonly usage?: never;
+        }
+    >;
+    readonly extracted: false;
+    readonly lifetime: RGResourceLifetime | null;
+}
+
+export type CompiledRGResource =
+    CompiledRGTextureResource | CompiledRGTextureViewResource | CompiledRGBufferResource;
 
 export interface CompiledRGPass {
     readonly handle: RGPassHandle;
@@ -114,23 +136,27 @@ type MutableCompilerStorageDiagnostics = {
     ]: RenderGraphCompilerStorageDiagnostics[Key];
 };
 
+type RGHazardKey = string;
+
 class RenderGraphCompilerWorkspace {
     readonly normalizedResources: CompiledRGResource[] = [];
     readonly resourceByHandle = new Map<RGResourceHandle, CompiledRGResource>();
     readonly resourceWriters = new Map<RGResourceHandle, number>();
-    readonly lastPreferredGraphWriter = new Map<RGResourceHandle, number>();
+    readonly lastPreferredGraphWriter = new Map<RGHazardKey, number>();
     readonly preferredGraphWriterReads = new Set<RGResourceHandle>();
-    readonly lastWriter = new Map<RGResourceHandle, number>();
-    readonly readersSinceWrite = new Map<RGResourceHandle, Set<number>>();
-    readonly contentAvailable = new Map<RGResourceHandle, boolean>();
-    readonly depthContentAvailable = new Map<RGResourceHandle, boolean>();
-    readonly stencilContentAvailable = new Map<RGResourceHandle, boolean>();
+    readonly hazardKeysByHandle = new Map<RGResourceHandle, readonly RGHazardKey[]>();
+    readonly lastWriter = new Map<RGHazardKey, number>();
+    readonly readersSinceWrite = new Map<RGHazardKey, Set<number>>();
+    readonly contentAvailable = new Map<RGHazardKey, boolean>();
     readonly passIndexByHandle = new Map<RGPassHandle, number>();
     readonly outgoing: Set<number>[] = [];
     readonly incoming: Set<number>[] = [];
     readonly roots = new Set<number>();
     readonly scratchReadSet = new Set<RGResourceHandle>();
     readonly scratchReadWriteSet = new Set<RGBufferHandle>();
+    readonly scratchReadHazards = new Set<RGHazardKey>();
+    readonly scratchWriteHazards = new Set<RGHazardKey>();
+    readonly scratchAttachmentHazards = new Set<RGHazardKey>();
     readonly firstUse = new Map<RGResourceHandle, number>();
     readonly lastUse = new Map<RGResourceHandle, number>();
     readonly indegree: number[] = [];
@@ -155,15 +181,17 @@ class RenderGraphCompilerWorkspace {
         this.resourceWriters.clear();
         this.lastPreferredGraphWriter.clear();
         this.preferredGraphWriterReads.clear();
+        this.hazardKeysByHandle.clear();
         this.lastWriter.clear();
         this.readersSinceWrite.clear();
         this.contentAvailable.clear();
-        this.depthContentAvailable.clear();
-        this.stencilContentAvailable.clear();
         this.passIndexByHandle.clear();
         this.roots.clear();
         this.scratchReadSet.clear();
         this.scratchReadWriteSet.clear();
+        this.scratchReadHazards.clear();
+        this.scratchWriteHazards.clear();
+        this.scratchAttachmentHazards.clear();
         this.firstUse.clear();
         this.lastUse.clear();
         this.indegree.length = 0;
@@ -198,7 +226,7 @@ class RenderGraphCompilerWorkspace {
         }
     }
 
-    acquireReaderSet(handle: RGResourceHandle): Set<number> {
+    acquireReaderSet(handle: RGHazardKey): Set<number> {
         let readers = this.readersSinceWrite.get(handle);
         if (readers) return readers;
         readers = this.#readerSetPool[this.#readerSetCursor];
@@ -219,15 +247,17 @@ class RenderGraphCompilerWorkspace {
         this.resourceWriters.clear();
         this.lastPreferredGraphWriter.clear();
         this.preferredGraphWriterReads.clear();
+        this.hazardKeysByHandle.clear();
         this.lastWriter.clear();
         this.readersSinceWrite.clear();
         this.contentAvailable.clear();
-        this.depthContentAvailable.clear();
-        this.stencilContentAvailable.clear();
         this.passIndexByHandle.clear();
         this.roots.clear();
         this.scratchReadSet.clear();
         this.scratchReadWriteSet.clear();
+        this.scratchReadHazards.clear();
+        this.scratchWriteHazards.clear();
+        this.scratchAttachmentHazards.clear();
         this.firstUse.clear();
         this.lastUse.clear();
         this.indegree.length = 0;
@@ -274,7 +304,8 @@ function stableTopologicalOrder(
 
 function normalizedResource(
     resource: RGResourceNode,
-    capabilities: RHICapabilities
+    capabilities: RHICapabilities,
+    resources: ReadonlyMap<RGResourceHandle, CompiledRGResource>
 ): CompiledRGResource {
     if (resource.kind === 'texture') {
         const descriptor = normalizeRHITextureDescriptor(
@@ -293,7 +324,31 @@ function normalizedResource(
             imported: resource.imported,
             provider: resource.provider,
             readFromLastGraphWriter: resource.readFromLastGraphWriter,
+            initiallyInitialized: resource.initiallyInitialized,
             extracted: resource.extracted,
+            lifetime: null
+        };
+    }
+    if (resource.kind === 'texture-view') {
+        const texture = resources.get(resource.texture);
+        if (texture?.kind !== 'texture') {
+            renderGraphFailure(
+                'invalid-handle',
+                `texture view ${resource.name} references an invalid texture`
+            );
+        }
+        const descriptor = normalizeRHITextureViewDescriptorForTextureDescriptor(
+            texture.descriptor,
+            resource.descriptor
+        );
+        return {
+            kind: 'texture-view',
+            handle: resource.handle,
+            name: resource.name,
+            origin: 'view',
+            texture: resource.texture,
+            descriptor,
+            extracted: false,
             lifetime: null
         };
     }
@@ -355,20 +410,110 @@ function markLivePasses(
     return live;
 }
 
-function requireTextureResource(
+interface CompiledRGTextureAccess {
+    readonly resource: CompiledRGTextureResource | CompiledRGTextureViewResource;
+    readonly texture: CompiledRGTextureResource;
+    readonly view: Readonly<RHINormalizedTextureViewDescriptor>;
+    readonly width: number;
+    readonly height: number;
+    readonly depthOrArrayLayers: number;
+}
+
+function requireTextureAccess(
     resources: ReadonlyMap<RGResourceHandle, CompiledRGResource>,
-    handle: RGTextureHandle,
+    handle: RGTextureAccessHandle,
     passName: string
-): CompiledRGTextureResource {
+): CompiledRGTextureAccess {
     const resource = resources.get(handle);
-    if (resource?.kind !== 'texture') {
+    if (resource?.kind !== 'texture' && resource?.kind !== 'texture-view') {
         renderGraphFailure(
             'invalid-handle',
-            `texture resource ${String(handle)} is not in this graph`,
+            `texture access ${String(handle)} is not in this graph`,
             passName
         );
     }
-    return resource;
+    const texture = resource.kind === 'texture' ? resource : resources.get(resource.texture);
+    if (texture?.kind !== 'texture') {
+        return renderGraphFailure(
+            'invalid-handle',
+            `texture access ${String(handle)} has no parent texture`,
+            passName
+        );
+    }
+    const view =
+        resource.kind === 'texture'
+            ? normalizeRHITextureViewDescriptorForTextureDescriptor(texture.descriptor)
+            : resource.descriptor;
+    const mipScale = 2 ** view.baseMipLevel;
+    return {
+        resource,
+        texture,
+        view,
+        width: Math.max(1, Math.floor(texture.descriptor.size.width / mipScale)),
+        height: Math.max(1, Math.floor(texture.descriptor.size.height / mipScale)),
+        depthOrArrayLayers:
+            texture.descriptor.dimension === '3d'
+                ? Math.max(1, Math.floor(texture.descriptor.size.depthOrArrayLayers / mipScale))
+                : view.arrayLayerCount
+    };
+}
+
+function textureAccessAspects(
+    access: CompiledRGTextureAccess
+): readonly ('color' | 'depth' | 'stencil')[] {
+    if (access.view.aspect === 'depth-only') return ['depth'];
+    if (access.view.aspect === 'stencil-only') return ['stencil'];
+    const depth = rhiTextureFormatHasDepth(access.view.format);
+    const stencil = rhiTextureFormatHasStencil(access.view.format);
+    if (depth && stencil) return ['depth', 'stencil'];
+    if (depth) return ['depth'];
+    if (stencil) return ['stencil'];
+    return ['color'];
+}
+
+function createTextureHazardKeys(access: CompiledRGTextureAccess): readonly RGHazardKey[] {
+    const keys: RGHazardKey[] = [];
+    const layers = access.texture.descriptor.dimension === '3d' ? 1 : access.view.arrayLayerCount;
+    const aspects = textureAccessAspects(access);
+    for (
+        let mip = access.view.baseMipLevel;
+        mip < access.view.baseMipLevel + access.view.mipLevelCount;
+        mip += 1
+    ) {
+        for (let layerOffset = 0; layerOffset < layers; layerOffset += 1) {
+            const layer = access.view.baseArrayLayer + layerOffset;
+            for (const aspect of aspects) {
+                keys.push(
+                    `${String(access.texture.handle)}:${String(mip)}:${String(layer)}:${aspect}`
+                );
+            }
+        }
+    }
+    return Object.freeze(keys);
+}
+
+function requireHazardKeys(
+    workspace: RenderGraphCompilerWorkspace,
+    handle: RGResourceHandle,
+    passName = ''
+): readonly RGHazardKey[] {
+    const keys = workspace.hazardKeysByHandle.get(handle);
+    if (keys === undefined) {
+        renderGraphFailure(
+            'invalid-handle',
+            `resource ${String(handle)} has no hazard identity`,
+            passName
+        );
+    }
+    return keys;
+}
+
+function filterHazardKeysByAspect(
+    keys: readonly RGHazardKey[],
+    aspect: 'depth' | 'stencil'
+): readonly RGHazardKey[] {
+    const suffix = `:${aspect}`;
+    return keys.filter(key => key.endsWith(suffix));
 }
 
 function validateLoadOp(value: unknown, path: string): asserts value is 'load' | 'clear' {
@@ -384,26 +529,30 @@ function validateStoreOp(value: unknown, path: string): asserts value is 'store'
 }
 
 function validateRenderAttachmentTexture(
-    resource: CompiledRGTextureResource,
+    access: CompiledRGTextureAccess,
     path: string,
     expected: 'color' | 'depth-stencil'
 ): void {
-    if ((resource.descriptor.usage & RHITextureUsage.RENDER_ATTACHMENT) === 0) {
+    if ((access.texture.descriptor.usage & RHITextureUsage.RENDER_ATTACHMENT) === 0) {
         renderGraphFailure(
             'invalid-descriptor',
             'attachment texture lacks RENDER_ATTACHMENT usage',
             path
         );
     }
-    if (resource.descriptor.viewDimension !== '2d') {
+    if (
+        access.view.dimension !== '2d' ||
+        access.view.mipLevelCount !== 1 ||
+        access.view.arrayLayerCount !== 1
+    ) {
         renderGraphFailure(
             'invalid-descriptor',
-            'attachment declaration requires a single 2D default view',
+            'attachment declaration requires one 2D mip and array layer',
             path
         );
     }
-    const depth = rhiTextureFormatHasDepth(resource.descriptor.format);
-    const stencil = rhiTextureFormatHasStencil(resource.descriptor.format);
+    const depth = rhiTextureFormatHasDepth(access.view.format);
+    const stencil = rhiTextureFormatHasStencil(access.view.format);
     if (expected === 'color' ? depth || stencil : !depth && !stencil) {
         renderGraphFailure(
             'invalid-descriptor',
@@ -416,17 +565,15 @@ function validateRenderAttachmentTexture(
 }
 
 function validateAttachmentCompatibility(
-    reference: CompiledRGTextureResource,
-    candidate: CompiledRGTextureResource,
+    reference: CompiledRGTextureAccess,
+    candidate: CompiledRGTextureAccess,
     path: string
 ): void {
-    const first = reference.descriptor;
-    const second = candidate.descriptor;
     if (
-        first.size.width !== second.size.width ||
-        first.size.height !== second.size.height ||
-        first.size.depthOrArrayLayers !== second.size.depthOrArrayLayers ||
-        first.sampleCount !== second.sampleCount
+        reference.width !== candidate.width ||
+        reference.height !== candidate.height ||
+        reference.depthOrArrayLayers !== candidate.depthOrArrayLayers ||
+        reference.texture.descriptor.sampleCount !== candidate.texture.descriptor.sampleCount
     ) {
         renderGraphFailure(
             'invalid-descriptor',
@@ -442,8 +589,8 @@ function validateColorAttachment(
     passName: string,
     index: number
 ): {
-    readonly source: CompiledRGTextureResource;
-    readonly resolve: CompiledRGTextureResource | null;
+    readonly source: CompiledRGTextureAccess;
+    readonly resolve: CompiledRGTextureAccess | null;
 } {
     const path = `${passName}.colorAttachments[${String(index)}]`;
     validateLoadOp(declaration.loadOp, `${path}.loadOp`);
@@ -464,14 +611,14 @@ function validateColorAttachment(
             );
         }
     }
-    const source = requireTextureResource(resources, declaration.texture, passName);
+    const source = requireTextureAccess(resources, declaration.texture, passName);
     validateRenderAttachmentTexture(source, `${path}.texture`, 'color');
     if (declaration.resolveTarget === undefined) return { source, resolve: null };
 
-    const resolve = requireTextureResource(resources, declaration.resolveTarget, passName);
+    const resolve = requireTextureAccess(resources, declaration.resolveTarget, passName);
     validateRenderAttachmentTexture(resolve, `${path}.resolveTarget`, 'color');
-    const sourceDescriptor = source.descriptor;
-    const resolveDescriptor = resolve.descriptor;
+    const sourceDescriptor = source.texture.descriptor;
+    const resolveDescriptor = resolve.texture.descriptor;
     if (sourceDescriptor.sampleCount <= 1 || resolveDescriptor.sampleCount !== 1) {
         renderGraphFailure(
             'invalid-descriptor',
@@ -479,19 +626,17 @@ function validateColorAttachment(
             `${path}.resolveTarget`
         );
     }
-    if (sourceDescriptor.format !== resolveDescriptor.format) {
+    if (source.view.format !== resolve.view.format) {
         renderGraphFailure(
             'invalid-descriptor',
             'resolve source and target formats must match',
             `${path}.resolveTarget`
         );
     }
-    const sourceSize = sourceDescriptor.size;
-    const resolveSize = resolveDescriptor.size;
     if (
-        sourceSize.width !== resolveSize.width ||
-        sourceSize.height !== resolveSize.height ||
-        sourceSize.depthOrArrayLayers !== resolveSize.depthOrArrayLayers
+        source.width !== resolve.width ||
+        source.height !== resolve.height ||
+        source.depthOrArrayLayers !== resolve.depthOrArrayLayers
     ) {
         renderGraphFailure(
             'invalid-descriptor',
@@ -562,12 +707,14 @@ function validateDepthStencilAttachment(
     declaration: RGDepthStencilAttachmentDeclaration,
     resources: ReadonlyMap<RGResourceHandle, CompiledRGResource>,
     passName: string
-): { readonly resource: CompiledRGTextureResource; readonly access: DepthStencilAccess } {
+): { readonly resource: CompiledRGTextureAccess; readonly access: DepthStencilAccess } {
     const path = `${passName}.depthStencilAttachment`;
-    const resource = requireTextureResource(resources, declaration.texture, passName);
+    const resource = requireTextureAccess(resources, declaration.texture, passName);
     validateRenderAttachmentTexture(resource, `${path}.texture`, 'depth-stencil');
-    const hasDepth = rhiTextureFormatHasDepth(resource.descriptor.format);
-    const hasStencil = rhiTextureFormatHasStencil(resource.descriptor.format);
+    const hasDepth =
+        resource.view.aspect !== 'stencil-only' && rhiTextureFormatHasDepth(resource.view.format);
+    const hasStencil =
+        resource.view.aspect !== 'depth-only' && rhiTextureFormatHasStencil(resource.view.format);
     const depth = validateDepthStencilAspect({
         path,
         label: 'depth',
@@ -669,35 +816,49 @@ export class RenderGraphCompiler {
         const lastWriter = workspace.lastWriter;
         const readersSinceWrite = workspace.readersSinceWrite;
         const contentAvailable = workspace.contentAvailable;
-        const depthContentAvailable = workspace.depthContentAvailable;
-        const stencilContentAvailable = workspace.stencilContentAvailable;
         const passIndexByHandle = workspace.passIndexByHandle;
         const outgoing = workspace.outgoing;
         const incoming = workspace.incoming;
         for (const resource of snapshot.resources) {
-            const normalized = normalizedResource(resource, capabilities);
+            const normalized = normalizedResource(resource, capabilities, resourceByHandle);
             normalizedResources.push(normalized);
             resourceByHandle.set(normalized.handle, normalized);
-            const imported = normalized.origin === 'imported';
-            contentAvailable.set(
-                normalized.handle,
-                normalized.kind === 'buffer' ? normalized.initiallyInitialized : imported
-            );
-            if (normalized.kind === 'texture') {
-                if (rhiTextureFormatHasDepth(normalized.descriptor.format)) {
-                    depthContentAvailable.set(normalized.handle, imported);
-                }
-                if (rhiTextureFormatHasStencil(normalized.descriptor.format)) {
-                    stencilContentAvailable.set(normalized.handle, imported);
+            if (normalized.kind === 'buffer') {
+                const key = `buffer:${String(normalized.handle)}`;
+                const keys = Object.freeze([key]);
+                workspace.hazardKeysByHandle.set(normalized.handle, keys);
+                contentAvailable.set(key, normalized.initiallyInitialized);
+            } else {
+                const access = requireTextureAccess(
+                    resourceByHandle,
+                    normalized.handle,
+                    normalized.name
+                );
+                const keys = createTextureHazardKeys(access);
+                workspace.hazardKeysByHandle.set(normalized.handle, keys);
+                if (normalized.kind === 'texture') {
+                    const initialized =
+                        normalized.origin === 'imported' && normalized.initiallyInitialized;
+                    for (const key of keys) contentAvailable.set(key, initialized);
                 }
             }
         }
         for (const pass of snapshot.passes) passIndexByHandle.set(pass.handle, pass.index);
 
-        const capturePreferredWriter = (handle: RGResourceHandle, pass: RGPassNode): void => {
+        const capturePreferredWriter = (
+            handle: RGResourceHandle,
+            pass: RGPassNode,
+            keys = requireHazardKeys(workspace, handle, pass.name)
+        ): void => {
             const resource = resourceByHandle.get(handle);
-            if (resource?.kind === 'texture' && resource.readFromLastGraphWriter) {
-                lastPreferredGraphWriter.set(handle, pass.index);
+            const texture =
+                resource?.kind === 'texture-view'
+                    ? resourceByHandle.get(resource.texture)
+                    : resource;
+            if (texture?.kind === 'texture' && texture.readFromLastGraphWriter) {
+                for (const key of keys) {
+                    lastPreferredGraphWriter.set(key, pass.index);
+                }
             }
         };
         for (const pass of snapshot.passes) {
@@ -716,7 +877,16 @@ export class RenderGraphCompiler {
                     pass.name
                 );
                 if (access.depth.writes || access.stencil.writes) {
-                    capturePreferredWriter(resource.handle, pass);
+                    const keys = requireHazardKeys(workspace, resource.resource.handle, pass.name);
+                    capturePreferredWriter(
+                        resource.resource.handle,
+                        pass,
+                        keys.filter(
+                            key =>
+                                (access.depth.writes && key.endsWith(':depth')) ||
+                                (access.stencil.writes && key.endsWith(':stencil'))
+                        )
+                    );
                 }
             }
         }
@@ -732,41 +902,76 @@ export class RenderGraphCompiler {
             }
             return resource;
         };
+        const readHazardDependencies = (keys: readonly RGHazardKey[], pass: RGPassNode): void => {
+            for (const key of keys) {
+                const writer = lastWriter.get(key);
+                if (writer !== undefined) addEdge(outgoing, incoming, writer, pass.index);
+                const readers = readersSinceWrite.get(key) ?? workspace.acquireReaderSet(key);
+                readers.add(pass.index);
+            }
+        };
+        const writeHazardDependencies = (keys: readonly RGHazardKey[], pass: RGPassNode): void => {
+            for (const key of keys) {
+                const writer = lastWriter.get(key);
+                if (writer !== undefined) addEdge(outgoing, incoming, writer, pass.index);
+                for (const reader of readersSinceWrite.get(key) ?? []) {
+                    addEdge(outgoing, incoming, reader, pass.index);
+                }
+                workspace.acquireReaderSet(key).clear();
+                lastWriter.set(key, pass.index);
+            }
+        };
         const readResourceDependency = (
             handle: RGResourceHandle,
             pass: RGPassNode,
             preferLastGraphWriter = false
         ): void => {
             const resource = requireResource(handle, pass);
-            const preferredWriter = preferLastGraphWriter
-                ? lastPreferredGraphWriter.get(handle)
-                : undefined;
-            if (resource.kind === 'texture' && resource.readFromLastGraphWriter) {
-                if (preferredWriter !== undefined) {
-                    addEdge(outgoing, incoming, preferredWriter, pass.index);
-                    preferredGraphWriterReads.add(handle);
-                    return;
+            const parent =
+                resource.kind === 'texture-view'
+                    ? resourceByHandle.get(resource.texture)
+                    : resource;
+            if (parent?.kind === 'texture' && parent.readFromLastGraphWriter) {
+                let usedPreferredWriter = false;
+                for (const key of requireHazardKeys(workspace, handle, pass.name)) {
+                    const preferredWriter = preferLastGraphWriter
+                        ? lastPreferredGraphWriter.get(key)
+                        : undefined;
+                    if (preferredWriter !== undefined) {
+                        addEdge(outgoing, incoming, preferredWriter, pass.index);
+                        usedPreferredWriter = true;
+                    } else readHazardDependencies([key], pass);
                 }
+                if (usedPreferredWriter) {
+                    preferredGraphWriterReads.add(handle);
+                }
+                return;
             }
-            const writer = lastWriter.get(handle);
-            if (writer !== undefined) addEdge(outgoing, incoming, writer, pass.index);
-            let readers = readersSinceWrite.get(handle);
-            readers ??= workspace.acquireReaderSet(handle);
-            readers.add(pass.index);
+            readHazardDependencies(requireHazardKeys(workspace, handle, pass.name), pass);
         };
-        const genericContentAvailable = (resource: CompiledRGResource): boolean =>
-            contentAvailable.get(resource.handle) === true;
+        const genericContentAvailable = (resource: CompiledRGResource): boolean => {
+            for (const key of requireHazardKeys(workspace, resource.handle)) {
+                if (contentAvailable.get(key) !== true) return false;
+            }
+            return true;
+        };
         const readResource = (
             handle: RGResourceHandle,
             pass: RGPassNode,
             preferLastGraphWriter = false
         ): void => {
             const resource = requireResource(handle, pass);
+            const preferredTexture =
+                resource.kind === 'texture-view'
+                    ? resourceByHandle.get(resource.texture)
+                    : resource;
             if (
                 preferLastGraphWriter &&
-                resource.kind === 'texture' &&
-                resource.readFromLastGraphWriter &&
-                lastPreferredGraphWriter.has(handle)
+                preferredTexture?.kind === 'texture' &&
+                preferredTexture.readFromLastGraphWriter &&
+                requireHazardKeys(workspace, handle, pass.name).some(key =>
+                    lastPreferredGraphWriter.has(key)
+                )
             ) {
                 readResourceDependency(handle, pass, true);
                 return;
@@ -785,26 +990,14 @@ export class RenderGraphCompiler {
             pass: RGPassNode
         ): CompiledRGResource => {
             const resource = requireResource(handle, pass);
-            const writer = lastWriter.get(handle);
-            if (writer !== undefined) addEdge(outgoing, incoming, writer, pass.index);
-            for (const reader of readersSinceWrite.get(handle) ?? []) {
-                addEdge(outgoing, incoming, reader, pass.index);
-            }
-            workspace.acquireReaderSet(handle).clear();
-            lastWriter.set(handle, pass.index);
+            writeHazardDependencies(requireHazardKeys(workspace, handle, pass.name), pass);
             resourceWriters.set(handle, pass.index);
             return resource;
         };
         const writeResource = (handle: RGResourceHandle, pass: RGPassNode): void => {
-            const resource = writeResourceDependency(handle, pass);
-            contentAvailable.set(handle, true);
-            if (resource.kind === 'texture') {
-                if (rhiTextureFormatHasDepth(resource.descriptor.format)) {
-                    depthContentAvailable.set(handle, true);
-                }
-                if (rhiTextureFormatHasStencil(resource.descriptor.format)) {
-                    stencilContentAvailable.set(handle, true);
-                }
+            writeResourceDependency(handle, pass);
+            for (const key of requireHazardKeys(workspace, handle, pass.name)) {
+                contentAvailable.set(key, true);
             }
         };
 
@@ -816,7 +1009,7 @@ export class RenderGraphCompiler {
                     pass.name
                 );
             }
-            let attachmentReference: CompiledRGTextureResource | null = null;
+            let attachmentReference: CompiledRGTextureAccess | null = null;
             const readSet = workspace.scratchReadSet;
             readSet.clear();
             for (const handle of pass.reads) readSet.add(handle);
@@ -833,14 +1026,53 @@ export class RenderGraphCompiler {
                 }
                 readWriteSet.add(handle);
             }
-            for (const handle of pass.writes) {
-                if (readSet.has(handle) && !readWriteSet.has(handle as RGBufferHandle)) {
-                    renderGraphFailure(
-                        'duplicate-access',
-                        'same-pass read/write feedback is not portable',
-                        pass.name
-                    );
+            const readHazards = workspace.scratchReadHazards;
+            const writeHazards = workspace.scratchWriteHazards;
+            const attachmentHazards = workspace.scratchAttachmentHazards;
+            readHazards.clear();
+            writeHazards.clear();
+            attachmentHazards.clear();
+            for (const handle of pass.reads) {
+                for (const key of requireHazardKeys(workspace, handle, pass.name)) {
+                    readHazards.add(key);
                 }
+            }
+            for (const handle of pass.writes) {
+                for (const key of requireHazardKeys(workspace, handle, pass.name)) {
+                    if (readHazards.has(key) && !readWriteSet.has(handle as RGBufferHandle)) {
+                        renderGraphFailure(
+                            'duplicate-access',
+                            'same-pass overlapping texture/buffer feedback is not portable',
+                            pass.name
+                        );
+                    }
+                    writeHazards.add(key);
+                }
+            }
+            const addAttachmentHazards = (handle: RGTextureAccessHandle): void => {
+                for (const key of requireHazardKeys(workspace, handle, pass.name)) {
+                    if (
+                        readHazards.has(key) ||
+                        writeHazards.has(key) ||
+                        attachmentHazards.has(key)
+                    ) {
+                        renderGraphFailure(
+                            'duplicate-access',
+                            'attachment overlaps another same-pass resource access',
+                            pass.name
+                        );
+                    }
+                    attachmentHazards.add(key);
+                }
+            };
+            for (const attachment of pass.colorAttachments) {
+                addAttachmentHazards(attachment.texture);
+                if (attachment.resolveTarget !== undefined) {
+                    addAttachmentHazards(attachment.resolveTarget);
+                }
+            }
+            if (pass.depthStencilAttachment !== null) {
+                addAttachmentHazards(pass.depthStencilAttachment.texture);
             }
             for (const access of pass.bufferAccesses) {
                 const resource = requireResource(access.buffer, pass);
@@ -905,10 +1137,13 @@ export class RenderGraphCompiler {
                         `${pass.name}.colorAttachments[${String(index)}]`
                     );
                 } else attachmentReference = source;
-                if (declaration.loadOp === 'load') readResource(source.handle, pass);
-                writeResource(source.handle, pass);
-                contentAvailable.set(source.handle, declaration.storeOp === 'store');
-                if (resolve) writeResource(resolve.handle, pass);
+                const sourceHandle = source.resource.handle;
+                if (declaration.loadOp === 'load') readResource(sourceHandle, pass);
+                writeResource(sourceHandle, pass);
+                for (const key of requireHazardKeys(workspace, sourceHandle, pass.name)) {
+                    contentAvailable.set(key, declaration.storeOp === 'store');
+                }
+                if (resolve) writeResource(resolve.resource.handle, pass);
             }
             if (pass.depthStencilAttachment) {
                 const { resource, access } = validateDepthStencilAttachment(
@@ -923,43 +1158,52 @@ export class RenderGraphCompiler {
                         `${pass.name}.depthStencilAttachment`
                     );
                 }
+                const resourceHandle = resource.resource.handle;
+                const resourceKeys = requireHazardKeys(workspace, resourceHandle, pass.name);
+                const depthKeys = filterHazardKeysByAspect(resourceKeys, 'depth');
+                const stencilKeys = filterHazardKeysByAspect(resourceKeys, 'stencil');
                 if (
                     access.depth.requiresLoad &&
-                    depthContentAvailable.get(resource.handle) !== true
+                    depthKeys.some(key => contentAvailable.get(key) !== true)
                 ) {
                     renderGraphFailure(
                         'uninitialized-read',
-                        `loads depth from ${resource.name} before initialization or after discard`,
+                        `loads depth from ${resource.resource.name} before initialization or after discard`,
                         pass.name
                     );
                 }
                 if (
                     access.stencil.requiresLoad &&
-                    stencilContentAvailable.get(resource.handle) !== true
+                    stencilKeys.some(key => contentAvailable.get(key) !== true)
                 ) {
                     renderGraphFailure(
                         'uninitialized-read',
-                        `loads stencil from ${resource.name} before initialization or after discard`,
+                        `loads stencil from ${resource.resource.name} before initialization or after discard`,
                         pass.name
                     );
                 }
                 if (access.depth.requiresLoad || access.stencil.requiresLoad) {
-                    readResourceDependency(resource.handle, pass);
+                    const readKeys: RGHazardKey[] = [];
+                    if (access.depth.requiresLoad) readKeys.push(...depthKeys);
+                    if (access.stencil.requiresLoad) readKeys.push(...stencilKeys);
+                    readHazardDependencies(readKeys, pass);
                 }
                 if (access.depth.writes || access.stencil.writes) {
-                    writeResourceDependency(resource.handle, pass);
+                    const writeKeys: RGHazardKey[] = [];
+                    if (access.depth.writes) writeKeys.push(...depthKeys);
+                    if (access.stencil.writes) writeKeys.push(...stencilKeys);
+                    writeHazardDependencies(writeKeys, pass);
                     if (access.depth.writes) {
-                        depthContentAvailable.set(resource.handle, access.depth.stores);
+                        for (const key of depthKeys) {
+                            contentAvailable.set(key, access.depth.stores);
+                        }
                     }
                     if (access.stencil.writes) {
-                        stencilContentAvailable.set(resource.handle, access.stencil.stores);
+                        for (const key of stencilKeys) {
+                            contentAvailable.set(key, access.stencil.stores);
+                        }
                     }
-                    contentAvailable.set(
-                        resource.handle,
-                        (!access.hasDepth || depthContentAvailable.get(resource.handle) === true) &&
-                            (!access.hasStencil ||
-                                stencilContentAvailable.get(resource.handle) === true)
-                    );
+                    resourceWriters.set(resourceHandle, pass.index);
                 }
             }
         }
@@ -989,17 +1233,21 @@ export class RenderGraphCompiler {
                     `output ${String(output)} is not in this graph`
                 );
             }
-            const writer = resourceWriters.get(output);
+            const outputWriters = new Set<number>();
+            for (const key of requireHazardKeys(workspace, output)) {
+                const writer = lastWriter.get(key);
+                if (writer !== undefined) outputWriters.add(writer);
+            }
             if (
-                contentAvailable.get(output) !== true &&
-                (writer === undefined || resource.extracted)
+                !genericContentAvailable(resource) &&
+                (outputWriters.size === 0 || resource.extracted)
             ) {
                 renderGraphFailure(
                     'uninitialized-read',
                     `output resource ${resource.name} is uninitialized or was discarded`
                 );
             }
-            if (writer !== undefined) roots.add(writer);
+            for (const writer of outputWriters) roots.add(writer);
         }
         const live = markLivePasses(roots, incoming, snapshot.passes.length, workspace);
         const scheduledSourceIndices = workspace.scheduledSourceIndices;
@@ -1033,7 +1281,7 @@ export class RenderGraphCompiler {
                     pass.name
                 );
                 (access.depth.writes || access.stencil.writes ? writes : reads).add(
-                    resource.handle
+                    resource.resource.handle
                 );
             }
             for (const handle of reads) {
@@ -1056,6 +1304,22 @@ export class RenderGraphCompiler {
                     writes,
                     bufferAccesses
                 })
+            );
+        }
+        for (const resource of normalizedResources) {
+            if (resource.kind !== 'texture-view') continue;
+            const viewFirstUse = firstUse.get(resource.handle);
+            if (viewFirstUse === undefined) continue;
+            const viewLastUse = lastUse.get(resource.handle) ?? viewFirstUse;
+            const parentFirstUse = firstUse.get(resource.texture);
+            const parentLastUse = lastUse.get(resource.texture);
+            firstUse.set(
+                resource.texture,
+                parentFirstUse === undefined ? viewFirstUse : Math.min(parentFirstUse, viewFirstUse)
+            );
+            lastUse.set(
+                resource.texture,
+                parentLastUse === undefined ? viewLastUse : Math.max(parentLastUse, viewLastUse)
             );
         }
         const compiledResources: CompiledRGResource[] = [];

--- a/src/render/graph/RenderGraphExecutor.ts
+++ b/src/render/graph/RenderGraphExecutor.ts
@@ -13,8 +13,15 @@ import type {
     CompiledRGResource,
     CompiledRenderGraph
 } from './RenderGraphCompiler';
-import type { RGBufferHandle, RGResourceHandle, RGTextureHandle } from './RenderGraphResource';
+import type {
+    RGBufferHandle,
+    RGResourceHandle,
+    RGTextureAccessHandle,
+    RGTextureHandle
+} from './RenderGraphResource';
 import { renderGraphFailure } from './RenderGraphValidation';
+
+type CompiledRGPhysicalResource = Exclude<CompiledRGResource, { readonly kind: 'texture-view' }>;
 
 function sameStringList(first: readonly string[], second: readonly string[]): boolean {
     if (first.length !== second.length) return false;
@@ -167,7 +174,7 @@ class PreparedRGResourceLookup {
 
 interface PooledRGResource {
     readonly key: number;
-    readonly compiled: CompiledRGResource;
+    readonly compiled: CompiledRGPhysicalResource;
     readonly deviceId: number;
     readonly deviceGeneration: number;
     readonly texture: RHITexture | null;
@@ -189,7 +196,7 @@ function mixPoolKeyString(hash: number, value: string): number {
 }
 
 /** Allocation-free numeric bucket; structural equality below makes hash collisions harmless. */
-function resourcePoolKey(resource: CompiledRGResource): number {
+function resourcePoolKey(resource: CompiledRGPhysicalResource): number {
     if (resource.kind === 'buffer') {
         const descriptor = resource.descriptor;
         let hash = mixPoolKey(0x811c9dc5, 1);
@@ -221,7 +228,7 @@ function resourcePoolKey(resource: CompiledRGResource): number {
 
 function samePooledResourceDescriptor(
     entry: PooledRGResource,
-    resource: CompiledRGResource
+    resource: CompiledRGPhysicalResource
 ): boolean {
     const cached = entry.compiled;
     if (cached.kind !== resource.kind) return false;
@@ -270,7 +277,11 @@ class TransientResourcePool {
         this.#ownerDeviceGeneration = device.generation;
     }
 
-    acquire(resource: CompiledRGResource, device: RHIDevice, result: PreparedRGResource): void {
+    acquire(
+        resource: CompiledRGPhysicalResource,
+        device: RHIDevice,
+        result: PreparedRGResource
+    ): void {
         this.useDevice(device);
         const key = resourcePoolKey(resource);
         const entries = this.#entries.get(key);
@@ -532,15 +543,15 @@ export interface RGExecutionOptions {
 
 export interface RGPassContext {
     readonly commandContext: RHICommandContext;
-    getTexture(handle: RGTextureHandle): RHITexture;
-    getTextureView(handle: RGTextureHandle): RHITextureView;
+    getTexture(handle: RGTextureAccessHandle): RHITexture;
+    getTextureView(handle: RGTextureAccessHandle): RHITextureView;
     getBuffer(handle: RGBufferHandle): RHIBuffer;
 }
 
 /** Resource-only scope used before queue.beginFrame; it intentionally exposes no command context. */
 export interface RGPrepareContext {
-    getTexture(handle: RGTextureHandle): RHITexture;
-    getTextureView(handle: RGTextureHandle): RHITextureView;
+    getTexture(handle: RGTextureAccessHandle): RHITexture;
+    getTextureView(handle: RGTextureAccessHandle): RHITextureView;
     getBuffer(handle: RGBufferHandle): RHIBuffer;
 }
 
@@ -553,7 +564,7 @@ class RGDeclaredResourceContext implements RGPrepareContext {
         this.activePass = pass;
     }
 
-    getTexture(handle: RGTextureHandle): RHITexture {
+    getTexture(handle: RGTextureAccessHandle): RHITexture {
         const resource = this.requireDeclared(handle);
         if (!resource.texture) {
             renderGraphFailure('invalid-handle', `resource ${String(handle)} is not a texture`);
@@ -561,7 +572,7 @@ class RGDeclaredResourceContext implements RGPrepareContext {
         return resource.texture;
     }
 
-    getTextureView(handle: RGTextureHandle): RHITextureView {
+    getTextureView(handle: RGTextureAccessHandle): RHITextureView {
         const resource = this.requireDeclared(handle);
         if (!resource.textureView) {
             renderGraphFailure('invalid-handle', `resource ${String(handle)} is not a texture`);
@@ -735,6 +746,19 @@ export class RenderGraphExecutor {
         try {
             for (const resource of graph.resources) {
                 const prepared = workspace.acquire(resource);
+                if (resource.kind === 'texture-view') {
+                    const parent = preparedByHandle.get(resource.texture);
+                    if (!parent?.texture) {
+                        renderGraphFailure(
+                            'invalid-state',
+                            'texture view parent was not prepared before the view',
+                            resource.name
+                        );
+                    }
+                    prepared.texture = parent.texture;
+                    prepared.textureView = parent.texture.createView(resource.descriptor);
+                    continue;
+                }
                 prepared.owned = resource.origin === 'transient';
                 prepared.allocated = prepared.owned;
                 if (prepared.owned && !resource.extracted) {

--- a/src/render/graph/RenderGraphResource.ts
+++ b/src/render/graph/RenderGraphResource.ts
@@ -6,22 +6,28 @@ import type {
     RHIResourceLifetime,
     RHIStoreOp,
     RHITexture,
-    RHITextureDescriptor
+    RHITextureDescriptor,
+    RHITextureViewDescriptor
 } from '../rhi/core';
 
 declare const rgTextureHandleBrand: unique symbol;
+declare const rgTextureViewHandleBrand: unique symbol;
 declare const rgBufferHandleBrand: unique symbol;
 declare const rgPassHandleBrand: unique symbol;
 
 /** Numeric texture identity scoped to one RenderGraphBuilder. */
 export type RGTextureHandle = number & { readonly [rgTextureHandleBrand]: true };
+/** Numeric texture-view identity scoped to one RenderGraphBuilder. */
+export type RGTextureViewHandle = number & { readonly [rgTextureViewHandleBrand]: true };
 /** Numeric buffer identity scoped to one RenderGraphBuilder. */
 export type RGBufferHandle = number & { readonly [rgBufferHandleBrand]: true };
 /** Numeric pass identity scoped to one RenderGraphBuilder. */
 export type RGPassHandle = number & { readonly [rgPassHandleBrand]: true };
-export type RGResourceHandle = RGTextureHandle | RGBufferHandle;
+export type RGTextureAccessHandle = RGTextureHandle | RGTextureViewHandle;
+export type RGResourceHandle = RGTextureAccessHandle | RGBufferHandle;
 
 export type RGTextureDescriptor = Omit<RHITextureDescriptor, 'lifetime'>;
+export type RGTextureViewDescriptor = RHITextureViewDescriptor;
 export type RGBufferDescriptor = Omit<RHIBufferDescriptor, 'lifetime' | 'initialData'>;
 
 /**
@@ -34,7 +40,7 @@ export type RGImportedTextureProvider = () => RHITexture;
 /** See {@link RGImportedTextureProvider}. */
 export type RGImportedBufferProvider = () => RHIBuffer;
 
-export type RGResourceKind = 'texture' | 'buffer';
+export type RGResourceKind = 'texture' | 'texture-view' | 'buffer';
 export type RGResourceOrigin = 'imported' | 'transient';
 
 /** Portable roles that consume initialized buffer contents. */
@@ -66,8 +72,8 @@ export type RGBufferAccessDeclaration =
 
 /** A color attachment is a render-pass read/write access, not sampled feedback. */
 export interface RGColorAttachmentDeclaration {
-    readonly texture: RGTextureHandle;
-    readonly resolveTarget?: RGTextureHandle;
+    readonly texture: RGTextureAccessHandle;
+    readonly resolveTarget?: RGTextureAccessHandle;
     readonly clearValue?: RHIColor;
     readonly loadOp: RHILoadOp;
     readonly storeOp: RHIStoreOp;
@@ -75,7 +81,7 @@ export interface RGColorAttachmentDeclaration {
 
 /** Depth/stencil access is tracked independently from ordinary sampled/copy reads and writes. */
 export interface RGDepthStencilAttachmentDeclaration {
-    readonly texture: RGTextureHandle;
+    readonly texture: RGTextureAccessHandle;
     readonly depthClearValue?: number;
     readonly depthLoadOp?: RHILoadOp;
     readonly depthStoreOp?: RHIStoreOp;
@@ -98,7 +104,19 @@ export interface RGTextureResourceNode {
     readonly resourceLifetime: RHIResourceLifetime;
     /** @internal Pure graph reads prefer this graph's complete writer chain when one exists. */
     readonly readFromLastGraphWriter: boolean;
+    /** Whether every selected subresource has contents before this graph invocation. */
+    readonly initiallyInitialized: boolean;
     readonly extracted: boolean;
+}
+
+/** @internal Compiler snapshot for one view into a graph texture resource. */
+export interface RGTextureViewResourceNode {
+    readonly kind: 'texture-view';
+    readonly handle: RGTextureViewHandle;
+    readonly name: string;
+    readonly texture: RGTextureHandle;
+    readonly descriptor: RGTextureViewDescriptor;
+    readonly extracted: false;
 }
 
 /** @internal Compiler snapshot; renderer features should use numeric handles instead. */
@@ -117,7 +135,8 @@ export interface RGBufferResourceNode {
 }
 
 /** @internal */
-export type RGResourceNode = RGTextureResourceNode | RGBufferResourceNode;
+export type RGResourceNode =
+    RGTextureResourceNode | RGTextureViewResourceNode | RGBufferResourceNode;
 
 export interface RGResourceLifetime {
     readonly firstUse: number;

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -7,7 +7,12 @@ import type { RenderGraphFrameBuildScope } from '../frame/RenderGraphFrame';
 import type { RenderGraphFrameContext } from '../frame/RenderGraphFrameContext';
 import type { RGPassBuilder, RenderPassTemplate } from '../graph/RenderGraphBuilder';
 import type { RGPassContext, RGPrepareContext } from '../graph/RenderGraphExecutor';
-import type { RGBufferHandle, RGPassHandle, RGTextureHandle } from '../graph/RenderGraphResource';
+import type {
+    RGBufferHandle,
+    RGPassHandle,
+    RGTextureAccessHandle,
+    RGTextureHandle
+} from '../graph/RenderGraphResource';
 import RenderList from '../RenderList';
 import { RenderGraphFramePlanner } from '../RenderGraphFramePlan';
 import type {
@@ -30,12 +35,19 @@ import {
     type RHIBindGroupLayout,
     type RHIBindingResource,
     type RHIBuffer,
+    type RHINormalizedTextureViewDescriptor,
     type RHIRenderPassEncoder,
     type RHISurface,
     type RHITexture,
+    type RHITextureDimension,
     type RHITextureFormat,
+    type RHITextureViewDimension,
     type RHIViewport
 } from '../rhi/core';
+import {
+    normalizeRHITextureDescriptor,
+    normalizeRHITextureViewDescriptorForTextureDescriptor
+} from '../rhi/core/RHIValidation';
 import type { RendererStorageBuffer, StorageBuffer } from '../StorageBuffer';
 import type {
     CullingOptions,
@@ -77,14 +89,20 @@ import type {
     RenderGraphBufferReadUse,
     RenderGraphBufferWriteUse,
     RenderGraphPassHandle,
+    RenderGraphTextureAccessHandle,
     RenderGraphTextureHandle,
+    RenderGraphTextureViewHandle,
     RenderPipelineBufferDescriptor,
     RenderPipelineColorAttachment,
     RenderPipelineDepthStencilAttachment,
     RenderPipelineExtent,
+    RenderPipelineHistoryTextureDescriptor,
+    RenderPipelineHistoryTextureResources,
     RenderPipelinePersistentTargetDescriptor,
+    RenderPipelinePersistentTextureUsage,
     RenderPipelineTargetResources,
     RenderPipelineTextureDescriptor,
+    RenderPipelineTextureViewDescriptor,
     ScriptableRenderCommands,
     ScriptableRenderGraph,
     ScriptableRenderPass,
@@ -112,7 +130,7 @@ import type {
     RenderTargetResourceRecord
 } from '../renderer/RenderTargetResourceCache';
 import type { RHIMeshDrawTargetDescriptor } from '../renderer/RHIDescriptorMapping';
-import type { ResourceRegistryHandle } from '../renderer/ResourceRegistry';
+import type { ResourceRegistry, ResourceRegistryHandle } from '../renderer/ResourceRegistry';
 import type { RHIRenderTarget } from '../renderer/RHIRenderTarget';
 import type { StorageBufferResourceCache } from '../renderer/StorageBufferResourceCache';
 import {
@@ -135,7 +153,7 @@ type TextureAccess =
     | 'storage-write'
     | 'copy-source'
     | 'copy-destination';
-type PipelineTextureFormat = RenderTargetColorFormat | RenderTargetDepthStencilFormat;
+type PipelineTextureFormat = RHITextureFormat;
 type MutableRHIViewport = { -readonly [Key in keyof RHIViewport]: RHIViewport[Key] };
 type MutableRenderTargetColor = {
     -readonly [Key in keyof RenderTargetColor]: RenderTargetColor[Key];
@@ -175,10 +193,11 @@ interface MutableTextureGraphDescriptor {
     readonly size: { width: number; height: number; depthOrArrayLayers: number };
     mipLevelCount: number;
     sampleCount: number;
-    dimension: '2d';
-    viewDimension: '2d';
+    dimension: RHITextureDimension;
+    viewDimension: RHITextureViewDimension;
     format: PipelineTextureFormat;
     usage: number;
+    readonly viewFormats: RHITextureFormat[];
 }
 
 interface MutableBufferGraphDescriptor {
@@ -198,21 +217,66 @@ interface MutablePersistentTargetResourceDescriptor extends RenderTargetResource
     depthStencilSampled: false;
 }
 
-interface TextureRecord {
-    handle: RenderGraphTextureHandle;
+interface TextureAccessRecordBase {
+    handle: RenderGraphTextureAccessHandle;
     name: string;
     format: PipelineTextureFormat;
     width: number;
     height: number;
+    depthOrArrayLayers: number;
     sampleCount: 1 | 4;
     mipLevelCount: number;
+    textureDimension: RHITextureDimension;
+    attachment: RGTextureAccessHandle | null;
+    readable: RGTextureAccessHandle | null;
+    writable: RGTextureAccessHandle | null;
+    resolveTarget: RGTextureAccessHandle | null;
+    outputRoot: RGTextureHandle | null;
+    transient: boolean;
+    historyState: PersistentHistoryState | null;
+    historyCurrent: boolean;
+}
+
+interface TextureRecord extends TextureAccessRecordBase {
+    readonly kind: 'texture';
+    handle: RenderGraphTextureHandle;
     attachment: RGTextureHandle | null;
     readable: RGTextureHandle | null;
     writable: RGTextureHandle | null;
     resolveTarget: RGTextureHandle | null;
-    outputRoot: RGTextureHandle | null;
-    transient: boolean;
+    viewDimension: RHITextureViewDimension;
+    viewFormats: readonly RHITextureFormat[];
     readonly graphDescriptor: MutableTextureGraphDescriptor;
+}
+
+interface TextureViewRecord extends TextureAccessRecordBase {
+    readonly kind: 'texture-view';
+    handle: RenderGraphTextureViewHandle;
+    texture: TextureRecord;
+    descriptor: Readonly<RHINormalizedTextureViewDescriptor>;
+}
+
+type TextureAccessRecord = TextureRecord | TextureViewRecord;
+
+interface TextureRecordSource {
+    readonly name: string;
+    readonly format: PipelineTextureFormat;
+    readonly width: number;
+    readonly height: number;
+    readonly depthOrArrayLayers?: number;
+    readonly sampleCount: 1 | 4;
+    readonly mipLevelCount: number;
+    readonly textureDimension?: RHITextureDimension;
+    readonly viewDimension?: RHITextureViewDimension;
+    readonly viewFormats?: readonly RHITextureFormat[];
+    readonly attachment: RGTextureHandle | null;
+    readonly readable: RGTextureHandle | null;
+    readonly writable: RGTextureHandle | null;
+    readonly resolveTarget: RGTextureHandle | null;
+    readonly outputRoot: RGTextureHandle | null;
+    readonly transient: boolean;
+    readonly historyState?: PersistentHistoryState | null;
+    readonly historyCurrent?: boolean;
 }
 
 interface BufferRecord {
@@ -233,12 +297,22 @@ interface RendererListRange {
 }
 
 interface MutableCopyCommand {
-    sourceHandle: RenderGraphTextureHandle;
-    destinationHandle: RenderGraphTextureHandle;
-    sourceInternal: RGTextureHandle;
-    destinationInternal: RGTextureHandle;
-    readonly source: { texture: RHITexture | null };
-    readonly destination: { texture: RHITexture | null };
+    sourceHandle: RenderGraphTextureAccessHandle;
+    destinationHandle: RenderGraphTextureAccessHandle;
+    sourceInternal: RGTextureAccessHandle;
+    destinationInternal: RGTextureAccessHandle;
+    readonly source: {
+        texture: RHITexture | null;
+        mipLevel: number;
+        readonly origin: { x: number; y: number; z: number };
+        aspect: 'all' | 'depth-only' | 'stencil-only';
+    };
+    readonly destination: {
+        texture: RHITexture | null;
+        mipLevel: number;
+        readonly origin: { x: number; y: number; z: number };
+        aspect: 'all' | 'depth-only' | 'stencil-only';
+    };
     readonly size: { width: number; height: number; depthOrArrayLayers: number };
 }
 
@@ -308,6 +382,48 @@ interface PersistentTargetState {
     pendingRelease: boolean;
 }
 
+interface PersistentHistoryState {
+    readonly key: object;
+    descriptor: Readonly<HistoryTextureRecipe> | null;
+    handles: ResourceRegistryHandle<RHITexture>[];
+    initialized: boolean[];
+    committedIndex: number;
+    registryGeneration: number;
+    generation: number;
+    pendingDescriptor: Readonly<HistoryTextureRecipe> | null;
+    pendingHandles: ResourceRegistryHandle<RHITexture>[];
+    pendingInitialized: boolean[];
+    frameHandles: ResourceRegistryHandle<RHITexture>[] | null;
+    frameInitialized: boolean[] | null;
+    frameWriteIndex: number;
+    lastAcquiredFrameIndex: number;
+    wroteThisFrame: boolean;
+    pendingRelease: boolean;
+}
+
+interface HistoryTextureRecipe {
+    readonly label: string;
+    readonly width: number;
+    readonly height: number;
+    readonly depthOrArrayLayers: number;
+    readonly mipLevelCount: number;
+    readonly sampleCount: 1 | 4;
+    readonly dimension: RHITextureDimension;
+    readonly viewDimension: RHITextureViewDimension;
+    readonly format: PipelineTextureFormat;
+    readonly usage: number;
+    readonly viewFormats: readonly RHITextureFormat[];
+    readonly bufferCount: 2 | 3;
+}
+
+interface PreparedHistoryTexture {
+    readonly state: PersistentHistoryState;
+    readonly handles: readonly ResourceRegistryHandle<RHITexture>[];
+    readonly initialized: readonly boolean[];
+    readonly writeIndex: number;
+    readonly generation: number;
+}
+
 /** @internal Renderer services deliberately narrower than either Renderer or the portable RHI. */
 export interface ScriptableRenderPipelineServices {
     readonly renderer: RendererCore;
@@ -358,10 +474,13 @@ export class ScriptableRenderPipelineResources {
     #runtimeOwner: object | null = null;
     #persistentByKey = new WeakMap<object, PersistentTargetState>();
     readonly #persistentStates = new Set<PersistentTargetState>();
+    #historyByKey = new WeakMap<object, PersistentHistoryState>();
+    readonly #historyStates = new Set<PersistentHistoryState>();
     readonly #deferredPersistentCleanupOwners = new Set<object>();
     readonly #frameBindGroups = new Set<RHIBindGroup>();
     readonly #cleanupFailures: unknown[] = [];
     #activeFrameIndex = -1;
+    #activeRegistry: ResourceRegistry | null = null;
     #nextHandle = 1;
 
     allocateHandle(): number {
@@ -463,7 +582,117 @@ export class ScriptableRenderPipelineResources {
         return true;
     }
 
-    beginFrame(frameIndex: number): void {
+    prepareHistoryTexture(
+        runtimeOwner: object,
+        key: unknown,
+        frameIndex: number,
+        registry: ResourceRegistry,
+        descriptor: Readonly<HistoryTextureRecipe>
+    ): PreparedHistoryTexture {
+        this.requirePersistentKey(runtimeOwner, key, 'history texture');
+        if (frameIndex !== this.#activeFrameIndex || registry !== this.#activeRegistry) {
+            throw new Error('History texture acquisition requires the active scriptable frame');
+        }
+        let state = this.#historyByKey.get(key as object);
+        if (state === undefined) {
+            state = {
+                key: key as object,
+                descriptor: null,
+                handles: [],
+                initialized: [],
+                committedIndex: -1,
+                registryGeneration: registry.generation,
+                generation: 1,
+                pendingDescriptor: null,
+                pendingHandles: [],
+                pendingInitialized: [],
+                frameHandles: null,
+                frameInitialized: null,
+                frameWriteIndex: -1,
+                lastAcquiredFrameIndex: -1,
+                wroteThisFrame: false,
+                pendingRelease: false
+            };
+            this.#historyByKey.set(key as object, state);
+            this.#historyStates.add(state);
+        }
+        if (state.pendingRelease) {
+            throw new Error('Cannot acquire a history texture pending release in this frame');
+        }
+        if (state.frameHandles !== null) {
+            if (
+                !sameHistoryTextureRecipe(state.pendingDescriptor ?? state.descriptor, descriptor)
+            ) {
+                throw new Error(
+                    'A history texture key cannot use multiple descriptors in one frame'
+                );
+            }
+            return this.preparedHistoryResult(state);
+        }
+        if (state.registryGeneration !== registry.generation && state.descriptor !== null) {
+            state.registryGeneration = registry.generation;
+            state.initialized.fill(false);
+            state.committedIndex = -1;
+            state.generation += 1;
+        }
+        if (sameHistoryTextureRecipe(state.descriptor, descriptor)) {
+            state.frameHandles = state.handles;
+            state.frameInitialized = state.initialized;
+        } else {
+            const snapshot = snapshotHistoryTextureRecipe(descriptor);
+            const handles = this.registerHistoryTextures(registry, snapshot);
+            state.pendingDescriptor = snapshot;
+            state.pendingHandles = handles;
+            state.pendingInitialized = new Array<boolean>(snapshot.bufferCount).fill(false);
+            state.frameHandles = handles;
+            state.frameInitialized = state.pendingInitialized;
+        }
+        const count = state.frameHandles.length;
+        state.frameWriteIndex =
+            state.pendingDescriptor === null && state.committedIndex >= 0
+                ? (state.committedIndex + 1) % count
+                : 0;
+        state.lastAcquiredFrameIndex = frameIndex;
+        state.wroteThisFrame = false;
+        return this.preparedHistoryResult(state);
+    }
+
+    noteHistoryTextureWrite(state: PersistentHistoryState): void {
+        if (
+            state.lastAcquiredFrameIndex !== this.#activeFrameIndex ||
+            state.frameHandles === null ||
+            state.frameWriteIndex < 0
+        ) {
+            throw new Error('History texture write does not belong to the active frame');
+        }
+        state.wroteThisFrame = true;
+    }
+
+    invalidateHistoryTexture(runtimeOwner: object, key: unknown): boolean {
+        this.requirePersistentKey(runtimeOwner, key, 'history texture');
+        const state = this.#historyByKey.get(key as object);
+        if (state === undefined) return false;
+        if (state.lastAcquiredFrameIndex === this.#activeFrameIndex) {
+            throw new Error('Invalidate history before acquiring it in the active frame');
+        }
+        state.initialized.fill(false);
+        state.committedIndex = -1;
+        state.generation += 1;
+        return true;
+    }
+
+    releaseHistoryTexture(runtimeOwner: object, key: unknown): boolean {
+        this.requirePersistentKey(runtimeOwner, key, 'history texture');
+        const state = this.#historyByKey.get(key as object);
+        if (state === undefined) return false;
+        if (state.lastAcquiredFrameIndex === this.#activeFrameIndex) {
+            throw new Error('Cannot release a history texture used by the active frame');
+        }
+        state.pendingRelease = true;
+        return true;
+    }
+
+    beginFrame(frameIndex: number, registry: ResourceRegistry): void {
         if (this.#frameBindGroups.size !== 0) {
             throw new Error('Scriptable frame bind groups escaped their previous frame');
         }
@@ -472,7 +701,13 @@ export class ScriptableRenderPipelineResources {
                 throw new Error('Persistent target staging escaped its previous frame');
             }
         }
+        for (const state of this.#historyStates) {
+            if (state.frameHandles !== null || state.pendingHandles.length !== 0) {
+                throw new Error('History texture staging escaped its previous frame');
+            }
+        }
         this.#activeFrameIndex = frameIndex;
+        this.#activeRegistry = registry;
     }
 
     trackFrameBindGroup(bindGroup: RHIBindGroup): void {
@@ -484,7 +719,11 @@ export class ScriptableRenderPipelineResources {
         bindGroup.destroy();
     }
 
-    endFrame(cache: RenderTargetResourceCache, submitted: boolean): void {
+    endFrame(
+        cache: RenderTargetResourceCache,
+        registry: ResourceRegistry,
+        submitted: boolean
+    ): void {
         const failures = this.#cleanupFailures;
         failures.length = 0;
         for (const bindGroup of this.#frameBindGroups) {
@@ -530,7 +769,76 @@ export class ScriptableRenderPipelineResources {
             }
             this.removeEmptyPersistentState(state);
         }
+        for (const state of this.#historyStates) {
+            const frameHandles = state.frameHandles;
+            const frameInitialized = state.frameInitialized;
+            if (frameHandles !== null && frameInitialized !== null) {
+                if (submitted) {
+                    for (const handle of frameHandles) {
+                        try {
+                            registry.markUsed(handle, this.#activeFrameIndex);
+                        } catch (error) {
+                            failures.push(error);
+                        }
+                    }
+                    if (state.wroteThisFrame) {
+                        frameInitialized[state.frameWriteIndex] = true;
+                    }
+                    if (state.pendingDescriptor !== null) {
+                        for (const handle of state.handles) {
+                            try {
+                                registry.release(handle);
+                            } catch (error) {
+                                failures.push(error);
+                            }
+                        }
+                        state.descriptor = state.pendingDescriptor;
+                        state.handles = state.pendingHandles;
+                        state.initialized = state.pendingInitialized;
+                        state.registryGeneration = registry.generation;
+                        state.generation += 1;
+                        state.committedIndex = state.wroteThisFrame ? state.frameWriteIndex : -1;
+                    } else if (state.wroteThisFrame) {
+                        state.committedIndex = state.frameWriteIndex;
+                    }
+                } else if (state.pendingDescriptor !== null) {
+                    for (const handle of state.pendingHandles) {
+                        try {
+                            registry.discardUnsubmitted(handle);
+                        } catch (error) {
+                            failures.push(error);
+                        }
+                    }
+                }
+            }
+            state.pendingDescriptor = null;
+            state.pendingHandles = [];
+            state.pendingInitialized = [];
+            state.frameHandles = null;
+            state.frameInitialized = null;
+            state.frameWriteIndex = -1;
+            state.lastAcquiredFrameIndex = -1;
+            state.wroteThisFrame = false;
+            if (state.pendingRelease) {
+                if (submitted) {
+                    for (const handle of state.handles) {
+                        try {
+                            registry.release(handle);
+                        } catch (error) {
+                            failures.push(error);
+                        }
+                    }
+                    state.handles = [];
+                    state.initialized = [];
+                    state.descriptor = null;
+                    state.committedIndex = -1;
+                    state.pendingRelease = false;
+                } else state.pendingRelease = false;
+            }
+            this.removeEmptyHistoryState(state);
+        }
         this.#activeFrameIndex = -1;
+        this.#activeRegistry = null;
         if (failures.length !== 0) {
             const failure = new AggregateError(
                 failures,
@@ -544,7 +852,7 @@ export class ScriptableRenderPipelineResources {
         }
     }
 
-    releasePersistentTargets(cache: RenderTargetResourceCache): void {
+    releasePersistentTargets(cache: RenderTargetResourceCache, registry: ResourceRegistry): void {
         if (this.#activeFrameIndex !== -1 || this.#frameBindGroups.size !== 0) {
             throw new Error('Cannot release scriptable resources during an active frame');
         }
@@ -571,6 +879,24 @@ export class ScriptableRenderPipelineResources {
         }
         this.#persistentStates.clear();
         this.#persistentByKey = new WeakMap();
+        for (const state of this.#historyStates) {
+            for (const handle of state.pendingHandles) {
+                try {
+                    registry.discardUnsubmitted(handle);
+                } catch (error) {
+                    failures.push(error);
+                }
+            }
+            for (const handle of state.handles) {
+                try {
+                    registry.release(handle);
+                } catch (error) {
+                    failures.push(error);
+                }
+            }
+        }
+        this.#historyStates.clear();
+        this.#historyByKey = new WeakMap();
         if (failures.length !== 0) {
             const failure = new AggregateError(
                 failures,
@@ -618,6 +944,72 @@ export class ScriptableRenderPipelineResources {
         this.#persistentByKey.delete(state.key);
         this.#persistentStates.delete(state);
     }
+
+    private removeEmptyHistoryState(state: PersistentHistoryState): void {
+        if (state.descriptor !== null || state.pendingDescriptor !== null || state.pendingRelease) {
+            return;
+        }
+        this.#historyByKey.delete(state.key);
+        this.#historyStates.delete(state);
+    }
+
+    private requirePersistentKey(runtimeOwner: object, key: unknown, label: string): void {
+        if ((typeof key !== 'object' && typeof key !== 'function') || key === null) {
+            throw new TypeError(`Persistent ${label} key must be an object`);
+        }
+        if (this.#runtimeOwner === null) this.#runtimeOwner = runtimeOwner;
+        else if (this.#runtimeOwner !== runtimeOwner) {
+            throw new Error('Scriptable render resources belong to another pipeline runtime');
+        }
+    }
+
+    private registerHistoryTextures(
+        registry: ResourceRegistry,
+        descriptor: Readonly<HistoryTextureRecipe>
+    ): ResourceRegistryHandle<RHITexture>[] {
+        const handles: ResourceRegistryHandle<RHITexture>[] = [];
+        try {
+            for (let index = 0; index < descriptor.bufferCount; index += 1) {
+                handles.push(
+                    registry.registerTexture({
+                        label: `${descriptor.label} [${String(index)}]`,
+                        lifetime: 'persistent',
+                        size: {
+                            width: descriptor.width,
+                            height: descriptor.height,
+                            depthOrArrayLayers: descriptor.depthOrArrayLayers
+                        },
+                        mipLevelCount: descriptor.mipLevelCount,
+                        sampleCount: descriptor.sampleCount,
+                        dimension: descriptor.dimension,
+                        viewDimension: descriptor.viewDimension,
+                        format: descriptor.format,
+                        usage: descriptor.usage,
+                        viewFormats: descriptor.viewFormats
+                    })
+                );
+            }
+        } catch (error) {
+            for (const handle of handles) registry.discardUnsubmitted(handle);
+            throw error;
+        }
+        return handles;
+    }
+
+    private preparedHistoryResult(state: PersistentHistoryState): PreparedHistoryTexture {
+        const handles = state.frameHandles;
+        const initialized = state.frameInitialized;
+        if (handles === null || initialized === null || state.frameWriteIndex < 0) {
+            throw new Error('History texture frame state is incomplete');
+        }
+        return {
+            state,
+            handles,
+            initialized,
+            writeIndex: state.frameWriteIndex,
+            generation: state.generation + (state.pendingDescriptor === null ? 0 : 1)
+        };
+    }
 }
 
 function samePersistentTargetDescriptor(
@@ -656,6 +1048,42 @@ function snapshotPersistentTargetDescriptor(
         multisampleAttachmentLifetime: descriptor.multisampleAttachmentLifetime ?? 'persistent',
         depthStencilFormat: descriptor.depthStencilFormat ?? null,
         depthStencilSampled: descriptor.depthStencilSampled ?? false
+    });
+}
+
+function sameHistoryTextureRecipe(
+    first: Readonly<HistoryTextureRecipe> | null,
+    second: Readonly<HistoryTextureRecipe>
+): boolean {
+    if (first === null) return false;
+    if (
+        first.label !== second.label ||
+        first.width !== second.width ||
+        first.height !== second.height ||
+        first.depthOrArrayLayers !== second.depthOrArrayLayers ||
+        first.mipLevelCount !== second.mipLevelCount ||
+        first.sampleCount !== second.sampleCount ||
+        first.dimension !== second.dimension ||
+        first.viewDimension !== second.viewDimension ||
+        first.format !== second.format ||
+        first.usage !== second.usage ||
+        first.bufferCount !== second.bufferCount ||
+        first.viewFormats.length !== second.viewFormats.length
+    ) {
+        return false;
+    }
+    for (let index = 0; index < first.viewFormats.length; index += 1) {
+        if (first.viewFormats[index] !== second.viewFormats[index]) return false;
+    }
+    return true;
+}
+
+function snapshotHistoryTextureRecipe(
+    descriptor: Readonly<HistoryTextureRecipe>
+): Readonly<HistoryTextureRecipe> {
+    return Object.freeze({
+        ...descriptor,
+        viewFormats: Object.freeze([...descriptor.viewFormats])
     });
 }
 
@@ -702,7 +1130,8 @@ function createTextureGraphDescriptor(): MutableTextureGraphDescriptor {
         dimension: '2d',
         viewDimension: '2d',
         format: 'rgba8unorm',
-        usage: RHITextureUsage.RENDER_ATTACHMENT
+        usage: RHITextureUsage.RENDER_ATTACHMENT,
+        viewFormats: []
     };
 }
 
@@ -727,6 +1156,46 @@ function graphBufferUsage(use: RenderGraphBufferReadUse | RenderGraphBufferWrite
         default:
             throw new TypeError(`Unsupported render graph buffer use ${String(use)}`);
     }
+}
+
+function historyTextureUsage(uses: readonly RenderPipelinePersistentTextureUsage[]): number {
+    const candidate: unknown = uses;
+    if (!Array.isArray(candidate) || uses.length === 0) {
+        throw new TypeError('History texture usage must be a non-empty array');
+    }
+    let usage = 0;
+    const seen = new Set<string>();
+    for (const use of uses) {
+        if (seen.has(use)) throw new TypeError(`Duplicate history texture usage ${use}`);
+        seen.add(use);
+        switch (use) {
+            case 'sampled':
+                usage |= RHITextureUsage.TEXTURE_BINDING;
+                break;
+            case 'storage':
+                usage |= RHITextureUsage.STORAGE_BINDING;
+                break;
+            case 'attachment':
+                usage |= RHITextureUsage.RENDER_ATTACHMENT;
+                break;
+            case 'copy-source':
+                usage |= RHITextureUsage.COPY_SRC;
+                break;
+            case 'copy-destination':
+                usage |= RHITextureUsage.COPY_DST;
+                break;
+            default:
+                throw new TypeError(`Unsupported history texture usage ${String(use)}`);
+        }
+    }
+    return usage;
+}
+
+function historyTextureBufferCount(value: unknown): 2 | 3 {
+    if (value !== 2 && value !== 3) {
+        throw new RangeError('History texture bufferCount must be two or three');
+    }
+    return value;
 }
 
 function normalizeBufferRange(
@@ -754,12 +1223,22 @@ function normalizeBufferRange(
 
 function createCopyCommand(): MutableCopyCommand {
     return {
-        sourceHandle: 0 as RenderGraphTextureHandle,
-        destinationHandle: 0 as RenderGraphTextureHandle,
-        sourceInternal: 0 as RGTextureHandle,
-        destinationInternal: 0 as RGTextureHandle,
-        source: { texture: null },
-        destination: { texture: null },
+        sourceHandle: 0 as RenderGraphTextureAccessHandle,
+        destinationHandle: 0 as RenderGraphTextureAccessHandle,
+        sourceInternal: 0 as RGTextureAccessHandle,
+        destinationInternal: 0 as RGTextureAccessHandle,
+        source: {
+            texture: null,
+            mipLevel: 0,
+            origin: { x: 0, y: 0, z: 0 },
+            aspect: 'all'
+        },
+        destination: {
+            texture: null,
+            mipLevel: 0,
+            origin: { x: 0, y: 0, z: 0 },
+            aspect: 'all'
+        },
         size: { width: 1, height: 1, depthOrArrayLayers: 1 }
     };
 }
@@ -1029,7 +1508,7 @@ function compareFrameBinding(
 
 class ScriptableFullscreenDraw {
     readonly draw: PreparedDraw;
-    readonly #inputHandles: RGTextureHandle[] = [];
+    readonly #inputHandles: RGTextureAccessHandle[] = [];
     readonly #uniformHandles: ResourceRegistryHandle<RHIBuffer>[] = [];
     readonly #groups: (FrameBindGroupScratch | undefined)[] = [];
     #pipeline: Readonly<PipelineResourceRecord> | null = null;
@@ -1041,7 +1520,7 @@ class ScriptableFullscreenDraw {
 
     configure(
         pipeline: Readonly<PipelineResourceRecord>,
-        inputs: readonly RGTextureHandle[],
+        inputs: readonly RGTextureAccessHandle[],
         uniformHandles: readonly ResourceRegistryHandle<RHIBuffer>[],
         frameIndex: number
     ): void {
@@ -1214,15 +1693,18 @@ class ScriptableRenderPassBuilderLease implements ScriptableRenderPassBuilder {
         Object.freeze(this);
     }
 
-    readTexture(texture: RenderGraphTextureHandle): void {
+    readTexture(texture: RenderGraphTextureAccessHandle): void {
         this.#slot.readTextureFromSetup(this.#lease, texture);
     }
 
-    writeStorageTexture(texture: RenderGraphTextureHandle): void {
+    writeStorageTexture(texture: RenderGraphTextureAccessHandle): void {
         this.#slot.writeStorageTextureFromSetup(this.#lease, texture);
     }
 
-    copyTexture(source: RenderGraphTextureHandle, destination: RenderGraphTextureHandle): void {
+    copyTexture(
+        source: RenderGraphTextureAccessHandle,
+        destination: RenderGraphTextureAccessHandle
+    ): void {
         this.#slot.copyTextureFromSetup(this.#lease, source, destination);
     }
 
@@ -1308,7 +1790,10 @@ class ScriptableRenderCommandsLease implements ScriptableRenderCommands {
         this.#slot.drawRendererListFromExecute(this.#lease, list);
     }
 
-    copyTexture(source: RenderGraphTextureHandle, destination: RenderGraphTextureHandle): void {
+    copyTexture(
+        source: RenderGraphTextureAccessHandle,
+        destination: RenderGraphTextureAccessHandle
+    ): void {
         this.#slot.copyTextureFromExecute(this.#lease, source, destination);
     }
 
@@ -1426,14 +1911,14 @@ class ScriptableGPUDrivenDrawServiceSlot implements ScriptableGPUDrivenDrawServi
 class ScriptablePassSlot {
     readonly draw = new SharedDrawPassParameters();
     readonly ranges: RendererListRange[] = [];
-    readonly sampledHandles = new Set<RenderGraphTextureHandle>();
-    readonly sampledInternals = new Map<RenderGraphTextureHandle, RGTextureHandle>();
-    readonly attachmentHandles = new Set<RenderGraphTextureHandle>();
-    readonly sampledInternalHandles = new Set<RGTextureHandle>();
-    readonly storageWriteInternalHandles = new Set<RGTextureHandle>();
-    readonly copySourceInternalHandles = new Set<RGTextureHandle>();
-    readonly copyDestinationInternalHandles = new Set<RGTextureHandle>();
-    readonly attachmentInternalHandles = new Set<RGTextureHandle>();
+    readonly sampledHandles = new Set<RenderGraphTextureAccessHandle>();
+    readonly sampledInternals = new Map<RenderGraphTextureAccessHandle, RGTextureAccessHandle>();
+    readonly attachmentHandles = new Set<RenderGraphTextureAccessHandle>();
+    readonly sampledInternalHandles = new Set<RGTextureAccessHandle>();
+    readonly storageWriteInternalHandles = new Set<RGTextureAccessHandle>();
+    readonly copySourceInternalHandles = new Set<RGTextureAccessHandle>();
+    readonly copyDestinationInternalHandles = new Set<RGTextureAccessHandle>();
+    readonly attachmentInternalHandles = new Set<RGTextureAccessHandle>();
     readonly rendererListHandles = new Set<RendererListHandle>();
     readonly colorFormats: (RHITextureFormat | null)[] = [];
     readonly targetDescriptor: RHIMeshDrawTargetDescriptor = {
@@ -1485,7 +1970,7 @@ class ScriptablePassSlot {
     #sceneStorageBindingCount = 0;
     #sceneStorageBindGroup: RHIBindGroup | null = null;
     #activeSceneStorage = false;
-    #sceneTextureHandle: RGTextureHandle | null = null;
+    #sceneTextureHandle: RGTextureAccessHandle | null = null;
     #sceneTextureBindGroup: RHIBindGroup | null = null;
     #activeSceneTexture = false;
     readonly #sceneTexturePreparation: SceneTexturePreparationState = {
@@ -2169,7 +2654,7 @@ class ScriptablePassSlot {
 
     readTextureFromSetup(
         lease: ScriptablePassCallbackLease,
-        texture: RenderGraphTextureHandle
+        texture: RenderGraphTextureAccessHandle
     ): void {
         this.assertSetupLeaseActive(lease);
         this.readTexture(texture);
@@ -2177,7 +2662,7 @@ class ScriptablePassSlot {
 
     writeStorageTextureFromSetup(
         lease: ScriptablePassCallbackLease,
-        texture: RenderGraphTextureHandle
+        texture: RenderGraphTextureAccessHandle
     ): void {
         this.assertSetupLeaseActive(lease);
         this.writeStorageTexture(texture);
@@ -2185,8 +2670,8 @@ class ScriptablePassSlot {
 
     copyTextureFromSetup(
         lease: ScriptablePassCallbackLease,
-        source: RenderGraphTextureHandle,
-        destination: RenderGraphTextureHandle
+        source: RenderGraphTextureAccessHandle,
+        destination: RenderGraphTextureAccessHandle
     ): void {
         this.assertSetupLeaseActive(lease);
         this.declareTextureCopy(source, destination);
@@ -2304,8 +2789,8 @@ class ScriptablePassSlot {
 
     copyTextureFromExecute(
         lease: ScriptablePassCallbackLease,
-        source: RenderGraphTextureHandle,
-        destination: RenderGraphTextureHandle
+        source: RenderGraphTextureAccessHandle,
+        destination: RenderGraphTextureAccessHandle
     ): void {
         this.assertExecuteLeaseActive(lease);
         this.copyTexture(source, destination);
@@ -2342,7 +2827,7 @@ class ScriptablePassSlot {
         }
     }
 
-    private readTexture(handle: RenderGraphTextureHandle): void {
+    private readTexture(handle: RenderGraphTextureAccessHandle): void {
         this.requireSetupBuilder();
         if (this.sampledHandles.has(handle)) return;
         const internal = this.requireOwner().resolveTexture(handle, 'sampled');
@@ -2356,7 +2841,7 @@ class ScriptablePassSlot {
         if (!alreadyRead) this.draw.addReadTexture(internal);
     }
 
-    private writeStorageTexture(handle: RenderGraphTextureHandle): void {
+    private writeStorageTexture(handle: RenderGraphTextureAccessHandle): void {
         const builder = this.requireSetupBuilder();
         const owner = this.requireOwner();
         const internal = owner.resolveTexture(handle, 'storage-write');
@@ -2483,8 +2968,8 @@ class ScriptablePassSlot {
     }
 
     private declareTextureCopy(
-        sourceHandle: RenderGraphTextureHandle,
-        destinationHandle: RenderGraphTextureHandle
+        sourceHandle: RenderGraphTextureAccessHandle,
+        destinationHandle: RenderGraphTextureAccessHandle
     ): void {
         this.requireSetupBuilder();
         if (sourceHandle === destinationHandle) {
@@ -2495,18 +2980,16 @@ class ScriptablePassSlot {
         const destinationRecord = owner.requireTexture(destinationHandle);
         if (
             sourceRecord.width !== destinationRecord.width ||
-            sourceRecord.height !== destinationRecord.height
+            sourceRecord.height !== destinationRecord.height ||
+            sourceRecord.depthOrArrayLayers !== destinationRecord.depthOrArrayLayers
         ) {
             throw new Error('Texture copy requires matching source and destination extents');
         }
         if (sourceRecord.format !== destinationRecord.format) {
             throw new Error('Texture copy requires matching source and destination formats');
         }
-        if (
-            sourceRecord.mipLevelCount !== destinationRecord.mipLevelCount ||
-            sourceRecord.mipLevelCount !== 1
-        ) {
-            throw new Error('Texture copy requires single-mip source and destination textures');
+        if (sourceRecord.mipLevelCount !== 1 || destinationRecord.mipLevelCount !== 1) {
+            throw new Error('Texture copy requires one selected source and destination mip');
         }
         const sourceInternal = owner.resolveTexture(sourceHandle, 'copy-source');
         const destinationInternal = owner.resolveTexture(destinationHandle, 'copy-destination');
@@ -2535,6 +3018,27 @@ class ScriptablePassSlot {
         command.destinationInternal = destinationInternal;
         command.source.texture = null;
         command.destination.texture = null;
+        command.source.mipLevel =
+            sourceRecord.kind === 'texture-view' ? sourceRecord.descriptor.baseMipLevel : 0;
+        command.destination.mipLevel =
+            destinationRecord.kind === 'texture-view'
+                ? destinationRecord.descriptor.baseMipLevel
+                : 0;
+        command.source.origin.z =
+            sourceRecord.kind === 'texture-view' && sourceRecord.textureDimension !== '3d'
+                ? sourceRecord.descriptor.baseArrayLayer
+                : 0;
+        command.destination.origin.z =
+            destinationRecord.kind === 'texture-view' && destinationRecord.textureDimension !== '3d'
+                ? destinationRecord.descriptor.baseArrayLayer
+                : 0;
+        command.source.aspect =
+            sourceRecord.kind === 'texture-view' ? sourceRecord.descriptor.aspect : 'all';
+        command.destination.aspect =
+            destinationRecord.kind === 'texture-view' ? destinationRecord.descriptor.aspect : 'all';
+        command.size.width = sourceRecord.width;
+        command.size.height = sourceRecord.height;
+        command.size.depthOrArrayLayers = sourceRecord.depthOrArrayLayers;
     }
 
     private useColorAttachment(options: Readonly<RenderPipelineColorAttachment>): void {
@@ -2545,7 +3049,7 @@ class ScriptablePassSlot {
         this.assertAttachmentInternalAccess(texture);
         this.attachmentHandles.add(options.texture);
         this.attachmentInternalHandles.add(texture);
-        let resolveTarget: RGTextureHandle | undefined;
+        let resolveTarget: RGTextureAccessHandle | undefined;
         if (options.resolveTarget !== undefined) {
             if (options.resolveTarget === options.texture) {
                 throw new Error('Color attachment resolve target must be distinct');
@@ -2635,7 +3139,7 @@ class ScriptablePassSlot {
         }
     }
 
-    private mergeTargetShape(record: TextureRecord): void {
+    private mergeTargetShape(record: TextureAccessRecord): void {
         if (!this.#hasTargetShape) {
             this.#hasTargetShape = true;
             (this.targetDescriptor as { sampleCount: number }).sampleCount = record.sampleCount;
@@ -2718,8 +3222,8 @@ class ScriptablePassSlot {
     }
 
     private copyTexture(
-        sourceHandle: RenderGraphTextureHandle,
-        destinationHandle: RenderGraphTextureHandle
+        sourceHandle: RenderGraphTextureAccessHandle,
+        destinationHandle: RenderGraphTextureAccessHandle
     ): void {
         if (this.#encoder !== null) {
             throw new Error('Texture copies cannot execute inside a raster pass');
@@ -2824,33 +3328,13 @@ class ScriptablePassSlot {
             }
             const source = context.getTexture(command.sourceInternal);
             const destination = context.getTexture(command.destinationInternal);
-            if (
-                source.width !== destination.width ||
-                source.height !== destination.height ||
-                source.depthOrArrayLayers !== destination.depthOrArrayLayers ||
-                source.mipLevelCount !== destination.mipLevelCount ||
-                source.dimension !== destination.dimension ||
-                source.descriptor.viewDimension !== destination.descriptor.viewDimension ||
-                source.format !== destination.format ||
-                source.sampleCount !== destination.sampleCount
-            ) {
-                throw new Error(
-                    'Texture copy requires matching source and destination descriptors'
-                );
-            }
-            if (source.sampleCount !== 1 || source.mipLevelCount !== 1) {
-                throw new Error(
-                    'Texture copy requires single-sample, single-mip source and destination textures'
-                );
-            }
             command.source.texture = source;
             command.destination.texture = destination;
-            command.size.width = source.width;
-            command.size.height = source.height;
-            command.size.depthOrArrayLayers = source.depthOrArrayLayers;
             validateRHITextureToTextureCopyParameters(
-                command.source as { readonly texture: RHITexture },
-                command.destination as { readonly texture: RHITexture },
+                command.source as typeof command.source & { readonly texture: RHITexture },
+                command.destination as typeof command.destination & {
+                    readonly texture: RHITexture;
+                },
                 command.size
             );
         }
@@ -2908,7 +3392,7 @@ class ScriptablePassSlot {
         for (const buffer of this.partialStorageBufferWrites) cache.stageGPUWrite(buffer);
     }
 
-    private assertReadableInternalAccess(handle: RGTextureHandle): void {
+    private assertReadableInternalAccess(handle: RGTextureAccessHandle): void {
         if (
             this.storageWriteInternalHandles.has(handle) ||
             this.copyDestinationInternalHandles.has(handle) ||
@@ -2918,7 +3402,7 @@ class ScriptablePassSlot {
         }
     }
 
-    private assertWritableInternalAccess(handle: RGTextureHandle): void {
+    private assertWritableInternalAccess(handle: RGTextureAccessHandle): void {
         if (
             this.sampledInternalHandles.has(handle) ||
             this.storageWriteInternalHandles.has(handle) ||
@@ -2930,7 +3414,7 @@ class ScriptablePassSlot {
         }
     }
 
-    private assertAttachmentInternalAccess(handle: RGTextureHandle): void {
+    private assertAttachmentInternalAccess(handle: RGTextureAccessHandle): void {
         if (
             this.sampledInternalHandles.has(handle) ||
             this.storageWriteInternalHandles.has(handle) ||
@@ -3255,6 +3739,15 @@ class RenderPipelineContextLease implements RenderPipelineContext, ScriptableRen
         return this.#owner.createTexture(name, descriptor);
     }
 
+    createTextureView(
+        name: string,
+        texture: RenderGraphTextureHandle,
+        descriptor: Readonly<RenderPipelineTextureViewDescriptor> = {}
+    ): RenderGraphTextureViewHandle {
+        this.#owner.assertLeaseActive(this.#lease);
+        return this.#owner.createTextureView(name, texture, descriptor);
+    }
+
     createBuffer(
         name: string,
         descriptor: Readonly<RenderPipelineBufferDescriptor>
@@ -3284,6 +3777,24 @@ class RenderPipelineContextLease implements RenderPipelineContext, ScriptableRen
     ): RenderPipelineTargetResources {
         this.#owner.assertLeaseActive(this.#lease);
         return this.#owner.acquirePersistentTarget(key, descriptor);
+    }
+
+    acquireHistoryTexture(
+        key: object,
+        descriptor: Readonly<RenderPipelineHistoryTextureDescriptor>
+    ): RenderPipelineHistoryTextureResources {
+        this.#owner.assertLeaseActive(this.#lease);
+        return this.#owner.acquireHistoryTexture(key, descriptor);
+    }
+
+    invalidateHistoryTexture(key: object): boolean {
+        this.#owner.assertLeaseActive(this.#lease);
+        return this.#owner.invalidateHistoryTexture(key);
+    }
+
+    releaseHistoryTexture(key: object): boolean {
+        this.#owner.assertLeaseActive(this.#lease);
+        return this.#owner.releaseHistoryTexture(key);
     }
 
     releasePersistentTarget(key: object): boolean {
@@ -3333,16 +3844,25 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
     readonly #rendererListByHandle = new Map<RendererListHandle, RendererListSlot>();
     readonly #textureRecords: TextureRecord[] = [];
     readonly #textureByHandle = new Map<RenderGraphTextureHandle, TextureRecord>();
+    readonly #textureViewRecords: TextureViewRecord[] = [];
+    readonly #textureAccessByHandle = new Map<
+        RenderGraphTextureAccessHandle,
+        TextureAccessRecord
+    >();
     readonly #bufferRecords: BufferRecord[] = [];
     readonly #bufferByHandle = new Map<RenderGraphBufferHandle, BufferRecord>();
     readonly #targetSlots: TargetResourcesSlot[] = [];
     readonly #passSlots: ScriptablePassSlot[] = [];
     readonly #passByHandle = new Map<RenderGraphPassHandle, RGPassHandle>();
     readonly #targetColorScratch: RenderGraphTextureHandle[] = [];
-    readonly #fullscreenInputScratch: RGTextureHandle[] = [];
+    readonly #fullscreenInputScratch: RGTextureAccessHandle[] = [];
     readonly #fullscreenUniformScratch: ResourceRegistryHandle<RHIBuffer>[] = [];
     readonly #outputColorFormats: RenderTargetColorFormat[] = [];
     readonly #persistentTargetDescriptors: MutablePersistentTargetResourceDescriptor[] = [];
+    readonly #historyFacadeByState = new Map<
+        PersistentHistoryState,
+        RenderPipelineHistoryTextureResources
+    >();
     readonly #beforeEventMeshSet = new Set<Mesh>();
     readonly #beforeEventMeshScratch: Mesh[] = [];
     readonly #eventMeshes: Mesh[] = [];
@@ -3360,6 +3880,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
     #cullingCursor = 0;
     #rendererListCursor = 0;
     #textureCursor = 0;
+    #textureViewCursor = 0;
     #bufferCursor = 0;
     #targetSlotCursor = 0;
     #passCursor = 0;
@@ -3428,6 +3949,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         this.#cullingCursor = 0;
         this.#rendererListCursor = 0;
         this.#textureCursor = 0;
+        this.#textureViewCursor = 0;
         this.#bufferCursor = 0;
         this.#targetSlotCursor = 0;
         this.#passCursor = 0;
@@ -3444,6 +3966,8 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         this.#cullingByHandle.clear();
         this.#rendererListByHandle.clear();
         this.#textureByHandle.clear();
+        this.#textureAccessByHandle.clear();
+        this.#historyFacadeByState.clear();
         this.#bufferByHandle.clear();
         this.#storageBufferBySource = new WeakMap();
         this.#passByHandle.clear();
@@ -3578,9 +4102,35 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
             record.source = null;
             record.initialized = false;
         }
+        for (let index = 0; index < this.#textureCursor; index += 1) {
+            const record = this.#textureRecords[index];
+            if (record === undefined) continue;
+            record.name = '';
+            record.attachment = null;
+            record.readable = null;
+            record.writable = null;
+            record.resolveTarget = null;
+            record.outputRoot = null;
+            record.historyState = null;
+            record.historyCurrent = false;
+        }
+        for (let index = 0; index < this.#textureViewCursor; index += 1) {
+            const record = this.#textureViewRecords[index];
+            if (record === undefined) continue;
+            record.name = '';
+            record.attachment = null;
+            record.readable = null;
+            record.writable = null;
+            record.resolveTarget = null;
+            record.outputRoot = null;
+            record.historyState = null;
+            record.historyCurrent = false;
+        }
         this.#cullingByHandle.clear();
         this.#rendererListByHandle.clear();
         this.#textureByHandle.clear();
+        this.#textureAccessByHandle.clear();
+        this.#historyFacadeByState.clear();
         this.#bufferByHandle.clear();
         this.#storageBufferBySource = new WeakMap();
         this.#passByHandle.clear();
@@ -3692,19 +4242,101 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         if (sampleCount > 1 && mipLevelCount !== 1) {
             throw new RangeError('Multisampled render graph textures require one mip level');
         }
+        const depthOrArrayLayers = positiveInteger(
+            descriptor.depthOrArrayLayers ?? 1,
+            'Render graph texture depthOrArrayLayers'
+        );
+        const dimension = descriptor.dimension ?? '2d';
+        const viewDimension =
+            descriptor.viewDimension ??
+            (dimension === '1d'
+                ? '1d'
+                : dimension === '3d'
+                  ? '3d'
+                  : depthOrArrayLayers === 1
+                    ? '2d'
+                    : '2d-array');
         return this.acquireTextureRecord({
             name,
             format: descriptor.format,
             width: extent.width,
             height: extent.height,
+            depthOrArrayLayers,
             sampleCount,
             mipLevelCount,
+            textureDimension: dimension,
+            viewDimension,
+            viewFormats: Object.freeze([...(descriptor.viewFormats ?? [])]),
             attachment: null,
             readable: null,
             writable: null,
             resolveTarget: null,
             outputRoot: null,
-            transient: true
+            transient: true,
+            historyState: null,
+            historyCurrent: false
+        }).handle;
+    }
+
+    createTextureView(
+        name: string,
+        texture: RenderGraphTextureHandle,
+        descriptor: Readonly<RenderPipelineTextureViewDescriptor> = {}
+    ): RenderGraphTextureViewHandle {
+        this.assertActive();
+        if (typeof name !== 'string' || name.length === 0) {
+            throw new TypeError('Render graph texture view name must be non-empty');
+        }
+        const parent = this.#textureByHandle.get(texture);
+        if (parent === undefined) {
+            throw new Error(`Render graph texture handle ${String(texture)} is stale or invalid`);
+        }
+        const normalizedTexture = normalizeRHITextureDescriptor(
+            {
+                label: parent.name,
+                lifetime: parent.transient ? 'transient' : 'persistent',
+                size: {
+                    width: parent.width,
+                    height: parent.height,
+                    depthOrArrayLayers: parent.depthOrArrayLayers
+                },
+                mipLevelCount: parent.mipLevelCount,
+                sampleCount: parent.sampleCount,
+                dimension: parent.textureDimension,
+                viewDimension: parent.viewDimension,
+                format: parent.format,
+                usage: RHITextureUsage.COPY_SRC,
+                viewFormats: parent.viewFormats
+            },
+            this.services.getScriptableMeshProcessor().registry.deviceCapabilities
+        );
+        const view = normalizeRHITextureViewDescriptorForTextureDescriptor(
+            normalizedTexture,
+            descriptor
+        );
+        const mipScale = 2 ** view.baseMipLevel;
+        return this.acquireTextureViewRecord({
+            name,
+            texture: parent,
+            descriptor: view,
+            format: view.format,
+            width: Math.max(1, Math.floor(parent.width / mipScale)),
+            height: Math.max(1, Math.floor(parent.height / mipScale)),
+            depthOrArrayLayers:
+                parent.textureDimension === '3d'
+                    ? Math.max(1, Math.floor(parent.depthOrArrayLayers / mipScale))
+                    : view.arrayLayerCount,
+            sampleCount: parent.sampleCount,
+            mipLevelCount: view.mipLevelCount,
+            textureDimension: parent.textureDimension,
+            attachment: null,
+            readable: null,
+            writable: null,
+            resolveTarget: null,
+            outputRoot: parent.outputRoot,
+            transient: parent.transient,
+            historyState: parent.historyState,
+            historyCurrent: parent.historyCurrent
         }).handle;
     }
 
@@ -3822,6 +4454,165 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         return this.resources.releasePersistentTarget(runtimeOwner, key);
     }
 
+    acquireHistoryTexture(
+        key: object,
+        descriptor: Readonly<RenderPipelineHistoryTextureDescriptor>
+    ): RenderPipelineHistoryTextureResources {
+        this.assertActive();
+        const runtimeOwner = this.#runtimeOwner;
+        if (runtimeOwner === null) throw new Error('Pipeline runtime owner is unavailable');
+        const extent = this.resolveExtent(descriptor.extent);
+        const usage = historyTextureUsage(descriptor.usage);
+        const bufferCount = historyTextureBufferCount(descriptor.bufferCount ?? 2);
+        const normalized = normalizeRHITextureDescriptor(
+            {
+                label: descriptor.label ?? 'Scriptable history texture',
+                lifetime: 'persistent',
+                size: {
+                    width: extent.width,
+                    height: extent.height,
+                    depthOrArrayLayers: descriptor.depthOrArrayLayers ?? 1
+                },
+                mipLevelCount: descriptor.mipLevelCount ?? 1,
+                sampleCount: descriptor.sampleCount ?? 1,
+                dimension: descriptor.dimension ?? '2d',
+                ...(descriptor.viewDimension === undefined
+                    ? {}
+                    : { viewDimension: descriptor.viewDimension }),
+                format: descriptor.format,
+                usage,
+                viewFormats: descriptor.viewFormats ?? []
+            },
+            this.services.getScriptableMeshProcessor().registry.deviceCapabilities
+        );
+        if (
+            normalized.dimension !== '2d' ||
+            normalized.viewDimension !== '2d' ||
+            normalized.size.depthOrArrayLayers !== 1 ||
+            normalized.mipLevelCount !== 1 ||
+            normalized.sampleCount !== 1 ||
+            rhiTextureFormatHasDepth(normalized.format) ||
+            rhiTextureFormatHasStencil(normalized.format)
+        ) {
+            throw new RangeError(
+                'History textures currently require one single-sample 2D color mip and array layer'
+            );
+        }
+        const recipe: Readonly<HistoryTextureRecipe> = {
+            label: normalized.label,
+            width: normalized.size.width,
+            height: normalized.size.height,
+            depthOrArrayLayers: normalized.size.depthOrArrayLayers,
+            mipLevelCount: normalized.mipLevelCount,
+            sampleCount: normalized.sampleCount,
+            dimension: normalized.dimension,
+            viewDimension: normalized.viewDimension,
+            format: normalized.format,
+            usage: normalized.usage,
+            viewFormats: normalized.viewFormats,
+            bufferCount
+        };
+        const registry = this.services.getScriptableMeshProcessor().registry;
+        const prepared = this.resources.prepareHistoryTexture(
+            runtimeOwner,
+            key,
+            this.frameIndex,
+            registry,
+            recipe
+        );
+        const existing = this.#historyFacadeByState.get(prepared.state);
+        if (existing !== undefined) return existing;
+        const graph = this.requireScope().graph;
+        const publicHandles: RenderGraphTextureHandle[] = [];
+        for (let index = 0; index < prepared.handles.length; index += 1) {
+            const registryHandle = prepared.handles[index];
+            if (registryHandle === undefined) {
+                throw new Error('History texture registry handle is incomplete');
+            }
+            const internal = graph.importTextureProvider(
+                `${recipe.label} [${String(index)}]`,
+                {
+                    label: `${recipe.label} [${String(index)}]`,
+                    size: {
+                        width: recipe.width,
+                        height: recipe.height,
+                        depthOrArrayLayers: recipe.depthOrArrayLayers
+                    },
+                    mipLevelCount: recipe.mipLevelCount,
+                    sampleCount: recipe.sampleCount,
+                    dimension: recipe.dimension,
+                    viewDimension: recipe.viewDimension,
+                    format: recipe.format,
+                    usage: recipe.usage,
+                    viewFormats: recipe.viewFormats
+                },
+                () => registry.resolve(registryHandle),
+                'persistent',
+                prepared.initialized[index] ?? false
+            );
+            const current = index === prepared.writeIndex;
+            publicHandles[index] = this.acquireTextureRecord({
+                name: `${recipe.label} [${String(index)}]`,
+                format: recipe.format,
+                width: recipe.width,
+                height: recipe.height,
+                depthOrArrayLayers: recipe.depthOrArrayLayers,
+                sampleCount: recipe.sampleCount,
+                mipLevelCount: recipe.mipLevelCount,
+                textureDimension: recipe.dimension,
+                viewDimension: recipe.viewDimension,
+                viewFormats: recipe.viewFormats,
+                attachment: internal,
+                readable: internal,
+                writable: internal,
+                resolveTarget: null,
+                outputRoot: current ? internal : null,
+                transient: false,
+                historyState: prepared.state,
+                historyCurrent: current
+            }).handle;
+        }
+        const historyIndices: number[] = [];
+        for (let index = 0; index < bufferCount - 1; index += 1) {
+            historyIndices.push((prepared.writeIndex - 1 - index + bufferCount * 2) % bufferCount);
+        }
+        const previousIndex = historyIndices[0];
+        const currentHandle = publicHandles[prepared.writeIndex];
+        if (currentHandle === undefined)
+            throw new Error('History texture current slot is incomplete');
+        const result: RenderPipelineHistoryTextureResources = Object.freeze({
+            current: currentHandle,
+            valid: previousIndex !== undefined && prepared.initialized[previousIndex] === true,
+            generation: prepared.generation,
+            historyCount: historyIndices.length,
+            history(index = 0): RenderGraphTextureHandle {
+                if (!Number.isSafeInteger(index) || index < 0 || index >= historyIndices.length) {
+                    throw new RangeError(`History texture index ${String(index)} does not exist`);
+                }
+                const slot = historyIndices[index];
+                const handle = slot === undefined ? undefined : publicHandles[slot];
+                if (handle === undefined) throw new Error('History texture slot is incomplete');
+                return handle;
+            }
+        });
+        this.#historyFacadeByState.set(prepared.state, result);
+        return result;
+    }
+
+    invalidateHistoryTexture(key: object): boolean {
+        this.assertActive();
+        const runtimeOwner = this.#runtimeOwner;
+        if (runtimeOwner === null) throw new Error('Pipeline runtime owner is unavailable');
+        return this.resources.invalidateHistoryTexture(runtimeOwner, key);
+    }
+
+    releaseHistoryTexture(key: object): boolean {
+        this.assertActive();
+        const runtimeOwner = this.#runtimeOwner;
+        if (runtimeOwner === null) throw new Error('Pipeline runtime owner is unavailable');
+        return this.resources.releaseHistoryTexture(runtimeOwner, key);
+    }
+
     addPass<P extends object>(pass: ScriptableRenderPass<P>, parameters: P): RenderGraphPassHandle {
         this.assertActive();
         const passCandidate: unknown = pass;
@@ -3879,8 +4670,8 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         return pass;
     }
 
-    requireTexture(handle: RenderGraphTextureHandle): TextureRecord {
-        const record = this.#textureByHandle.get(handle);
+    requireTexture(handle: RenderGraphTextureAccessHandle): TextureAccessRecord {
+        const record = this.#textureAccessByHandle.get(handle);
         if (record === undefined) {
             throw new Error(`Render graph texture handle ${String(handle)} is stale or invalid`);
         }
@@ -3920,16 +4711,43 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         return internal;
     }
 
-    resolveTexture(handle: RenderGraphTextureHandle, access: TextureAccess): RGTextureHandle {
+    resolveTexture(
+        handle: RenderGraphTextureAccessHandle,
+        access: TextureAccess
+    ): RGTextureAccessHandle {
         const record = this.requireTexture(handle);
         if (
             access === 'storage-write' &&
             (record.sampleCount !== 1 || record.mipLevelCount !== 1)
         ) {
             throw new RangeError(
-                `${record.name} storage writes require one complete single-sample 2d mip subresource`
+                `${record.name} storage writes require one complete single-sample 2d mip subresource or one explicit single-mip view`
             );
         }
+        if (record.kind === 'texture-view') {
+            let internal =
+                access === 'attachment'
+                    ? record.attachment
+                    : access === 'sampled' || access === 'copy-source'
+                      ? record.readable
+                      : record.writable;
+            if (internal !== null) return internal;
+            const parent = this.resolvePhysicalTexture(record.texture, access);
+            internal = this.requireScope().graph.createTextureView(
+                record.name,
+                parent,
+                record.descriptor
+            );
+            if (access === 'attachment') record.attachment = internal;
+            else if (access === 'sampled' || access === 'copy-source') {
+                record.readable = internal;
+            } else record.writable = internal;
+            return internal;
+        }
+        return this.resolvePhysicalTexture(record, access);
+    }
+
+    private resolvePhysicalTexture(record: TextureRecord, access: TextureAccess): RGTextureHandle {
         const usage =
             access === 'attachment' || access === 'resolve-target'
                 ? RHITextureUsage.RENDER_ATTACHMENT
@@ -3954,11 +4772,18 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
             descriptor.label = record.name;
             descriptor.size.width = record.width;
             descriptor.size.height = record.height;
-            descriptor.size.depthOrArrayLayers = 1;
+            descriptor.size.depthOrArrayLayers = record.depthOrArrayLayers;
             descriptor.mipLevelCount = record.mipLevelCount;
             descriptor.sampleCount = record.sampleCount;
+            descriptor.dimension = record.textureDimension;
+            descriptor.viewDimension = record.viewDimension;
             descriptor.format = record.format;
             descriptor.usage = usage;
+            descriptor.viewFormats.length = record.viewFormats.length;
+            for (let index = 0; index < record.viewFormats.length; index += 1) {
+                const format = record.viewFormats[index];
+                if (format !== undefined) descriptor.viewFormats[index] = format;
+            }
             internal = this.requireScope().graph.createTexture(record.name, descriptor);
             record.attachment ??= internal;
             record.readable ??= internal;
@@ -3967,8 +4792,17 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         return internal;
     }
 
-    noteTextureWrite(handle: RenderGraphTextureHandle): void {
-        if (this.requireTexture(handle).outputRoot !== null) this.#hasTerminalWork = true;
+    noteTextureWrite(handle: RenderGraphTextureAccessHandle): void {
+        const record = this.requireTexture(handle);
+        if (record.historyCurrent && record.historyState !== null) {
+            this.resources.noteHistoryTextureWrite(record.historyState);
+            const output = record.outputRoot;
+            if (output === null) throw new Error('History texture current slot has no graph root');
+            this.requireScope().graph.markOutput(output);
+            this.#hasTerminalWork = true;
+        } else if (record.historyState !== null) {
+            throw new Error('Only the current history texture slot may be written');
+        } else if (record.outputRoot !== null) this.#hasTerminalWork = true;
     }
 
     noteBufferWrite(record: BufferRecord, internal: RGBufferHandle): void {
@@ -3984,7 +4818,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
     }
 
     passAttachmentDimensions(
-        attachments: ReadonlySet<RenderGraphTextureHandle>
+        attachments: ReadonlySet<RenderGraphTextureAccessHandle>
     ): Readonly<{ width: number; height: number }> {
         let width = 0;
         let height = 0;
@@ -4158,7 +4992,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         pass: FullscreenRenderPass,
         parameters: FullscreenRenderPassParameters,
         target: RHIMeshDrawTargetDescriptor,
-        declaredInputs: ReadonlyMap<RenderGraphTextureHandle, RGTextureHandle>
+        declaredInputs: ReadonlyMap<RenderGraphTextureAccessHandle, RGTextureAccessHandle>
     ): ScriptableFullscreenDraw {
         this.services.prepareScriptableCullingScene(this.scene, this.camera);
         const context = this.services.createScriptableFrameContext(
@@ -4416,25 +5250,30 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         });
     }
 
-    private acquireTextureRecord(
-        source: Omit<TextureRecord, 'handle' | 'graphDescriptor'>
-    ): TextureRecord {
+    private acquireTextureRecord(source: TextureRecordSource): TextureRecord {
         let record = this.#textureRecords[this.#textureCursor++];
         if (record === undefined) {
             record = {
+                kind: 'texture',
                 handle: 0 as RenderGraphTextureHandle,
                 name: '',
                 format: 'rgba8unorm',
                 width: 1,
                 height: 1,
+                depthOrArrayLayers: 1,
                 sampleCount: 1,
                 mipLevelCount: 1,
+                textureDimension: '2d',
+                viewDimension: '2d',
+                viewFormats: Object.freeze([]),
                 attachment: null,
                 readable: null,
                 writable: null,
                 resolveTarget: null,
                 outputRoot: null,
                 transient: false,
+                historyState: null,
+                historyCurrent: false,
                 graphDescriptor: createTextureGraphDescriptor()
             };
             this.#textureRecords.push(record);
@@ -4444,15 +5283,74 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         record.format = source.format;
         record.width = source.width;
         record.height = source.height;
+        record.depthOrArrayLayers = source.depthOrArrayLayers ?? 1;
         record.sampleCount = source.sampleCount;
         record.mipLevelCount = source.mipLevelCount;
+        record.textureDimension = source.textureDimension ?? '2d';
+        record.viewDimension = source.viewDimension ?? '2d';
+        record.viewFormats = source.viewFormats ?? Object.freeze([]);
         record.attachment = source.attachment;
         record.readable = source.readable;
         record.writable = source.writable;
         record.resolveTarget = source.resolveTarget;
         record.outputRoot = source.outputRoot;
         record.transient = source.transient;
+        record.historyState = source.historyState ?? null;
+        record.historyCurrent = source.historyCurrent ?? false;
         this.#textureByHandle.set(record.handle, record);
+        this.#textureAccessByHandle.set(record.handle, record);
+        return record;
+    }
+
+    private acquireTextureViewRecord(
+        source: Omit<TextureViewRecord, 'kind' | 'handle'>
+    ): TextureViewRecord {
+        let record = this.#textureViewRecords[this.#textureViewCursor++];
+        if (record === undefined) {
+            record = {
+                kind: 'texture-view',
+                handle: 0 as RenderGraphTextureViewHandle,
+                name: '',
+                texture: source.texture,
+                descriptor: source.descriptor,
+                format: 'rgba8unorm',
+                width: 1,
+                height: 1,
+                depthOrArrayLayers: 1,
+                sampleCount: 1,
+                mipLevelCount: 1,
+                textureDimension: '2d',
+                attachment: null,
+                readable: null,
+                writable: null,
+                resolveTarget: null,
+                outputRoot: null,
+                transient: false,
+                historyState: null,
+                historyCurrent: false
+            };
+            this.#textureViewRecords.push(record);
+        }
+        record.handle = this.allocateHandle() as RenderGraphTextureViewHandle;
+        record.name = source.name;
+        record.texture = source.texture;
+        record.descriptor = source.descriptor;
+        record.format = source.format;
+        record.width = source.width;
+        record.height = source.height;
+        record.depthOrArrayLayers = source.depthOrArrayLayers;
+        record.sampleCount = source.sampleCount;
+        record.mipLevelCount = source.mipLevelCount;
+        record.textureDimension = source.textureDimension;
+        record.attachment = source.attachment;
+        record.readable = source.readable;
+        record.writable = source.writable;
+        record.resolveTarget = source.resolveTarget;
+        record.outputRoot = source.outputRoot;
+        record.transient = source.transient;
+        record.historyState = source.historyState;
+        record.historyCurrent = source.historyCurrent;
+        this.#textureAccessByHandle.set(record.handle, record);
         return record;
     }
 

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -580,7 +580,11 @@ class SharedRendererDriver
         }
         if (this.#scriptableResourcesFrameStarted) {
             try {
-                this.#scriptablePipelineResources.endFrame(resources.targets, submitted);
+                this.#scriptablePipelineResources.endFrame(
+                    resources.targets,
+                    resources.processor.registry,
+                    submitted
+                );
             } catch (error) {
                 failures.push(error);
             }
@@ -662,7 +666,7 @@ class SharedRendererDriver
             if (frameIndex === null) {
                 throw new Error('Scriptable pipeline resources require an active frame');
             }
-            this.#scriptablePipelineResources.beginFrame(frameIndex);
+            this.#scriptablePipelineResources.beginFrame(frameIndex, resources.processor.registry);
             resources.storageBuffers.beginFrame(
                 frameIndex,
                 this.#pipelineHost.requireActiveScope().uploads
@@ -1485,7 +1489,10 @@ class SharedRendererDriver
             resources.storageBuffers.destroy();
         });
         attempt(() => {
-            this.#scriptablePipelineResources.releasePersistentTargets(resources.targets);
+            this.#scriptablePipelineResources.releasePersistentTargets(
+                resources.targets,
+                resources.processor.registry
+            );
         });
         attempt(() => {
             resources.targets.destroy();

--- a/src/render/pipeline/RenderPipeline.ts
+++ b/src/render/pipeline/RenderPipeline.ts
@@ -17,6 +17,7 @@ import type {
     RendererListHandle
 } from './RendererList';
 import type { ScriptableRenderGraph } from './ScriptableRenderGraph';
+import type { RenderPipelineTextureFormat } from './RenderPipelineTexture';
 
 /** Optional renderer capabilities exposed only after their complete SRP/RHI path is available. */
 export type RenderPipelineCapabilityName =
@@ -78,7 +79,7 @@ export interface RenderPipelineCapabilities {
     supportsCapability(capability: RenderPipelineCapabilityName): boolean;
     /** Return whether a texture format supports a portable role and sample count. */
     supportsTextureFormat(
-        format: RenderTargetColorFormat | RenderTargetDepthStencilFormat,
+        format: RenderPipelineTextureFormat,
         use: RenderPipelineTextureUse,
         sampleCount?: RenderTargetSampleCount
     ): boolean;
@@ -87,7 +88,7 @@ export interface RenderPipelineCapabilities {
 /** One texture-format constraint validated before the pipeline runtime is created. */
 export interface RenderPipelineTextureRequirement {
     /** Required portable format. */
-    readonly format: RenderTargetColorFormat | RenderTargetDepthStencilFormat;
+    readonly format: RenderPipelineTextureFormat;
     /** Required graph or pass role. */
     readonly use: RenderPipelineTextureUse;
     /** Required sample count, defaulting to one. */

--- a/src/render/pipeline/RenderPipelineCapabilities.ts
+++ b/src/render/pipeline/RenderPipelineCapabilities.ts
@@ -1,7 +1,8 @@
 import {
     rhiTextureFormatHasDepth,
     rhiTextureFormatHasStencil,
-    type RHICapabilities
+    type RHICapabilities,
+    type RHITextureFormat
 } from '../rhi/core';
 import type {
     RenderPipelineCapabilities,
@@ -11,11 +12,7 @@ import type {
     RenderPipelineTextureRequirement,
     RenderPipelineTextureUse
 } from './RenderPipeline';
-import type {
-    RenderTargetColorFormat,
-    RenderTargetDepthStencilFormat,
-    RenderTargetSampleCount
-} from '../RenderTarget';
+import type { RenderTargetSampleCount } from '../RenderTarget';
 
 // Atomic release gate: flip only after public passes, graph access, RHI, both backend policies,
 // recovery, and browser coverage are all present. Per-device predicates below remain fail-closed.
@@ -26,18 +23,68 @@ const PIPELINE_CAPABILITY_NAMES: readonly RenderPipelineCapabilityName[] = Objec
     'compute-pass',
     'indirect-draw'
 ]);
-const PUBLIC_TEXTURE_FORMATS: readonly (
-    RenderTargetColorFormat | RenderTargetDepthStencilFormat
-)[] = Object.freeze([
+const PUBLIC_TEXTURE_FORMATS: readonly RHITextureFormat[] = Object.freeze([
+    'r8unorm',
+    'r8snorm',
+    'r8uint',
+    'r8sint',
+    'r16uint',
+    'r16sint',
+    'r16float',
+    'rg8unorm',
+    'rg8snorm',
+    'rg8uint',
+    'rg8sint',
+    'r32uint',
+    'r32sint',
+    'r32float',
+    'rg16uint',
+    'rg16sint',
+    'rg16float',
     'rgba8unorm',
     'rgba8unorm-srgb',
+    'rgba8snorm',
+    'rgba8uint',
+    'rgba8sint',
+    'bgra8unorm',
+    'bgra8unorm-srgb',
+    'rgb10a2unorm',
+    'rgb10a2uint',
+    'rg11b10ufloat',
+    'rgb9e5ufloat',
+    'rg32uint',
+    'rg32sint',
+    'rg32float',
+    'rgba16uint',
+    'rgba16sint',
     'rgba16float',
+    'rgba32uint',
+    'rgba32sint',
     'rgba32float',
+    'stencil8',
     'depth16unorm',
     'depth24plus',
     'depth24plus-stencil8',
     'depth32float',
-    'depth32float-stencil8'
+    'depth32float-stencil8',
+    'bc1-rgba-unorm',
+    'bc1-rgba-unorm-srgb',
+    'bc2-rgba-unorm',
+    'bc2-rgba-unorm-srgb',
+    'bc3-rgba-unorm',
+    'bc3-rgba-unorm-srgb',
+    'etc2-rgb8unorm',
+    'etc2-rgb8unorm-srgb',
+    'etc2-rgb8a1unorm',
+    'etc2-rgb8a1unorm-srgb',
+    'etc2-rgba8unorm',
+    'etc2-rgba8unorm-srgb',
+    'eac-r11unorm',
+    'eac-r11snorm',
+    'eac-rg11unorm',
+    'eac-rg11snorm',
+    'astc-4x4-unorm',
+    'astc-4x4-unorm-srgb'
 ]);
 const PUBLIC_TEXTURE_USES: readonly RenderPipelineTextureUse[] = Object.freeze([
     'sampled',
@@ -103,9 +150,7 @@ function publicPipelineLimit(
     }
 }
 
-function isDepthStencilFormat(
-    format: RenderTargetColorFormat | RenderTargetDepthStencilFormat
-): boolean {
+function isDepthStencilFormat(format: RHITextureFormat): boolean {
     return rhiTextureFormatHasDepth(format) || rhiTextureFormatHasStencil(format);
 }
 
@@ -176,28 +221,29 @@ export function createRenderPipelineCapabilities(
                       capabilities.limits.maxComputeWorkgroupsPerDimension
               })
     });
-    const formats = new Map<
-        RenderTargetColorFormat | RenderTargetDepthStencilFormat,
-        Readonly<PublicTextureFormatSnapshot>
-    >();
-    for (const format of PUBLIC_TEXTURE_FORMATS) {
+    const formats = new Map<RHITextureFormat, Readonly<PublicTextureFormatSnapshot>>();
+    const resolveFormatCapabilities = (
+        format: RHITextureFormat
+    ): Readonly<PublicTextureFormatSnapshot> => {
+        const cached = formats.get(format);
+        if (cached !== undefined) return cached;
         const source = capabilities.getTextureFormatCapabilities(format);
-        formats.set(
-            format,
-            Object.freeze({
-                supported:
-                    source.sampled ||
-                    source.renderable ||
-                    source.storage ||
-                    source.sampleCounts.length !== 0,
-                sampled: source.sampled,
-                filterable: source.filterable,
-                renderable: source.renderable,
-                storage: source.storage,
-                sampleCounts: Object.freeze([...source.sampleCounts])
-            })
-        );
-    }
+        const snapshot = Object.freeze({
+            supported:
+                source.sampled ||
+                source.renderable ||
+                source.storage ||
+                source.sampleCounts.length !== 0,
+            sampled: source.sampled,
+            filterable: source.filterable,
+            renderable: source.renderable,
+            storage: source.storage,
+            sampleCounts: Object.freeze([...source.sampleCounts])
+        });
+        formats.set(format, snapshot);
+        return snapshot;
+    };
+    for (const format of PUBLIC_TEXTURE_FORMATS) resolveFormatCapabilities(format);
     const storageBufferSupport =
         ENABLED_PUBLIC_CAPABILITY_RELEASES.has('compute-storage') &&
         capabilities.features.has('storage-buffers') &&
@@ -232,12 +278,11 @@ export function createRenderPipelineCapabilities(
             return supportedCapabilities[capability];
         },
         supportsTextureFormat(
-            format: RenderTargetColorFormat | RenderTargetDepthStencilFormat,
+            format: RHITextureFormat,
             use: RenderPipelineTextureUse,
             sampleCount: RenderTargetSampleCount = 1
         ): boolean {
-            const formatCapabilities = formats.get(format);
-            if (formatCapabilities === undefined) return false;
+            const formatCapabilities = resolveFormatCapabilities(format);
             const depthStencil = isDepthStencilFormat(format);
             switch (use) {
                 case 'sampled':

--- a/src/render/pipeline/RenderPipelineTexture.ts
+++ b/src/render/pipeline/RenderPipelineTexture.ts
@@ -1,0 +1,73 @@
+/** Physical dimension of a scriptable render-pipeline texture. */
+export type RenderPipelineTextureDimension = '1d' | '2d' | '3d';
+
+/** Dimension exposed by one scriptable render-pipeline texture view. */
+export type RenderPipelineTextureViewDimension =
+    '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
+
+/** Aspect selected by one scriptable render-pipeline texture view. */
+export type RenderPipelineTextureAspect = 'all' | 'stencil-only' | 'depth-only';
+
+/** Portable texture formats accepted by graph, compute, copy, and raster validation. */
+export type RenderPipelineTextureFormat =
+    | 'r8unorm'
+    | 'r8snorm'
+    | 'r8uint'
+    | 'r8sint'
+    | 'r16uint'
+    | 'r16sint'
+    | 'r16float'
+    | 'rg8unorm'
+    | 'rg8snorm'
+    | 'rg8uint'
+    | 'rg8sint'
+    | 'r32uint'
+    | 'r32sint'
+    | 'r32float'
+    | 'rg16uint'
+    | 'rg16sint'
+    | 'rg16float'
+    | 'rgba8unorm'
+    | 'rgba8unorm-srgb'
+    | 'rgba8snorm'
+    | 'rgba8uint'
+    | 'rgba8sint'
+    | 'bgra8unorm'
+    | 'bgra8unorm-srgb'
+    | 'rgb10a2unorm'
+    | 'rgb10a2uint'
+    | 'rg11b10ufloat'
+    | 'rgb9e5ufloat'
+    | 'rg32uint'
+    | 'rg32sint'
+    | 'rg32float'
+    | 'rgba16uint'
+    | 'rgba16sint'
+    | 'rgba16float'
+    | 'rgba32uint'
+    | 'rgba32sint'
+    | 'rgba32float'
+    | 'stencil8'
+    | 'depth16unorm'
+    | 'depth24plus'
+    | 'depth24plus-stencil8'
+    | 'depth32float'
+    | 'depth32float-stencil8'
+    | 'bc1-rgba-unorm'
+    | 'bc1-rgba-unorm-srgb'
+    | 'bc2-rgba-unorm'
+    | 'bc2-rgba-unorm-srgb'
+    | 'bc3-rgba-unorm'
+    | 'bc3-rgba-unorm-srgb'
+    | 'etc2-rgb8unorm'
+    | 'etc2-rgb8unorm-srgb'
+    | 'etc2-rgb8a1unorm'
+    | 'etc2-rgb8a1unorm-srgb'
+    | 'etc2-rgba8unorm'
+    | 'etc2-rgba8unorm-srgb'
+    | 'eac-r11unorm'
+    | 'eac-r11snorm'
+    | 'eac-rg11unorm'
+    | 'eac-rg11snorm'
+    | 'astc-4x4-unorm'
+    | 'astc-4x4-unorm-srgb';

--- a/src/render/pipeline/ScriptableRenderGraph.ts
+++ b/src/render/pipeline/ScriptableRenderGraph.ts
@@ -10,9 +10,16 @@ import type {
 import type { RendererViewport } from '../RendererCore';
 import type { StorageBuffer } from '../StorageBuffer';
 import type { RenderPipelineCapabilities } from './RenderPipeline';
+import type {
+    RenderPipelineTextureAspect,
+    RenderPipelineTextureDimension,
+    RenderPipelineTextureFormat,
+    RenderPipelineTextureViewDimension
+} from './RenderPipelineTexture';
 import type { RendererListHandle } from './RendererList';
 
 declare const renderGraphTextureHandleBrand: unique symbol;
+declare const renderGraphTextureViewHandleBrand: unique symbol;
 declare const renderGraphBufferHandleBrand: unique symbol;
 declare const renderGraphPassHandleBrand: unique symbol;
 
@@ -20,6 +27,15 @@ declare const renderGraphPassHandleBrand: unique symbol;
 export type RenderGraphTextureHandle = number & {
     readonly [renderGraphTextureHandleBrand]: true;
 };
+
+/** Opaque view identity selecting subresources from one graph texture. */
+export type RenderGraphTextureViewHandle = number & {
+    readonly [renderGraphTextureViewHandleBrand]: true;
+};
+
+/** A complete graph texture or one explicit mip/layer/aspect view. */
+export type RenderGraphTextureAccessHandle =
+    RenderGraphTextureHandle | RenderGraphTextureViewHandle;
 
 /** Opaque buffer identity scoped to one scriptable frame. */
 export type RenderGraphBufferHandle = number & {
@@ -44,13 +60,41 @@ export type RenderPipelineExtent =
 /** Backend-neutral transient texture descriptor. Usage is inferred from pass declarations. */
 export interface RenderPipelineTextureDescriptor {
     /** Color or depth/stencil format. */
-    readonly format: RenderTargetColorFormat | RenderTargetDepthStencilFormat;
+    readonly format: RenderPipelineTextureFormat;
     /** Absolute or output-relative dimensions. */
     readonly extent: RenderPipelineExtent;
     /** Raster sample count, defaulting to one. */
     readonly sampleCount?: RenderTargetSampleCount;
     /** Mip count, defaulting to one; multisampled textures require one mip. */
     readonly mipLevelCount?: number;
+    /** Texture depth or array-layer count, defaulting to one. */
+    readonly depthOrArrayLayers?: number;
+    /** Physical texture dimension, defaulting to `2d`. */
+    readonly dimension?: RenderPipelineTextureDimension;
+    /** Default whole-resource view dimension. */
+    readonly viewDimension?: RenderPipelineTextureViewDimension;
+    /** Compatible formats that explicit views may select. */
+    readonly viewFormats?: readonly RenderPipelineTextureFormat[];
+}
+
+/** Explicit subresource selection into one graph texture. */
+export interface RenderPipelineTextureViewDescriptor {
+    /** Optional diagnostic label. */
+    readonly label?: string;
+    /** Optional compatible format reinterpretation declared by the parent texture. */
+    readonly format?: RenderPipelineTextureFormat;
+    /** View dimensionality. */
+    readonly dimension?: RenderPipelineTextureViewDimension;
+    /** Color, depth, stencil, or all compatible aspects. */
+    readonly aspect?: RenderPipelineTextureAspect;
+    /** First selected mip. */
+    readonly baseMipLevel?: number;
+    /** Number of selected mips. */
+    readonly mipLevelCount?: number;
+    /** First selected array layer. */
+    readonly baseArrayLayer?: number;
+    /** Number of selected array layers. */
+    readonly arrayLayerCount?: number;
 }
 
 /** Backend-neutral transient buffer descriptor. Usage is inferred from pass declarations. */
@@ -100,12 +144,45 @@ export interface RenderPipelinePersistentTargetDescriptor {
     readonly sampleCount?: RenderTargetSampleCount;
 }
 
+/** Explicit creation roles for a recovery-aware history texture. */
+export type RenderPipelinePersistentTextureUsage =
+    'sampled' | 'storage' | 'attachment' | 'copy-source' | 'copy-destination';
+
+/**
+ * Recovery recipe for a renderer-owned double- or triple-buffered history texture.
+ *
+ * The first release accepts one single-sample 2D color mip and array layer. This fail-closed
+ * boundary ensures any submitted current-slot writer fully initializes the next readable slot.
+ */
+export interface RenderPipelineHistoryTextureDescriptor extends RenderPipelineTextureDescriptor {
+    /** Optional diagnostic label. */
+    readonly label?: string;
+    /** Complete immutable usage set required by every history slot. */
+    readonly usage: readonly RenderPipelinePersistentTextureUsage[];
+    /** Number of rotating slots, defaulting to two. */
+    readonly bufferCount?: 2 | 3;
+}
+
+/** Frame-scoped handles for one persistent history ring. */
+export interface RenderPipelineHistoryTextureResources {
+    /** Slot that this frame may completely replace. */
+    readonly current: RenderGraphTextureHandle;
+    /** Whether the immediately previous slot contains valid submitted contents. */
+    readonly valid: boolean;
+    /** Invalidation generation for cached temporal state. */
+    readonly generation: number;
+    /** Number of readable history slots. */
+    readonly historyCount: number;
+    /** Return history slot zero (previous frame) through `historyCount - 1`. */
+    history(index?: number): RenderGraphTextureHandle;
+}
+
 /** One setup-declared color attachment. */
 export interface RenderPipelineColorAttachment {
     /** Attachment source texture. */
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
     /** Optional single-sample resolve destination. */
-    readonly resolveTarget?: RenderGraphTextureHandle;
+    readonly resolveTarget?: RenderGraphTextureAccessHandle;
     /** Whether existing contents are loaded or cleared. */
     readonly loadOp: RenderTargetLoadOp;
     /** Whether resulting contents remain available after the pass. */
@@ -117,7 +194,7 @@ export interface RenderPipelineColorAttachment {
 /** One setup-declared depth/stencil attachment. */
 export interface RenderPipelineDepthStencilAttachment {
     /** Depth/stencil texture handle. */
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
     /** Depth aspect load operation. */
     readonly depthLoadOp?: RenderTargetLoadOp;
     /** Depth aspect store operation. */
@@ -139,14 +216,17 @@ export interface RenderPipelineDepthStencilAttachment {
 /** Setup-only dependency declaration surface for one pass. */
 export interface ScriptableRenderPassBuilder {
     /** Declare a sampled texture read. */
-    readTexture(texture: RenderGraphTextureHandle): void;
+    readTexture(texture: RenderGraphTextureAccessHandle): void;
     /**
      * Declare a write-only storage-texture binding that completely replaces its subresource.
      * Partial in-place texture updates are intentionally outside the first public compute ABI.
      */
-    writeStorageTexture(texture: RenderGraphTextureHandle): void;
-    /** Declare one complete texture copy and its exact source/destination dependency pair. */
-    copyTexture(source: RenderGraphTextureHandle, destination: RenderGraphTextureHandle): void;
+    writeStorageTexture(texture: RenderGraphTextureAccessHandle): void;
+    /** Declare one complete selected-subresource copy and its exact dependency pair. */
+    copyTexture(
+        source: RenderGraphTextureAccessHandle,
+        destination: RenderGraphTextureAccessHandle
+    ): void;
     /** Declare one initialized buffer read for the given portable role. */
     readBuffer(buffer: RenderGraphBufferHandle, use: RenderGraphBufferReadUse): void;
     /** Declare a complete buffer replacement for the given portable role. */
@@ -179,8 +259,11 @@ export interface ScriptableRenderCommands {
     setStencilReference(reference: number): void;
     /** Draw a renderer list declared during setup. */
     drawRendererList(list: RendererListHandle): void;
-    /** Copy the complete single-sample source texture into the destination. */
-    copyTexture(source: RenderGraphTextureHandle, destination: RenderGraphTextureHandle): void;
+    /** Copy the complete selected single-sample subresource into the destination. */
+    copyTexture(
+        source: RenderGraphTextureAccessHandle,
+        destination: RenderGraphTextureAccessHandle
+    ): void;
     /** Copy one complete buffer using a source/destination pair declared during setup. */
     copyBuffer(source: RenderGraphBufferHandle, destination: RenderGraphBufferHandle): void;
     /** Clear the exact destination byte range declared during setup. */
@@ -230,6 +313,12 @@ export interface ScriptableRenderGraph {
         name: string,
         descriptor: Readonly<RenderPipelineTextureDescriptor>
     ): RenderGraphTextureHandle;
+    /** Create one explicit mip/layer/aspect view into a graph texture. */
+    createTextureView(
+        name: string,
+        texture: RenderGraphTextureHandle,
+        descriptor?: Readonly<RenderPipelineTextureViewDescriptor>
+    ): RenderGraphTextureViewHandle;
     /** Create a logical transient buffer whose usage is inferred from live passes. */
     createBuffer(
         name: string,
@@ -246,6 +335,15 @@ export interface ScriptableRenderGraph {
         key: object,
         descriptor: Readonly<RenderPipelinePersistentTargetDescriptor>
     ): RenderPipelineTargetResources;
+    /** Acquire one renderer-owned history ring; it rotates only after a successful write frame. */
+    acquireHistoryTexture(
+        key: object,
+        descriptor: Readonly<RenderPipelineHistoryTextureDescriptor>
+    ): RenderPipelineHistoryTextureResources;
+    /** Invalidate submitted history before acquiring it in the active frame. */
+    invalidateHistoryTexture(key: object): boolean;
+    /** Transactionally release one renderer-owned history ring. */
+    releaseHistoryTexture(key: object): boolean;
     /**
      * Release one persistent target by runtime-owned key.
      *

--- a/src/render/pipeline/index.ts
+++ b/src/render/pipeline/index.ts
@@ -15,6 +15,7 @@ export {
 } from './RenderPassParameterPool';
 export type * from './RendererList';
 export type * from './RenderPipeline';
+export type * from './RenderPipelineTexture';
 export type * from './ScriptableRenderGraph';
 export * from './passes';
 export * from '../postprocessing';

--- a/src/render/pipeline/passes/ComputeRenderPass.ts
+++ b/src/render/pipeline/passes/ComputeRenderPass.ts
@@ -4,7 +4,7 @@ import ComputeKernel from '../../compute/ComputeKernel';
 import type ComputeSampler from '../../compute/ComputeSampler';
 import type {
     RenderGraphBufferHandle,
-    RenderGraphTextureHandle,
+    RenderGraphTextureAccessHandle,
     ScriptableRenderPass,
     ScriptableRenderPassBuilder,
     ScriptableRenderPassContext
@@ -25,7 +25,7 @@ export interface ComputeBufferBinding {
 /** One graph texture consumed by a sampled- or storage-texture binding. */
 export interface ComputeTextureBinding {
     /** Complete single-sample two-dimensional graph texture subresource. */
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
 }
 
 /** A whole std140 uniform buffer or one explicitly selected range. */

--- a/src/render/pipeline/passes/FullscreenRenderPass.ts
+++ b/src/render/pipeline/passes/FullscreenRenderPass.ts
@@ -3,7 +3,7 @@ import Shader from '../../../shader/Shader';
 import type UniformBuffer from '../../UniformBuffer';
 import type { RendererViewport } from '../../RendererCore';
 import type {
-    RenderGraphTextureHandle,
+    RenderGraphTextureAccessHandle,
     RenderPipelineColorAttachment,
     RenderPipelineDepthStencilAttachment,
     ScriptableRenderPass,
@@ -27,7 +27,7 @@ export interface FullscreenRenderPassOptions {
 /** Frame-scoped graph resources and dynamic state for one fullscreen draw. */
 export interface FullscreenRenderPassParameters {
     /** Linear-filterable sampled textures in reflected sampler order. */
-    readonly inputTextures: readonly RenderGraphTextureHandle[];
+    readonly inputTextures: readonly RenderGraphTextureAccessHandle[];
     /** Color attachments in fragment-output location order. */
     readonly colorAttachments: readonly Readonly<RenderPipelineColorAttachment>[];
     /** Optional depth/stencil attachment. */

--- a/src/render/pipeline/passes/SceneRenderPass.ts
+++ b/src/render/pipeline/passes/SceneRenderPass.ts
@@ -3,7 +3,7 @@ import type StorageGraphicsShader from '../../compute/StorageGraphicsShader';
 import type { RendererListHandle } from '../RendererList';
 import type {
     RenderGraphBufferHandle,
-    RenderGraphTextureHandle,
+    RenderGraphTextureAccessHandle,
     RenderPipelineColorAttachment,
     RenderPipelineDepthStencilAttachment,
     ScriptableRenderPass,
@@ -61,7 +61,7 @@ export interface SceneRenderPassParameters {
      * Opaque scene color sampled by transmission/volume materials in this pass. The graph keeps
      * this input distinct from the active color attachment, preventing raster feedback.
      */
-    readonly opaqueTexture?: RenderGraphTextureHandle;
+    readonly opaqueTexture?: RenderGraphTextureAccessHandle;
     /** Optional WebGPU-only storage-aware shader variant for the ordinary renderer-list path. */
     readonly storageShaderVariant?: Readonly<SceneStorageShaderVariant>;
 }

--- a/src/render/pipeline/passes/TextureCopyPass.ts
+++ b/src/render/pipeline/passes/TextureCopyPass.ts
@@ -1,19 +1,19 @@
 import type {
-    RenderGraphTextureHandle,
+    RenderGraphTextureAccessHandle,
     ScriptableRenderPass,
     ScriptableRenderPassBuilder,
     ScriptableRenderPassContext
 } from '../ScriptableRenderGraph';
 
-/** Full-subresource texture copy parameters. Both textures must have matching descriptors. */
+/** Full selected-subresource copy parameters. Views may have different parent descriptors. */
 export interface TextureCopyPassParameters {
     /** Initialized single-sample copy source. */
-    readonly source: RenderGraphTextureHandle;
+    readonly source: RenderGraphTextureAccessHandle;
     /** Same-format, same-extent single-sample copy destination. */
-    readonly destination: RenderGraphTextureHandle;
+    readonly destination: RenderGraphTextureAccessHandle;
 }
 
-/** Portable full-texture copy pass emitted through the selected RHI backend. */
+/** Portable full selected-subresource copy pass emitted through the selected RHI backend. */
 export class TextureCopyPass implements ScriptableRenderPass<TextureCopyPassParameters> {
     /** Stable diagnostic pass name. */
     readonly name: string;

--- a/src/render/renderer/ScriptableComputeDispatch.ts
+++ b/src/render/renderer/ScriptableComputeDispatch.ts
@@ -1,7 +1,7 @@
 import UniformBuffer, { type UniformBufferRange } from '../UniformBuffer';
 import type { ComputeShaderBinding } from '../compute/ComputeShader';
 import ComputeSampler from '../compute/ComputeSampler';
-import type { RGBufferHandle, RGTextureHandle } from '../graph/RenderGraphResource';
+import type { RGBufferHandle, RGTextureAccessHandle } from '../graph/RenderGraphResource';
 import type { RGPassContext, RGPrepareContext } from '../graph/RenderGraphExecutor';
 import type {
     ComputeRenderPassParameters,
@@ -11,7 +11,7 @@ import type ComputeRenderPass from '../pipeline/passes/ComputeRenderPass';
 import type {
     RenderGraphBufferHandle,
     RenderGraphBufferReadUse,
-    RenderGraphTextureHandle
+    RenderGraphTextureAccessHandle
 } from '../pipeline/ScriptableRenderGraph';
 import {
     RHIBufferUsage,
@@ -41,9 +41,9 @@ export interface ScriptableComputeGraphResolver {
     resolveBuffer(handle: RenderGraphBufferHandle, use: RenderGraphBufferReadUse): RGBufferHandle;
     bufferByteLength(handle: RenderGraphBufferHandle): number;
     resolveTexture(
-        handle: RenderGraphTextureHandle,
+        handle: RenderGraphTextureAccessHandle,
         access: 'sampled' | 'storage-write'
-    ): RGTextureHandle;
+    ): RGTextureAccessHandle;
 }
 
 /** @internal Submission-fenced owner for graph-dependent frame bind groups. */
@@ -94,7 +94,7 @@ interface MutableComputeBindingPlan {
     binding: ComputeShaderBinding | null;
     uniformHandle: ResourceRegistryHandle<RHIBuffer> | null;
     graphBuffer: RGBufferHandle | null;
-    graphTexture: RGTextureHandle | null;
+    graphTexture: RGTextureAccessHandle | null;
     sampler: ComputeSampler | null;
     byteOffset: number;
     byteLength: number;

--- a/src/render/renderer/ScriptableGPUDrivenDraw.ts
+++ b/src/render/renderer/ScriptableGPUDrivenDraw.ts
@@ -1,7 +1,7 @@
 import UniformBuffer, { type UniformBufferRange } from '../UniformBuffer';
 import type { ShaderReadBinding } from '../compute/ComputeShader';
 import ComputeSampler from '../compute/ComputeSampler';
-import type { RGBufferHandle, RGTextureHandle } from '../graph/RenderGraphResource';
+import type { RGBufferHandle, RGTextureAccessHandle } from '../graph/RenderGraphResource';
 import type { RGPrepareContext } from '../graph/RenderGraphExecutor';
 import type {
     GPUDrivenRenderPassParameters,
@@ -10,7 +10,7 @@ import type {
 import type {
     RenderGraphBufferHandle,
     RenderGraphBufferReadUse,
-    RenderGraphTextureHandle
+    RenderGraphTextureAccessHandle
 } from '../pipeline/ScriptableRenderGraph';
 import {
     RHIBufferUsage,
@@ -46,7 +46,10 @@ function requireRuntimeArray(value: unknown, path: string): void {
 export interface ScriptableGPUDrivenGraphResolver {
     resolveBuffer(handle: RenderGraphBufferHandle, use: RenderGraphBufferReadUse): RGBufferHandle;
     bufferByteLength(handle: RenderGraphBufferHandle): number;
-    resolveTexture(handle: RenderGraphTextureHandle, access: 'sampled'): RGTextureHandle;
+    resolveTexture(
+        handle: RenderGraphTextureAccessHandle,
+        access: 'sampled'
+    ): RGTextureAccessHandle;
 }
 
 /** @internal Submission-fenced owner for graph-dependent frame bind groups. */
@@ -97,7 +100,7 @@ interface MutableBindingPlan {
     binding: ShaderReadBinding | null;
     uniformSource: UniformBuffer | null;
     graphBuffer: RGBufferHandle | null;
-    graphTexture: RGTextureHandle | null;
+    graphTexture: RGTextureAccessHandle | null;
     sampler: ComputeSampler | null;
     byteOffset: number;
     byteLength: number;

--- a/src/render/renderer/passes/SharedDrawPass.ts
+++ b/src/render/renderer/passes/SharedDrawPass.ts
@@ -7,7 +7,7 @@ import type {
     RGColorAttachmentDeclaration,
     RGDepthStencilAttachmentDeclaration,
     RGPassHandle,
-    RGTextureHandle
+    RGTextureAccessHandle
 } from '../../graph/RenderGraphResource';
 import {
     RHITextureUsage,
@@ -80,8 +80,8 @@ interface MutableColorAttachmentDescriptor {
 }
 
 interface ColorAttachmentSlot {
-    texture: RGTextureHandle | null;
-    resolveTarget: RGTextureHandle | null;
+    texture: RGTextureAccessHandle | null;
+    resolveTarget: RGTextureAccessHandle | null;
     readonly clearValue: MutableColor;
     readonly descriptor: MutableColorAttachmentDescriptor;
     readonly graphDeclaration: MutableGraphColorAttachmentDeclaration;
@@ -137,7 +137,7 @@ function createColorAttachmentSlot(): ColorAttachmentSlot {
             storeOp: 'store'
         },
         graphDeclaration: {
-            texture: 0 as RGTextureHandle,
+            texture: 0 as RGTextureAccessHandle,
             loadOp: 'load',
             storeOp: 'store'
         }
@@ -188,15 +188,15 @@ export interface SharedDrawPassCapacity {
 }
 
 export interface SharedDrawPassColorAttachment {
-    readonly texture: RGTextureHandle;
-    readonly resolveTarget?: RGTextureHandle;
+    readonly texture: RGTextureAccessHandle;
+    readonly resolveTarget?: RGTextureAccessHandle;
     readonly clearValue?: RHIColor;
     readonly loadOp: RHILoadOp;
     readonly storeOp: RHIStoreOp;
 }
 
 export interface SharedDrawPassDepthStencilAttachment {
-    readonly texture: RGTextureHandle;
+    readonly texture: RGTextureAccessHandle;
     readonly depthClearValue?: number;
     readonly depthLoadOp?: RHILoadOp;
     readonly depthStoreOp?: RHIStoreOp;
@@ -237,13 +237,13 @@ export class SharedDrawPassParameters {
         stencilReadOnly: undefined
     };
     private readonly depthStencilGraphDeclaration: MutableGraphDepthStencilAttachmentDeclaration = {
-        texture: 0 as RGTextureHandle
+        texture: 0 as RGTextureAccessHandle
     };
-    private depthStencilTexture: RGTextureHandle | null = null;
+    private depthStencilTexture: RGTextureAccessHandle | null = null;
 
-    private readonly readTextures: (RGTextureHandle | null)[] = [];
+    private readonly readTextures: (RGTextureAccessHandle | null)[] = [];
     private readTextureCount = 0;
-    private readonly writeTextures: (RGTextureHandle | null)[] = [];
+    private readonly writeTextures: (RGTextureAccessHandle | null)[] = [];
     private writeTextureCount = 0;
     private readonly readBuffers: (RGBufferHandle | null)[] = [];
     private readonly readBufferUses: (RGBufferReadUse | null)[] = [];
@@ -420,11 +420,11 @@ export class SharedDrawPassParameters {
         this.prepared = false;
     }
 
-    addReadTexture(handle: RGTextureHandle): void {
+    addReadTexture(handle: RGTextureAccessHandle): void {
         this.readTextures[this.readTextureCount++] = handle;
     }
 
-    addWriteTexture(handle: RGTextureHandle): void {
+    addWriteTexture(handle: RGTextureAccessHandle): void {
         this.writeTextures[this.writeTextureCount++] = handle;
     }
 

--- a/src/render/rhi/core/RHIValidation.ts
+++ b/src/render/rhi/core/RHIValidation.ts
@@ -570,8 +570,21 @@ function rhiTextureViewFormatsCompatible(
     );
 }
 
+type RHITextureViewNormalizationSource = Pick<
+    RHITexture,
+    | 'width'
+    | 'height'
+    | 'depthOrArrayLayers'
+    | 'mipLevelCount'
+    | 'sampleCount'
+    | 'dimension'
+    | 'format'
+> & {
+    readonly descriptor: Pick<RHINormalizedTextureDescriptor, 'viewDimension' | 'viewFormats'>;
+};
+
 function defaultTextureViewArrayLayerCount(
-    texture: RHITexture,
+    texture: RHITextureViewNormalizationSource,
     dimension: RHITextureViewDimension,
     baseArrayLayer: number
 ): number {
@@ -597,13 +610,10 @@ function textureViewDimensionIsCompatible(
     return false;
 }
 
-export function normalizeRHITextureViewDescriptor(
-    texture: RHITexture,
+function normalizeTextureViewDescriptor(
+    texture: RHITextureViewNormalizationSource,
     descriptor: RHITextureViewDescriptor = {}
 ): Readonly<RHINormalizedTextureViewDescriptor> {
-    if (texture.destroyed) {
-        fail('destroyed-object', 'texture has been destroyed', 'textureView.texture');
-    }
     const baseMipLevel = descriptor.baseMipLevel ?? 0;
     const baseArrayLayer = descriptor.baseArrayLayer ?? 0;
     const dimension = descriptor.dimension ?? texture.descriptor.viewDimension;
@@ -729,6 +739,36 @@ export function normalizeRHITextureViewDescriptor(
         baseArrayLayer,
         arrayLayerCount
     });
+}
+
+/** Normalize a texture view against an already-normalized backend-neutral texture descriptor. */
+export function normalizeRHITextureViewDescriptorForTextureDescriptor(
+    texture: Readonly<RHINormalizedTextureDescriptor>,
+    descriptor: RHITextureViewDescriptor = {}
+): Readonly<RHINormalizedTextureViewDescriptor> {
+    return normalizeTextureViewDescriptor(
+        {
+            width: texture.size.width,
+            height: texture.size.height,
+            depthOrArrayLayers: texture.size.depthOrArrayLayers,
+            mipLevelCount: texture.mipLevelCount,
+            sampleCount: texture.sampleCount,
+            dimension: texture.dimension,
+            format: texture.format,
+            descriptor: texture
+        },
+        descriptor
+    );
+}
+
+export function normalizeRHITextureViewDescriptor(
+    texture: RHITexture,
+    descriptor: RHITextureViewDescriptor = {}
+): Readonly<RHINormalizedTextureViewDescriptor> {
+    if (texture.destroyed) {
+        fail('destroyed-object', 'texture has been destroyed', 'textureView.texture');
+    }
+    return normalizeTextureViewDescriptor(texture, descriptor);
 }
 
 export function normalizeRHISamplerDescriptor(

--- a/test/spec/renderer/RenderGraph.test.ts
+++ b/test/spec/renderer/RenderGraph.test.ts
@@ -5,7 +5,10 @@ import type {
     RGPassContext,
     RGPrepareContext
 } from '../../../src/render/graph/RenderGraphExecutor';
-import type { RGTextureHandle } from '../../../src/render/graph/RenderGraphResource';
+import type {
+    RGTextureAccessHandle,
+    RGTextureHandle
+} from '../../../src/render/graph/RenderGraphResource';
 import type { RenderGraphError } from '../../../src/render/graph/RenderGraphValidation';
 import { RHIBufferUsage, RHITextureUsage } from '../../../src/render/rhi/core';
 import {
@@ -16,8 +19,8 @@ import {
 } from '../rhi/portable/FakeRHIBackend';
 
 interface AccessParams {
-    readonly reads?: readonly RGTextureHandle[];
-    readonly writes?: readonly RGTextureHandle[];
+    readonly reads?: readonly RGTextureAccessHandle[];
+    readonly writes?: readonly RGTextureAccessHandle[];
     readonly log: string[];
     readonly name: string;
     readonly sideEffect?: boolean;
@@ -301,6 +304,166 @@ describe('RenderGraph compile', () => {
         expect(() => graph.compile(cycle, device.capabilities)).toThrow(
             expect.objectContaining({ code: 'cycle' })
         );
+        backend.destroy();
+    });
+
+    it('tracks non-overlapping mip views independently and keeps their parent alive', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const graph = new RenderGraph();
+        const builder = graph.createBuilder();
+        const pyramid = builder.createTexture('depth pyramid', {
+            size: { width: 16, height: 16 },
+            mipLevelCount: 3,
+            format: 'r32float',
+            usage: RHITextureUsage.TEXTURE_BINDING | RHITextureUsage.STORAGE_BINDING
+        });
+        const mip0 = builder.createTextureView('depth pyramid mip 0', pyramid, {
+            baseMipLevel: 0,
+            mipLevelCount: 1
+        });
+        const mip1 = builder.createTextureView('depth pyramid mip 1', pyramid, {
+            baseMipLevel: 1,
+            mipLevelCount: 1
+        });
+        const mip2 = builder.createTextureView('depth pyramid mip 2', pyramid, {
+            baseMipLevel: 2,
+            mipLevelCount: 1
+        });
+        const observedMipLevels: number[] = [];
+        builder.addPass(texturePass, { writes: [mip0], log: [], name: 'seed mip 0' });
+        builder.addPass(
+            {
+                name: 'reduce mip 1',
+                setup(pass) {
+                    pass.readTexture(mip0);
+                    pass.writeTexture(mip1);
+                },
+                prepare(context) {
+                    observedMipLevels.push(context.getTextureView(mip0).descriptor.baseMipLevel);
+                    observedMipLevels.push(context.getTextureView(mip1).descriptor.baseMipLevel);
+                    expect(context.getTexture(mip0)).toBe(context.getTexture(mip1));
+                },
+                execute() {
+                    // Dependency and prepared-view contracts are under test.
+                }
+            },
+            undefined
+        );
+        builder.addPass(texturePass, {
+            reads: [mip1],
+            writes: [mip2],
+            log: [],
+            name: 'reduce mip 2'
+        });
+        builder.markOutput(mip2);
+
+        const compiled = graph.compile(builder, device.capabilities);
+        expect(compiled.passes).toHaveLength(3);
+        expect(compiled.resources.map(resource => resource.name)).toEqual([
+            'depth pyramid',
+            'depth pyramid mip 0',
+            'depth pyramid mip 1',
+            'depth pyramid mip 2'
+        ]);
+        expect(compiled.resourceByHandle.get(pyramid)?.lifetime).toEqual({
+            firstUse: 0,
+            lastUse: 2
+        });
+
+        graph.execute(compiled, device);
+        expect(observedMipLevels).toEqual([0, 1]);
+        graph.destroy();
+        backend.destroy();
+    });
+
+    it('allows disjoint same-pass views and rejects overlapping view feedback', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const graph = new RenderGraph();
+        const importedTexture = device.createTexture({
+            size: { width: 8, height: 8 },
+            mipLevelCount: 2,
+            format: 'rgba8unorm',
+            usage: RHITextureUsage.TEXTURE_BINDING | RHITextureUsage.STORAGE_BINDING
+        });
+
+        const disjoint = graph.createBuilder();
+        const disjointTexture = disjoint.importTexture('disjoint texture', importedTexture);
+        const readMip0 = disjoint.createTextureView('read mip 0', disjointTexture, {
+            baseMipLevel: 0,
+            mipLevelCount: 1
+        });
+        const writeMip1 = disjoint.createTextureView('write mip 1', disjointTexture, {
+            baseMipLevel: 1,
+            mipLevelCount: 1
+        });
+        disjoint.addPass(texturePass, {
+            reads: [readMip0],
+            writes: [writeMip1],
+            log: [],
+            name: 'disjoint feedback',
+            sideEffect: true
+        });
+        expect(() => graph.compile(disjoint, device.capabilities)).not.toThrow();
+
+        const overlapping = graph.createBuilder();
+        const overlappingTexture = overlapping.importTexture(
+            'overlapping texture',
+            importedTexture
+        );
+        const firstMip0 = overlapping.createTextureView('first mip 0', overlappingTexture, {
+            baseMipLevel: 0,
+            mipLevelCount: 1
+        });
+        const secondMip0 = overlapping.createTextureView('second mip 0', overlappingTexture, {
+            baseMipLevel: 0,
+            mipLevelCount: 1
+        });
+        overlapping.addPass(texturePass, {
+            reads: [firstMip0],
+            writes: [secondMip0],
+            log: [],
+            name: 'overlapping feedback',
+            sideEffect: true
+        });
+        expect(() => graph.compile(overlapping, device.capabilities)).toThrow(
+            expect.objectContaining<Partial<RenderGraphError>>({ code: 'duplicate-access' })
+        );
+
+        graph.destroy();
+        importedTexture.destroy();
+        backend.destroy();
+    });
+
+    it('preserves explicit imported-texture initialization across subresource views', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const graph = new RenderGraph();
+        const texture = device.createTexture({
+            size: { width: 4, height: 4 },
+            mipLevelCount: 2,
+            format: 'rgba8unorm',
+            usage: RHITextureUsage.TEXTURE_BINDING
+        });
+        const builder = graph.createBuilder();
+        const imported = builder.importTexture('uninitialized history', texture, false);
+        const mip = builder.createTextureView('uninitialized history mip', imported, {
+            baseMipLevel: 1,
+            mipLevelCount: 1
+        });
+        builder.addPass(texturePass, {
+            reads: [mip],
+            log: [],
+            name: 'invalid history read',
+            sideEffect: true
+        });
+
+        expect(() => graph.compile(builder, device.capabilities)).toThrow(
+            expect.objectContaining<Partial<RenderGraphError>>({ code: 'uninitialized-read' })
+        );
+        graph.destroy();
+        texture.destroy();
         backend.destroy();
     });
 
@@ -882,6 +1045,74 @@ describe('RenderGraph compile', () => {
 
         expect(graph.compile(builder, device.capabilities).passes).toHaveLength(2);
         graph.destroy();
+        backend.destroy();
+    });
+
+    it('selects the last graph writer independently for depth and stencil views', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const texture = device.createTexture({
+            size: { width: 4, height: 4 },
+            format: 'depth24plus-stencil8',
+            usage: RHITextureUsage.RENDER_ATTACHMENT | RHITextureUsage.TEXTURE_BINDING,
+            lifetime: 'persistent'
+        });
+        const graph = new RenderGraph();
+        const builder = graph.createBuilder();
+        const depthStencil = builder.importTexture('persistent depth stencil', texture, false);
+        builder.readTextureFromLastGraphWriter(depthStencil);
+        const depth = builder.createTextureView('depth aspect', depthStencil, {
+            aspect: 'depth-only'
+        });
+        const stencil = builder.createTextureView('stencil aspect', depthStencil, {
+            aspect: 'stencil-only'
+        });
+        builder.addPass(texturePass, {
+            reads: [stencil],
+            log: [],
+            name: 'read stencil',
+            sideEffect: true
+        });
+        builder.addPass(
+            {
+                name: 'write stencil',
+                setup(pass) {
+                    pass.useDepthStencilAttachment({
+                        texture: stencil,
+                        stencilClearValue: 0,
+                        stencilLoadOp: 'clear',
+                        stencilStoreOp: 'store'
+                    });
+                },
+                execute() {
+                    // Dependency and culling selection are asserted below.
+                }
+            },
+            undefined
+        );
+        builder.addPass(
+            {
+                name: 'write depth',
+                setup(pass) {
+                    pass.useDepthStencilAttachment({
+                        texture: depth,
+                        depthClearValue: 1,
+                        depthLoadOp: 'clear',
+                        depthStoreOp: 'store'
+                    });
+                },
+                execute() {
+                    // A depth-only writer must not satisfy the stencil read.
+                }
+            },
+            undefined
+        );
+
+        const compiled = graph.compile(builder, device.capabilities);
+        expect(compiled.passes.map(pass => pass.name)).toEqual(['write stencil', 'texture access']);
+
+        graph.destroy();
+        texture.destroy();
         backend.destroy();
     });
 

--- a/test/spec/renderer/RenderPipelineCapabilities.test.ts
+++ b/test/spec/renderer/RenderPipelineCapabilities.test.ts
@@ -202,6 +202,29 @@ describe('RenderPipelineCapabilities', () => {
         backend.destroy();
     });
 
+    it('preserves storage-oriented graph texture formats across device replacement', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const source = backend.createDevice().capabilities;
+        const minimum = createRenderPipelineCapabilities(source);
+        const reduced = createRenderPipelineCapabilities(
+            overrideFormat(
+                source,
+                'r32float',
+                formatCapabilities(source, 'r32float', {
+                    sampled: false,
+                    filterable: false,
+                    storage: false
+                })
+            )
+        );
+
+        expect(minimum.supportsTextureFormat('r32float', 'sampled')).toBe(true);
+        expect(() => {
+            validateRenderPipelineCapabilitySuperset(minimum, reduced);
+        }).toThrow(/r32float sampled/u);
+        backend.destroy();
+    });
+
     it('rejects replacement devices with narrower compute limits or stricter storage alignment', () => {
         const backend = new FakeWebGPURHIBackend();
         const source = backend.createDevice().capabilities;

--- a/test/spec/renderer/ScriptableRenderPipeline.test.ts
+++ b/test/spec/renderer/ScriptableRenderPipeline.test.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../../src/render/pipeline/RenderPipeline';
 import type {
     RenderGraphBufferHandle,
+    RenderGraphTextureAccessHandle,
     RenderGraphTextureHandle,
     RenderPipelineColorAttachment,
     RenderPipelineTargetResources,
@@ -211,7 +212,7 @@ class CopyPipelineFactory implements RenderPipelineFactory {
 }
 
 interface TextureReadParameters {
-    readonly texture: RenderGraphTextureHandle;
+    readonly texture: RenderGraphTextureAccessHandle;
 }
 
 class TextureReadSideEffectPass implements ScriptableRenderPass<TextureReadParameters> {
@@ -427,6 +428,54 @@ fn main() { textureStore(output, vec2<i32>(0), vec4<f32>(1.0)); }`,
             textures: [{ texture }],
             dispatch: { x: 1 }
         });
+    }
+
+    destroy(): void {
+        // ComputeKernel contains no renderer-local resources.
+    }
+}
+
+class StorageTextureMipViewPipeline implements RenderPipeline {
+    readonly name = 'storage-texture-mip-view';
+    readonly pass = new ComputeRenderPass(
+        new ComputeKernel({
+            shader: new ComputeShader({
+                source: `
+@group(0) @binding(0) var output: texture_storage_2d<rgba8unorm, write>;
+@compute @workgroup_size(1)
+fn main() { textureStore(output, vec2<i32>(0), vec4<f32>(1.0, 0.0, 0.0, 1.0)); }`,
+                workgroupSize: [1],
+                bindings: [
+                    {
+                        name: 'output',
+                        group: 0,
+                        binding: 0,
+                        kind: 'storage-texture',
+                        access: 'write-only',
+                        format: 'rgba8unorm'
+                    }
+                ]
+            })
+        })
+    );
+    readonly readPass = new TextureReadSideEffectPass();
+
+    record(context: RenderPipelineContext): void {
+        const texture = context.graph.createTexture('storage mip chain', {
+            format: 'rgba8unorm',
+            extent: { width: 4, height: 4 },
+            mipLevelCount: 2
+        });
+        const mip1 = context.graph.createTextureView('storage mip 1', texture, {
+            baseMipLevel: 1,
+            mipLevelCount: 1
+        });
+        context.graph.addPass(this.pass, {
+            buffers: [],
+            textures: [{ texture: mip1 }],
+            dispatch: { x: 1 }
+        });
+        context.graph.addPass(this.readPass, { texture: mip1 });
     }
 
     destroy(): void {
@@ -786,6 +835,96 @@ class PersistentTargetPipeline implements RenderPipeline {
 
     destroy(): void {
         // No renderer-local resources.
+    }
+}
+
+interface SubresourcePassParameters {
+    readonly input?: RenderGraphTextureAccessHandle;
+    readonly output: RenderGraphTextureAccessHandle;
+    readonly sideEffect?: boolean;
+}
+
+class SubresourcePass implements ScriptableRenderPass<SubresourcePassParameters> {
+    readonly name = 'Subresource view pass';
+
+    setup(builder: ScriptableRenderPassBuilder, parameters: SubresourcePassParameters): void {
+        if (parameters.input !== undefined) builder.readTexture(parameters.input);
+        builder.useColorAttachment({
+            texture: parameters.output,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: { r: 0, g: 0, b: 0, a: 1 }
+        });
+        if (parameters.sideEffect) builder.markSideEffect();
+    }
+
+    execute(): void {
+        // Graph subresource scheduling is under test; no native draw is required.
+    }
+}
+
+class SubresourceViewPipeline implements RenderPipeline {
+    readonly name = 'subresource-view-pipeline';
+    readonly pass = new SubresourcePass();
+    overlap = false;
+
+    record(context: RenderPipelineContext): void {
+        const texture = context.graph.createTexture('public mip chain', {
+            format: 'r32float',
+            extent: { width: 8, height: 8 },
+            mipLevelCount: 2
+        });
+        const mip0 = context.graph.createTextureView('public mip 0', texture, {
+            baseMipLevel: 0,
+            mipLevelCount: 1
+        });
+        const output = context.graph.createTextureView(
+            this.overlap ? 'overlapping public mip 0' : 'public mip 1',
+            texture,
+            {
+                baseMipLevel: this.overlap ? 0 : 1,
+                mipLevelCount: 1
+            }
+        );
+        context.graph.addPass(this.pass, { output: mip0 });
+        context.graph.addPass(this.pass, { input: mip0, output, sideEffect: true });
+    }
+
+    destroy(): void {
+        // No renderer-local resources.
+    }
+}
+
+class HistoryTexturePipeline implements RenderPipeline {
+    readonly name = 'history-texture-pipeline';
+    readonly key = Object.freeze({});
+    readonly pass = new SubresourcePass();
+    readonly valid: boolean[] = [];
+    readonly generations: number[] = [];
+    width = 4;
+    mipLevelCount = 1;
+    failAfterRecord = false;
+
+    record(context: RenderPipelineContext): void {
+        const history = context.graph.acquireHistoryTexture(this.key, {
+            label: 'temporal color history',
+            format: 'rgba8unorm',
+            extent: { width: this.width, height: 4 },
+            mipLevelCount: this.mipLevelCount,
+            usage: ['sampled', 'attachment'],
+            bufferCount: 3
+        });
+        this.valid.push(history.valid);
+        this.generations.push(history.generation);
+        context.graph.addPass(this.pass, {
+            ...(history.valid ? { input: history.history() } : {}),
+            output: history.current
+        });
+        if (this.failAfterRecord) throw new Error('history frame failed');
+    }
+
+    destroy(): void {
+        // The renderer owns and releases the history recipes.
     }
 }
 
@@ -1336,6 +1475,23 @@ describe('Scriptable render pipeline', () => {
         expect(beginFrame).not.toHaveBeenCalled();
     });
 
+    it('binds one explicit mip view as a real WebGPU storage texture', async () => {
+        const renderer = await Renderer.create({
+            backend: 'webgpu',
+            domElement: document.createElement('canvas'),
+            width: 4,
+            height: 4,
+            antialias: false,
+            renderPipeline: new FixedRuntimeFactory(new StorageTextureMipViewPipeline())
+        });
+        activeRenderers.push(renderer);
+
+        expect(() => {
+            renderer.render(new Node(), new PerspectiveCamera());
+        }).not.toThrow();
+        await renderer.waitForIdle();
+    });
+
     it('keeps sampled depth reads independent from COPY_SRC usage', async () => {
         const runtime = new SampledDepthPipeline();
         const renderer = await Renderer.create({
@@ -1531,6 +1687,66 @@ describe('Scriptable render pipeline', () => {
         renderer.render(new Node(), new PerspectiveCamera());
 
         expect(renderer.renderInfo.drawCount).toBe(1);
+    });
+
+    it('schedules public mip views independently and rejects overlapping feedback', async () => {
+        const runtime = new SubresourceViewPipeline();
+        const renderer = await Renderer.create({
+            backend: 'webgpu',
+            domElement: document.createElement('canvas'),
+            width: 8,
+            height: 8,
+            antialias: false,
+            renderPipeline: new FixedRuntimeFactory(runtime)
+        });
+        activeRenderers.push(renderer);
+
+        expect(() => {
+            renderer.render(new Node(), new PerspectiveCamera());
+        }).not.toThrow();
+        runtime.overlap = true;
+        expect(() => {
+            renderer.render(new Node(), new PerspectiveCamera());
+        }).toThrow(/overlaps|feedback|duplicate|same-pass/u);
+    });
+
+    it('commits history rotation and descriptor generations only after successful frames', async () => {
+        const runtime = new HistoryTexturePipeline();
+        const renderer = await Renderer.create({
+            backend: 'webgpu',
+            domElement: document.createElement('canvas'),
+            width: 4,
+            height: 4,
+            antialias: false,
+            renderPipeline: new FixedRuntimeFactory(runtime)
+        });
+        activeRenderers.push(renderer);
+        const scene = new Node();
+        const camera = new PerspectiveCamera();
+
+        renderer.render(scene, camera);
+        renderer.render(scene, camera);
+        expect(runtime.valid).toEqual([false, true]);
+        expect(runtime.generations[1]).toBe(runtime.generations[0]);
+
+        runtime.width = 8;
+        runtime.failAfterRecord = true;
+        expect(() => {
+            renderer.render(scene, camera);
+        }).toThrow(/history frame failed/u);
+        const failedGeneration = runtime.generations[2];
+
+        runtime.width = 4;
+        runtime.failAfterRecord = false;
+        renderer.render(scene, camera);
+        expect(runtime.valid[3]).toBe(true);
+        expect(runtime.generations[3]).toBe(runtime.generations[1]);
+        expect(failedGeneration).toBe((runtime.generations[1] ?? 0) + 1);
+
+        runtime.mipLevelCount = 2;
+        expect(() => {
+            renderer.render(scene, camera);
+        }).toThrow(/one single-sample 2D color mip and array layer/u);
     });
 
     it('commits persistent target descriptor changes only after successful submission', async () => {

--- a/test/spec/renderer/ScriptableRenderPipelineResources.test.ts
+++ b/test/spec/renderer/ScriptableRenderPipelineResources.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { ScriptableRenderPipelineResources } from '../../../src/render/internal/ScriptableRenderPipelineContext';
+import { RHITextureUsage } from '../../../src/render/rhi/core';
+import type { RenderTargetResourceCache } from '../../../src/render/renderer/RenderTargetResourceCache';
+import { ResourceRegistry } from '../../../src/render/renderer/ResourceRegistry';
+import { FakeWebGPURHIBackend } from '../rhi/portable/FakeRHIBackend';
+
+const HISTORY_RECIPE = Object.freeze({
+    label: 'transactional history',
+    width: 8,
+    height: 4,
+    depthOrArrayLayers: 1,
+    mipLevelCount: 1,
+    sampleCount: 1 as const,
+    dimension: '2d' as const,
+    viewDimension: '2d' as const,
+    format: 'rgba8unorm' as const,
+    usage: RHITextureUsage.TEXTURE_BINDING | RHITextureUsage.RENDER_ATTACHMENT,
+    viewFormats: Object.freeze([]),
+    bufferCount: 3 as const
+});
+
+describe('ScriptableRenderPipelineResources history', () => {
+    it('rolls back failed rotation and invalidates rebuilt device generations', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const registry = new ResourceRegistry(device);
+        const resources = new ScriptableRenderPipelineResources();
+        const targets = {} as unknown as RenderTargetResourceCache;
+        const runtimeOwner = Object.freeze({});
+        const key = Object.freeze({});
+
+        resources.beginFrame(0, registry);
+        const first = resources.prepareHistoryTexture(
+            runtimeOwner,
+            key,
+            0,
+            registry,
+            HISTORY_RECIPE
+        );
+        expect(first.writeIndex).toBe(0);
+        expect(first.initialized).toEqual([false, false, false]);
+        resources.noteHistoryTextureWrite(first.state);
+        resources.endFrame(targets, registry, true);
+
+        resources.beginFrame(1, registry);
+        const failed = resources.prepareHistoryTexture(
+            runtimeOwner,
+            key,
+            1,
+            registry,
+            HISTORY_RECIPE
+        );
+        expect(failed.writeIndex).toBe(1);
+        expect(failed.initialized).toEqual([true, false, false]);
+        resources.noteHistoryTextureWrite(failed.state);
+        resources.endFrame(targets, registry, false);
+
+        resources.beginFrame(2, registry);
+        const retried = resources.prepareHistoryTexture(
+            runtimeOwner,
+            key,
+            2,
+            registry,
+            HISTORY_RECIPE
+        );
+        expect(retried.writeIndex).toBe(1);
+        expect(retried.initialized).toEqual([true, false, false]);
+        resources.noteHistoryTextureWrite(retried.state);
+        resources.endFrame(targets, registry, true);
+
+        const replacementDevice = backend.createDevice();
+        registry.recover(replacementDevice);
+        resources.beginFrame(3, registry);
+        const recovered = resources.prepareHistoryTexture(
+            runtimeOwner,
+            key,
+            3,
+            registry,
+            HISTORY_RECIPE
+        );
+        expect(recovered.writeIndex).toBe(0);
+        expect(recovered.initialized).toEqual([false, false, false]);
+        expect(recovered.generation).toBe(retried.generation + 1);
+        resources.endFrame(targets, registry, false);
+
+        resources.beginFrame(4, registry);
+        expect(resources.releaseHistoryTexture(runtimeOwner, key)).toBe(true);
+        resources.endFrame(targets, registry, true);
+        expect(registry.collect(4)).toBe(3);
+        resources.releasePersistentTargets(targets, registry);
+        registry.destroy();
+        backend.destroy();
+    });
+
+    it('commits an unwritten descriptor revision as wholly invalid history', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const registry = new ResourceRegistry(backend.createDevice());
+        const resources = new ScriptableRenderPipelineResources();
+        const targets = {} as unknown as RenderTargetResourceCache;
+        const runtimeOwner = Object.freeze({});
+        const key = Object.freeze({});
+
+        resources.beginFrame(0, registry);
+        const initial = resources.prepareHistoryTexture(
+            runtimeOwner,
+            key,
+            0,
+            registry,
+            HISTORY_RECIPE
+        );
+        resources.noteHistoryTextureWrite(initial.state);
+        resources.endFrame(targets, registry, true);
+
+        resources.beginFrame(1, registry);
+        const revised = resources.prepareHistoryTexture(runtimeOwner, key, 1, registry, {
+            ...HISTORY_RECIPE,
+            width: 16
+        });
+        expect(revised.writeIndex).toBe(0);
+        expect(revised.initialized).toEqual([false, false, false]);
+        resources.endFrame(targets, registry, true);
+
+        resources.beginFrame(2, registry);
+        const next = resources.prepareHistoryTexture(runtimeOwner, key, 2, registry, {
+            ...HISTORY_RECIPE,
+            width: 16
+        });
+        expect(next.writeIndex).toBe(0);
+        expect(next.initialized).toEqual([false, false, false]);
+        resources.endFrame(targets, registry, false);
+
+        resources.releasePersistentTargets(targets, registry);
+        registry.destroy();
+        backend.destroy();
+    });
+});

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -56,7 +56,11 @@ import {
     type RenderPipelineOutputDepthStencilAttachment,
     type RenderPipelineRequirements,
     type RenderGraphBufferHandle,
+    type RenderGraphTextureAccessHandle,
     type RenderGraphTextureHandle,
+    type RenderGraphTextureViewHandle,
+    type RenderPipelineHistoryTextureResources,
+    type RenderPipelineTextureFormat,
     type RendererListHandle,
     type StorageBuffer,
     type StorageBufferReadback,
@@ -219,6 +223,28 @@ const webgpuIdlePromise: Promise<void> = webgpuRenderer.waitForIdle();
 declare const scriptableGraph: ScriptableRenderGraph;
 declare const forwardFeatureContext: ForwardRenderFeatureContext;
 declare const pipelineOutput: RenderPipelineOutput;
+const graphTextureFormat: RenderPipelineTextureFormat = 'r32float';
+const graphMipChain: RenderGraphTextureHandle = scriptableGraph.createTexture('typed mip chain', {
+    format: graphTextureFormat,
+    extent: { width: 8, height: 8 },
+    mipLevelCount: 2
+});
+const graphMipView: RenderGraphTextureViewHandle = scriptableGraph.createTextureView(
+    'typed mip view',
+    graphMipChain,
+    { baseMipLevel: 1, mipLevelCount: 1 }
+);
+const graphTextureAccess: RenderGraphTextureAccessHandle = graphMipView;
+const typedHistory: RenderPipelineHistoryTextureResources = scriptableGraph.acquireHistoryTexture(
+    Object.freeze({}),
+    {
+        format: 'rgba16float',
+        extent: { relativeTo: 'output', scale: 1 },
+        usage: ['sampled', 'storage'],
+        bufferCount: 3
+    }
+);
+const typedPreviousHistory: RenderGraphTextureHandle = typedHistory.history();
 const persistentTargetReleased: boolean = scriptableGraph.releasePersistentTarget(
     Object.freeze({})
 );
@@ -227,6 +253,8 @@ const outputColorPolicy: Readonly<RenderPipelineOutputColorAttachment> =
     pipelineOutput.colorAttachment(0);
 const outputDepthStencilPolicy: Readonly<RenderPipelineOutputDepthStencilAttachment> | null =
     pipelineOutput.depthStencilAttachment;
+void graphTextureAccess;
+void typedPreviousHistory;
 
 const textureParameters = {
     uv: 0,


### PR DESCRIPTION
## Summary

Implements the first modern WebGPU rendering foundation phase described in #71.

- adds explicit Render Graph texture-view handles for mip, layer, dimension, compatible-format, and depth/stencil-aspect access
- tracks hazards, initialization/discard state, dependencies, culling, and physical texture lifetime at subresource granularity
- threads texture views through sampled, storage, attachment, copy, fullscreen, compute, scene, and GPU-driven paths
- adds renderer-owned double/triple-buffered history textures with transactional rotation, descriptor revision rollback, explicit invalidation/release, and device-recovery invalidation
- exposes complete portable graph texture formats and public texture dimension/view/aspect types without leaking internal RHI types
- updates architecture/compute/SRP documentation, changelog, API report, and package type-consumer coverage

## Why

Modern effects such as Hi-Z, bloom pyramids, temporal accumulation, TAA, SSR, volumetrics, and GPU-driven post-processing need explicit subresource identity and recovery-aware history resources. The previous graph modeled only whole textures and forced persistent texture ownership outside the scriptable pipeline.

The first history release is deliberately fail-closed to one single-sample 2D color mip/layer so `valid` always means the complete slot was initialized by a submitted writer.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run docs:check`
- `npm run api:check`
- `npm run test:types`
- `npm run test:package`
- `npm run test:unit` — 1703 tests
- `npm run test:render:architecture` — 132 tests
- `npm run test:rhi` — 208 portable + 3 native tests
- targeted Render Graph/SRP/history/capability suite — 108 tests
- `npm run test:webgpu` — 15 real Chromium WebGPU/WebGL2 tests
