### PR TITLE
feat(render): add WebGPU capabilities timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ### Changes
 
+- Add modern WebGPU capability discovery for `subgroups`, adapter subgroup-size limits,
+  `shader-f16`, and `timestamp-query`; expose renderer feature queries for explicit f32/workgroup
+  fallback selection. Direct WGSL f16 now preserves the exact native artifact while completing Naga
+  validation through an equivalent f32 specialization. Compute buffer `minBindingSize` is derived
+  from WGSL store types, including the required one-element runtime-array minimum.
+- Add submission-aware timestamp QuerySets, pass timestamp writes, explicit resolves, and validated
+  debug groups/markers to the portable RHI. Opt-in renderer diagnostics now publish Render Graph
+  record/compile/prepare/execute CPU timing, per-pass asynchronous GPU timing, and compiled resource
+  lifetime intervals through a non-blocking three-slot readback ring; the default diagnostics-off
+  path creates no query resources.
 - Add explicit Render Graph texture views for mip, array-layer, dimension, compatible-format, and
   depth/stencil-aspect access across sampled, storage, attachment, and copy paths. Add
   renderer-owned double/triple-buffer history textures whose recipes survive device recovery, whose

--- a/documentation/COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md
+++ b/documentation/COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md
@@ -137,7 +137,8 @@ WGSL core 的 atomics、workgroup memory 和 barriers 可以直接在 `ComputeSh
 - 不把 subgroup、shader-f16、timestamp-query 等可选特性变成 compute 基线要求。
 - 不同时设计通用 GPGPU 框架、粒子系统、物理引擎或节点式 shader 编辑器。
 
-以下条目描述最初首发边界；其中 graph subresource 与 persistent history 已由后续 F0 工作包解除：
+以下条目描述最初首发边界；其中 graph subresource/persistent history 已由 F0 解除，f16 与 exact
+binding size 已由 F1 解除：
 
 - compute graph texture 已可绑定显式 array/cube/3D、mip/layer/aspect
   view；同一 subresource 的 sampled/write feedback 仍拒绝。
@@ -147,11 +148,10 @@ WGSL core 的 atomics、workgroup memory 和 barriers 可以直接在 `ComputeSh
 - `StorageBuffer.read()` 每个 Renderer 同时只允许一个 pending request；应用应串行等待。
 - `SceneRenderPass` storage variant 遇到 instanced batch 时展开为 per-mesh direct draw。
 - 内置 `ForwardRenderPipelineFeature.sampledDepth` 仍关闭；完整 Forward+ 通过自定义 SRP 显式组合。
-- Direct WGSL `f16` 因当前 Naga WGSL validation 路径限制而 fail-closed，即使设备暴露 `shader-f16`
-  也不会绕过编译器。
-- buffer `minBindingSize` 是调用方声明的 shader ABI 下界；编译器会校验 binding
-  kind/name/location，runtime 会在开帧前校验声明值与实际 range，但首发尚未从 WGSL/GLSL 类型布局反推出更大的真实下界。错误地低报该值仍可能由 WebGPU
-  native validation 在 dispatch/draw 时拒绝。
+- Direct WGSL `f16` 保留原始 artifact，由 Naga frontend、等价 f32 validator/writer、RHI `shader-f16`
+  gate 与真实 WebGPU pipeline 共同验证。
+- compute buffer `minBindingSize` 已从 WGSL store type 推导 exact minimum；runtime
+  array 按一个元素计算。调用方低报会在 native pipeline 创建前拒绝。
 - 只有一个 frame command scope，不提供 async compute 或 multi-queue。
 
 ## 3. 实施基线与首发范围
@@ -308,8 +308,8 @@ Direct WGSL compute 使用 WGSL host-shareable address-space layout，不能继�
   `atomic<i32>`/`atomic<u32>` 的 CPU byte representation；
 - 按 WGSL storage address space 的 alignment、size 和 array stride 计算；
 - `bool` 不作为 host-shareable 存储字段；
-- `f16` 不在首发 `StorageLayout` host packing 合同中；Direct WGSL `f16` 也因 Naga
-  validation 路径限制明确 fail-closed；
+- `f16` 不在首发 `StorageLayout` host packing 合同中；Direct WGSL `f16` 则由 F1 的 compiler/RHI
+  capability 路径支持，两者不是同一个 CPU packing 合同；
 - atomic 字段的 CPU 表示限定为对应的 `i32/u32` bytes，原子语义只发生在 shader 中；
 - 提供 allocation-free `writeInto()` 与字段 offset 查询；
 - 可以作为 `StorageBufferDescriptor.initialData` 的构造辅助，但 raw bytes 始终是底层正式合同。
@@ -661,9 +661,9 @@ compiler 必须：
 
 显式 `ComputeShaderBinding[]` 仍是 engine pipeline ABI；compiler 会把它与 WGSL
 declarations 一一比对，并拒绝缺失、多余、kind/access/type 不一致、override-dependent workgroup
-metadata 或无法证明固定大小的 workgroup allocation。当前 `web-naga` 版本不能可靠完成 Direct WGSL
-`f16` 的 validator/writer 路径，因此 `f16`
-明确 fail-closed，而不是只 parse 后跳过验证。禁止用宽松正则猜测任意 WGSL 并伪造通过。
+metadata 或无法证明固定大小的 workgroup allocation。当前 `web-naga`
+writer 不能直接序列化 f16，F1 因此让原始源码先过 frontend，再把 token-safe 等价 f32 特化送入 validator/writer；原始源码仍交给 capability-gated 真实 WebGPU
+pipeline。禁止只 parse 后跳过验证，或用宽松正则猜测任意 WGSL 并伪造通过。
 
 ### 6.3 静态规则调整
 
@@ -1398,9 +1398,9 @@ npm run validate
 - [x] compute→storage/vertex/index/indirect graphics input 全部由 graph access 建边。
 - [x] read-write buffer 有显式 access，不通过谎报 write 绕过初始化。
 - [x] storage texture format/access/sample count 全部在 frame 前验证。
-- [x] layout、binding kind/name/location、调用方声明的 `minBindingSize`、实际 range、dynamic
-      offset 和 device limits 全部 fail-closed；shader-derived exact
-      minimum 的 hardening 见首发边界。
+- [x] layout、binding kind/name/location、shader-derived exact
+      `minBindingSize`、调用方更强下界、实际 range、dynamic offset 和 device
+      limits 全部 fail-closed。
 - [x] WebGL 2 没有模拟路径，required capability 不会静默降级。
 - [x] Structured WebGPU backend mock 的 compute 写入/readback 得到精确结果
       `[7, 8, 9, 10]`，且走生产 WebGPU backend 命令映射。
@@ -1440,7 +1440,7 @@ npm run validate
 | CPU shadow 被误解为 GPU checkpoint           | 明确恢复到初始/最后 CPU bytes；GPU mutation 不会被暗中 map 回 CPU                                   |
 | 同 pass read-write 破坏现有 graph invariant  | 只增加 buffer 专用 `readWriteBuffer()`；texture feedback 继续拒绝                                   |
 | Graph texture view 与 history 完整性混淆     | view 显式建模 mip/layer/aspect hazard；history 首版限定完整单 mip 2D color slot                     |
-| Naga `f16` 路径未形成完整验证闭环            | Direct WGSL `f16` 在 pipeline 前 fail-closed，不以 parse-only 冒充支持                              |
+| Naga writer 不能直接序列化 `f16`             | 原始 frontend parse + 等价 f32 validator/writer + capability-gated native pipeline                  |
 | 并发 readback 复用同一 frame/staging 状态    | 每 Renderer 一次 pending request；并发请求明确拒绝，调用方串行等待                                  |
 | StorageLayout 被误做成 std140/std430 混合    | 以 WGSL host-shareable layout 为唯一 storage 规则，独立于 UniformBuffer                             |
 | API 表面过宽                                 | 公开稳定高层 kernel/pass/resource，不公开 RHI/native encoder                                        |
@@ -1448,7 +1448,7 @@ npm run validate
 | WebGL 2 用户体验                             | 创建前 capability 筛选和独立 graphics fallback factory，不运行时跳过                                |
 | Compute 影响默认路径                         | capability 冷路径选择，默认 recorder 无新逐 draw 分支，专用性能门禁                                 |
 | WebGPU validation 太晚                       | portable validation 和 prepare 必须先完成，native pipeline 错误仍发生在 beginFrame 前               |
-| buffer ABI 低报真实 `minBindingSize`         | 首发把它作为显式调用方 promise 并提前校验 range；后续从 shader 类型布局反射 exact minimum           |
+| buffer ABI 低报真实 `minBindingSize`         | 从 WGSL store type 推导 exact minimum；runtime array 按一个 element；native 调用前拒绝低报          |
 | 单文件复杂度继续增长                         | 新增独立 compiler/cache/pass 模块，只抽共享基础，不堆进 graphics 文件                               |
 
 ## 21. Definition of Done

--- a/documentation/ENGINEERING_MODERNIZATION.md
+++ b/documentation/ENGINEERING_MODERNIZATION.md
@@ -314,8 +314,11 @@ renderer 或运行时 precision 变化不会交叉复用错误源码。`commonOp
 WebGPU-only compute 是独立且受控的例外：`ComputeShader` 接受 Direct
 WGSL，不走 GLSL 转换，但必须经过 Naga WGSL
 frontend/validator、selected-entry/workgroup/workgroup-storage/override metadata 检查、显式 binding
-ABI 比对和真实 WebGPU pipeline validation。它只能声明 `@compute`，不能借此提交 graphics
-WGSL。当前 Naga 路径不能可靠完整验证 `f16`，因此 Direct WGSL `f16` 在 pipeline 创建前 fail-closed。
+ABI 比对和真实 WebGPU pipeline validation。它只能声明 `@compute`，不能借此提交 graphics WGSL。`f16`
+原始源码先通过 Naga frontend；当前 `web-naga`
+writer 使用 token-safe 等价 f32 特化完成 validator/backend，原始 artifact 再经 `shader-f16`
+capability 和真实 WebGPU pipeline 验证。buffer `minBindingSize` 从 WGSL store type 推导，runtime
+array 按一个元素计算，低报在 native 调用前失败。
 
 WebGPU-only storage-aware raster 仍不接受 graphics WGSL。`StorageGraphicsShader` 使用受控 GLSL ES
 3.10 readonly-std430 subset，经引擎 preprocessing、Vulkan GLSL

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -1,6 +1,6 @@
 # Hilo3D 现代 WebGPU 渲染缺口与落地路线
 
-> 审计基线：`296a18d`（2026-08-01）；实施状态更新：2026-08-01，F0 已落地。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
+> 审计基线：`296a18d`（2026-08-01）；实施状态更新：2026-08-01，F0、F1 已落地。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
 > 2 功能对等作为路线目标。
 
 ## 结论先行
@@ -88,7 +88,7 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 | Screen-space lighting                | 缺失         | 无 depth pyramid、normal/roughness attribute buffer、GTAO、SSR、SSGI                                      |
 | Volumetrics / atmosphere             | 缺失         | 无 froxel volume、temporal reprojection、physical sky 或 volumetric cloud                                 |
 | Geometry / texture streaming         | 缺失         | 无 GPU LOD/meshlet/cluster streaming；KTX loader 仅支持 KTX 1.1 2D 容器                                   |
-| GPU profiling / graph debugging      | 部分具备     | 有 CPU/RHI diagnostics 和可请求 `timestamp-query` feature，但 RHI/Graph 没有通用 query/timeline API       |
+| GPU profiling / graph debugging      | 生产基线     | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 时不创建 query   |
 
 ### 2.1 现有实现中最关键的限制
 
@@ -102,16 +102,17 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 - 公共 graph texture 虽有 `mipLevelCount`，但 pass 只能引用整张 2D texture；Compute storage
   texture 也是 transient、write-only、完整 2D view。没有 mip/layer/aspect view 或独立 persistent
   storage texture。
-- Direct WGSL `f16` 当前 fail-closed；RHI capability 也尚未表达 WebGPU `subgroups`、
-  `subgroup-size-control` 等现代 compute 可选能力。
+- Direct WGSL `f16`、`subgroups`
+  与 timestamp-query 已进入 capability/compiler/RHI 闭环；当前 WebGPU 标准未暴露
+  `subgroup-size-control` feature，因此只记录 adapter 的 subgroup min/max，不虚构非标准 gate。
 - Render Graph 每帧 Build/Compile，已有 pass culling 和跨帧 transient pool，但没有 compiled graph
   reuse 或同帧物理 alias。
 - Camera 只有当前 `view/projection/viewProjection`；普通 mesh/frame ABI 没有 previous
   transform、camera jitter 或 history generation。
 - 当前 turnkey post-processing 只有 Bloom 与 Color Uber。Opaque scene
   texture 只能支持最低边界的屏幕空间 transmission。
-- RHI 没有 query set、pass timestamp、debug group/render graph timeline，也没有 occlusion-query
-  command。
+- RHI 已有 timestamp QuerySet、pass timestamp、debug group/marker 和 Render Graph
+  timeline；occlusion query 仍不在当前合同内。
 - KTX loader 明确只解析 KTX 1.1、单 face 2D；没有 KTX 2、Basis Universal transcode、mip
   residency 或带宽预算。
 
@@ -138,7 +139,8 @@ Forward/Deferred 架构；Unreal 的 Nanite、VSM、Lumen 和 TSR 也分别解�
 - Compute shader、workgroup memory、barrier、32-bit atomic、storage buffer/texture；
 - direct/indirect dispatch，direct/indirect indexed/non-indexed draw；
 - texture array、3D texture、mip/layer view、MRT、MSAA、depth sampling；
-- capability-gated `shader-f16`、`subgroups`、`subgroup-size-control` 和 `timestamp-query`；
+- capability-gated `shader-f16`、`subgroups` 和 `timestamp-query`；subgroup size 只读 adapter
+  min/max，当前标准没有 `subgroup-size-control` feature；
 - buffer/texture copy、异步 map readback、OffscreenCanvas 和 Worker 侧资源处理；
 - 通过普通 texture + buffer 模拟 page table、physical atlas 和 software BVH。
 
@@ -180,7 +182,7 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 `P0` 是“现代 WebGPU renderer”定义所需能力；`P1` 是高画质生产 profile；`P2`
 是依赖场景规模、内容管线和长期性能投入的虚拟化能力。
 
-实施状态：**F0 已完成**；后续工作包可把 subresource view 与 history owner 作为现有基础使用。
+实施状态：**F0、F1 已完成**；后续工作包可把 subresource/history 与 GPU timeline 作为现有基础使用。
 
 ## 6. 可落地工作包
 
@@ -213,7 +215,7 @@ revision 后失效、device loss 后按 recipe 重建，失败 record/submission
 Graph、SRP、capability、ResourceRegistry、真实 WebGPU storage-view 和 package
 type-consumer 均有自动化覆盖。
 
-#### F1：现代 WebGPU capability 与 GPU timeline
+#### F1：现代 WebGPU capability 与 GPU timeline（已完成）
 
 ![F1：GPU 能力发现、时间戳与性能时间线](./images/modern-webgpu-roadmap/gpu-capabilities-profiling.jpg)
 
@@ -221,10 +223,10 @@ type-consumer 均有自动化覆盖。
 | ---------------------------- | ---------------------------------------------- | --------------------------------- | ------------------------------------------ |
 | adapter features、graph pass | `f16`/subgroup gate、timestamp resolve、marker | CPU/GPU pass 时间线、能力降级路径 | 关闭 query 无热路径成本，fallback 结果一致 |
 
-需要增加：
+已落地：
 
-- `RHIFeatureName`/`RendererFeatureName` 支持 `subgroups` 和可选
-  `subgroup-size-control`；记录 adapter 的 subgroup min/max；
+- `RHIFeatureName`/`RendererFeatureName` 支持 `subgroups`，记录 adapter 的 subgroup
+  min/max；当前标准没有 `subgroup-size-control` feature，故未把它加入可请求能力；
 - 修通 Naga/Direct WGSL 的 `shader-f16` 验证和 pipeline 闭环；不支持设备继续使用 f32 kernel；
 - QuerySet、timestamp write/resolve、submission-fenced asynchronous result；
 - Render Graph 自动生成 pass timestamp range，结果延迟若干帧读取，生产帧不等待；
@@ -234,6 +236,12 @@ type-consumer 均有自动化覆盖。
 完成标准：同一场景可输出 CPU record/compile/prepare/execute 与 GPU
 per-pass 时间线；关闭 query 时热路径不增加逐 draw 成本；subgroup/f16 kernel 必须有 f32/workgroup
 fallback 和相同结果测试。
+
+实现说明：timeline 以已注册 `RendererDiagnostics` 为开关，三槽 query/readback
+ring 在 submission 完成后异步 map；槽位繁忙时报告 `saturated`，不等待 GPU。Direct WGSL
+f16 保留原始 native artifact，Naga validator/writer 使用等价 f32 特化；设备没有 `shader-f16`
+时 RHI 明确拒绝，pipeline 可通过 `supportsFeature()` 选择 f32/workgroup
+fallback。仓库未引入新的内置 subgroup/f16 kernel，因此不存在需要伪装为双后端等价的隐式降级结果。
 
 #### D0：现代深度与帧坐标合同
 

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -222,9 +222,11 @@ variant 当前不合并 instanced batch，而是确定性展开为逐 Mesh direc
 draw，保证正确性且不建立第二套场景渲染器。
 
 Direct WGSL compiler 会反射并验证 entry point、literal workgroup size、workgroup storage、binding
-ABI 与 pipeline override。当前 Naga WGSL validation/writer 路径不能可靠承载 Direct WGSL
-`f16`，因此即使设备可申请 `shader-f16`，compute source 中的 `f16`
-仍在 pipeline 创建前明确 fail-closed。
+ABI 与 pipeline override。Direct WGSL `f16` 先由 Naga
+frontend 解析原始源码，再把 token-safe 的等价 f32 特化送入当前 `web-naga`
+validator/writer；原始 f16 源码仍是 WebGPU artifact，并在 RHI 检查设备已启用 `shader-f16`
+后进入原生 shader module/pipeline validation。不支持该 feature 的设备必须由 pipeline 根据
+`supportsFeature('shader-f16')` 选择 f32 kernel，不能静默降级同一 shader。
 
 WebGL 2 对 compute pipeline、storage binding 和 indirect draw 提供的是明确的 negative
 implementation：在任何 native GL compute/storage 模拟之前失败，不使用 texture-backed SSBO、transform
@@ -320,11 +322,27 @@ Executor 的顺序是：
 
 相关代码：[`RenderGraphExecutor.ts`](../src/render/graph/RenderGraphExecutor.ts)、[`RenderGraph.ts`](../src/render/graph/RenderGraph.ts)。
 
+### 2.4 可选 CPU/GPU 时间线
+
+只有 Canvas 注册 `RendererDiagnostics` 时，`RenderGraphFrame` 才创建帧级 timeline
+recorder。它记录 record、compile、prepare、execute 四个 CPU 区间、逐 Pass CPU 时间以及编译后的资源
+`firstUse / lastUse`。启用 `timestamp-query`
+的 WebGPU 设备还会为每个声明了原生 render/compute 类别的 Graph Pass 自动写入起止 timestamp，经
+`QUERY_RESOLVE -> COPY_DST|MAP_READ` 三槽 ring 异步回读；生产帧从不等待 map，槽位占满只把该帧标记为
+`saturated`。没有注册 diagnostics 时不创建 QuerySet/resolve/readback 资源，也不在逐 draw 路径增加分支。
+
+RHI 同时提供 submission-aware `RHIQuerySet`、pass timestamp
+writes、显式 resolve，以及 command、render pass、compute pass 的 debug
+group/marker。WebGPU 转发原生命令；WebGL 2 对 query/timestamp 明确 fail-fast，debug
+annotation 保留嵌套验证但不伪造扩展能力。
+
+相关代码：[`RenderGraphTimeline.ts`](../src/render/graph/RenderGraphTimeline.ts)、[`RenderGraphGPUProfiler.ts`](../src/render/graph/RenderGraphGPUProfiler.ts)、[`RHIQueryValidation.ts`](../src/render/rhi/core/RHIQueryValidation.ts)。
+
 ## 3. RHI 设计
 
 ### 3.1 WebGPU 风格、可移植子集
 
-RHI 的对象模型接近 WebGPU：`Device / Queue / CommandContext / RenderPass / ComputePass / Surface / Buffer / Texture / Sampler / Shader / BindGroup / GraphicsPipeline / ComputePipeline`。但它不是 WebGPU
+RHI 的对象模型接近 WebGPU：`Device / Queue / CommandContext / RenderPass / ComputePass / Surface / Buffer / Texture / QuerySet / Sampler / Shader / BindGroup / GraphicsPipeline / ComputePipeline`。但它不是 WebGPU
 API 的简单拷贝。普通 raster 合同是 WebGPU 与 WebGL 2 的可移植子集；WebGPU-only compute/storage/
 indirect 合同仍定义在 backend-neutral core 中，并要求不支持的 WebGL 2 后端在 native
 call 前明确拒绝。
@@ -402,7 +420,10 @@ Artifact。这样 Shader 语言差异不会污染 RenderGraph 或 RHI 命令层�
 WebGPU compute 是一个有意的独立 source contract：`ComputeShader` 接受 Direct WGSL，
 `WgslComputeShaderCompiler` 必须先用 Naga WGSL frontend 校验语法、entry point、workgroup
 metadata 与显式 binding ABI，再形成 RHI artifact。它不经过 GLSL 转换，也不改变普通 graphics
-shader 的单一 GLSL 来源。storage-aware raster 则使用 `StorageGraphicsShaderCompiler` 的受控 GLSL ES
+shader 的单一 GLSL 来源。f16 原始源码通过 Naga frontend，validator/writer 使用等价 f32 特化规避当前
+`web-naga` writer 缺陷；原始源码仍必须通过 capability gate 和真实 WebGPU pipeline。buffer
+binding 的 exact minimum 则按 WGSL store type 的 `SizeOf` 推导，runtime
+array 按一个元素计算。storage-aware raster 则使用 `StorageGraphicsShaderCompiler` 的受控 GLSL ES
 3.10 readonly storage subset，仍经 engine preprocessing、Vulkan GLSL
 4.50 和 Naga 生成 WGSL；仓库不维护手写 graphics WGSL 镜像。
 
@@ -595,11 +616,11 @@ Renderer 的组合式 Pass，使未来加入新的图优化、调试可视化或
   noise、回归/轨道/鼠标力场、低频流星头部碰撞和尾迹力场与边界碰撞共用一次 compute。compute 同帧生成两组 draw
   arguments，deep field、velocity halo 和 luminous core 由 Render Graph 中三次 storage-aware
   indirect `GPUDrivenRenderPass` 完成，不走原生 WebGPU bypass 或粒子状态 readback。
-- Direct WGSL `f16` 当前因 Naga validation 路径限制而 fail-closed；workgroup
-  memory、barrier、atomic 与受验证的 scalar override 仍可直接使用。
-- compute/storage buffer 的 `minBindingSize` 是显式 ABI
-  promise；引擎会在开帧前校验调用方声明值与实际绑定 range，但当前不会从 WGSL/GLSL 类型布局反射更大的 exact
-  minimum。错误低报仍可能由 native WebGPU validation 在 dispatch/draw 时拒绝。
+- Direct WGSL `f16` 已进入 Naga frontend、等价 f32 validator/writer、RHI feature gate 与真实 WebGPU
+  pipeline 的闭环；workgroup memory、barrier、atomic 与受验证的 scalar override 继续使用同一路径。
+- compute buffer 的 `minBindingSize` 由 WGSL store type 精确推导；runtime
+  array 按标准要求替换为一个 element。调用方仍可声明更强下界，但低于 shader-derived
+  minimum 会在创建任何 native pipeline 前拒绝。
 - RenderGraph 每帧重新 Build/Compile，依靠高水位存储复用降低成本；当前没有跨帧复用完整的 Compiled
   Graph。
 - 已有 Pass 裁剪、资源生命周期区间和跨帧瞬态资源池，但没有宣称同帧物理内存别名复用。

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -5330,7 +5330,7 @@ export type RendererCreateOptions = RendererExplicitOptions | RendererAutoOption
 export type RendererExplicitOptions = RendererOptions;
 
 // @public
-export type RendererFeatureName = 'texture-compression-bc' | 'texture-compression-etc2' | 'texture-compression-astc' | 'timestamp-query' | 'shader-f16' | 'depth32float-stencil8' | 'float32-filterable' | 'float32-blendable';
+export type RendererFeatureName = 'texture-compression-bc' | 'texture-compression-etc2' | 'texture-compression-astc' | 'timestamp-query' | 'shader-f16' | 'subgroups' | 'depth32float-stencil8' | 'float32-filterable' | 'float32-blendable';
 
 // @public
 export interface RendererFrame {
@@ -5542,6 +5542,7 @@ export interface RenderPipelineBufferDescriptor {
 export interface RenderPipelineCapabilities {
     readonly limits: Readonly<RenderPipelineLimits>;
     supportsCapability(capability: RenderPipelineCapabilityName): boolean;
+    supportsFeature(feature: RendererFeatureName): boolean;
     supportsTextureFormat(format: RenderPipelineTextureFormat, use: RenderPipelineTextureUse, sampleCount?: RenderTargetSampleCount): boolean;
 }
 
@@ -5644,6 +5645,8 @@ export interface RenderPipelineLimits {
     readonly maxStorageTexturesPerShaderStage?: number;
     readonly maxTextureDimension2D: number;
     readonly minStorageBufferOffsetAlignment?: number;
+    readonly subgroupMaxSize?: number;
+    readonly subgroupMinSize?: number;
 }
 
 // @public

--- a/src/render/RendererCore.ts
+++ b/src/render/RendererCore.ts
@@ -7,6 +7,7 @@ import LightManager from '../light/LightManager';
 import type Material from '../material/Material';
 import Color from '../math/Color';
 import type { RendererDiagnostics, RendererDiagnosticsSnapshot } from './RendererDiagnostics';
+import type { RenderGraphTimelineSink } from './graph/RenderGraphTimeline';
 import type { Resource, ShaderPrecision } from './types';
 import GraphicsResourceManager from './GraphicsResourceManager';
 import RenderInfo from './RenderInfo';
@@ -248,6 +249,11 @@ export abstract class RendererCore extends EventDispatcher implements RendererCo
     /** @internal Snapshot opt-in counters for benchmark and renderer diagnostics tooling. */
     getDiagnosticsSnapshot(): Readonly<RendererDiagnosticsSnapshot> | null {
         return this.diagnosticsSink?.snapshot() ?? null;
+    }
+
+    /** @internal Opt-in timeline sink resolved once during renderer initialization. */
+    getRenderGraphTimelineSink(): RenderGraphTimelineSink | null {
+        return this.diagnosticsSink;
     }
 
     abstract resize(width: number, height: number, force?: boolean): void;

--- a/src/render/RendererDiagnostics.ts
+++ b/src/render/RendererDiagnostics.ts
@@ -1,4 +1,8 @@
 import type { RHICacheCounters } from './rhi/core';
+import type {
+    RenderGraphTimelineSink,
+    RenderGraphTimelineSnapshot
+} from './graph/RenderGraphTimeline';
 
 export type RendererNativeObjectKind =
     | 'buffer'
@@ -101,6 +105,8 @@ export interface RendererDiagnosticsSnapshot {
     readonly nativeObjects: RendererNativeObjectDiagnosticsSnapshot;
     readonly caches: RendererCacheDiagnosticsSnapshot;
     readonly frame: RendererFrameDiagnosticsSnapshot;
+    /** Latest opt-in Render Graph CPU/GPU timeline, updated after asynchronous GPU readback. */
+    readonly renderGraph: Readonly<RenderGraphTimelineSnapshot> | null;
 }
 
 const NATIVE_CREATED = 0;
@@ -255,8 +261,18 @@ function requireSize(size: number): void {
  * Backend-neutral renderer counters. A renderer owns one instance and reuses its fixed typed-array
  * storage across frames. Recording methods do not allocate; only an explicit snapshot does.
  */
-export class RendererDiagnostics {
+export class RendererDiagnostics implements RenderGraphTimelineSink {
     readonly #counters = new Float64Array(COUNTER_COUNT);
+    #renderGraphTimeline: Readonly<RenderGraphTimelineSnapshot> | null = null;
+
+    recordRenderGraphTimeline(snapshot: Readonly<RenderGraphTimelineSnapshot>): void {
+        if (
+            this.#renderGraphTimeline === null ||
+            snapshot.frameIndex >= this.#renderGraphTimeline.frameIndex
+        ) {
+            this.#renderGraphTimeline = snapshot;
+        }
+    }
 
     recordNativeObjectCreated(kind: RendererNativeObjectKind, count = 1): void {
         requirePositiveCount(count);
@@ -505,7 +521,8 @@ export class RendererDiagnostics {
                 uploads: this.value(FRAME_UPLOADS),
                 submissions: this.value(FRAME_SUBMISSIONS),
                 arenaGrowths: this.value(FRAME_ARENA_GROWTHS)
-            })
+            }),
+            renderGraph: this.#renderGraphTimeline
         });
     }
 

--- a/src/render/RendererOptions.ts
+++ b/src/render/RendererOptions.ts
@@ -18,6 +18,7 @@ export type RendererFeatureName =
     | 'texture-compression-astc'
     | 'timestamp-query'
     | 'shader-f16'
+    | 'subgroups'
     | 'depth32float-stencil8'
     | 'float32-filterable'
     | 'float32-blendable';

--- a/src/render/frame/RenderGraphFrame.ts
+++ b/src/render/frame/RenderGraphFrame.ts
@@ -1,6 +1,10 @@
 import { RenderGraph } from '../graph/RenderGraph';
 import type { RenderGraphBuilder } from '../graph/RenderGraphBuilder';
 import type { RGExecutionResult } from '../graph/RenderGraphExecutor';
+import {
+    RenderGraphTimelineRecorder,
+    type RenderGraphTimelineSink
+} from '../graph/RenderGraphTimeline';
 import type { RHIFrameDiagnostics } from '../rhi/core';
 import { FrameArena } from './FrameArena';
 import { RHIUploadBatch } from './RHIUploadBatch';
@@ -75,7 +79,8 @@ export class RenderGraphFrame {
     execute(
         context: RenderGraphFrameContext,
         build: RenderGraphFrameBuildCallback,
-        abortSignal?: RenderGraphFrameAbortSignal
+        abortSignal?: RenderGraphFrameAbortSignal,
+        timelineSink?: RenderGraphTimelineSink | null
     ): RGExecutionResult {
         if (this.#active)
             throw new Error('Nested execution on the same RenderGraphFrame is not allowed');
@@ -85,20 +90,34 @@ export class RenderGraphFrame {
         this.arena.reset();
         this.uploads.reset();
         const growthsBeforeBuild = this.arena.growthCount;
+        const timeline =
+            timelineSink === undefined || timelineSink === null
+                ? undefined
+                : new RenderGraphTimelineRecorder(context.frameIndex, timelineSink);
         try {
             const graph = this.#renderGraph.createBuilder();
+            const recordStart = timeline === undefined ? 0 : performance.now();
             const result = build(
                 Object.freeze({ context, graph, arena: this.arena, uploads: this.uploads })
             );
             if (isPromiseLike(result)) {
                 throw new TypeError('Render frame build callbacks must be synchronous');
             }
+            if (timeline !== undefined) {
+                timeline.setRecordDuration(performance.now() - recordStart);
+            }
+            const compileStart = timeline === undefined ? 0 : performance.now();
             const compiled = this.#renderGraph.compile(graph, context.rhi.capabilities);
+            if (timeline !== undefined) {
+                timeline.setCompileDuration(performance.now() - compileStart);
+                timeline.captureGraph(compiled);
+            }
             this.uploads.validate(context.rhi);
             const execution = this.#renderGraph.execute(compiled, context.rhi, {
                 frameIndex: context.frameIndex,
                 diagnostics: this.diagnostics,
                 prePassCommands: this.uploads,
+                ...(timeline === undefined ? {} : { timeline }),
                 ...(abortSignal === undefined ? {} : { abortSignal })
             });
             this.uploads.commit(execution.submission);

--- a/src/render/graph/RenderGraphBuilder.ts
+++ b/src/render/graph/RenderGraphBuilder.ts
@@ -6,6 +6,7 @@ import {
     type RHITextureUsageFlags
 } from '../rhi/core';
 import type { RGPassContext, RGPrepareContext } from './RenderGraphExecutor';
+import type { RGPassTimestampKind } from './RenderGraphTimeline';
 import type {
     RGBufferDescriptor,
     RGBufferAccessDeclaration,
@@ -56,6 +57,8 @@ function allocateGraphHandle(): RGResourceHandle | RGPassHandle {
  */
 export interface RenderPassTemplate<P> {
     readonly name: string;
+    /** Native pass category used only by opt-in automatic GPU timestamp instrumentation. */
+    timestampKind?(params: P): RGPassTimestampKind | null;
     setup(builder: RGPassBuilder, params: P): void;
     prepare?(context: RGPrepareContext, params: P): void;
     execute(context: RGPassContext, params: P): void;

--- a/src/render/graph/RenderGraphExecutor.ts
+++ b/src/render/graph/RenderGraphExecutor.ts
@@ -4,6 +4,7 @@ import type {
     RHIDevice,
     RHIFrameDiagnostics,
     RHISubmission,
+    RHITimestampWrites,
     RHITexture,
     RHITextureView
 } from '../rhi/core';
@@ -20,6 +21,8 @@ import type {
     RGTextureHandle
 } from './RenderGraphResource';
 import { renderGraphFailure } from './RenderGraphValidation';
+import { RenderGraphGPUProfiler, type RenderGraphGPUProfileFrame } from './RenderGraphGPUProfiler';
+import type { RenderGraphTimelineRecorder } from './RenderGraphTimeline';
 
 type CompiledRGPhysicalResource = Exclude<CompiledRGResource, { readonly kind: 'texture-view' }>;
 
@@ -539,10 +542,13 @@ export interface RGExecutionOptions {
     readonly prePassCommands?: { flush(context: RHICommandContext): void };
     /** @internal Frame-owner cancellation gate checked before submission and between callbacks. */
     readonly abortSignal?: { throwIfAborted(): void };
+    /** @internal Enables pass markers, CPU phases and automatic WebGPU timestamp queries. */
+    readonly timeline?: RenderGraphTimelineRecorder;
 }
 
 export interface RGPassContext {
     readonly commandContext: RHICommandContext;
+    readonly timestampWrites: Readonly<RHITimestampWrites> | undefined;
     getTexture(handle: RGTextureAccessHandle): RHITexture;
     getTextureView(handle: RGTextureAccessHandle): RHITextureView;
     getBuffer(handle: RGBufferHandle): RHIBuffer;
@@ -606,11 +612,26 @@ class RGDeclaredResourceContext implements RGPrepareContext {
 }
 
 class RGPassContextImpl extends RGDeclaredResourceContext implements RGPassContext {
+    timestampWrites: Readonly<RHITimestampWrites> | undefined;
+
     constructor(
         readonly commandContext: RHICommandContext,
         prepared: PreparedRGResourceLookup
     ) {
         super(prepared);
+    }
+
+    override setPass(pass: CompiledRGPass | null): void {
+        super.setPass(pass);
+        this.timestampWrites = undefined;
+    }
+
+    setProfiledPass(
+        pass: CompiledRGPass,
+        timestampWrites: Readonly<RHITimestampWrites> | undefined
+    ): void {
+        super.setPass(pass);
+        this.timestampWrites = timestampWrites;
     }
 }
 
@@ -696,6 +717,7 @@ function releaseAfterSubmission(
 /** Allocates only after a graph compiled successfully, then executes its stable pass schedule. */
 export class RenderGraphExecutor {
     readonly #transientPool = new TransientResourcePool();
+    readonly #gpuProfiler = new RenderGraphGPUProfiler();
     readonly #workspaces: RenderGraphExecutorWorkspace[] = [];
     readonly #availableWorkspaces: RenderGraphExecutorWorkspace[] = [];
     readonly #storageDiagnostics: {
@@ -730,6 +752,7 @@ export class RenderGraphExecutor {
         if (this.#destroyed) return;
         this.#destroyed = true;
         this.#transientPool.destroy();
+        this.#gpuProfiler.destroy();
         this.#availableWorkspaces.length = 0;
     }
 
@@ -741,6 +764,8 @@ export class RenderGraphExecutor {
         if (this.#destroyed) throw new Error('Render graph executor is destroyed');
         this.#transientPool.useDevice(device);
         const workspace = this.acquireWorkspace();
+        const timeline = options.timeline;
+        const prepareStart = timeline === undefined ? 0 : performance.now();
         const preparedList = workspace.resources;
         const preparedByHandle = workspace.preparedByHandle;
         try {
@@ -828,6 +853,9 @@ export class RenderGraphExecutor {
                 options.abortSignal?.throwIfAborted();
             }
             prepareContext.setPass(null);
+            if (timeline !== undefined) {
+                timeline.setPrepareDuration(performance.now() - prepareStart);
+            }
         } catch (error) {
             prepareContext.setPass(null);
             releaseBeforeFrame(preparedList, this.#transientPool);
@@ -855,17 +883,38 @@ export class RenderGraphExecutor {
         }
         context.diagnostics.transientAllocations += transientAllocations;
         const passContext = new RGPassContextImpl(context, preparedByHandle);
+        let gpuProfile: RenderGraphGPUProfileFrame | null =
+            timeline === undefined ? null : this.#gpuProfiler.begin(device, timeline);
+        const executeStart = timeline === undefined ? 0 : performance.now();
         try {
             options.prePassCommands?.flush(context);
             options.abortSignal?.throwIfAborted();
-            for (const pass of graph.passes) {
-                passContext.setPass(pass);
+            for (let passIndex = 0; passIndex < graph.passes.length; passIndex += 1) {
+                const pass = graph.passes[passIndex];
+                if (pass === undefined) continue;
+                const timestampWrites =
+                    gpuProfile !== null && timeline?.passKind(passIndex) !== null
+                        ? gpuProfile.timestampWrites(passIndex)
+                        : undefined;
+                passContext.setProfiledPass(pass, timestampWrites);
+                const passStart = timeline === undefined ? 0 : performance.now();
+                if (timeline !== undefined) context.insertDebugMarker(`RenderGraph: ${pass.name}`);
                 pass.template.execute(passContext, pass.params);
+                if (timeline !== undefined) {
+                    timeline.setPassCPUTime(passIndex, performance.now() - passStart);
+                }
                 options.abortSignal?.throwIfAborted();
             }
             passContext.setPass(null);
             options.abortSignal?.throwIfAborted();
+            gpuProfile?.resolve(context);
             const submission = queue.endFrame(context);
+            if (timeline !== undefined) {
+                timeline.setExecuteDuration(performance.now() - executeStart);
+                gpuProfile?.submitted(submission);
+                timeline.publish();
+            }
+            gpuProfile = null;
             let extracted: Map<RGResourceHandle, ExtractedRGResource> | null = null;
             for (const resource of preparedList) {
                 if (resource.compiled.extracted) {
@@ -886,6 +935,7 @@ export class RenderGraphExecutor {
             return new RGExecutionResultImpl(submission, context.diagnostics, extracted);
         } catch (error) {
             passContext.setPass(null);
+            gpuProfile?.abort();
             try {
                 queue.abortFrame(context, error);
             } catch {

--- a/src/render/graph/RenderGraphGPUProfiler.ts
+++ b/src/render/graph/RenderGraphGPUProfiler.ts
@@ -1,0 +1,229 @@
+import {
+    RHIBufferUsage,
+    type RHIBuffer,
+    type RHICommandContext,
+    type RHIDevice,
+    type RHIQuerySet,
+    type RHISubmission,
+    type RHITimestampWrites
+} from '../rhi/core';
+import type { RenderGraphTimelineRecorder } from './RenderGraphTimeline';
+
+const MAX_IN_FLIGHT_TIMELINES = 3;
+const MAX_TIMESTAMP_QUERY_COUNT = 8192;
+
+interface TimestampSlot {
+    deviceId: number;
+    generation: number;
+    capacity: number;
+    querySet: RHIQuerySet;
+    resolveBuffer: RHIBuffer;
+    readbackBuffer: RHIBuffer;
+    busy: boolean;
+    disposeWhenFree: boolean;
+}
+
+function queryCapacity(required: number): number {
+    let capacity = 2;
+    while (capacity < required) capacity *= 2;
+    return capacity;
+}
+
+function destroySlot(slot: TimestampSlot): void {
+    slot.querySet.destroy();
+    slot.resolveBuffer.destroy();
+    slot.readbackBuffer.destroy();
+}
+
+function createSlot(device: RHIDevice, capacity: number): TimestampSlot {
+    let querySet: RHIQuerySet | null = null;
+    let resolveBuffer: RHIBuffer | null = null;
+    let readbackBuffer: RHIBuffer | null = null;
+    try {
+        querySet = device.createQuerySet({
+            label: 'Render Graph timestamp queries',
+            lifetime: 'persistent',
+            type: 'timestamp',
+            count: capacity
+        });
+        resolveBuffer = device.createBuffer({
+            label: 'Render Graph timestamp resolve',
+            lifetime: 'persistent',
+            size: capacity * 8,
+            usage: RHIBufferUsage.QUERY_RESOLVE | RHIBufferUsage.COPY_SRC
+        });
+        readbackBuffer = device.createBuffer({
+            label: 'Render Graph timestamp readback',
+            lifetime: 'persistent',
+            size: capacity * 8,
+            usage: RHIBufferUsage.COPY_DST | RHIBufferUsage.MAP_READ
+        });
+        return {
+            deviceId: device.id,
+            generation: device.generation,
+            capacity,
+            querySet,
+            resolveBuffer,
+            readbackBuffer,
+            busy: false,
+            disposeWhenFree: false
+        };
+    } catch (error) {
+        readbackBuffer?.destroy();
+        resolveBuffer?.destroy();
+        querySet?.destroy();
+        throw error;
+    }
+}
+
+/** @internal One submission's timestamp plan and asynchronous readback ownership. */
+export class RenderGraphGPUProfileFrame {
+    readonly #queryPassIndices: number[] = [];
+    #queryCount = 0;
+    #settled = false;
+
+    constructor(
+        readonly slot: TimestampSlot,
+        readonly recorder: RenderGraphTimelineRecorder,
+        readonly release: (slot: TimestampSlot) => void
+    ) {}
+
+    timestampWrites(passIndex: number): Readonly<RHITimestampWrites> {
+        const beginningOfPassWriteIndex = this.#queryCount;
+        this.#queryCount += 2;
+        this.#queryPassIndices.push(passIndex);
+        return Object.freeze({
+            querySet: this.slot.querySet,
+            beginningOfPassWriteIndex,
+            endOfPassWriteIndex: beginningOfPassWriteIndex + 1
+        });
+    }
+
+    resolve(context: RHICommandContext): void {
+        if (this.#queryCount === 0) return;
+        context.resolveQuerySet(this.slot.querySet, 0, this.#queryCount, this.slot.resolveBuffer);
+        context.copyBufferToBuffer(
+            this.slot.resolveBuffer,
+            0,
+            this.slot.readbackBuffer,
+            0,
+            this.#queryCount * 8
+        );
+    }
+
+    submitted(submission: RHISubmission): void {
+        if (this.#queryCount === 0) {
+            this.releaseSlot();
+            return;
+        }
+        this.recorder.markGPUPending();
+        const byteLength = this.#queryCount * 8;
+        void submission.done
+            .then(async () => {
+                await this.slot.readbackBuffer.mapAsync('read', 0, byteLength);
+                const mapped = this.slot.readbackBuffer.getMappedRange(0, byteLength);
+                const timestamps = new BigUint64Array(
+                    new BigUint64Array(mapped, 0, this.#queryCount)
+                );
+                this.slot.readbackBuffer.unmap();
+                this.releaseSlot();
+                this.recorder.completeGPU(this.#queryPassIndices, timestamps);
+            })
+            .catch(() => {
+                if (this.slot.readbackBuffer.mapState === 'mapped') {
+                    try {
+                        this.slot.readbackBuffer.unmap();
+                    } catch {
+                        // Device loss may make even cleanup validation unavailable.
+                    }
+                }
+                this.releaseSlot();
+                this.recorder.failGPU();
+            });
+    }
+
+    abort(): void {
+        this.releaseSlot();
+    }
+
+    private releaseSlot(): void {
+        if (this.#settled) return;
+        this.#settled = true;
+        this.release(this.slot);
+    }
+}
+
+/** @internal Small timestamp-query ring; it exists only when a timeline sink is registered. */
+export class RenderGraphGPUProfiler {
+    readonly #slots: TimestampSlot[] = [];
+    #destroyed = false;
+    readonly #releaseSlot = (slot: TimestampSlot): void => {
+        slot.busy = false;
+        if (slot.disposeWhenFree || this.#destroyed) {
+            destroySlot(slot);
+            const index = this.#slots.indexOf(slot);
+            if (index >= 0) this.#slots.splice(index, 1);
+        }
+    };
+
+    begin(
+        device: RHIDevice,
+        recorder: RenderGraphTimelineRecorder
+    ): RenderGraphGPUProfileFrame | null {
+        if (this.#destroyed || !device.capabilities.features.has('timestamp-query')) {
+            recorder.markGPUUnavailable('unavailable');
+            return null;
+        }
+        const passCount = recorder.timestampPassCount;
+        if (passCount === 0) {
+            recorder.markGPUUnavailable('unavailable');
+            return null;
+        }
+        const required = passCount * 2;
+        if (required > MAX_TIMESTAMP_QUERY_COUNT) {
+            recorder.markGPUUnavailable('saturated');
+            return null;
+        }
+        let slot = this.#slots.find(
+            candidate =>
+                !candidate.busy &&
+                candidate.deviceId === device.id &&
+                candidate.generation === device.generation &&
+                candidate.capacity >= required
+        );
+        if (slot === undefined) {
+            slot = this.#slots.find(candidate => !candidate.busy);
+            if (slot !== undefined) {
+                destroySlot(slot);
+                const index = this.#slots.indexOf(slot);
+                this.#slots.splice(index, 1);
+                slot = undefined;
+            }
+        }
+        if (slot === undefined && this.#slots.length < MAX_IN_FLIGHT_TIMELINES) {
+            const capacity = queryCapacity(required);
+            slot = createSlot(device, capacity);
+            this.#slots.push(slot);
+        }
+        if (slot === undefined) {
+            recorder.markGPUUnavailable('saturated');
+            return null;
+        }
+        slot.busy = true;
+        return new RenderGraphGPUProfileFrame(slot, recorder, this.#releaseSlot);
+    }
+
+    destroy(): void {
+        if (this.#destroyed) return;
+        this.#destroyed = true;
+        for (let index = this.#slots.length - 1; index >= 0; index -= 1) {
+            const slot = this.#slots[index];
+            if (slot === undefined) continue;
+            if (slot.busy) slot.disposeWhenFree = true;
+            else {
+                destroySlot(slot);
+                this.#slots.splice(index, 1);
+            }
+        }
+    }
+}

--- a/src/render/graph/RenderGraphTimeline.ts
+++ b/src/render/graph/RenderGraphTimeline.ts
@@ -1,0 +1,162 @@
+import type { CompiledRenderGraph } from './RenderGraphCompiler';
+
+export type RGPassTimestampKind = 'render' | 'compute';
+
+export type RenderGraphGPUTimelineStatus =
+    'unavailable' | 'pending' | 'ready' | 'failed' | 'saturated';
+
+export interface RenderGraphPassTimelineSnapshot {
+    readonly name: string;
+    readonly kind: RGPassTimestampKind | null;
+    readonly cpuDurationMs: number;
+    readonly gpuDurationMs: number | null;
+}
+
+export interface RenderGraphResourceLifetimeSnapshot {
+    readonly name: string;
+    readonly kind: 'texture' | 'texture-view' | 'buffer';
+    readonly origin: 'imported' | 'transient' | 'view';
+    readonly firstUse: number | null;
+    readonly lastUse: number | null;
+}
+
+/** One immutable CPU/GPU view of a compiled and submitted Render Graph frame. */
+export interface RenderGraphTimelineSnapshot {
+    readonly frameIndex: number;
+    readonly recordDurationMs: number;
+    readonly compileDurationMs: number;
+    readonly prepareDurationMs: number;
+    readonly executeDurationMs: number;
+    readonly gpuStatus: RenderGraphGPUTimelineStatus;
+    readonly passes: readonly RenderGraphPassTimelineSnapshot[];
+    readonly resources: readonly RenderGraphResourceLifetimeSnapshot[];
+}
+
+/** Optional diagnostics consumer; absence is the Render Graph profiling fast path. */
+export interface RenderGraphTimelineSink {
+    recordRenderGraphTimeline(snapshot: Readonly<RenderGraphTimelineSnapshot>): void;
+}
+
+interface MutablePassTimeline {
+    name: string;
+    kind: RGPassTimestampKind | null;
+    cpuDurationMs: number;
+    gpuDurationMs: number | null;
+}
+
+/** @internal Frame-scoped recorder retained until optional GPU readback settles. */
+export class RenderGraphTimelineRecorder {
+    readonly #passes: MutablePassTimeline[] = [];
+    readonly #resources: RenderGraphResourceLifetimeSnapshot[] = [];
+    #recordDurationMs = 0;
+    #compileDurationMs = 0;
+    #prepareDurationMs = 0;
+    #executeDurationMs = 0;
+    #gpuStatus: RenderGraphGPUTimelineStatus = 'unavailable';
+
+    constructor(
+        readonly frameIndex: number,
+        readonly sink: RenderGraphTimelineSink
+    ) {}
+
+    get timestampPassCount(): number {
+        let count = 0;
+        for (const pass of this.#passes) {
+            if (pass.kind !== null) count++;
+        }
+        return count;
+    }
+
+    setRecordDuration(durationMs: number): void {
+        this.#recordDurationMs = durationMs;
+    }
+
+    setCompileDuration(durationMs: number): void {
+        this.#compileDurationMs = durationMs;
+    }
+
+    setPrepareDuration(durationMs: number): void {
+        this.#prepareDurationMs = durationMs;
+    }
+
+    setExecuteDuration(durationMs: number): void {
+        this.#executeDurationMs = durationMs;
+    }
+
+    captureGraph(graph: CompiledRenderGraph): void {
+        this.#passes.length = 0;
+        for (const pass of graph.passes) {
+            const kind = pass.template.timestampKind?.(pass.params) ?? null;
+            this.#passes.push({ name: pass.name, kind, cpuDurationMs: 0, gpuDurationMs: null });
+        }
+        this.#resources.length = 0;
+        for (const resource of graph.resources) {
+            this.#resources.push(
+                Object.freeze({
+                    name: resource.name,
+                    kind: resource.kind,
+                    origin: resource.origin,
+                    firstUse: resource.lifetime?.firstUse ?? null,
+                    lastUse: resource.lifetime?.lastUse ?? null
+                })
+            );
+        }
+    }
+
+    passKind(index: number): RGPassTimestampKind | null {
+        return this.#passes[index]?.kind ?? null;
+    }
+
+    setPassCPUTime(index: number, durationMs: number): void {
+        const pass = this.#passes[index];
+        if (pass !== undefined) pass.cpuDurationMs = durationMs;
+    }
+
+    markGPUPending(): void {
+        this.#gpuStatus = 'pending';
+    }
+
+    markGPUUnavailable(status: 'unavailable' | 'saturated'): void {
+        this.#gpuStatus = status;
+    }
+
+    completeGPU(queryPassIndices: readonly number[], timestamps: BigUint64Array): void {
+        for (let index = 0; index < queryPassIndices.length; index += 1) {
+            const pass = this.#passes[queryPassIndices[index] ?? -1];
+            const beginning = timestamps[index * 2];
+            const end = timestamps[index * 2 + 1];
+            if (pass === undefined || beginning === undefined || end === undefined) continue;
+            pass.gpuDurationMs = end >= beginning ? Number(end - beginning) / 1_000_000 : null;
+        }
+        this.#gpuStatus = 'ready';
+        this.publish();
+    }
+
+    failGPU(): void {
+        this.#gpuStatus = 'failed';
+        this.publish();
+    }
+
+    publish(): void {
+        const passes = this.#passes.map(pass =>
+            Object.freeze({
+                name: pass.name,
+                kind: pass.kind,
+                cpuDurationMs: pass.cpuDurationMs,
+                gpuDurationMs: pass.gpuDurationMs
+            })
+        );
+        this.sink.recordRenderGraphTimeline(
+            Object.freeze({
+                frameIndex: this.frameIndex,
+                recordDurationMs: this.#recordDurationMs,
+                compileDurationMs: this.#compileDurationMs,
+                prepareDurationMs: this.#prepareDurationMs,
+                executeDurationMs: this.#executeDurationMs,
+                gpuStatus: this.#gpuStatus,
+                passes: Object.freeze(passes),
+                resources: Object.freeze([...this.#resources])
+            })
+        );
+    }
+}

--- a/src/render/internal/RenderPipelineBackendSelection.ts
+++ b/src/render/internal/RenderPipelineBackendSelection.ts
@@ -35,7 +35,12 @@ interface BackendSelectionOptions {
 export function describeWebGPUOnlyRendererFeature(
     features: readonly RendererFeatureName[] | undefined
 ): string | null {
-    return features?.includes('shader-f16') === true ? 'renderer feature shader-f16' : null;
+    for (const feature of features ?? []) {
+        if (feature === 'shader-f16' || feature === 'subgroups' || feature === 'timestamp-query') {
+            return `renderer feature ${feature}`;
+        }
+    }
+    return null;
 }
 
 /** @internal Describe the first pipeline constraint that WebGL2 cannot satisfy. */

--- a/src/render/internal/RenderPipelineHost.ts
+++ b/src/render/internal/RenderPipelineHost.ts
@@ -2,6 +2,7 @@ import type Camera from '../../camera/Camera';
 import { RenderGraphFrame, type RenderGraphFrameBuildScope } from '../frame/RenderGraphFrame';
 import type { RenderGraphFrameContext } from '../frame/RenderGraphFrameContext';
 import type { RGExecutionResult } from '../graph/RenderGraphExecutor';
+import type { RenderGraphTimelineSink } from '../graph/RenderGraphTimeline';
 import type { RHICapabilities } from '../rhi/core';
 import type { RenderTarget } from '../RenderTarget';
 import type { RendererScene } from '../RendererCore';
@@ -43,6 +44,7 @@ export interface RenderPipelineHostLifecycle {
         runtimeOwner: object
     ): RenderPipelineContext;
     endPipelineInvocation(completed: boolean): void;
+    getRenderGraphTimelineSink?(): RenderGraphTimelineSink | null;
 }
 
 /**
@@ -291,7 +293,12 @@ export class RenderPipelineHost {
             lifecycleStarted = true;
             this.lifecycle.beginFrame(frameIndex);
             const context = this.lifecycle.createFrameContext(frameIndex);
-            const execution = this.#frame.execute(context, this.#buildFrame, this.#abortSignal);
+            const execution = this.#frame.execute(
+                context,
+                this.#buildFrame,
+                this.#abortSignal,
+                this.lifecycle.getRenderGraphTimelineSink?.() ?? null
+            );
             submitted = true;
             this.lifecycle.completeFrame(frameIndex, execution, this.#frame.uploads.pendingCount);
         } catch (error) {

--- a/src/render/internal/RendererFactory.ts
+++ b/src/render/internal/RendererFactory.ts
@@ -27,6 +27,7 @@ const REQUESTABLE_WEBGPU_FEATURES: ReadonlySet<string> = new Set([
     'texture-compression-astc',
     'timestamp-query',
     'shader-f16',
+    'subgroups',
     'depth32float-stencil8',
     'float32-filterable',
     'float32-blendable'

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -7,6 +7,7 @@ import type { RenderGraphFrameBuildScope } from '../frame/RenderGraphFrame';
 import type { RenderGraphFrameContext } from '../frame/RenderGraphFrameContext';
 import type { RGPassBuilder, RenderPassTemplate } from '../graph/RenderGraphBuilder';
 import type { RGPassContext, RGPrepareContext } from '../graph/RenderGraphExecutor';
+import type { RGPassTimestampKind } from '../graph/RenderGraphTimeline';
 import type {
     RGBufferHandle,
     RGPassHandle,
@@ -2031,6 +2032,9 @@ class ScriptablePassSlot {
             get name(): string {
                 return getPassName();
             },
+            timestampKind(params: ScriptablePassSlot): RGPassTimestampKind | null {
+                return params.timestampKind();
+            },
             setup(builder: RGPassBuilder, params: ScriptablePassSlot): void {
                 params.setup(builder);
             },
@@ -2178,6 +2182,12 @@ class ScriptablePassSlot {
             this.#activeSetupLease = null;
             this.#setupBuilder = null;
         }
+    }
+
+    timestampKind(): RGPassTimestampKind | null {
+        if (this.#hasRasterAttachments) return 'render';
+        if (this.#activeComputeDispatch) return 'compute';
+        return null;
     }
 
     private finishSetup(builder: RGPassBuilder): void {

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -150,6 +150,9 @@ interface PendingAfterSceneEvent {
 }
 
 const OPTIONAL_WEBGPU_FEATURES: readonly RHIRequestableWebGPUFeature[] = Object.freeze([
+    'timestamp-query',
+    'shader-f16',
+    'subgroups',
     'float32-filterable',
     'texture-compression-bc',
     'texture-compression-etc2',
@@ -158,8 +161,6 @@ const OPTIONAL_WEBGPU_FEATURES: readonly RHIRequestableWebGPUFeature[] = Object.
 
 const REQUESTABLE_WEBGPU_FEATURES = new Set<string>([
     ...OPTIONAL_WEBGPU_FEATURES,
-    'timestamp-query',
-    'shader-f16',
     'depth32float-stencil8',
     'float32-blendable'
 ]);

--- a/src/render/pipeline/RenderPipeline.ts
+++ b/src/render/pipeline/RenderPipeline.ts
@@ -69,12 +69,18 @@ export interface RenderPipelineLimits {
     readonly maxComputeWorkgroupSizeZ?: number;
     /** Maximum direct dispatch count in each dimension. */
     readonly maxComputeWorkgroupsPerDimension?: number;
+    /** Minimum native subgroup size when the optional subgroups feature is enabled. */
+    readonly subgroupMinSize?: number;
+    /** Maximum native subgroup size when the optional subgroups feature is enabled. */
+    readonly subgroupMaxSize?: number;
 }
 
 /** Frozen effective capabilities for one renderer device generation. */
 export interface RenderPipelineCapabilities {
     /** Backend-neutral limit snapshot. */
     readonly limits: Readonly<RenderPipelineLimits>;
+    /** Return whether one optional renderer device feature is enabled for this generation. */
+    supportsFeature(feature: RendererFeatureName): boolean;
     /** Return whether an optional pipeline capability is fully implemented end to end. */
     supportsCapability(capability: RenderPipelineCapabilityName): boolean;
     /** Return whether a texture format supports a portable role and sample count. */

--- a/src/render/pipeline/RenderPipelineCapabilities.ts
+++ b/src/render/pipeline/RenderPipelineCapabilities.ts
@@ -13,6 +13,7 @@ import type {
     RenderPipelineTextureUse
 } from './RenderPipeline';
 import type { RenderTargetSampleCount } from '../RenderTarget';
+import type { RendererFeatureName } from '../RendererOptions';
 
 // Atomic release gate: flip only after public passes, graph access, RHI, both backend policies,
 // recovery, and browser coverage are all present. Per-device predicates below remain fail-closed.
@@ -22,6 +23,17 @@ const PIPELINE_CAPABILITY_NAMES: readonly RenderPipelineCapabilityName[] = Objec
     'storage-texture',
     'compute-pass',
     'indirect-draw'
+]);
+const PUBLIC_RENDERER_FEATURES: readonly RendererFeatureName[] = Object.freeze([
+    'texture-compression-bc',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'timestamp-query',
+    'shader-f16',
+    'subgroups',
+    'depth32float-stencil8',
+    'float32-filterable',
+    'float32-blendable'
 ]);
 const PUBLIC_TEXTURE_FORMATS: readonly RHITextureFormat[] = Object.freeze([
     'r8unorm',
@@ -145,6 +157,10 @@ function publicPipelineLimit(
             return limits.maxComputeWorkgroupSizeZ;
         case 'maxComputeWorkgroupsPerDimension':
             return limits.maxComputeWorkgroupsPerDimension;
+        case 'subgroupMinSize':
+            return limits.subgroupMinSize;
+        case 'subgroupMaxSize':
+            return limits.subgroupMaxSize;
         default:
             return undefined;
     }
@@ -219,8 +235,18 @@ export function createRenderPipelineCapabilities(
             : {
                   maxComputeWorkgroupsPerDimension:
                       capabilities.limits.maxComputeWorkgroupsPerDimension
-              })
+              }),
+        ...(capabilities.limits.subgroupMinSize === undefined
+            ? {}
+            : { subgroupMinSize: capabilities.limits.subgroupMinSize }),
+        ...(capabilities.limits.subgroupMaxSize === undefined
+            ? {}
+            : { subgroupMaxSize: capabilities.limits.subgroupMaxSize })
     });
+    const supportedFeatures = new Set<RendererFeatureName>();
+    for (const feature of PUBLIC_RENDERER_FEATURES) {
+        if (capabilities.features.has(feature)) supportedFeatures.add(feature);
+    }
     const formats = new Map<RHITextureFormat, Readonly<PublicTextureFormatSnapshot>>();
     const resolveFormatCapabilities = (
         format: RHITextureFormat
@@ -274,6 +300,9 @@ export function createRenderPipelineCapabilities(
         });
     return Object.freeze({
         limits,
+        supportsFeature(feature: RendererFeatureName): boolean {
+            return supportedFeatures.has(feature);
+        },
         supportsCapability(capability: RenderPipelineCapabilityName): boolean {
             return supportedCapabilities[capability];
         },
@@ -346,7 +375,8 @@ export function validateRenderPipelineCapabilitySuperset(
         'maxComputeWorkgroupSizeX',
         'maxComputeWorkgroupSizeY',
         'maxComputeWorkgroupSizeZ',
-        'maxComputeWorkgroupsPerDimension'
+        'maxComputeWorkgroupsPerDimension',
+        'subgroupMaxSize'
     ] as const) {
         const required = minimum.limits[name];
         if (required !== undefined && (candidate.limits[name] ?? -1) < required) {
@@ -363,11 +393,24 @@ export function validateRenderPipelineCapabilitySuperset(
             'Replacement RHI device reduces render pipeline limit minStorageBufferOffsetAlignment'
         );
     }
+    const minimumSubgroupSize = minimum.limits.subgroupMinSize;
+    const candidateSubgroupSize = candidate.limits.subgroupMinSize;
+    if (
+        minimumSubgroupSize !== undefined &&
+        (candidateSubgroupSize === undefined || candidateSubgroupSize > minimumSubgroupSize)
+    ) {
+        throw new Error('Replacement RHI device reduces render pipeline limit subgroupMinSize');
+    }
     for (const capability of PIPELINE_CAPABILITY_NAMES) {
         if (minimum.supportsCapability(capability) && !candidate.supportsCapability(capability)) {
             throw new Error(
                 `Replacement RHI device removes render pipeline capability ${capability}`
             );
+        }
+    }
+    for (const feature of PUBLIC_RENDERER_FEATURES) {
+        if (minimum.supportsFeature(feature) && !candidate.supportsFeature(feature)) {
+            throw new Error(`Replacement RHI device removes render pipeline feature ${feature}`);
         }
     }
     for (const format of PUBLIC_TEXTURE_FORMATS) {

--- a/src/render/renderer/ComputePipelineResourceCache.ts
+++ b/src/render/renderer/ComputePipelineResourceCache.ts
@@ -121,9 +121,10 @@ function bindingLayoutEntry(binding: ComputeShaderBinding): Readonly<RHIBindGrou
 
 function compileBindingLayout(
     shader: ComputeShader,
+    compiledBindings: readonly ComputeShaderBinding[],
     maxBindGroups: number
 ): Readonly<ComputeBindingLayoutPlan> {
-    const highestGroup = shader.bindings.at(-1)?.group ?? -1;
+    const highestGroup = compiledBindings.at(-1)?.group ?? -1;
     if (highestGroup >= maxBindGroups) {
         throw new RangeError(
             `ComputeShader binding group ${String(highestGroup)} exceeds maxBindGroups ${String(maxBindGroups)}`
@@ -131,7 +132,7 @@ function compileBindingLayout(
     }
     const descriptors: RHIBindGroupLayoutDescriptor[] = [];
     for (let group = 0; group <= highestGroup; group += 1) {
-        const entries = shader.bindings
+        const entries = compiledBindings
             .filter(binding => binding.group === group)
             .map(bindingLayoutEntry);
         descriptors.push(
@@ -144,7 +145,7 @@ function compileBindingLayout(
     }
     return Object.freeze({
         bindGroupLayoutDescriptors: Object.freeze(descriptors),
-        bindings: shader.bindings
+        bindings: compiledBindings
     });
 }
 
@@ -281,6 +282,7 @@ export class ComputePipelineResourceCache {
         const shaderLabel = shader.label || 'ComputeShader';
         const bindingPlan = compileBindingLayout(
             shader,
+            compiled.bindings,
             this.registry.deviceCapabilities.limits.maxBindGroups
         );
         const shaderHandle = this.registry.register<RHIShader>({

--- a/src/render/renderer/ScriptableComputeDispatch.ts
+++ b/src/render/renderer/ScriptableComputeDispatch.ts
@@ -20,7 +20,9 @@ import {
     type RHIBindGroupLayout,
     type RHIBindingResource,
     type RHIBuffer,
+    type RHIComputePassDescriptor,
     type RHIComputePipeline,
+    type RHITimestampWrites,
     type RHISampler
 } from '../rhi/core';
 import type { BufferResourceCache } from './BufferResourceCache';
@@ -215,7 +217,10 @@ export class ScriptableComputeDispatch {
     readonly #groups: (ComputeBindGroupScratch | undefined)[] = [];
     readonly #activeGroups: number[] = [];
     readonly #cleanupFailures: unknown[] = [];
-    readonly #computePassDescriptor = { label: '' };
+    readonly #computePassDescriptor: {
+        label: string;
+        timestampWrites: Readonly<RHITimestampWrites> | undefined;
+    } = { label: '', timestampWrites: undefined };
     readonly #uniformBindingScratch: MutableNormalizedUniformBinding = {
         source: null,
         byteOffset: 0,
@@ -490,7 +495,15 @@ export class ScriptableComputeDispatch {
         const services = this.requireServices();
         let primaryFailure: unknown = null;
         try {
-            const encoder = context.commandContext.beginComputePass(this.#computePassDescriptor);
+            this.#computePassDescriptor.timestampWrites = context.timestampWrites;
+            let encoder;
+            try {
+                encoder = context.commandContext.beginComputePass(
+                    this.#computePassDescriptor as unknown as RHIComputePassDescriptor
+                );
+            } finally {
+                this.#computePassDescriptor.timestampWrites = undefined;
+            }
             encoder.setPipeline(this.#pipeline);
             for (const groupIndex of this.#activeGroups) {
                 const group = this.#groups[groupIndex];

--- a/src/render/renderer/passes/SharedDrawPass.ts
+++ b/src/render/renderer/passes/SharedDrawPass.ts
@@ -20,6 +20,7 @@ import {
     type RHIRenderPassDescriptor,
     type RHIRenderPassEncoder,
     type RHIStoreOp,
+    type RHITimestampWrites,
     type RHITexture,
     type RHITextureView,
     type RHIViewport
@@ -113,6 +114,7 @@ interface MutableRenderPassDescriptor {
     label: string | undefined;
     readonly colorAttachments: (MutableColorAttachmentDescriptor | null)[];
     depthStencilAttachment: MutableDepthStencilAttachmentDescriptor | undefined;
+    timestampWrites: Readonly<RHITimestampWrites> | undefined;
 }
 
 type MutableRHIViewport = {
@@ -284,7 +286,8 @@ export class SharedDrawPassParameters {
     private readonly descriptor: MutableRenderPassDescriptor = {
         label: undefined,
         colorAttachments: [],
-        depthStencilAttachment: undefined
+        depthStencilAttachment: undefined,
+        timestampWrites: undefined
     };
 
     constructor(capacity: SharedDrawPassCapacity = {}) {
@@ -712,9 +715,15 @@ export class SharedDrawPassParameters {
     /** @internal Allocation-free steady-state command path. */
     execute(context: RGPassContext): void {
         if (!this.prepared) throw UNPREPARED_PASS_ERROR;
-        const pass = context.commandContext.beginRenderPass(
-            this.descriptor as unknown as RHIRenderPassDescriptor
-        );
+        this.descriptor.timestampWrites = context.timestampWrites;
+        let pass: RHIRenderPassEncoder;
+        try {
+            pass = context.commandContext.beginRenderPass(
+                this.descriptor as unknown as RHIRenderPassDescriptor
+            );
+        } finally {
+            this.descriptor.timestampWrites = undefined;
+        }
         if (this.hasViewport) {
             pass.setViewportRecord(this.viewport);
             this.drawViewportState.minDepth = this.viewport.minDepth;
@@ -740,9 +749,15 @@ export class SharedDrawPassParameters {
     /** @internal Begin a prepared raster pass for a scriptable command facade. */
     beginExecute(context: RGPassContext): RHIRenderPassEncoder {
         if (!this.prepared) throw UNPREPARED_PASS_ERROR;
-        const pass = context.commandContext.beginRenderPass(
-            this.descriptor as unknown as RHIRenderPassDescriptor
-        );
+        this.descriptor.timestampWrites = context.timestampWrites;
+        let pass: RHIRenderPassEncoder;
+        try {
+            pass = context.commandContext.beginRenderPass(
+                this.descriptor as unknown as RHIRenderPassDescriptor
+            );
+        } finally {
+            this.descriptor.timestampWrites = undefined;
+        }
         if (this.hasViewport) {
             pass.setViewportRecord(this.viewport);
             this.drawViewportState.minDepth = this.viewport.minDepth;
@@ -802,6 +817,7 @@ export function createSharedDrawPassTemplate(
     if (name.length === 0) throw new Error('Shared draw pass template name must be non-empty');
     const template: RenderPassTemplate<SharedDrawPassParameters> = {
         name,
+        timestampKind: () => 'render',
         setup(builder, params) {
             params.declare(builder, forceSideEffect);
         },

--- a/src/render/rhi/RHIFactory.ts
+++ b/src/render/rhi/RHIFactory.ts
@@ -39,6 +39,7 @@ export type RHIRequestableWebGPUFeature = Extract<
     | 'texture-compression-astc'
     | 'timestamp-query'
     | 'shader-f16'
+    | 'subgroups'
     | 'depth32float-stencil8'
     | 'float32-filterable'
     | 'float32-blendable'

--- a/src/render/rhi/backends/webgl2/WebGL2Commands.ts
+++ b/src/render/rhi/backends/webgl2/WebGL2Commands.ts
@@ -14,6 +14,7 @@ import {
     validateRHICopyTextureToTexture,
     validateRHIRenderPassPipelineDepthStencilAccess,
     snapshotRHIRenderPassDescriptorInto,
+    validateRHIDebugLabel,
     type RHIBindGroup,
     type RHIBuffer,
     type RHIColor,
@@ -38,6 +39,7 @@ import {
     type RHIIndexFormat,
     type RHIQueue,
     type RHIQueueState,
+    type RHIQuerySet,
     type RHIRect,
     type RHIRenderPassDescriptor,
     type RHIRenderPassDescriptorSnapshotStorage,
@@ -1046,6 +1048,7 @@ export class WebGL2CommandContext extends WebGL2ObjectBase implements RHICommand
     #state: RHICommandContextState = 'open';
     #activePass: WebGL2RenderPass | null = null;
     #externalImageUploadPhase = true;
+    #debugGroupDepth = 0;
 
     constructor(
         owner: WebGL2RHIDevice,
@@ -1205,6 +1208,13 @@ export class WebGL2CommandContext extends WebGL2ObjectBase implements RHICommand
 
     beginRenderPass(descriptor: RHIRenderPassDescriptor): WebGL2RenderPass {
         this.requireOpen();
+        if (descriptor.timestampWrites !== undefined) {
+            throw new RHIValidationError(
+                'unsupported-feature',
+                'WebGL2 does not support timestamp writes',
+                'renderPass.timestampWrites'
+            );
+        }
         const storage = this.queue.acquireRenderPassStorage(descriptor, this.diagnostics);
         this.closeExternalImageUploadPhase();
         const pass = new WebGL2RenderPass(this.owner, this, storage);
@@ -1339,6 +1349,44 @@ export class WebGL2CommandContext extends WebGL2ObjectBase implements RHICommand
         this.diagnostics.commandCount++;
     }
 
+    resolveQuerySet(
+        _querySet: RHIQuerySet,
+        _firstQuery: number,
+        _queryCount: number,
+        _destination: RHIBuffer,
+        _destinationOffset = 0
+    ): void {
+        this.requireOpen();
+        throw new RHIValidationError(
+            'unsupported-feature',
+            'WebGL2 does not support query resolves',
+            'resolveQuerySet'
+        );
+    }
+
+    pushDebugGroup(label: string): void {
+        this.requireOpen();
+        validateRHIDebugLabel(label, 'context.debugGroup');
+        this.#debugGroupDepth += 1;
+    }
+
+    popDebugGroup(): void {
+        this.requireOpen();
+        if (this.#debugGroupDepth === 0) {
+            throw new RHIValidationError(
+                'invalid-state',
+                'context debug group stack is empty',
+                'context'
+            );
+        }
+        this.#debugGroupDepth -= 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.requireOpen();
+        validateRHIDebugLabel(label, 'context.debugMarker');
+    }
+
     nativeSucceeded(operation: string): void {
         this.owner.assertNoNativeError(operation);
     }
@@ -1368,12 +1416,21 @@ export class WebGL2CommandContext extends WebGL2ObjectBase implements RHICommand
     }
 
     finish(): void {
+        this.requireOpen();
+        if (this.#debugGroupDepth !== 0) {
+            throw new RHIValidationError(
+                'invalid-state',
+                'context has unclosed debug groups',
+                'context'
+            );
+        }
         this.#state = 'ended';
     }
 
     abort(): void {
         this.#activePass?.abort();
         this.#activePass = null;
+        this.#debugGroupDepth = 0;
         this.#state = 'aborted';
     }
 
@@ -1854,6 +1911,7 @@ export class WebGL2RenderPass
     #scissorStateChanged = false;
     #observedResourcesValid = true;
     #observingResources = true;
+    #debugGroupDepth = 0;
 
     constructor(
         owner: WebGL2RHIDevice,
@@ -2700,8 +2758,38 @@ export class WebGL2RenderPass
         );
     }
 
+    pushDebugGroup(label: string): void {
+        this.requireOpen();
+        validateRHIDebugLabel(label, 'renderPass.debugGroup');
+        this.#debugGroupDepth += 1;
+    }
+
+    popDebugGroup(): void {
+        this.requireOpen();
+        if (this.#debugGroupDepth === 0) {
+            throw new RHIValidationError(
+                'invalid-state',
+                'render pass debug group stack is empty',
+                'renderPass'
+            );
+        }
+        this.#debugGroupDepth -= 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.requireOpen();
+        validateRHIDebugLabel(label, 'renderPass.debugMarker');
+    }
+
     end(): void {
         this.requireOpen();
+        if (this.#debugGroupDepth !== 0) {
+            throw new RHIValidationError(
+                'invalid-state',
+                'render pass has unclosed debug groups',
+                'renderPass'
+            );
+        }
         try {
             this.flushPendingDrawBatch();
             this.assertAttachmentResourcesUsable();
@@ -2712,6 +2800,7 @@ export class WebGL2RenderPass
         }
         this.#state = 'ended';
         this.#pipeline = null;
+        this.#debugGroupDepth = 0;
         this.unsubscribeObservedResources();
         this.context.finishPass(this, this.#storage);
         this.context.diagnostics.commandCount++;

--- a/src/render/rhi/backends/webgl2/WebGL2Device.ts
+++ b/src/render/rhi/backends/webgl2/WebGL2Device.ts
@@ -20,6 +20,8 @@ import {
     type RHIGraphicsPipeline,
     type RHIGraphicsPipelineDescriptor,
     type RHIPipelineLayoutDescriptor,
+    type RHIQuerySet,
+    type RHIQuerySetDescriptor,
     type RHISampler,
     type RHISamplerDescriptor,
     type RHIShader,
@@ -231,6 +233,15 @@ export class WebGL2RHIDevice implements RHIDevice {
     createShader(descriptor: RHIShaderDescriptor): WebGL2Shader {
         this.assertAlive();
         return new WebGL2Shader(this, descriptor);
+    }
+
+    createQuerySet(_descriptor: RHIQuerySetDescriptor): RHIQuerySet {
+        this.assertAlive();
+        throw new RHIValidationError(
+            'unsupported-feature',
+            'WebGL2 does not support portable query sets',
+            'querySet'
+        );
     }
 
     createBindGroupLayout(descriptor: RHIBindGroupLayoutDescriptor): WebGL2BindGroupLayout {

--- a/src/render/rhi/backends/webgpu/WebGPUCapabilities.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUCapabilities.ts
@@ -231,6 +231,7 @@ function createFeatures(device: GPUDevice): ReadonlySet<RHIFeatureName> {
     const portableNativeFeatures: readonly RHIFeatureName[] = [
         'timestamp-query',
         'shader-f16',
+        'subgroups',
         'texture-compression-bc',
         'texture-compression-etc2',
         'texture-compression-astc',
@@ -253,7 +254,21 @@ function createFeatures(device: GPUDevice): ReadonlySet<RHIFeatureName> {
     return result;
 }
 
-function createLimits(native: GPUSupportedLimits): Readonly<RHILimits> {
+function adapterSubgroupSize(
+    info: Pick<GPUAdapterInfo, 'subgroupMinSize' | 'subgroupMaxSize'> | undefined,
+    name: 'subgroupMinSize' | 'subgroupMaxSize'
+): number | undefined {
+    const value = info?.[name];
+    return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+        ? value
+        : undefined;
+}
+
+function createLimits(
+    native: GPUSupportedLimits,
+    features: ReadonlySet<RHIFeatureName>,
+    adapterInfo?: Pick<GPUAdapterInfo, 'subgroupMinSize' | 'subgroupMaxSize'>
+): Readonly<RHILimits> {
     const maxStorageBuffersPerShaderStage = nativeLimit(
         native,
         'maxStorageBuffersPerShaderStage',
@@ -264,6 +279,12 @@ function createLimits(native: GPUSupportedLimits): Readonly<RHILimits> {
         'maxStorageTexturesPerShaderStage',
         4
     );
+    const subgroupMinSize = features.has('subgroups')
+        ? adapterSubgroupSize(adapterInfo, 'subgroupMinSize')
+        : undefined;
+    const subgroupMaxSize = features.has('subgroups')
+        ? adapterSubgroupSize(adapterInfo, 'subgroupMaxSize')
+        : undefined;
     return Object.freeze({
         maxTextureDimension1D: nativeLimit(native, 'maxTextureDimension1D', 8192),
         maxTextureDimension2D: nativeLimit(native, 'maxTextureDimension2D', 8192),
@@ -328,7 +349,9 @@ function createLimits(native: GPUSupportedLimits): Readonly<RHILimits> {
             native,
             'maxComputeWorkgroupsPerDimension',
             65_535
-        )
+        ),
+        ...(subgroupMinSize === undefined ? {} : { subgroupMinSize }),
+        ...(subgroupMaxSize === undefined ? {} : { subgroupMaxSize })
     });
 }
 
@@ -338,10 +361,13 @@ export class WebGPUCapabilities implements RHICapabilities {
     readonly #nativeFeatures: GPUSupportedFeatures;
     readonly #formatCapabilities = new Map<RHITextureFormat, RHITextureFormatCapabilities>();
 
-    constructor(device: GPUDevice) {
+    constructor(
+        device: GPUDevice,
+        adapterInfo?: Pick<GPUAdapterInfo, 'subgroupMinSize' | 'subgroupMaxSize'>
+    ) {
         this.#nativeFeatures = device.features;
         this.features = createFeatures(device);
-        this.limits = createLimits(device.limits);
+        this.limits = createLimits(device.limits, this.features, adapterInfo);
     }
 
     getTextureFormatCapabilities(format: RHITextureFormat): RHITextureFormatCapabilities {

--- a/src/render/rhi/backends/webgpu/WebGPUCommands.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUCommands.ts
@@ -8,7 +8,8 @@ import type {
     RHIImageCopyExternalImageToTexture,
     RHIImageDataLayout,
     RHIImageCopyTexture,
-    RHIRenderPassDescriptor
+    RHIRenderPassDescriptor,
+    RHITimestampWrites
 } from '../../core/RHICommands';
 import { validateRHIClearBuffer } from '../../core/RHICommandValidation';
 import {
@@ -22,14 +23,24 @@ import {
     validateRHIWriteTexture,
     getRHITextureFormatBlockInfo
 } from '../../core/RHICopyValidation';
-import type { RHIBuffer, RHIDeviceOwnedObject, RHITexture } from '../../core/RHIResources';
+import type {
+    RHIBuffer,
+    RHIDeviceOwnedObject,
+    RHIQuerySet,
+    RHITexture
+} from '../../core/RHIResources';
+import {
+    validateRHIDebugLabel,
+    validateRHIResolveQuerySet,
+    validateRHITimestampWrites
+} from '../../core/RHIQueryValidation';
 import type { RHIFrameDescriptor } from '../../core/RHIQueue';
 import type { RHIDataSource, RHIExtent3D } from '../../core/RHITypes';
 import { RHIValidationError } from '../../core/RHIValidation';
 import { WebGPUDestroyableObject, WebGPUObject } from './WebGPUBase';
 import { nativeWebGPUOrigin } from './WebGPUDescriptors';
 import type { WebGPUDevice } from './WebGPUDevice';
-import { WebGPUBuffer, WebGPUTexture } from './WebGPUResources';
+import { WebGPUBuffer, WebGPUQuerySet, WebGPUTexture } from './WebGPUResources';
 import type { WebGPUQueue, WebGPUUploadAllocation } from './WebGPUQueue';
 import { WebGPURenderPass, type WebGPURenderPassStorage } from './WebGPURenderPass';
 import { WebGPUComputePass, type WebGPUComputePassStorage } from './WebGPUComputePass';
@@ -122,6 +133,31 @@ function webGPUTexture(
     return texture;
 }
 
+function webGPUQuerySet(device: WebGPUDevice, querySet: RHIQuerySet, path: string): WebGPUQuerySet {
+    device.assertUsable(querySet, path);
+    if (!(querySet instanceof WebGPUQuerySet) || querySet.owner !== device) {
+        return validationFailure('wrong-device', 'expected a WebGPU RHI query set', path);
+    }
+    return querySet;
+}
+
+function nativeTimestampWrites(
+    device: WebGPUDevice,
+    writes: Readonly<RHITimestampWrites>,
+    path: string
+): GPURenderPassTimestampWrites {
+    const querySet = webGPUQuerySet(device, writes.querySet, `${path}.querySet`);
+    return {
+        querySet: querySet.nativeHandle,
+        ...(writes.beginningOfPassWriteIndex === undefined
+            ? {}
+            : { beginningOfPassWriteIndex: writes.beginningOfPassWriteIndex }),
+        ...(writes.endOfPassWriteIndex === undefined
+            ? {}
+            : { endOfPassWriteIndex: writes.endOfPassWriteIndex })
+    };
+}
+
 function nativeImageCopyTexture(
     device: WebGPUDevice,
     copy: RHIImageCopyTexture,
@@ -158,6 +194,7 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
     #activePass: WebGPURenderPass | WebGPUComputePass | null = null;
     #externalImageUploadPhase = true;
     #directUploadPhase: boolean;
+    #debugGroupDepth = 0;
     readonly #retainedReferences: WebGPUFrameReferences;
     readonly #uploadAllocation: WebGPUUploadAllocation = { buffer: null, offset: 0 };
 
@@ -417,13 +454,29 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
 
     beginRenderPass(descriptor: RHIRenderPassDescriptor): WebGPURenderPass {
         this.assertOpen();
+        validateRHITimestampWrites(
+            this.owner,
+            descriptor.timestampWrites,
+            'renderPass.timestampWrites'
+        );
         const storage = this.queue.acquireRenderPassStorage(descriptor, this);
         const snapshot = storage.snapshot.descriptor;
         this.closeExternalImageUploadPhase();
         let nativePass: GPURenderPassEncoder;
         try {
+            const cachedDescriptor = this.owner.framebufferCache.lookup(snapshot);
+            const writes = descriptor.timestampWrites;
             nativePass = this.#nativeEncoder.beginRenderPass(
-                this.owner.framebufferCache.lookup(snapshot)
+                writes === undefined
+                    ? cachedDescriptor
+                    : {
+                          ...cachedDescriptor,
+                          timestampWrites: nativeTimestampWrites(
+                              this.owner,
+                              writes,
+                              'renderPass.timestampWrites'
+                          )
+                      }
             );
         } catch (error) {
             this.queue.releaseRenderPassStorage(storage);
@@ -446,6 +499,15 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
             this.retain(snapshot.depthStencilAttachment.view);
             this.retain(snapshot.depthStencilAttachment.view.texture);
         }
+        if (descriptor.timestampWrites !== undefined) {
+            this.retain(
+                webGPUQuerySet(
+                    this.owner,
+                    descriptor.timestampWrites.querySet,
+                    'renderPass.timestampWrites.querySet'
+                )
+            );
+        }
         this.#contextState = 'render-pass';
         this.diagnostics.commandCount += 1;
         this.diagnostics.nativeStateCalls += 1;
@@ -459,7 +521,26 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
         if (!this.owner.capabilities.features.has('compute-pipelines')) {
             validationFailure('unsupported-feature', 'compute passes are unsupported', 'context');
         }
+        validateRHITimestampWrites(
+            this.owner,
+            descriptor.timestampWrites,
+            'computePass.timestampWrites'
+        );
         const storage = this.queue.acquireComputePassStorage(descriptor, this);
+        if (descriptor.timestampWrites !== undefined) {
+            storage.nativeDescriptor.timestampWrites = nativeTimestampWrites(
+                this.owner,
+                descriptor.timestampWrites,
+                'computePass.timestampWrites'
+            );
+            this.retain(
+                webGPUQuerySet(
+                    this.owner,
+                    descriptor.timestampWrites.querySet,
+                    'computePass.timestampWrites.querySet'
+                )
+            );
+        }
         this.closeExternalImageUploadPhase();
         let nativePass: GPUComputePassEncoder;
         try {
@@ -577,6 +658,66 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
         this.recordNativeCommand();
     }
 
+    resolveQuerySet(
+        querySet: RHIQuerySet,
+        firstQuery: number,
+        queryCount: number,
+        destination: RHIBuffer,
+        destinationOffset = 0
+    ): void {
+        this.assertOpen();
+        validateRHIResolveQuerySet(
+            this.owner,
+            querySet,
+            firstQuery,
+            queryCount,
+            destination,
+            destinationOffset
+        );
+        const nativeQuerySet = webGPUQuerySet(this.owner, querySet, 'resolveQuerySet.querySet');
+        const nativeDestination = webGPUBuffer(
+            this.owner,
+            destination,
+            'resolveQuerySet.destination'
+        );
+        this.retain(nativeQuerySet);
+        this.retain(nativeDestination);
+        this.closeExternalImageUploadPhase();
+        this.#nativeEncoder.resolveQuerySet(
+            nativeQuerySet.nativeHandle,
+            firstQuery,
+            queryCount,
+            nativeDestination.nativeHandle,
+            destinationOffset
+        );
+        this.recordNativeCommand();
+    }
+
+    pushDebugGroup(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'context.debugGroup');
+        this.#nativeEncoder.pushDebugGroup(label);
+        this.#debugGroupDepth += 1;
+        this.diagnostics.nativeStateCalls += 1;
+    }
+
+    popDebugGroup(): void {
+        this.assertOpen();
+        if (this.#debugGroupDepth === 0) {
+            validationFailure('invalid-state', 'context debug group stack is empty', 'context');
+        }
+        this.#nativeEncoder.popDebugGroup();
+        this.#debugGroupDepth -= 1;
+        this.diagnostics.nativeStateCalls += 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'context.debugMarker');
+        this.#nativeEncoder.insertDebugMarker(label);
+        this.diagnostics.nativeStateCalls += 1;
+    }
+
     /** @internal */
     retain(object: RHIDeviceOwnedObject): void {
         this.owner.assertUsable(object, 'frame.resource');
@@ -631,6 +772,9 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
     /** @internal */
     finishForSubmission(): GPUCommandBuffer {
         this.assertOpen();
+        if (this.#debugGroupDepth !== 0) {
+            validationFailure('invalid-state', 'context has unclosed debug groups', 'context');
+        }
         const commandBuffer = this.#nativeEncoder.finish();
         this.owner.recordNativeObjectCreated('commandBuffer', 'creation-only');
         this.#contextState = 'ended';
@@ -648,6 +792,7 @@ export class WebGPUCommandContext extends WebGPUObject implements RHICommandCont
         }
         this.#activePass?.abort();
         this.#activePass = null;
+        this.#debugGroupDepth = 0;
         this.#contextState = 'aborted';
         return this.#retainedReferences;
     }

--- a/src/render/rhi/backends/webgpu/WebGPUComputePass.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUComputePass.ts
@@ -1,4 +1,5 @@
 import type { RHIComputePassEncoder, RHIComputePassState } from '../../core/RHICommands';
+import { validateRHIDebugLabel } from '../../core/RHIQueryValidation';
 import {
     validateRHIDispatchWorkgroups,
     validateRHIDispatchWorkgroupsIndirect
@@ -49,6 +50,7 @@ export class WebGPUComputePassStorage {
     release(): void {
         this.boundBindGroups.fill(null);
         this.nativeDescriptor.label = '';
+        delete this.nativeDescriptor.timestampWrites;
     }
 }
 
@@ -59,6 +61,7 @@ export class WebGPUComputePass extends WebGPUObject implements RHIComputePassEnc
     readonly #boundBindGroups: (WebGPUBindGroup | null)[];
     #passState: RHIComputePassState = 'open';
     #pipeline: WebGPUComputePipeline | null = null;
+    #debugGroupDepth = 0;
 
     constructor(
         readonly context: WebGPUCommandContext,
@@ -150,8 +153,44 @@ export class WebGPUComputePass extends WebGPUObject implements RHIComputePassEnc
         this.context.diagnostics.nativeStateCalls += 1;
     }
 
+    pushDebugGroup(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'computePass.debugGroup');
+        this.#nativePass.pushDebugGroup(label);
+        this.#debugGroupDepth += 1;
+        this.context.diagnostics.nativeStateCalls += 1;
+    }
+
+    popDebugGroup(): void {
+        this.assertOpen();
+        if (this.#debugGroupDepth === 0) {
+            validationFailure(
+                'invalid-state',
+                'compute pass debug group stack is empty',
+                'computePass'
+            );
+        }
+        this.#nativePass.popDebugGroup();
+        this.#debugGroupDepth -= 1;
+        this.context.diagnostics.nativeStateCalls += 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'computePass.debugMarker');
+        this.#nativePass.insertDebugMarker(label);
+        this.context.diagnostics.nativeStateCalls += 1;
+    }
+
     end(): void {
         this.assertOpen();
+        if (this.#debugGroupDepth !== 0) {
+            validationFailure(
+                'invalid-state',
+                'compute pass has unclosed debug groups',
+                'computePass'
+            );
+        }
         this.#nativePass.end();
         this.context.diagnostics.commandCount += 1;
         this.context.diagnostics.nativeStateCalls += 1;
@@ -165,6 +204,7 @@ export class WebGPUComputePass extends WebGPUObject implements RHIComputePassEnc
         if (this.#passState !== 'open') return;
         this.#passState = 'aborted';
         this.#pipeline = null;
+        this.#debugGroupDepth = 0;
         this.context.abortComputePass(this, this.#storage);
     }
 

--- a/src/render/rhi/backends/webgpu/WebGPUDevice.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUDevice.ts
@@ -1,4 +1,5 @@
 import type { RHICapabilities } from '../../core/RHICapabilities';
+import { normalizeRHIQuerySetDescriptor } from '../../core/RHIQueryValidation';
 import {
     allocateRHIDeviceId,
     createRHIObjectIdAllocator,
@@ -17,6 +18,7 @@ import type {
     RHIDeviceLostInfo,
     RHIDeviceOwnedObject,
     RHIGraphicsShaderArtifactInput,
+    RHIQuerySetDescriptor,
     RHISamplerDescriptor,
     RHIShaderDescriptor,
     RHITextureDescriptor
@@ -58,7 +60,13 @@ import {
     nativeWebGPUGraphicsPipelineDescriptor
 } from './WebGPUPipeline';
 import { WebGPUQueue } from './WebGPUQueue';
-import { WebGPUBuffer, WebGPUSampler, WebGPUShader, WebGPUTexture } from './WebGPUResources';
+import {
+    WebGPUBuffer,
+    WebGPUQuerySet,
+    WebGPUSampler,
+    WebGPUShader,
+    WebGPUTexture
+} from './WebGPUResources';
 import { WebGPUSurface } from './WebGPUSurface';
 import { WebGPUFramebufferCache } from './WebGPUFramebufferCache';
 import { WebGPUMipmapGenerator } from './WebGPUMipmapGenerator';
@@ -135,12 +143,13 @@ export class WebGPUDevice implements RHIDevice, WebGPUObjectOwner {
     constructor(
         nativeHandle: GPUDevice,
         diagnosticsSink: RHIDiagnosticsSink | null = null,
-        mipmapShaderArtifacts: Readonly<RHIGraphicsShaderArtifactInput> | null = null
+        mipmapShaderArtifacts: Readonly<RHIGraphicsShaderArtifactInput> | null = null,
+        adapterInfo?: Pick<GPUAdapterInfo, 'subgroupMinSize' | 'subgroupMaxSize'>
     ) {
         this.#nativeHandle = nativeHandle;
         this.#diagnosticsSink = diagnosticsSink;
         this.#objectIds = createRHIObjectIdAllocator(this.id);
-        this.capabilities = new WebGPUCapabilities(nativeHandle);
+        this.capabilities = new WebGPUCapabilities(nativeHandle, adapterInfo);
         this.label = nativeHandle.label;
         this.#lostSignal = createWebGPUDeferred<RHIDeviceLostInfo>();
         this.lost = this.#lostSignal.promise;
@@ -300,6 +309,17 @@ export class WebGPUDevice implements RHIDevice, WebGPUObjectOwner {
             code: normalized.artifact.code
         });
         return new WebGPUShader(this, nativeShader, normalized);
+    }
+
+    createQuerySet(descriptor: RHIQuerySetDescriptor): WebGPUQuerySet {
+        this.assertOperational();
+        const normalized = normalizeRHIQuerySetDescriptor(descriptor, this.capabilities);
+        const nativeQuerySet = this.#nativeHandle.createQuerySet({
+            label: normalized.label,
+            type: normalized.type,
+            count: normalized.count
+        });
+        return new WebGPUQuerySet(this, nativeQuerySet, normalized);
     }
 
     createBindGroupLayout(descriptor: RHIBindGroupLayoutDescriptor): WebGPUBindGroupLayout {
@@ -508,7 +528,8 @@ export async function createWebGPUDevice(
         return new WebGPUDevice(
             nativeDevice,
             options.diagnosticsSink ?? null,
-            options.mipmapShaderArtifacts ?? null
+            options.mipmapShaderArtifacts ?? null,
+            adapter.info
         );
     } catch (error) {
         nativeDevice.destroy();

--- a/src/render/rhi/backends/webgpu/WebGPURenderPass.ts
+++ b/src/render/rhi/backends/webgpu/WebGPURenderPass.ts
@@ -7,6 +7,7 @@ import type {
     RHIVertexBufferBindingRecord
 } from '../../core/RHICommands';
 import { validateRHIDrawIndirect } from '../../core/RHICommandValidation';
+import { validateRHIDebugLabel } from '../../core/RHIQueryValidation';
 import type { RHIBindGroup, RHIGraphicsPipeline } from '../../core/RHIPipeline';
 import type { RHIBuffer } from '../../core/RHIResources';
 import {
@@ -125,6 +126,7 @@ export class WebGPURenderPass extends WebGPUObject implements RHIRenderPassEncod
     #indexSize = 0;
     #viewportStateChanged = false;
     #scissorStateChanged = false;
+    #debugGroupDepth = 0;
 
     constructor(
         readonly context: WebGPUCommandContext,
@@ -693,8 +695,44 @@ export class WebGPURenderPass extends WebGPUObject implements RHIRenderPassEncod
         this.context.diagnostics.nativeStateCalls += 1;
     }
 
+    pushDebugGroup(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'renderPass.debugGroup');
+        this.#nativePass.pushDebugGroup(label);
+        this.#debugGroupDepth += 1;
+        this.context.diagnostics.nativeStateCalls += 1;
+    }
+
+    popDebugGroup(): void {
+        this.assertOpen();
+        if (this.#debugGroupDepth === 0) {
+            validationFailure(
+                'invalid-state',
+                'render pass debug group stack is empty',
+                'renderPass'
+            );
+        }
+        this.#nativePass.popDebugGroup();
+        this.#debugGroupDepth -= 1;
+        this.context.diagnostics.nativeStateCalls += 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'renderPass.debugMarker');
+        this.#nativePass.insertDebugMarker(label);
+        this.context.diagnostics.nativeStateCalls += 1;
+    }
+
     end(): void {
         this.assertOpen();
+        if (this.#debugGroupDepth !== 0) {
+            validationFailure(
+                'invalid-state',
+                'render pass has unclosed debug groups',
+                'renderPass'
+            );
+        }
         this.#nativePass.end();
         this.context.diagnostics.commandCount += 1;
         this.context.diagnostics.nativeStateCalls += 1;
@@ -710,6 +748,7 @@ export class WebGPURenderPass extends WebGPUObject implements RHIRenderPassEncod
         this.#passState = 'aborted';
         this.#pipeline = null;
         this.#indexBuffer = null;
+        this.#debugGroupDepth = 0;
         this.context.abortPass(this, this.#storage);
     }
 

--- a/src/render/rhi/backends/webgpu/WebGPUResources.ts
+++ b/src/render/rhi/backends/webgpu/WebGPUResources.ts
@@ -3,10 +3,12 @@ import type {
     RHIBufferMapMode,
     RHIBufferMapState,
     RHINormalizedBufferDescriptor,
+    RHINormalizedQuerySetDescriptor,
     RHINormalizedSamplerDescriptor,
     RHINormalizedShaderDescriptor,
     RHINormalizedTextureDescriptor,
     RHINormalizedTextureViewDescriptor,
+    RHIQuerySet,
     RHISampler,
     RHIShader,
     RHITexture,
@@ -120,6 +122,37 @@ export class WebGPUBuffer
     protected override releaseNative(): void {
         this.#mappedOffset = 0;
         this.#mappedSize = 0;
+        this.#nativeHandle.destroy();
+    }
+}
+
+export class WebGPUQuerySet
+    extends WebGPUResource<RHINormalizedQuerySetDescriptor>
+    implements RHIQuerySet
+{
+    readonly descriptor: Readonly<RHINormalizedQuerySetDescriptor>;
+    readonly type;
+    readonly count: number;
+    readonly #nativeHandle: GPUQuerySet;
+
+    constructor(
+        owner: WebGPUDevice,
+        nativeHandle: GPUQuerySet,
+        descriptor: Readonly<RHINormalizedQuerySetDescriptor>
+    ) {
+        super(owner, descriptor.label, descriptor.lifetime);
+        this.#nativeHandle = nativeHandle;
+        this.descriptor = descriptor;
+        this.type = descriptor.type;
+        this.count = descriptor.count;
+    }
+
+    /** @internal */
+    get nativeHandle(): GPUQuerySet {
+        return this.#nativeHandle;
+    }
+
+    protected override releaseNative(): void {
         this.#nativeHandle.destroy();
     }
 }

--- a/src/render/rhi/core/RHICapabilities.ts
+++ b/src/render/rhi/core/RHICapabilities.ts
@@ -12,6 +12,7 @@ export type RHIFeatureName =
     | 'storage-textures'
     | 'compute-pipelines'
     | 'shader-f16'
+    | 'subgroups'
     | 'timestamp-query'
     | 'anisotropic-filtering'
     | 'texture-compression-bc'
@@ -54,6 +55,10 @@ export interface RHILimits {
     readonly maxComputeWorkgroupSizeY?: number;
     readonly maxComputeWorkgroupSizeZ?: number;
     readonly maxComputeWorkgroupsPerDimension?: number;
+    /** Minimum invocation count in a native subgroup when the subgroups feature is enabled. */
+    readonly subgroupMinSize?: number;
+    /** Maximum invocation count in a native subgroup when the subgroups feature is enabled. */
+    readonly subgroupMaxSize?: number;
 }
 
 /** Immutable capabilities for one texture format on one device generation. */

--- a/src/render/rhi/core/RHICommands.ts
+++ b/src/render/rhi/core/RHICommands.ts
@@ -1,5 +1,11 @@
 import type { RHIBindGroup, RHIComputePipeline, RHIGraphicsPipeline } from './RHIPipeline';
-import type { RHIBuffer, RHIDeviceOwnedObject, RHITexture, RHITextureView } from './RHIResources';
+import type {
+    RHIBuffer,
+    RHIDeviceOwnedObject,
+    RHIQuerySet,
+    RHITexture,
+    RHITextureView
+} from './RHIResources';
 import type {
     RHIColor,
     RHIDataSource,
@@ -38,6 +44,14 @@ export interface RHIRenderPassDescriptor {
     readonly label?: string;
     readonly colorAttachments: readonly (RHIRenderPassColorAttachment | null)[];
     readonly depthStencilAttachment?: RHIRenderPassDepthStencilAttachment;
+    readonly timestampWrites?: RHITimestampWrites;
+}
+
+/** Timestamp indices written by one native render or compute pass. */
+export interface RHITimestampWrites {
+    readonly querySet: RHIQuerySet;
+    readonly beginningOfPassWriteIndex?: number;
+    readonly endOfPassWriteIndex?: number;
 }
 
 export interface RHIImageCopyTexture {
@@ -133,13 +147,21 @@ export type RHICommandContextState = 'open' | 'render-pass' | 'compute-pass' | '
 export type RHIRenderPassState = 'open' | 'ended' | 'aborted';
 export type RHIComputePassState = 'open' | 'ended' | 'aborted';
 
+/** Debug annotations map to native markers when available and preserve validated nesting. */
+export interface RHIDebugCommands {
+    pushDebugGroup(label: string): void;
+    popDebugGroup(): void;
+    insertDebugMarker(label: string): void;
+}
+
 /** Optional debug metadata for a backend-neutral compute pass. */
 export interface RHIComputePassDescriptor {
     readonly label?: string;
+    readonly timestampWrites?: RHITimestampWrites;
 }
 
 /** Command encoder valid only while its parent context is in the compute-pass state. */
-export interface RHIComputePassEncoder extends RHIDeviceOwnedObject {
+export interface RHIComputePassEncoder extends RHIDeviceOwnedObject, RHIDebugCommands {
     readonly contextId: number;
     readonly state: RHIComputePassState;
 
@@ -153,7 +175,7 @@ export interface RHIComputePassEncoder extends RHIDeviceOwnedObject {
 }
 
 /** A render pass is valid only while both it and its parent frame context are open. */
-export interface RHIRenderPassEncoder extends RHIDeviceOwnedObject {
+export interface RHIRenderPassEncoder extends RHIDeviceOwnedObject, RHIDebugCommands {
     readonly contextId: number;
     readonly state: RHIRenderPassState;
 
@@ -208,7 +230,7 @@ export interface RHIRenderPassEncoder extends RHIDeviceOwnedObject {
  * Portable frame command scope. Implementations may execute immediately or encode native deferred
  * work; clients cannot observe or branch on that strategy.
  */
-export interface RHICommandContext extends RHIDeviceOwnedObject {
+export interface RHICommandContext extends RHIDeviceOwnedObject, RHIDebugCommands {
     readonly frameId: number;
     readonly state: RHICommandContextState;
     readonly diagnostics: RHIFrameDiagnostics;
@@ -274,5 +296,13 @@ export interface RHICommandContext extends RHIDeviceOwnedObject {
         source: RHIImageCopyTexture,
         destination: RHIImageCopyTexture,
         copySize: RHIExtent3D
+    ): void;
+    /** Resolve a contiguous query range into an unmapped QUERY_RESOLVE buffer. */
+    resolveQuerySet(
+        querySet: RHIQuerySet,
+        firstQuery: number,
+        queryCount: number,
+        destination: RHIBuffer,
+        destinationOffset?: number
     ): void;
 }

--- a/src/render/rhi/core/RHIQueryValidation.ts
+++ b/src/render/rhi/core/RHIQueryValidation.ts
@@ -1,0 +1,178 @@
+import type { RHITimestampWrites } from './RHICommands';
+import type { RHICapabilities } from './RHICapabilities';
+import type {
+    RHIBuffer,
+    RHIDevice,
+    RHINormalizedQuerySetDescriptor,
+    RHIQuerySet,
+    RHIQuerySetDescriptor
+} from './RHIResources';
+import { RHIBufferUsage } from './RHITypes';
+import { RHIValidationError, assertRHIObjectOwnedBy } from './RHIValidation';
+
+const MAX_QUERY_COUNT = 8192;
+
+function nonNegativeInteger(value: number, path: string): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+        throw new RHIValidationError(
+            'invalid-descriptor',
+            'must be a non-negative safe integer',
+            path
+        );
+    }
+}
+
+function positiveInteger(value: number, path: string): void {
+    if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RHIValidationError('invalid-descriptor', 'must be a positive safe integer', path);
+    }
+}
+
+/** Normalize a timestamp query descriptor before any native query allocation. */
+export function normalizeRHIQuerySetDescriptor(
+    descriptor: Readonly<RHIQuerySetDescriptor>,
+    capabilities: RHICapabilities
+): Readonly<RHINormalizedQuerySetDescriptor> {
+    if (!capabilities.features.has('timestamp-query')) {
+        throw new RHIValidationError(
+            'unsupported-feature',
+            'timestamp queries require the timestamp-query feature',
+            'querySet.type'
+        );
+    }
+    positiveInteger(descriptor.count, 'querySet.count');
+    if (descriptor.count > MAX_QUERY_COUNT) {
+        throw new RHIValidationError(
+            'out-of-bounds',
+            `query count exceeds ${String(MAX_QUERY_COUNT)}`,
+            'querySet.count'
+        );
+    }
+    return Object.freeze({
+        label: descriptor.label ?? '',
+        lifetime: descriptor.lifetime ?? 'persistent',
+        type: descriptor.type,
+        count: descriptor.count
+    });
+}
+
+/** Validate pass timestamp indices and ownership before beginning a native pass. */
+export function validateRHITimestampWrites(
+    device: RHIDevice,
+    writes: Readonly<RHITimestampWrites> | undefined,
+    path: string
+): void {
+    if (writes === undefined) return;
+    if (!device.capabilities.features.has('timestamp-query')) {
+        throw new RHIValidationError(
+            'unsupported-feature',
+            'timestamp writes require the timestamp-query feature',
+            path
+        );
+    }
+    const querySet = writes.querySet;
+    assertRHIObjectOwnedBy(device, querySet, `${path}.querySet`);
+    if (querySet.destroyed) {
+        throw new RHIValidationError(
+            'destroyed-object',
+            'query set is destroyed',
+            `${path}.querySet`
+        );
+    }
+    const beginning = writes.beginningOfPassWriteIndex;
+    const end = writes.endOfPassWriteIndex;
+    if (beginning === undefined && end === undefined) {
+        throw new RHIValidationError(
+            'invalid-descriptor',
+            'timestamp writes require a beginning or end index',
+            path
+        );
+    }
+    for (const [name, value] of [
+        ['beginningOfPassWriteIndex', beginning],
+        ['endOfPassWriteIndex', end]
+    ] as const) {
+        if (value === undefined) continue;
+        nonNegativeInteger(value, `${path}.${name}`);
+        if (value >= querySet.count) {
+            throw new RHIValidationError(
+                'out-of-bounds',
+                'query index exceeds query set',
+                `${path}.${name}`
+            );
+        }
+    }
+    if (beginning !== undefined && beginning === end) {
+        throw new RHIValidationError(
+            'invalid-descriptor',
+            'beginning and end timestamp indices must differ',
+            path
+        );
+    }
+}
+
+/** Validate one explicit query resolve command before native command emission. */
+export function validateRHIResolveQuerySet(
+    device: RHIDevice,
+    querySet: RHIQuerySet,
+    firstQuery: number,
+    queryCount: number,
+    destination: RHIBuffer,
+    destinationOffset: number
+): void {
+    assertRHIObjectOwnedBy(device, querySet, 'resolveQuerySet.querySet');
+    assertRHIObjectOwnedBy(device, destination, 'resolveQuerySet.destination');
+    if (querySet.destroyed) {
+        throw new RHIValidationError(
+            'destroyed-object',
+            'query set is destroyed',
+            'resolveQuerySet.querySet'
+        );
+    }
+    if (destination.destroyed) {
+        throw new RHIValidationError(
+            'destroyed-object',
+            'destination buffer is destroyed',
+            'resolveQuerySet.destination'
+        );
+    }
+    nonNegativeInteger(firstQuery, 'resolveQuerySet.firstQuery');
+    positiveInteger(queryCount, 'resolveQuerySet.queryCount');
+    if (firstQuery > querySet.count || queryCount > querySet.count - firstQuery) {
+        throw new RHIValidationError(
+            'out-of-bounds',
+            'query range exceeds query set',
+            'resolveQuerySet'
+        );
+    }
+    nonNegativeInteger(destinationOffset, 'resolveQuerySet.destinationOffset');
+    if (destinationOffset % 256 !== 0) {
+        throw new RHIValidationError(
+            'invalid-descriptor',
+            'destination offset must be 256-byte aligned',
+            'resolveQuerySet.destinationOffset'
+        );
+    }
+    if ((destination.usage & RHIBufferUsage.QUERY_RESOLVE) === 0) {
+        throw new RHIValidationError(
+            'invalid-descriptor',
+            'destination buffer lacks QUERY_RESOLVE usage',
+            'resolveQuerySet.destination.usage'
+        );
+    }
+    const byteLength = queryCount * 8;
+    if (destinationOffset > destination.size || byteLength > destination.size - destinationOffset) {
+        throw new RHIValidationError(
+            'out-of-bounds',
+            'resolved query bytes exceed destination buffer',
+            'resolveQuerySet.destination'
+        );
+    }
+}
+
+/** Debug labels are required to be non-empty so native captures remain actionable. */
+export function validateRHIDebugLabel(label: string, path: string): void {
+    if (typeof label !== 'string' || label.length === 0) {
+        throw new RHIValidationError('invalid-descriptor', 'debug label must be non-empty', path);
+    }
+}

--- a/src/render/rhi/core/RHIResources.ts
+++ b/src/render/rhi/core/RHIResources.ts
@@ -339,6 +339,28 @@ export interface RHIShader extends RHIResource {
     readonly stage: RHIShaderStageName;
 }
 
+/** Query kinds exposed by the portable RHI. Timestamp queries remain capability-gated. */
+export type RHIQueryType = 'timestamp';
+
+export interface RHIQuerySetDescriptor extends RHIResourceDescriptorBase {
+    readonly type: RHIQueryType;
+    readonly count: number;
+}
+
+export interface RHINormalizedQuerySetDescriptor {
+    readonly label: string;
+    readonly lifetime: RHIResourceLifetime;
+    readonly type: RHIQueryType;
+    readonly count: number;
+}
+
+/** Device-owned query storage resolved explicitly into a QUERY_RESOLVE buffer. */
+export interface RHIQuerySet extends RHIResource {
+    readonly descriptor: Readonly<RHINormalizedQuerySetDescriptor>;
+    readonly type: RHIQueryType;
+    readonly count: number;
+}
+
 export type RHIDeviceLostReason =
     'destroyed' | 'context-lost' | 'adapter-removed' | 'reset' | 'unknown';
 
@@ -370,6 +392,8 @@ export interface RHIDevice extends RHIDestroyable {
     createTexture(descriptor: RHITextureDescriptor): RHITexture;
     createSampler(descriptor?: RHISamplerDescriptor): RHISampler;
     createShader(descriptor: RHIShaderDescriptor): RHIShader;
+    /** Create a query set or fail before native work when its feature is unavailable. */
+    createQuerySet(descriptor: RHIQuerySetDescriptor): RHIQuerySet;
     createBindGroupLayout(descriptor: RHIBindGroupLayoutDescriptor): RHIBindGroupLayout;
     createPipelineLayout(descriptor: RHIPipelineLayoutDescriptor): RHIPipelineLayout;
     createBindGroup(descriptor: RHIBindGroupDescriptor): RHIBindGroup;

--- a/src/render/rhi/core/index.ts
+++ b/src/render/rhi/core/index.ts
@@ -12,3 +12,4 @@ export type * from './RHISurface';
 export * from './RHIValidation';
 export * from './RHICopyValidation';
 export * from './RHICommandValidation';
+export * from './RHIQueryValidation';

--- a/src/render/shader/WgslComputeCompiler.ts
+++ b/src/render/shader/WgslComputeCompiler.ts
@@ -100,6 +100,7 @@ interface ComputeModuleMetadata {
     readonly overrides: readonly Readonly<RHIShaderOverrideReflection>[];
     readonly requiresF16: boolean;
     readonly nagaValidationSource: string;
+    readonly bufferMinBindingSizes: ReadonlyMap<string, number>;
 }
 
 interface TypeLayout {
@@ -113,6 +114,15 @@ interface TypeLayoutEnvironment {
     readonly structures: ReadonlyMap<string, SourceStructDeclaration>;
     readonly constants: ReadonlyMap<string, readonly SourceToken[]>;
     readonly overrides: ReadonlyMap<string, SourceOverrideDeclaration>;
+    readonly runtimeArrayElementCount: number | null;
+}
+
+interface SourceBufferVariable {
+    readonly name: string;
+    readonly group: number;
+    readonly binding: number;
+    readonly typeTokens: readonly SourceToken[];
+    readonly offset: number;
 }
 
 export interface CompiledWgslComputeShader {
@@ -578,8 +588,13 @@ function parseOverrideDeclaration(
 function parseWorkgroupVariable(
     source: string,
     tokens: readonly SourceToken[],
-    varIndex: number
-): { readonly variable: SourceWorkgroupVariable | null; readonly nextIndex: number } {
+    varIndex: number,
+    attributes: readonly SourceAttribute[]
+): {
+    readonly variable: SourceWorkgroupVariable | null;
+    readonly bufferVariable: SourceBufferVariable | null;
+    readonly nextIndex: number;
+} {
     const varToken = tokens[varIndex];
     let cursor = varIndex + 1;
     let addressSpace: string | null = null;
@@ -604,12 +619,24 @@ function parseWorkgroupVariable(
     if (cursor + 2 === typeEnd) {
         failSource(source, name.offset, `WGSL variable ${name.value} requires a type`);
     }
+    const typeTokens = Object.freeze(tokens.slice(cursor + 2, typeEnd));
+    const resourceAddressSpace = addressSpace === 'uniform' || addressSpace === 'storage';
+    const group = resourceAddressSpace ? parseLocationAttribute(source, attributes, 'group') : null;
+    const binding = resourceAddressSpace
+        ? parseLocationAttribute(source, attributes, 'binding')
+        : null;
     return {
         variable:
             addressSpace === 'workgroup'
+                ? { name: name.value, typeTokens, offset: name.offset }
+                : null,
+        bufferVariable:
+            resourceAddressSpace && group !== null && binding !== null
                 ? {
                       name: name.value,
-                      typeTokens: Object.freeze(tokens.slice(cursor + 2, typeEnd)),
+                      group,
+                      binding,
+                      typeTokens,
                       offset: name.offset
                   }
                 : null,
@@ -1048,28 +1075,34 @@ function layoutType(
         }
     }
     if (first.value === 'array') {
-        if (arguments_.length !== 2) {
+        if (
+            arguments_.length !== 2 &&
+            !(arguments_.length === 1 && environment.runtimeArrayElementCount !== null)
+        ) {
             failSource(
                 environment.source,
                 first.offset,
-                'WGSL workgroup arrays must have a fixed element count'
+                'WGSL layout array requires a fixed element count'
             );
         }
         const elementTokens = arguments_[0] ?? [];
-        const countTokens = arguments_[1] ?? [];
         const element = layoutType(environment, elementTokens, resolving);
-        const count = evaluateLayoutInteger(
-            environment.source,
-            countTokens,
-            environment.constants,
-            environment.overrides,
-            'WGSL workgroup array element count'
-        );
+        const countTokens = arguments_[1];
+        const count =
+            countTokens === undefined
+                ? (environment.runtimeArrayElementCount ?? 0)
+                : evaluateLayoutInteger(
+                      environment.source,
+                      countTokens,
+                      environment.constants,
+                      environment.overrides,
+                      'WGSL array element count'
+                  );
         if (count < 1) {
             failSource(
                 environment.source,
-                countTokens[0]?.offset ?? first.offset,
-                'WGSL workgroup array element count must be positive'
+                countTokens?.[0]?.offset ?? first.offset,
+                'WGSL array element count must be positive'
             );
         }
         const stride = roundUpLayout(
@@ -1077,7 +1110,7 @@ function layoutType(
             first.offset,
             element.alignment,
             element.size,
-            'WGSL workgroup array stride'
+            'WGSL array stride'
         );
         return {
             alignment: element.alignment,
@@ -1086,7 +1119,7 @@ function layoutType(
                 first.offset,
                 count,
                 stride,
-                'WGSL workgroup array size'
+                'WGSL array size'
             )
         };
     }
@@ -1204,6 +1237,59 @@ function createNagaValidationSource(
     return result;
 }
 
+/**
+ * web-naga 1.0.1 parses modern f16 WGSL but its WGSL writer traps while validating it. Preserve
+ * the exact-source frontend parse, then validate an isomorphic f32 specialization through Naga's
+ * validator/writer. The exact f16 source remains the native artifact and is capability-gated by
+ * the RHI before WebGPU performs its own shader-module and pipeline validation.
+ */
+function createNagaF16ValidationSource(source: string): string {
+    const tokens = tokenize(source);
+    const rewrites: SourceRewrite[] = [];
+    for (let index = 0; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        if (token === undefined) continue;
+        if (
+            token.value === 'enable' &&
+            tokens[index + 1]?.value === 'f16' &&
+            tokens[index + 2]?.value === ';'
+        ) {
+            const end = (tokens[index + 2]?.offset ?? token.offset) + 1;
+            rewrites.push({
+                start: token.offset,
+                end,
+                text: blankSourceRange(source, token.offset, end)
+            });
+            index += 2;
+            continue;
+        }
+        let replacement: string | null = null;
+        if (token.kind === 'identifier') {
+            if (token.value === 'f16') replacement = 'f32';
+            else if (/^vec[234]h$/u.test(token.value)) {
+                replacement = `${token.value.slice(0, -1)}f`;
+            } else if (/^mat[234]x[234]h$/u.test(token.value)) {
+                replacement = `${token.value.slice(0, -1)}f`;
+            }
+        } else if (token.kind === 'number' && token.value.endsWith('h')) {
+            replacement = `${token.value.slice(0, -1)}f`;
+        }
+        if (replacement !== null) {
+            rewrites.push({
+                start: token.offset,
+                end: token.offset + token.value.length,
+                text: replacement
+            });
+        }
+    }
+    rewrites.sort((left, right) => right.start - left.start || right.end - left.end);
+    let result = source;
+    for (const rewrite of rewrites) {
+        result = `${result.slice(0, rewrite.start)}${rewrite.text}${result.slice(rewrite.end)}`;
+    }
+    return result;
+}
+
 function analyzeComputeMetadata(source: string, entryPoint: string): ComputeModuleMetadata {
     const tokens = tokenize(source);
     const requiresF16 = tokens.some(
@@ -1218,6 +1304,7 @@ function analyzeComputeMetadata(source: string, entryPoint: string): ComputeModu
     const constants = new Map<string, readonly SourceToken[]>();
     const overrides = new Map<string, SourceOverrideDeclaration>();
     const workgroupVariables: SourceWorkgroupVariable[] = [];
+    const bufferVariables: SourceBufferVariable[] = [];
     const functions = new Map<string, SourceFunctionUsage>();
     let attributes: SourceAttribute[] = [];
     let braceDepth = 0;
@@ -1266,8 +1353,9 @@ function analyzeComputeMetadata(source: string, entryPoint: string): ComputeModu
             continue;
         }
         if (token.value === 'var') {
-            const parsed = parseWorkgroupVariable(source, tokens, index);
+            const parsed = parseWorkgroupVariable(source, tokens, index, attributes);
             if (parsed.variable !== null) workgroupVariables.push(parsed.variable);
+            if (parsed.bufferVariable !== null) bufferVariables.push(parsed.bufferVariable);
             attributes = [];
             index = parsed.nextIndex;
             continue;
@@ -1303,7 +1391,8 @@ function analyzeComputeMetadata(source: string, entryPoint: string): ComputeModu
         aliases,
         structures,
         constants,
-        overrides
+        overrides,
+        runtimeArrayElementCount: null
     };
     let workgroupStorageSize = 0;
     const staticallyUsed = staticallyUsedWorkgroupVariables(
@@ -1341,11 +1430,24 @@ function analyzeComputeMetadata(source: string, entryPoint: string): ComputeModu
         }
         seenOverrideNames.add(override.name);
     }
+    const bufferMinBindingSizes = new Map<string, number>();
+    const bufferEnvironment: TypeLayoutEnvironment = {
+        ...environment,
+        runtimeArrayElementCount: 1
+    };
+    for (const variable of bufferVariables) {
+        const key = `${String(variable.group)}:${String(variable.binding)}`;
+        if (bufferMinBindingSizes.has(key)) {
+            failSource(source, variable.offset, `WGSL contains duplicate buffer binding ${key}`);
+        }
+        bufferMinBindingSizes.set(key, layoutType(bufferEnvironment, variable.typeTokens).size);
+    }
     return {
         workgroupStorageSize,
         overrides: reflectedOverrides,
         requiresF16,
-        nagaValidationSource: createNagaValidationSource(environment, overrideDeclarations)
+        nagaValidationSource: createNagaValidationSource(environment, overrideDeclarations),
+        bufferMinBindingSizes
     };
 }
 
@@ -1767,13 +1869,42 @@ function reflectionBinding(binding: ComputeShaderBinding): Readonly<RHIShaderBin
     }
 }
 
-function createReflection(
+function deriveBufferBindingSizes(
     shader: ComputeShader,
+    metadata: ComputeModuleMetadata
+): readonly ComputeShaderBinding[] {
+    return Object.freeze(
+        shader.bindings.map(binding => {
+            if (
+                binding.kind !== 'uniform-buffer' &&
+                binding.kind !== 'read-only-storage-buffer' &&
+                binding.kind !== 'storage-buffer'
+            ) {
+                return binding;
+            }
+            const key = `${String(binding.group)}:${String(binding.binding)}`;
+            const exact = metadata.bufferMinBindingSizes.get(key);
+            if (exact === undefined) {
+                throw new TypeError(`ComputeShader buffer binding ${key} has no WGSL store type`);
+            }
+            if (binding.minBindingSize !== undefined && binding.minBindingSize < exact) {
+                throw new RangeError(
+                    `ComputeShader binding ${key} minBindingSize ${String(binding.minBindingSize)} is below the shader-derived minimum ${String(exact)}`
+                );
+            }
+            return Object.freeze({ ...binding, minBindingSize: exact });
+        })
+    );
+}
+
+function createReflection(
+    bindings: readonly ComputeShaderBinding[],
+    workgroupSize: NormalizedComputeWorkgroupSize,
     metadata: ComputeModuleMetadata
 ): Readonly<RHIShaderReflection> {
     return Object.freeze({
-        bindings: Object.freeze(shader.bindings.map(reflectionBinding)),
-        workgroupSize: shader.workgroupSize,
+        bindings: Object.freeze(bindings.map(reflectionBinding)),
+        workgroupSize,
         workgroupStorageSize: metadata.workgroupStorageSize,
         overrides: metadata.overrides,
         requiresF16: metadata.requiresF16
@@ -1817,25 +1948,20 @@ export class WgslComputeShaderCompiler {
         // unsupported override-dependent workgroup footprints before some Naga versions reach an
         // internal assertion instead of returning a source diagnostic.
         const metadata = analyzeComputeMetadata(shader.source, shader.entryPoint);
-        if (metadata.requiresF16) {
-            throw new TypeError(
-                'Direct WGSL f16 is fail-closed because the required Naga WGSL validation path is unavailable'
-            );
-        }
         try {
             useNagaResource(compiler.WgslFrontend.new(), frontend => {
-                if (metadata.nagaValidationSource !== shader.source) {
+                const nagaValidationSource = metadata.requiresF16
+                    ? createNagaF16ValidationSource(metadata.nagaValidationSource)
+                    : metadata.nagaValidationSource;
+                if (nagaValidationSource !== shader.source) {
                     // web-naga 1.0.1 parses override declarations but its WGSL writer reaches an
                     // internal assertion when serializing them. Parse the original first, then run
                     // Naga's validator/backend against a metadata-derived const specialization.
                     // The native artifact remains the original Direct WGSL source.
                     useNagaShaderModule(frontend.parse(shader.source), () => undefined);
-                    useNagaShaderModule(
-                        frontend.parse(metadata.nagaValidationSource),
-                        activeModule => {
-                            void activeModule.to_wgsl();
-                        }
-                    );
+                    useNagaShaderModule(frontend.parse(nagaValidationSource), activeModule => {
+                        void activeModule.to_wgsl();
+                    });
                 } else {
                     const module = frontend.parse(shader.source);
                     useNagaShaderModule(module, activeModule => {
@@ -1853,13 +1979,14 @@ export class WgslComputeShaderCompiler {
         const sourceInterface = analyzeSource(shader.source);
         validateEntryPoint(shader, sourceInterface);
         validateBindings(shader, sourceInterface);
+        const compiledBindings = deriveBufferBindingSizes(shader, metadata);
         const cacheKey = this.allocateCacheKey();
         const compiled = Object.freeze({
             source: shader.source,
             entryPoint: shader.entryPoint,
             workgroupSize: shader.workgroupSize,
-            bindings: shader.bindings,
-            reflection: createReflection(shader, metadata),
+            bindings: compiledBindings,
+            reflection: createReflection(compiledBindings, shader.workgroupSize, metadata),
             cacheKey
         });
         this.#records.set(shader, compiled);

--- a/test/spec/renderer/RenderGraphFrame.test.ts
+++ b/test/spec/renderer/RenderGraphFrame.test.ts
@@ -5,10 +5,12 @@ import { RenderGraphFrame } from '../../../src/render/frame/RenderGraphFrame';
 import { createRenderGraphFrameContext } from '../../../src/render/frame/RenderGraphFrameContext';
 import type { RenderPassTemplate } from '../../../src/render/graph/RenderGraphBuilder';
 import type { RGBufferHandle } from '../../../src/render/graph/RenderGraphResource';
-import { RHIBufferUsage } from '../../../src/render/rhi/core';
+import { RHIBufferUsage, RHITextureUsage } from '../../../src/render/rhi/core';
+import { RendererDiagnostics } from '../../../src/render/RendererDiagnostics';
 import { describe, expect, it, vi } from 'vitest';
 import {
     FakeWebGLRHIBackend,
+    FakeWebGPURHIBackend,
     type FakeRHIBuffer,
     type FakeRHIDevice
 } from '../rhi/portable/FakeRHIBackend';
@@ -51,6 +53,88 @@ describe('RenderGraphFrameContext', () => {
 });
 
 describe('RenderGraphFrame', () => {
+    it('publishes CPU, GPU pass, and resource-lifetime timelines only when opted in', async () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const frame = new RenderGraphFrame();
+        const diagnostics = new RendererDiagnostics();
+        const result = frame.execute(
+            frameContext(device, 9),
+            scope => {
+                const output = scope.graph.createBuffer('timeline output', {
+                    size: 4,
+                    usage: RHIBufferUsage.COPY_DST
+                });
+                const color = scope.graph.createTexture('timeline color', {
+                    size: { width: 1, height: 1 },
+                    format: 'rgba8unorm',
+                    usage: RHITextureUsage.RENDER_ATTACHMENT
+                });
+                const pass: RenderPassTemplate<undefined> = {
+                    name: 'timed render pass',
+                    timestampKind: () => 'render',
+                    setup(builder) {
+                        builder.writeBuffer(output, 'copy-destination');
+                        builder.useColorAttachment({
+                            texture: color,
+                            clearValue: { r: 0, g: 0, b: 0, a: 1 },
+                            loadOp: 'clear',
+                            storeOp: 'store'
+                        });
+                        builder.markSideEffect();
+                    },
+                    execute(context) {
+                        context.commandContext.clearBuffer(context.getBuffer(output));
+                        const encoder = context.commandContext.beginRenderPass({
+                            label: 'timed render pass',
+                            colorAttachments: [
+                                {
+                                    view: context.getTextureView(color),
+                                    clearValue: { r: 0, g: 0, b: 0, a: 1 },
+                                    loadOp: 'clear',
+                                    storeOp: 'store'
+                                }
+                            ],
+                            ...(context.timestampWrites === undefined
+                                ? {}
+                                : { timestampWrites: context.timestampWrites })
+                        });
+                        encoder.end();
+                    }
+                };
+                scope.graph.addPass(pass, undefined);
+            },
+            undefined,
+            diagnostics
+        );
+
+        const pendingTimeline = diagnostics.snapshot().renderGraph;
+        expect(pendingTimeline).toMatchObject({
+            frameIndex: 9,
+            gpuStatus: 'pending',
+            passes: [{ name: 'timed render pass', kind: 'render', gpuDurationMs: null }]
+        });
+        expect(pendingTimeline?.resources).toContainEqual({
+            name: 'timeline output',
+            kind: 'buffer',
+            origin: 'transient',
+            firstUse: 0,
+            lastUse: 0
+        });
+        backend.completeNextSubmission();
+        await result.submission.done;
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(diagnostics.snapshot().renderGraph).toMatchObject({
+            frameIndex: 9,
+            gpuStatus: 'ready',
+            passes: [{ name: 'timed render pass', gpuDurationMs: 0 }]
+        });
+
+        frame.destroy();
+        backend.destroy();
+    });
+
     it('builds, compiles, executes, and returns extracted resources in one frame', async () => {
         const backend = new FakeWebGLRHIBackend();
         const device = backend.createDevice();

--- a/test/spec/renderer/RenderPipelineCapabilities.test.ts
+++ b/test/spec/renderer/RenderPipelineCapabilities.test.ts
@@ -77,6 +77,11 @@ describe('RenderPipelineCapabilities', () => {
         expect(released.supportsCapability('storage-texture')).toBe(true);
         expect(released.supportsCapability('compute-pass')).toBe(true);
         expect(released.supportsCapability('indirect-draw')).toBe(true);
+        expect(released.supportsFeature('shader-f16')).toBe(true);
+        expect(released.supportsFeature('subgroups')).toBe(true);
+        expect(released.supportsFeature('timestamp-query')).toBe(true);
+        expect(released.limits.subgroupMinSize).toBe(4);
+        expect(released.limits.subgroupMaxSize).toBe(32);
 
         const withoutCompute = new Set(source.features);
         withoutCompute.delete('compute-pipelines');
@@ -94,6 +99,7 @@ describe('RenderPipelineCapabilities', () => {
         expect(fallback.supportsCapability('storage-buffer')).toBe(false);
         expect(fallback.supportsCapability('compute-pass')).toBe(false);
         expect(fallback.supportsCapability('indirect-draw')).toBe(false);
+        expect(fallback.supportsFeature('subgroups')).toBe(false);
 
         webgpu.destroy();
         webgl2.destroy();

--- a/test/spec/renderer/ScriptableComputeDispatch.test.ts
+++ b/test/spec/renderer/ScriptableComputeDispatch.test.ts
@@ -171,6 +171,7 @@ function prepareContexts(buffers: ReadonlyMap<RGBufferHandle, RHIBuffer>): Reado
         prepare: { getBuffer, getTexture: noTexture, getTextureView: noTextureView },
         execute: commandContext => ({
             commandContext,
+            timestampWrites: undefined,
             getBuffer,
             getTexture: noTexture,
             getTextureView: noTextureView

--- a/test/spec/renderer/WgslComputeCompiler.test.ts
+++ b/test/spec/renderer/WgslComputeCompiler.test.ts
@@ -106,28 +106,34 @@ describe('WgslComputeShaderCompiler', () => {
         expect(compiled).toMatchObject({
             source,
             entryPoint: 'compact',
-            workgroupSize: [8, 4, 1],
-            bindings: shader.bindings
+            workgroupSize: [8, 4, 1]
         });
+        expect(compiled.bindings.slice(0, 3)).toMatchObject([
+            { minBindingSize: 4 },
+            { minBindingSize: 4 },
+            { minBindingSize: 4 }
+        ]);
         expect(compiled.reflection.bindings).toEqual([
             {
                 name: 'params',
                 group: 0,
                 binding: 0,
                 kind: 'uniform-buffer',
-                minBindingSize: 16
+                minBindingSize: 4
             },
             {
                 name: 'inputData',
                 group: 0,
                 binding: 1,
-                kind: 'read-only-storage-buffer'
+                kind: 'read-only-storage-buffer',
+                minBindingSize: 4
             },
             {
                 name: 'outputData',
                 group: 0,
                 binding: 2,
-                kind: 'storage-buffer'
+                kind: 'storage-buffer',
+                minBindingSize: 4
             },
             {
                 name: 'sourceTexture',
@@ -275,22 +281,74 @@ override OPTIONAL_SCALE: f32 = 1.0;
         expect(reflection.requiresF16).toBe(false);
     });
 
-    it('fails closed for f16 until the required Naga WGSL validation path is available', () => {
-        expect(() =>
-            compiler.compile(
-                createShader({
-                    source: `
+    it('validates f16 metadata through Naga and preserves the exact native WGSL artifact', () => {
+        const f16Source = `
 enable f16;
 override HALF_SCALE: f16 = 1.0h;
 var<workgroup> values: array<vec3<f16>, 2>;
 @compute @workgroup_size(1) fn metadata() {}
-`,
-                    entryPoint: 'metadata',
+`;
+        const compiled = compiler.compile(
+            createShader({
+                source: f16Source,
+                entryPoint: 'metadata',
+                workgroupSize: [1],
+                bindings: []
+            })
+        );
+
+        expect(compiled.source).toBe(f16Source);
+        expect(compiled.reflection.requiresF16).toBe(true);
+        expect(compiled.reflection.overrides).toEqual([
+            { name: 'HALF_SCALE', type: 'f16', required: false }
+        ]);
+    });
+
+    it('derives exact minimum buffer binding sizes from WGSL store types', () => {
+        const exactSource = `
+struct Values {
+    header: vec3<f32>,
+    items: array<vec2<f32>, 2>,
+}
+@group(0) @binding(0) var<storage, read> values: Values;
+@compute @workgroup_size(1) fn main() { _ = values.header; }
+`;
+        const exact = compiler.compile(
+            createShader({
+                source: exactSource,
+                entryPoint: 'main',
+                workgroupSize: [1],
+                bindings: [
+                    {
+                        name: 'values',
+                        group: 0,
+                        binding: 0,
+                        kind: 'read-only-storage-buffer'
+                    }
+                ]
+            })
+        );
+        expect(exact.bindings[0]).toMatchObject({ minBindingSize: 32 });
+        expect(exact.reflection.bindings[0]).toMatchObject({ minBindingSize: 32 });
+
+        expect(() =>
+            compiler.compile(
+                createShader({
+                    source: exactSource,
+                    entryPoint: 'main',
                     workgroupSize: [1],
-                    bindings: []
+                    bindings: [
+                        {
+                            name: 'values',
+                            group: 0,
+                            binding: 0,
+                            kind: 'read-only-storage-buffer',
+                            minBindingSize: 16
+                        }
+                    ]
                 })
             )
-        ).toThrow(/Direct WGSL f16 is fail-closed/u);
+        ).toThrow(/below the shader-derived minimum 32/u);
     });
 
     it('fails closed when overrides or non-literal expressions determine compute metadata', () => {

--- a/test/spec/rhi/portable/FakeRHIBackend.ts
+++ b/test/spec/rhi/portable/FakeRHIBackend.ts
@@ -39,6 +39,12 @@ import {
     validateRHICommandCopyExternalImageToTexture,
     validateRHICommandGenerateMipmaps
 } from '../../../../src/render/rhi/core/RHICopyValidation';
+import {
+    normalizeRHIQuerySetDescriptor,
+    validateRHIDebugLabel,
+    validateRHIResolveQuerySet,
+    validateRHITimestampWrites
+} from '../../../../src/render/rhi/core/RHIQueryValidation';
 import type {
     RHIBindGroup,
     RHIBindGroupDescriptor,
@@ -71,12 +77,15 @@ import type {
     RHIDeviceOwnedObject,
     RHIDeviceOwnedDestroyable,
     RHINormalizedBufferDescriptor,
+    RHINormalizedQuerySetDescriptor,
     RHINormalizedSamplerDescriptor,
     RHINormalizedShaderDescriptor,
     RHINormalizedTextureDescriptor,
     RHINormalizedTextureViewDescriptor,
     RHIResource,
     RHIResourceLifetime,
+    RHIQuerySet,
+    RHIQuerySetDescriptor,
     RHISampler,
     RHISamplerDescriptor,
     RHIShader,
@@ -431,6 +440,23 @@ export class FakeRHITextureView extends FakeDestroyableObject implements RHIText
     }
 }
 
+export class FakeRHIQuerySet
+    extends FakeResource<RHINormalizedQuerySetDescriptor>
+    implements RHIQuerySet
+{
+    readonly descriptor: Readonly<RHINormalizedQuerySetDescriptor>;
+    readonly type;
+    readonly count;
+
+    constructor(owner: FakeRHIDevice, source: RHIQuerySetDescriptor) {
+        const descriptor = normalizeRHIQuerySetDescriptor(source, owner.capabilities);
+        super(owner, descriptor.label, descriptor.lifetime);
+        this.descriptor = descriptor;
+        this.type = descriptor.type;
+        this.count = descriptor.count;
+    }
+}
+
 export class FakeRHISampler
     extends FakeResource<RHINormalizedSamplerDescriptor>
     implements RHISampler
@@ -590,7 +616,9 @@ class FakeRHICapabilities implements RHICapabilities {
                       'storage-buffers' as const,
                       'storage-textures' as const,
                       'compute-pipelines' as const,
-                      'shader-f16' as const
+                      'shader-f16' as const,
+                      'timestamp-query' as const,
+                      'subgroups' as const
                   ]
                 : [])
         ]);
@@ -624,7 +652,9 @@ class FakeRHICapabilities implements RHICapabilities {
                       maxComputeWorkgroupSizeX: 256,
                       maxComputeWorkgroupSizeY: 256,
                       maxComputeWorkgroupSizeZ: 64,
-                      maxComputeWorkgroupsPerDimension: 65_535
+                      maxComputeWorkgroupsPerDimension: 65_535,
+                      subgroupMinSize: 4,
+                      subgroupMaxSize: 32
                   }
                 : {})
         });
@@ -752,6 +782,11 @@ export class FakeRHIDevice implements RHIDevice {
     createBuffer(descriptor: RHIBufferDescriptor): FakeRHIBuffer {
         this.assertAlive();
         return new FakeRHIBuffer(this, descriptor);
+    }
+
+    createQuerySet(descriptor: RHIQuerySetDescriptor): FakeRHIQuerySet {
+        this.assertAlive();
+        return new FakeRHIQuerySet(this, descriptor);
     }
 
     createTexture(descriptor: RHITextureDescriptor): FakeRHITexture {
@@ -984,6 +1019,7 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
     private readonly deferredCommands: FakeRHICommand[] = [];
     private readonly retainedObjects = new Set<RHIDeviceOwnedObject>();
     private externalImageUploadPhase = true;
+    private debugGroupDepth = 0;
 
     constructor(
         readonly queue: FakeRHIQueue,
@@ -1078,6 +1114,11 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
 
     beginRenderPass(descriptor: RHIRenderPassDescriptor): RHIRenderPassEncoder {
         this.assertOpen();
+        validateRHITimestampWrites(
+            this.owner,
+            descriptor.timestampWrites,
+            'renderPass.timestampWrites'
+        );
         const normalizedDescriptor = snapshotRHIRenderPassDescriptor(this.owner, descriptor);
         const attachments: RHIDeviceOwnedObject[] = [];
         for (const attachment of normalizedDescriptor.colorAttachments) {
@@ -1092,6 +1133,9 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
                 normalizedDescriptor.depthStencilAttachment.view,
                 normalizedDescriptor.depthStencilAttachment.view.texture
             );
+        }
+        if (descriptor.timestampWrites !== undefined) {
+            attachments.push(descriptor.timestampWrites.querySet);
         }
         this.closeExternalImageUploadPhase();
         this.retainAll(attachments);
@@ -1110,6 +1154,14 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
                 'compute passes are unsupported',
                 'computePass'
             );
+        }
+        validateRHITimestampWrites(
+            this.owner,
+            descriptor.timestampWrites,
+            'computePass.timestampWrites'
+        );
+        if (descriptor.timestampWrites !== undefined) {
+            this.retainAll([descriptor.timestampWrites.querySet]);
         }
         this.closeExternalImageUploadPhase();
         this.contextState = 'compute-pass';
@@ -1210,6 +1262,53 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
         this.issue(`copy-texture:${String(source.texture.id)}:${String(destination.texture.id)}`);
     }
 
+    resolveQuerySet(
+        querySet: RHIQuerySet,
+        firstQuery: number,
+        queryCount: number,
+        destination: RHIBuffer,
+        destinationOffset = 0
+    ): void {
+        this.assertOpen();
+        validateRHIResolveQuerySet(
+            this.owner,
+            querySet,
+            firstQuery,
+            queryCount,
+            destination,
+            destinationOffset
+        );
+        this.retainAll([querySet, destination]);
+        this.closeExternalImageUploadPhase();
+        this.issue(
+            `resolve-query-set:${String(querySet.id)}:${String(firstQuery)}:${String(queryCount)}`,
+            () => {
+                if (destination instanceof FakeRHIBuffer) {
+                    destination.writeBytes(destinationOffset, new Uint8Array(queryCount * 8));
+                }
+            }
+        );
+    }
+
+    pushDebugGroup(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'context.debugGroup');
+        this.debugGroupDepth += 1;
+    }
+
+    popDebugGroup(): void {
+        this.assertOpen();
+        if (this.debugGroupDepth === 0) {
+            validationFailure('invalid-state', 'context debug group stack is empty', 'context');
+        }
+        this.debugGroupDepth -= 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'context.debugMarker');
+    }
+
     issue(label: string, apply?: () => void): void {
         this.diagnostics.commandCount++;
         if (this.owner.fakeBackend.executionMode === 'immediate') {
@@ -1258,6 +1357,9 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
         readonly references: readonly RHIDeviceOwnedObject[];
     } {
         this.assertOpen();
+        if (this.debugGroupDepth !== 0) {
+            validationFailure('invalid-state', 'context has unclosed debug groups', 'context');
+        }
         this.contextState = 'ended';
         return {
             commands: this.deferredCommands,
@@ -1275,6 +1377,7 @@ export class FakeRHICommandContext extends FakeDeviceObject implements RHIComman
         }
         this.activePass?.abort();
         this.activePass = null;
+        this.debugGroupDepth = 0;
         this.contextState = 'aborted';
         this.deferredCommands.length = 0;
         return [...this.retainedObjects];
@@ -1304,6 +1407,7 @@ class FakeRHIRenderPass extends FakeDeviceObject implements RHIRenderPassEncoder
     private readonly bindGroups = new Map<number, RHIBindGroup>();
     private readonly vertexBuffers = new Set<number>();
     private hasIndexBuffer = false;
+    private debugGroupDepth = 0;
 
     constructor(
         readonly context: FakeRHICommandContext,
@@ -1642,15 +1746,48 @@ class FakeRHIRenderPass extends FakeDeviceObject implements RHIRenderPassEncoder
         this.context.issue(`draw-indexed-indirect:${String(buffer.id)}:${String(offset)}`);
     }
 
+    pushDebugGroup(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'renderPass.debugGroup');
+        this.debugGroupDepth += 1;
+    }
+
+    popDebugGroup(): void {
+        this.assertOpen();
+        if (this.debugGroupDepth === 0) {
+            validationFailure(
+                'invalid-state',
+                'render pass debug group stack is empty',
+                'renderPass'
+            );
+        }
+        this.debugGroupDepth -= 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'renderPass.debugMarker');
+    }
+
     end(): void {
         this.assertOpen();
+        if (this.debugGroupDepth !== 0) {
+            validationFailure(
+                'invalid-state',
+                'render pass has unclosed debug groups',
+                'renderPass'
+            );
+        }
         this.context.issue('render-pass:end');
         this.passState = 'ended';
         this.context.closePass(this);
     }
 
     abort(): void {
-        if (this.passState === 'open') this.passState = 'aborted';
+        if (this.passState === 'open') {
+            this.passState = 'aborted';
+            this.debugGroupDepth = 0;
+        }
     }
 
     private assertOpen(): void {
@@ -1850,6 +1987,7 @@ class FakeRHIComputePass extends FakeDeviceObject implements RHIComputePassEncod
     private passState: RHIComputePassState = 'open';
     private pipeline: RHIComputePipeline | null = null;
     private readonly bindGroups = new Map<number, RHIBindGroup>();
+    private debugGroupDepth = 0;
 
     constructor(
         readonly context: FakeRHICommandContext,
@@ -1918,8 +2056,38 @@ class FakeRHIComputePass extends FakeDeviceObject implements RHIComputePassEncod
         this.context.issue(`dispatch-indirect:${String(buffer.id)}:${String(offset)}`);
     }
 
+    pushDebugGroup(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'computePass.debugGroup');
+        this.debugGroupDepth += 1;
+    }
+
+    popDebugGroup(): void {
+        this.assertOpen();
+        if (this.debugGroupDepth === 0) {
+            validationFailure(
+                'invalid-state',
+                'compute pass debug group stack is empty',
+                'computePass'
+            );
+        }
+        this.debugGroupDepth -= 1;
+    }
+
+    insertDebugMarker(label: string): void {
+        this.assertOpen();
+        validateRHIDebugLabel(label, 'computePass.debugMarker');
+    }
+
     end(): void {
         this.assertOpen();
+        if (this.debugGroupDepth !== 0) {
+            validationFailure(
+                'invalid-state',
+                'compute pass has unclosed debug groups',
+                'computePass'
+            );
+        }
         this.context.issue('compute-pass:end');
         this.passState = 'ended';
         this.pipeline = null;
@@ -1930,6 +2098,7 @@ class FakeRHIComputePass extends FakeDeviceObject implements RHIComputePassEncod
         if (this.passState === 'open') {
             this.passState = 'aborted';
             this.pipeline = null;
+            this.debugGroupDepth = 0;
         }
     }
 

--- a/test/spec/rhi/portable/RHIQueryContract.test.ts
+++ b/test/spec/rhi/portable/RHIQueryContract.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { RHIBufferUsage, RHITextureUsage } from '../../../../src/render/rhi/core';
+import { FakeWebGLRHIBackend, FakeWebGPURHIBackend } from './FakeRHIBackend';
+
+describe('portable RHI query and debug contract', () => {
+    it('resolves timestamp queries and retains their native lifetime through submission', async () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const querySet = device.createQuerySet({
+            label: 'timestamps',
+            type: 'timestamp',
+            count: 2
+        });
+        const resolve = device.createBuffer({
+            size: 256,
+            usage: RHIBufferUsage.QUERY_RESOLVE | RHIBufferUsage.COPY_SRC
+        });
+        const color = device.createTexture({
+            size: { width: 1, height: 1 },
+            format: 'rgba8unorm',
+            usage: RHITextureUsage.RENDER_ATTACHMENT
+        });
+        const colorView = color.createView();
+        const context = device.graphicsQueue.beginFrame();
+        context.pushDebugGroup('frame');
+        context.insertDebugMarker('before pass');
+        const pass = context.beginRenderPass({
+            label: 'timed pass',
+            colorAttachments: [
+                {
+                    view: colorView,
+                    clearValue: { r: 0, g: 0, b: 0, a: 1 },
+                    loadOp: 'clear',
+                    storeOp: 'store'
+                }
+            ],
+            timestampWrites: {
+                querySet,
+                beginningOfPassWriteIndex: 0,
+                endOfPassWriteIndex: 1
+            }
+        });
+        pass.pushDebugGroup('draws');
+        pass.insertDebugMarker('empty pass');
+        pass.popDebugGroup();
+        pass.end();
+        context.resolveQuerySet(querySet, 0, 2, resolve);
+        context.popDebugGroup();
+        const submission = device.graphicsQueue.endFrame(context);
+
+        querySet.destroy();
+        expect(querySet.nativeReleased).toBe(false);
+        backend.completeNextSubmission();
+        await submission.done;
+        expect(querySet.nativeReleased).toBe(true);
+
+        resolve.destroy();
+        colorView.destroy();
+        color.destroy();
+        backend.destroy();
+    });
+
+    it('rejects invalid query ranges, resolve buffers, and unbalanced debug groups', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const device = backend.createDevice();
+        const querySet = device.createQuerySet({ type: 'timestamp', count: 2 });
+        const invalidResolve = device.createBuffer({
+            size: 16,
+            usage: RHIBufferUsage.COPY_DST
+        });
+        const context = device.graphicsQueue.beginFrame();
+
+        expect(() =>
+            context.beginRenderPass({
+                colorAttachments: [],
+                timestampWrites: {
+                    querySet,
+                    beginningOfPassWriteIndex: 2
+                }
+            })
+        ).toThrow(/query index exceeds/u);
+        expect(() => {
+            context.resolveQuerySet(querySet, 0, 2, invalidResolve);
+        }).toThrow(/QUERY_RESOLVE/u);
+        expect(() => {
+            context.popDebugGroup();
+        }).toThrow(/stack is empty/u);
+        context.pushDebugGroup('unclosed');
+        expect(() => device.graphicsQueue.endFrame(context)).toThrow(/unclosed debug groups/u);
+        device.graphicsQueue.abortFrame(context);
+
+        querySet.destroy();
+        invalidResolve.destroy();
+        backend.destroy();
+    });
+
+    it('fails before native work on the WebGL2 backend', () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+
+        expect(() => device.createQuerySet({ type: 'timestamp', count: 2 })).toThrow(
+            /timestamp-query feature/u
+        );
+        backend.destroy();
+    });
+});

--- a/test/spec/rhi/portable/WebGPUBackend.native.test.ts
+++ b/test/spec/rhi/portable/WebGPUBackend.native.test.ts
@@ -3,9 +3,100 @@ import { ShaderArtifactCompiler } from '../../../../src/render/renderer/ShaderAr
 import { prepareWebGPUMipmapShaderArtifacts } from '../../../../src/render/renderer/WebGPUMipmapShader';
 import { expect, it } from 'vitest';
 import { createWebGPUDevice } from '../../../../src/render/rhi/backends/webgpu';
+import ComputeShader from '../../../../src/render/compute/ComputeShader';
+import { WgslComputeShaderCompiler } from '../../../../src/render/shader/WgslComputeCompiler';
 import { expectRHIPhase2Conformance, runRHIPhase2Conformance } from './RHIPhase2Conformance';
 
 const nativeWebGPUAvailable = typeof navigator !== 'undefined' && 'gpu' in navigator;
+
+it.skipIf(!nativeWebGPUAvailable)(
+    'validates and executes a Direct WGSL f16 compute pipeline on capable native WebGPU',
+    async testContext => {
+        const adapter = await navigator.gpu.requestAdapter();
+        if (!adapter?.features.has('shader-f16')) {
+            testContext.skip();
+            return;
+        }
+        const compiler = new WgslComputeShaderCompiler();
+        await compiler.initialize();
+        const compiled = compiler.compile(
+            new ComputeShader({
+                source: `
+enable f16;
+struct Output { value: f16, }
+@group(0) @binding(0) var<storage, read_write> output: Output;
+@compute @workgroup_size(1) fn main() { output.value = 1.5h; }
+`,
+                workgroupSize: [1],
+                bindings: [
+                    {
+                        name: 'output',
+                        group: 0,
+                        binding: 0,
+                        kind: 'storage-buffer',
+                        access: 'write-discard'
+                    }
+                ]
+            })
+        );
+        const device = await createWebGPUDevice({ adapter, requiredFeatures: ['shader-f16'] });
+        const output = device.createBuffer({
+            size: 4,
+            usage: RHIBufferUsage.STORAGE | RHIBufferUsage.COPY_SRC
+        });
+        const readback = device.createBuffer({
+            size: 4,
+            usage: RHIBufferUsage.COPY_DST | RHIBufferUsage.MAP_READ
+        });
+        try {
+            const shader = device.createShader({
+                artifact: {
+                    backend: 'webgpu',
+                    stage: 'compute',
+                    code: compiled.source,
+                    entryPoint: compiled.entryPoint,
+                    reflection: compiled.reflection,
+                    cacheKey: compiled.cacheKey
+                }
+            });
+            const bindGroupLayout = device.createBindGroupLayout({
+                entries: [
+                    {
+                        binding: 0,
+                        visibility: RHIShaderStage.COMPUTE,
+                        buffer: { type: 'storage', minBindingSize: 2 }
+                    }
+                ]
+            });
+            const layout = device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] });
+            const pipeline = device.createComputePipeline({ layout, compute: { shader } });
+            const bindGroup = device.createBindGroup({
+                layout: bindGroupLayout,
+                entries: [{ binding: 0, resource: { buffer: output } }]
+            });
+            const frame = device.graphicsQueue.beginFrame();
+            const pass = frame.beginComputePass();
+            pass.setPipeline(pipeline);
+            pass.setBindGroup(0, bindGroup);
+            pass.dispatchWorkgroups(1);
+            pass.end();
+            frame.copyBufferToBuffer(output, 0, readback, 0, 4);
+            await device.graphicsQueue.endFrame(frame).done;
+            await readback.mapAsync('read');
+            expect(new Uint16Array(readback.getMappedRange())[0]).toBe(0x3e00);
+            readback.unmap();
+            bindGroup.destroy();
+            pipeline.destroy();
+            layout.destroy();
+            bindGroupLayout.destroy();
+            shader.destroy();
+        } finally {
+            output.destroy();
+            readback.destroy();
+            device.destroy();
+        }
+    }
+);
 
 it.skipIf(!nativeWebGPUAvailable)(
     'executes the shared offscreen Phase 2 scene matrix on native WebGPU',

--- a/test/spec/rhi/portable/WebGPUBackend.test.ts
+++ b/test/spec/rhi/portable/WebGPUBackend.test.ts
@@ -255,6 +255,9 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
                 log.push('pass.drawIndexed');
                 renderPassCalls.push({ name: 'drawIndexed', args });
             },
+            pushDebugGroup: (label: string) => log.push(`pass.pushDebugGroup:${label}`),
+            popDebugGroup: () => log.push('pass.popDebugGroup'),
+            insertDebugMarker: (label: string) => log.push(`pass.insertDebugMarker:${label}`),
             end: () => log.push('pass.end')
         } as unknown as GPURenderPassEncoder;
     }
@@ -286,6 +289,19 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
             },
             copyTextureToBuffer: () => log.push('encoder.copyTextureToBuffer'),
             copyTextureToTexture: () => log.push('encoder.copyTextureToTexture'),
+            resolveQuerySet: (
+                _querySet: GPUQuerySet,
+                firstQuery: number,
+                queryCount: number,
+                destination: GPUBuffer,
+                offset: number
+            ) =>
+                log.push(
+                    `encoder.resolveQuerySet:${String(firstQuery)}:${String(queryCount)}:${destination.label}:${String(offset)}`
+                ),
+            pushDebugGroup: (label: string) => log.push(`encoder.pushDebugGroup:${label}`),
+            popDebugGroup: () => log.push('encoder.popDebugGroup'),
+            insertDebugMarker: (label: string) => log.push(`encoder.insertDebugMarker:${label}`),
             finish: () => {
                 log.push('encoder.finish');
                 const failure = nextEncoderFinishFailure;
@@ -399,7 +415,11 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
 
     const device = {
         label: 'structured native device',
-        features: new Set<string>(['core-features-and-limits']) as unknown as GPUSupportedFeatures,
+        features: new Set<string>([
+            'core-features-and-limits',
+            'timestamp-query',
+            'subgroups'
+        ]) as unknown as GPUSupportedFeatures,
         limits,
         queue: nativeQueue,
         lost: lost.promise,
@@ -413,6 +433,12 @@ function createNativeHarness(options: NativeHarnessOptions = {}): NativeHarness 
             log.push('createShaderModule');
             return { label: 'native shader' } as GPUShaderModule;
         },
+        createQuerySet: (descriptor: GPUQuerySetDescriptor) => ({
+            label: descriptor.label ?? '',
+            type: descriptor.type,
+            count: descriptor.count,
+            destroy: () => log.push(`querySet.destroy:${descriptor.label ?? ''}`)
+        }),
         createBindGroupLayout: () => {
             log.push('createBindGroupLayout');
             return { label: 'native bind group layout' };
@@ -542,6 +568,84 @@ function createTriangleResources(device: WebGPUDevice) {
 }
 
 describe('WebGPU RHI native backend', () => {
+    it('maps subgroup features and adapter subgroup-size limits into portable capabilities', () => {
+        const harness = createNativeHarness();
+        const device = new WebGPUDevice(harness.device, null, null, {
+            subgroupMinSize: 4,
+            subgroupMaxSize: 32
+        });
+
+        expect(device.capabilities.features.has('subgroups')).toBe(true);
+        expect(device.capabilities.limits.subgroupMinSize).toBe(4);
+        expect(device.capabilities.limits.subgroupMaxSize).toBe(32);
+        device.destroy();
+    });
+
+    it('forwards timestamp queries, resolves, and debug annotations to native WebGPU', async () => {
+        const harness = createNativeHarness();
+        const device = new WebGPUDevice(harness.device);
+        const querySet = device.createQuerySet({
+            label: 'native timestamps',
+            type: 'timestamp',
+            count: 2
+        });
+        const resolve = device.createBuffer({
+            label: 'native query resolve',
+            size: 256,
+            usage: RHIBufferUsage.QUERY_RESOLVE | RHIBufferUsage.COPY_SRC
+        });
+        const color = device.createTexture({
+            size: { width: 1, height: 1 },
+            format: 'rgba8unorm',
+            usage: RHITextureUsage.RENDER_ATTACHMENT
+        });
+        const view = color.createView();
+        const context = device.graphicsQueue.beginFrame();
+        context.pushDebugGroup('graph');
+        context.insertDebugMarker('timed pass');
+        const pass = context.beginRenderPass({
+            colorAttachments: [
+                {
+                    view,
+                    clearValue: { r: 0, g: 0, b: 0, a: 1 },
+                    loadOp: 'clear',
+                    storeOp: 'store'
+                }
+            ],
+            timestampWrites: {
+                querySet,
+                beginningOfPassWriteIndex: 0,
+                endOfPassWriteIndex: 1
+            }
+        });
+        pass.pushDebugGroup('draws');
+        pass.insertDebugMarker('empty');
+        pass.popDebugGroup();
+        pass.end();
+        context.resolveQuerySet(querySet, 0, 2, resolve);
+        context.popDebugGroup();
+        const submission = device.graphicsQueue.endFrame(context);
+
+        expect(harness.renderPassDescriptors[0]?.timestampWrites).toMatchObject({
+            beginningOfPassWriteIndex: 0,
+            endOfPassWriteIndex: 1
+        });
+        expect(harness.log).toContain('encoder.pushDebugGroup:graph');
+        expect(harness.log).toContain('pass.insertDebugMarker:empty');
+        expect(harness.log).toContain('encoder.resolveQuerySet:0:2:native query resolve:0');
+        querySet.destroy();
+        expect(harness.log).not.toContain('querySet.destroy:native timestamps');
+        harness.resolveWork();
+        await submission.done;
+        await flushMicrotasks();
+        expect(harness.log).toContain('querySet.destroy:native timestamps');
+
+        resolve.destroy();
+        view.destroy();
+        color.destroy();
+        device.destroy();
+    });
+
     it('reuses a persistent default native texture view without sharing logical lifetime', () => {
         const harness = createNativeHarness();
         const diagnostics = new RendererDiagnostics();


### PR DESCRIPTION
## Summary

- expose WebGPU `subgroups`, `shader-f16`, and `timestamp-query` capabilities, subgroup size limits, and public `supportsFeature()` queries
- add portable RHI QuerySets, pass timestamp writes, explicit resolves, and validated debug groups/markers
- publish opt-in Render Graph CPU phases, asynchronous per-pass GPU timing, and resource lifetime snapshots through renderer diagnostics
- derive exact WGSL buffer `minBindingSize` values and complete the Direct WGSL f16 validation/native pipeline path
- update the rendering architecture, modernization guidance, roadmap, changelog, and API report to mark F1 complete

## Why

This completes the F1 modern WebGPU capability and GPU timeline work package after the F0 graph subresource/history foundation. It gives pipelines explicit feature gates and non-blocking profiling data without adding query resources or per-draw work when diagnostics are disabled.

## WebGL2 policy

WebGL2 remains an explicit negative implementation for WebGPU-only capabilities:

- `supportsFeature()` reports `false` for subgroups, shader-f16, and timestamp queries
- required WebGPU-only features reject WebGL2 selection instead of silently degrading
- QuerySet creation, timestamp writes, and resolves fail before native GL work
- diagnostics still publish CPU phases and resource lifetimes, while GPU timing is `unavailable`
- debug marker/group calls retain portable validation and balanced nesting but are native no-ops

## Validation

- `npm run api:check`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run docs:check`
- `npm run test:types`
- `npm run test:package`
- targeted affected tests: 86 passed; final contract rerun: 23 passed
- `npm run test:render:architecture`: 134 passed
- `npm run test:rhi`: 213 portable tests passed; native suite 3 passed, 1 environment skip
- `npm run test:webgpu`: 15 passed
- `npm run test:ui:webgpu`: 12 contract + 89 browser tests passed
- `npm run test:ui:webgl2`: 12 contract + 83 browser tests passed

## Evidence limitation

The physical-GPU f16 test is present but skipped in the local native Vitest environment. The current `web-naga` version parses the exact f16 source but its WGSL writer cannot serialize it, so validation uses a token-safe f32 specialization while preserving the exact f16 artifact for native WebGPU shader-module and pipeline validation.