### PR TITLE
feat(render): complete D0 depth history and refresh homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Unreleased
 
+### Breaking changes
+
+- Expand the fixed Camera/Model/Skinning/Morph/Instance std140 ABI with current/previous transforms,
+  render origins, and history/depth flags. Custom shaders that redeclare built-in blocks must use
+  the updated field order and capacities.
+
 ### Changes
+
+- Add the `high-end` rendering profile, per-camera standard/reversed depth modes, finite/infinite
+  reversed-Z projection, depth-convention-aware surfaces, render targets, shadows, storage graphics,
+  and GPU picking. Add optional camera-relative GPU transforms while preserving CPU world identity,
+  plus submission-transactional current/previous camera, mesh, instance, skinning, and morph state.
+  `Node.invalidateTransformHistory()` resets discontinuous motion deterministically.
 
 - Add modern WebGPU capability discovery for `subgroups`, adapter subgroup-size limits,
   `shader-f16`, and `timestamp-query`; expose renderer feature queries for explicit f32/workgroup

--- a/documentation/ENGINEERING_MODERNIZATION.md
+++ b/documentation/ENGINEERING_MODERNIZATION.md
@@ -329,18 +329,18 @@ WebGPU-only storage-aware raster 仍不接受 graphics WGSL。`StorageGraphicsSh
 所有内置数值 shader 数据按所有权和更新频率进入固定 std140 block。WebGL 2 使用稳定的 flat
 binding；WebGPU 将同一逻辑 ABI 分到四个 bind group，避免高频对象数据导致全局或材质资源重新绑定：
 
-| Block           | 数据所有者与典型内容                                           | 更新时机                      | WebGL 2 | WebGPU |
-| --------------- | -------------------------------------------------------------- | ----------------------------- | ------: | -----: |
-| `FrameBlock`    | render size、时间与帧序号                                      | 每个 renderer frame 一次      |       0 |    0/0 |
-| `CameraBlock`   | view/projection、逆矩阵、相机位置、裁剪平面与物理像素 viewport | 每个 camera/render pass 一次  |       1 |    0/1 |
-| `SceneBlock`    | fog 等 scene-owned 状态                                        | scene revision 变化时         |       2 |    0/2 |
-| `LightBlock`    | view-space 灯光、衰减、阴影 atlas 参数                         | 每个 camera/render pass 一次  |       3 |    0/3 |
-| `MaterialBlock` | Basic/PBR、IBL、UV 变换与材质标志                              | 最终 std140 字段变化时        |       4 |    1/0 |
-| `ModelBlock`    | model 与 world-normal 变换                                     | 非实例对象 transform 变化时   |       5 |    2/0 |
-| `GeometryBlock` | position/normal/UV decode 变换                                 | geometry revision 变化时      |       6 |    2/1 |
-| `SkinningBlock` | joint palette                                                  | skeleton pose 变化时          |       7 |    2/2 |
-| `MorphBlock`    | morph weights 与 target 状态                                   | morph pose 变化时             |       8 |    2/3 |
-| `InstanceBlock` | 每批 model/normal matrix array                                 | WebGPU instanced batch 变化时 |       — |    2/4 |
+| Block           | 数据所有者与典型内容                                                                           | 更新时机                      | WebGL 2 | WebGPU |
+| --------------- | ---------------------------------------------------------------------------------------------- | ----------------------------- | ------: | -----: |
+| `FrameBlock`    | render size、时间与帧序号                                                                      | 每个 renderer frame 一次      |       0 |    0/0 |
+| `CameraBlock`   | current/previous view/projection、逆矩阵、render origin、history/depth 标志、物理像素 viewport | 每个 camera/render pass 一次  |       1 |    0/1 |
+| `SceneBlock`    | fog 等 scene-owned 状态                                                                        | scene revision 变化时         |       2 |    0/2 |
+| `LightBlock`    | view-space 灯光、衰减、阴影 atlas 参数                                                         | 每个 camera/render pass 一次  |       3 |    0/3 |
+| `MaterialBlock` | Basic/PBR、IBL、UV 变换与材质标志                                                              | 最终 std140 字段变化时        |       4 |    1/0 |
+| `ModelBlock`    | current/previous model 与 world-normal 变换                                                    | 非实例对象 transform 变化时   |       5 |    2/0 |
+| `GeometryBlock` | position/normal/UV decode 变换                                                                 | geometry revision 变化时      |       6 |    2/1 |
+| `SkinningBlock` | current/previous joint palette                                                                 | skeleton pose 变化时          |       7 |    2/2 |
+| `MorphBlock`    | current/previous morph weights 与 target 状态                                                  | morph pose 变化时             |       8 |    2/3 |
+| `InstanceBlock` | 每批 current/previous model 与 normal matrix array                                             | WebGPU instanced batch 变化时 |       — |    2/4 |
 
 WebGPU group 0 是 frame/pass/scene 全局域，group 1 是 material 与纹理域，group
 2 是 object/geometry/pose 域，group
@@ -349,6 +349,12 @@ WebGPU group 0 是 frame/pass/scene 全局域，group 1 是 material 与纹理�
 `CameraBlock.u_viewport` 的语义固定为当前 attachment 的物理像素
 `(x, y, width, height)`；canvas、RenderTarget、平面阴影与点光六面阴影切换 camera/pass 时都更新同一 std140 字段，不保留 classic
 `uniform` 兼容路径。
+
+前后帧状态属于 submission transaction，而不是“执行过一次 CPU
+update”就推进：成功提交后才把 pending 变成 previous，record/prepare/execute 失败统一 rollback；device
+recovery 使旧 generation 无效。Camera cut、teleport、world-origin shift、pose
+reset 等不连续变化通过公开 `Node.invalidateTransformHistory()`
+把下一次 previous 设为 current。spawn 首帧同样 previous=current；despawn 不产生 motion 输入。
 
 公开 `Std140Schema`
 是刻意固定的扁平 scalar/vector/matrix（含定长数组）模型；嵌套 struct 不在这套跨 WebGL
@@ -592,6 +598,10 @@ layout。
   `InstanceBlock`，由 `gl_InstanceIndex`
   读取固定数组，并在超过 128 个实例时拆成多个 draw。两个路径都由 `HILO_WEBGPU` 的编译期 shader
   variant 明确表达，不运行时改写 uniform 声明。
+- WebGPU `InstanceBlock` 保存真正的 current/previous model array；WebGL 2 的现有 attribute
+  budget 保持 current model，shader 把 previous alias 到 current，因而 WebGL 2 instanced
+  draw 的 motion 输入确定为零，而不虚构跨帧 attribute
+  stream。普通 draw、skinning 与 morph 在两端均携带真实 previous。
 - `ModelBlock` 只服务普通 draw 或整个 batch 的公共数据；model-view 与 MVP 在 shader 中由
   `CameraBlock × ModelBlock` 推导，不重复上传 camera-dependent 派生矩阵。
 - vertex geometry/morph attribute 按兼容格式打包到尽量少的 interleaved GPU buffer，并同时校验

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -1,6 +1,6 @@
 # Hilo3D 现代 WebGPU 渲染缺口与落地路线
 
-> 审计基线：`902b9a7`（2026-08-01）；实施状态更新：2026-08-01，F0、F1 已落地；同日补充 E0 自动曝光、虚拟纹理术语边界和 SDF 准入门槛。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
+> 审计基线：`902b9a7`（2026-08-01）；实施状态更新：2026-08-01，F0、F1、D0 已落地；同日补充 E0 自动曝光、虚拟纹理术语边界和 SDF 准入门槛。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
 > 2 功能对等作为路线目标。
 
 ## 结论先行
@@ -190,7 +190,8 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 `P0` 是“现代 WebGPU renderer”定义所需能力；`P1` 是高画质生产 profile；`P2`
 是依赖场景规模、内容管线和长期性能投入的虚拟化能力。
 
-实施状态：**F0、F1 已完成**；后续工作包可把 subresource/history 与 GPU timeline 作为现有基础使用。
+实施状态：**F0、F1、D0 已完成**；后续工作包可把 subresource/history、GPU
+timeline 与确定的前后帧坐标 ABI 作为现有基础使用。
 
 ## 6. 可落地工作包
 
@@ -251,7 +252,7 @@ f16 保留原始 native artifact，Naga validator/writer 使用等价 f32 特化
 时 RHI 明确拒绝，pipeline 可通过 `supportsFeature()` 选择 f32/workgroup
 fallback。仓库未引入新的内置 subgroup/f16 kernel，因此不存在需要伪装为双后端等价的隐式降级结果。
 
-#### D0：现代深度与帧坐标合同
+#### D0：现代深度与帧坐标合同（已完成）
 
 ![D0：Reversed-Z、相机相对坐标与远距离精度](./images/modern-webgpu-roadmap/depth-camera-relative.jpg)
 
@@ -259,16 +260,32 @@ fallback。仓库未引入新的内置 subgroup/f16 kernel，因此不存在需�
 | ------------------------------ | ------------------------------------------------------- | --------------------------------- | ------------------------------------------ |
 | 世界坐标、near/far、前后帧变换 | reversed-Z、floating far、camera-relative、previous ABI | 稳定深度、可靠 motion-vector 输入 | 大尺度场景无明显 z-fighting 与 origin 抖动 |
 
-需要增加：
+已落地：
 
-- high-end profile 使用 reversed-Z + floating/infinite far projection；
-- depth clear、compare、depth pyramid reduction、shadow depth 与 picking 坐标合同统一；
-- camera-relative GPU transform；CPU scene identity 和世界坐标不变；
-- frame/camera/mesh ABI 同时保存 current 与 previous transform；
-- camera cut、teleport、spawn/despawn、skinning/morph 和 origin shift 的 previous-state 规则。
+- `renderingProfile: 'high-end'` 启用 reversed-Z camera 与 camera-relative GPU transform；portable
+  profile 继续默认 standard depth，Camera 也可单独选择 `depthMode`。Perspective projection支持有限或
+  `far: null` 的无限远，两后端继续共享 OpenGL clip-space shader 源；
+- surface、RenderTarget、pipeline depth compare、Shadow Atlas clear/comparison
+  sampler/bias 与 MeshPicker 使用同一个 depth mode；未来 Hi-Z
+  reduction 必须按 standard=min、reversed=max 选择，不能再猜测约定；
+- camera-relative 只修改每帧 GPU view/model/instance bytes；CPU scene identity、world
+  matrix、culling、project/unproject 与 pointer 坐标不变。一个 application
+  frame 使用同一个主相机 origin，避免多 camera/pass 改写 object UBO；
+- `CameraBlock`、`ModelBlock`、`SkinningBlock`、`MorphBlock` 与 WebGPU `InstanceBlock`
+  同时携带 current/previous transform；origin 与 history-valid 也进入固定 ABI；
+- 首次出现、spawn 和显式 `Node.invalidateTransformHistory()`
+  后 previous=current；正常 motion 读取最后一次成功 submission；失败 build/prepare/execute 回滚 pending
+  history，device recovery 递增 generation。despawn 不生成 draw，重新出现按 owner
+  history 或显式 invalidation 处理；skinning/morph 遵守同一提交边界。
 
 完成标准：大 near/far 比场景不出现明显 z-fighting 回退；WebGPU/WebGL
 2 共享 shader 的坐标适配不被破坏；所有 motion vector 输入都有确定的首次出现和 invalidation 行为。
+
+验收证据：有限/无限 reversed-Z
+near/far 映射、正交相机、RenderTarget 默认 clear/compare、普通与 storage-aware pipeline
+cache、shadow sampler、camera-relative
+packing、实例 current/previous、成功提交/失败回滚和显式 invalidation 均有合同测试；真实 WebGPU/WebGL
+2 pipeline 与浏览器 lane 继续复用同一 GLSL ES 3.00 坐标适配链。
 
 ### 6.2 Milestone 1A：规模化场景主线
 

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -441,6 +441,23 @@ pass，不创建这些原生对象。
 
 共享前端使用一套明确的坐标合同，业务代码不能用“当前后端是 WebGPU”作为临时翻转条件：
 
+- public projection 保持 OpenGL `[-1, 1]` clip Z；WebGPU shader artifact 仍只在统一编译边界映射到
+  `[0, 1]`。`Camera.depthMode='standard'` 把 near/far 映射到 `-1/+1`，`reversed` 映射到
+  `+1/-1`；Perspective `far:null` 使用无限远投影。
+- depth mode 同时决定 attachment clear（standard `1`、reversed `0`）、material
+  compare 方向、sampled-depth comparison sampler、shadow bias 符号和 picking
+  target。RenderTarget 明确保存 `depthMode`，与 active
+  Camera 不匹配时在 graph 执行前失败；多 camera 只有 depth mode 相同才能 load 前一 camera 的 surface
+  depth。
+- `cameraRelative:true`（high-end profile 自动启用）按 application
+  frame 的首个主 Camera 选择一个共享 render origin。GPU camera/model/instance
+  translation 减去该 origin；CPU world matrix、scene
+  identity、frustum、project/unproject 和交互坐标不改写。共享 origin 使同一帧的 shadow、overlay 与多 camera
+  pass 可以引用同一 object-frequency UBO。
+- current/previous camera、model、instance、joint palette 与 morph weight 随 upload
+  transaction 提交；首次出现或 `Node.invalidateTransformHistory()`
+  后 previous=current，失败帧回滚，device recovery 使旧 generation 无效。
+
 - world、view、clip 与交互物理空间都以 `+Y` 向上；DOM pointer 的 `+Y` 向下只在输入边界转换一次。
 - glTF UV、引擎管理的 2D Texture、CubeTexture 各 face、texture
   upload/update 和公开 readback 都把第 0 行定义为顶部。WebGL
@@ -467,7 +484,7 @@ Atlas、compute particles、compute path tracer、普通 glTF 材质与 cube
 IBL。方向性 fixture 同时验证 WebGL 2/WebGPU 的 render-target copy、managed 2D texture、cube-face
 top/bottom 和不对称投影阴影，避免某个 example 修正后另一个路径再次反向。
 
-相关代码：[`portableCoordinates.glsl`](../src/shader/method/portableCoordinates.glsl)、[`uv.frag`](../src/shader/chunk/uv.frag)、[`textureEnvMap.glsl`](../src/shader/method/textureEnvMap.glsl)、[`fullscreen-orientation.ts`](../test/ui/fixtures/fullscreen-orientation.ts)、[`shadow-orientation.ts`](../test/ui/fixtures/shadow-orientation.ts)。
+相关代码：[`Camera.ts`](../src/camera/Camera.ts)、[`DepthConvention.ts`](../src/render/renderer/DepthConvention.ts)、[`BuiltInUniformBlockManager.ts`](../src/render/BuiltInUniformBlockManager.ts)、[`portableCoordinates.glsl`](../src/shader/method/portableCoordinates.glsl)、[`uv.frag`](../src/shader/chunk/uv.frag)、[`textureEnvMap.glsl`](../src/shader/method/textureEnvMap.glsl)、[`fullscreen-orientation.ts`](../test/ui/fixtures/fullscreen-orientation.ts)、[`shadow-orientation.ts`](../test/ui/fixtures/shadow-orientation.ts)。
 
 ## 4. WebGPU / WebGL 2 双后端如何实现同一合同
 

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -581,6 +581,8 @@ export class Camera extends Node_2 {
     clearColor: boolean;
     clearDepth: boolean;
     clearStencil: boolean;
+    get depthMode(): CameraDepthMode;
+    set depthMode(value: CameraDepthMode);
     // (undocumented)
     protected readonly _frustum: Frustum;
     // (undocumented)
@@ -642,6 +644,9 @@ export interface Camera2DParameters extends Omit<OrthographicCameraParameters, '
 }
 
 // @public
+export type CameraDepthMode = 'standard' | 'reversed';
+
+// @public
 export class CameraHelper extends Mesh {
     constructor(params?: CameraHelperParameters);
     // (undocumented)
@@ -670,6 +675,7 @@ export interface CameraParameters extends NodeParameters {
     clearColor?: boolean;
     clearDepth?: boolean;
     clearStencil?: boolean;
+    depthMode?: CameraDepthMode;
     priority?: number;
     visibility?: number;
 }
@@ -4266,6 +4272,7 @@ class Node_2 extends EventDispatcher {
     getConcatenatedMatrix(ancestor?: Node_2): Matrix4;
     // (undocumented)
     id: string;
+    invalidateTransformHistory(): this;
     // (undocumented)
     isCamera: boolean;
     // (undocumented)
@@ -5125,6 +5132,8 @@ export class Renderer<Backend extends RendererBackend = RendererBackend> impleme
     // (undocumented)
     readonly backend: Backend;
     // (undocumented)
+    readonly cameraRelative: RendererContract['cameraRelative'];
+    // (undocumented)
     readonly className: 'Renderer';
     // (undocumented)
     clearColor: RendererContract['clearColor'];
@@ -5179,6 +5188,8 @@ export class Renderer<Backend extends RendererBackend = RendererBackend> impleme
     // (undocumented)
     readonly renderInfo: RendererContract['renderInfo'];
     // (undocumented)
+    readonly renderingProfile: RendererContract['renderingProfile'];
+    // (undocumented)
     readonly renderTarget: RendererContract['renderTarget'];
     // (undocumented)
     readonly renderToTarget: RendererContract['renderToTarget'];
@@ -5219,6 +5230,7 @@ export interface RendererCommonOptions {
     alpha?: boolean;
     // (undocumented)
     antialias?: boolean;
+    cameraRelative?: boolean;
     // (undocumented)
     clearColor?: Color;
     // (undocumented)
@@ -5243,6 +5255,7 @@ export interface RendererCommonOptions {
     pixelRatio?: number;
     // (undocumented)
     premultipliedAlpha?: boolean;
+    renderingProfile?: RendererRenderingProfile;
     renderPipeline?: RenderPipelineFactory;
     // (undocumented)
     stencil?: boolean;
@@ -5263,6 +5276,8 @@ export type RendererContextPowerPreference = 'default' | RendererAdapterPowerPre
 export interface RendererContract {
     // (undocumented)
     readonly backend: RendererBackend;
+    // (undocumented)
+    readonly cameraRelative: boolean;
     // (undocumented)
     readonly className: string;
     // (undocumented)
@@ -5302,6 +5317,8 @@ export interface RendererContract {
     renderFrame(callback: RendererFrameCallback): void;
     // (undocumented)
     readonly renderInfo: RenderInfo;
+    // (undocumented)
+    readonly renderingProfile: 'portable' | 'high-end';
     // (undocumented)
     readonly renderTarget: RenderTarget | null;
     // (undocumented)
@@ -5380,6 +5397,9 @@ export interface RendererOptionsMap {
     // (undocumented)
     readonly webgpu: RendererWebGPUOptions;
 }
+
+// @public
+export type RendererRenderingProfile = 'portable' | 'high-end';
 
 // @public
 export interface RendererResourceDiagnostics {
@@ -5844,6 +5864,7 @@ export interface RenderTargetDepthStencilAttachmentOptions {
     readonly depthClearValue?: number;
     // (undocumented)
     readonly depthLoadOp?: RenderTargetLoadOp;
+    readonly depthMode?: CameraDepthMode;
     // (undocumented)
     readonly depthStoreOp?: RenderTargetStoreOp;
     // (undocumented)

--- a/examples/bloom.ts
+++ b/examples/bloom.ts
@@ -136,11 +136,6 @@ layout(std140) uniform CameraBlock {
     mat4 u_viewMatrix;
     mat4 u_projectionMatrix;
     mat4 u_viewProjectionMatrix;
-    mat4 u_viewInverseMatrix;
-    mat4 u_projectionInverseMatrix;
-    mat3 u_viewInverseNormalMatrix;
-    vec4 u_cameraPositionNear;
-    vec4 u_cameraParams;
 };
 void main() {
     v_direction = a_position;
@@ -232,11 +227,6 @@ layout(std140) uniform CameraBlock {
     mat4 u_viewMatrix;
     mat4 u_projectionMatrix;
     mat4 u_viewProjectionMatrix;
-    mat4 u_viewInverseMatrix;
-    mat4 u_projectionInverseMatrix;
-    mat3 u_viewInverseNormalMatrix;
-    vec4 u_cameraPositionNear;
-    vec4 u_cameraParams;
 };
 void main() {
     v_uv = a_texcoord0;

--- a/examples/compute_eclipse_shrine.ts
+++ b/examples/compute_eclipse_shrine.ts
@@ -765,11 +765,6 @@ layout(std140) uniform CameraBlock {
     mat4 u_viewMatrix;
     mat4 u_projectionMatrix;
     mat4 u_viewProjectionMatrix;
-    mat4 u_viewInverseMatrix;
-    mat4 u_projectionInverseMatrix;
-    mat3 u_viewInverseNormalMatrix;
-    vec4 u_cameraPositionNear;
-    vec4 u_cameraParams;
 };
 void main() {
     v_direction = a_position;

--- a/examples/snow.ts
+++ b/examples/snow.ts
@@ -72,11 +72,6 @@ const vertexShader = `#version 300 es
         mat4 u_viewMatrix;
         mat4 u_projectionMatrix;
         mat4 u_viewProjectionMatrix;
-        mat4 u_viewInverseMatrix;
-        mat4 u_projectionInverseMatrix;
-        mat3 u_viewInverseNormalMatrix;
-        vec4 u_cameraPositionNear;
-        vec4 u_cameraParams;
     };
 
     void main(void) {

--- a/src/2d/SpriteMaterial.ts
+++ b/src/2d/SpriteMaterial.ts
@@ -10,18 +10,11 @@ layout(std140) uniform CameraBlock {
     mat4 u_viewMatrix;
     mat4 u_projectionMatrix;
     mat4 u_viewProjectionMatrix;
-    mat4 u_viewInverseMatrix;
-    mat4 u_projectionInverseMatrix;
-    mat3 u_viewInverseNormalMatrix;
-    vec4 u_cameraPositionNear;
-    vec4 u_cameraParams;
-    vec4 u_viewport;
 };
 
 #ifdef HILO_WEBGPU
 layout(std140) uniform InstanceBlock {
     mat4 u_instanceModelMatrices[128];
-    mat4 u_instanceNormalMatrices[128];
 };
 #define u_modelMatrix u_instanceModelMatrices[gl_InstanceIndex]
 #else

--- a/src/Hilo3d.ts
+++ b/src/Hilo3d.ts
@@ -53,7 +53,7 @@ export {
 } from './core/Tween';
 export { default as version } from './core/version';
 
-export { default as Camera, type CameraParameters } from './camera/Camera';
+export { default as Camera, type CameraDepthMode, type CameraParameters } from './camera/Camera';
 export { default as Camera2D, type Camera2DParameters, DEFAULT_2D_LAYER } from './camera/Camera2D';
 export {
     default as OrthographicCamera,
@@ -230,6 +230,7 @@ export {
     type RendererFrameCallback,
     type RendererOptions,
     type RendererOptionsMap,
+    type RendererRenderingProfile,
     type RendererResourceDiagnostics,
     type RendererResourceManager,
     type RendererScene,

--- a/src/camera/Camera.ts
+++ b/src/camera/Camera.ts
@@ -8,7 +8,21 @@ import type Mesh from '../core/Mesh';
 const tempMatrix4 = new Matrix4();
 const tempSphere = new Sphere();
 
+/** Depth convention used by projection, depth testing, shadows, and picking. */
+export type CameraDepthMode = 'standard' | 'reversed';
+
+function assertCameraDepthMode(value: unknown): asserts value is CameraDepthMode {
+    if (value !== 'standard' && value !== 'reversed') {
+        throw new TypeError('Camera.depthMode must be "standard" or "reversed".');
+    }
+}
+
 export interface CameraParameters extends NodeParameters {
+    /**
+     * Depth convention. `reversed` maps the near plane to 1 and far/infinity to 0, improving
+     * floating-point depth precision. Defaults to `standard` for compatibility.
+     */
+    depthMode?: CameraDepthMode;
     /**
      * Camera visibility bit mask. A renderable node is collected when
      * `(camera.visibility & node.layer) !== 0`.
@@ -55,6 +69,19 @@ class Camera extends Node {
     clearDepth = true;
     /** Whether this camera clears stencil before drawing. */
     clearStencil = true;
+    private depthModeValue: CameraDepthMode = 'standard';
+    /** Active projection/depth-buffer convention. */
+    get depthMode(): CameraDepthMode {
+        return this.depthModeValue;
+    }
+    set depthMode(value: CameraDepthMode) {
+        assertCameraDepthMode(value);
+        if (value === this.depthModeValue) return;
+        this.depthModeValue = value;
+        this._needUpdateProjectionMatrix = true;
+        this._isGeometryDirty = true;
+        this.invalidateTransformHistory();
+    }
     private priorityValue = 0;
     /** Camera composition priority. Lower values render first and receive pointer input last. */
     get priority(): number {

--- a/src/camera/OrthographicCamera.ts
+++ b/src/camera/OrthographicCamera.ts
@@ -88,13 +88,22 @@ class OrthographicCamera extends Camera {
      * 更新投影矩阵
      */
     override updateProjectionMatrix(): void {
+        const { left, right, bottom, top, near, far } = this;
+        if (![left, right, bottom, top, near, far].every(Number.isFinite)) {
+            throw new RangeError('OrthographicCamera projection bounds must be finite.');
+        }
+        if (left === right || bottom === top || far <= near) {
+            throw new RangeError(
+                'OrthographicCamera bounds must be non-degenerate and far must be greater than near.'
+            );
+        }
         this.projectionMatrix.ortho(
-            this.left,
-            this.right,
-            this.bottom,
-            this.top,
-            this.near,
-            this.far
+            left,
+            right,
+            bottom,
+            top,
+            this.depthMode === 'reversed' ? far : near,
+            this.depthMode === 'reversed' ? near : far
         );
     }
     override getGeometry(forceUpdate = false): Geometry {

--- a/src/camera/PerspectiveCamera.ts
+++ b/src/camera/PerspectiveCamera.ts
@@ -99,13 +99,27 @@ class PerspectiveCamera extends Camera {
         elements[5] = f;
         elements[11] = -1;
         elements[15] = 0;
-        if (far) {
-            const nf = 1 / (near - far);
+        if (!Number.isFinite(near) || near <= 0) {
+            throw new RangeError('PerspectiveCamera.near must be finite and greater than zero.');
+        }
+        if (!Number.isFinite(aspect) || aspect <= 0) {
+            throw new RangeError('PerspectiveCamera.aspect must be finite and greater than zero.');
+        }
+        if (!Number.isFinite(fov) || fov <= 0 || fov >= 180) {
+            throw new RangeError('PerspectiveCamera.fov must be finite and between 0 and 180.');
+        }
+        if (far !== null && (!Number.isFinite(far) || far <= near)) {
+            throw new RangeError(
+                'PerspectiveCamera.far must be null or finite and greater than near.'
+            );
+        }
+        if (far !== null) {
+            const nf = this.depthMode === 'reversed' ? 1 / (far - near) : 1 / (near - far);
             elements[10] = (near + far) * nf;
             elements[14] = 2 * far * near * nf;
         } else {
-            elements[10] = -1;
-            elements[14] = -2 * near;
+            elements[10] = this.depthMode === 'reversed' ? 1 : -1;
+            elements[14] = this.depthMode === 'reversed' ? 2 * near : -2 * near;
         }
     }
     override getGeometry(forceUpdate = false): Geometry {

--- a/src/core/Node.ts
+++ b/src/core/Node.ts
@@ -12,6 +12,7 @@ import Geometry, { type Bounds } from '../geometry/Geometry';
 import Skeleton from './Skeleton';
 import type { Renderer } from '../render/Renderer';
 import math from '../math/math';
+import { invalidateTransformHistory as invalidateNodeTransformHistory } from './TransformHistory';
 const defaultUp = new Vector3(0, 1, 0);
 const tempMatrix4 = new Matrix4();
 const TRAVERSE_STOP_NONE = 0 as const;
@@ -388,6 +389,17 @@ class Node extends EventDispatcher {
         if (this.parent) {
             this.parent.removeChild(this);
         }
+        return this;
+    }
+    /**
+     * Reset this node's previous-frame transform on its next submitted render.
+     *
+     * Call this after a discontinuous teleport, origin shift, camera cut, or animation reset so
+     * temporal effects receive `previous === current` instead of a false motion vector.
+     * @returns this
+     */
+    invalidateTransformHistory(): this {
+        invalidateNodeTransformHistory(this);
         return this;
     }
     /**

--- a/src/core/TransformHistory.ts
+++ b/src/core/TransformHistory.ts
@@ -1,0 +1,13 @@
+import type Node from './Node';
+
+const revisions = new WeakMap<Node, number>();
+
+/** @internal Monotonic application-controlled discontinuity revision. */
+export function getTransformHistoryRevision(node: Node): number {
+    return revisions.get(node) ?? 0;
+}
+
+/** @internal Mark a transform discontinuity without changing CPU scene identity. */
+export function invalidateTransformHistory(node: Node): void {
+    revisions.set(node, getTransformHistoryRevision(node) + 1);
+}

--- a/src/math/Plane.ts
+++ b/src/math/Plane.ts
@@ -59,7 +59,15 @@ class Plane {
      * @returns this
      */
     normalize(): this {
-        const inverseNormalLength = 1.0 / this.normal.length();
+        const normalLength = this.normal.length();
+        if (normalLength === 0) {
+            // Infinite perspective projections contain one disabled far plane. Represent it as a
+            // plane that accepts every finite point instead of producing NaNs during culling.
+            this.normal.set(0, 0, 0);
+            this.distance = Infinity;
+            return this;
+        }
+        const inverseNormalLength = 1.0 / normalLength;
         this.normal.scale(inverseNormalLength);
         this.distance *= inverseNormalLength;
         return this;

--- a/src/render/BuiltInUniformBlockManager.ts
+++ b/src/render/BuiltInUniformBlockManager.ts
@@ -14,6 +14,7 @@ import {
     materialBlockLayout,
     modelBlockLayout,
     morphBlockLayout,
+    MAX_SKIN_JOINTS,
     paddedStd140Value,
     sceneBlockLayout,
     skinningBlockLayout
@@ -22,10 +23,14 @@ import type { Std140Layout, Std140WriteResult } from './ubo/Std140Layout';
 import { getMeshPickingIdentity } from './PickingIdentity';
 import type { RendererViewport } from './Renderer';
 import type { SemanticFrameState } from './frame/SemanticFrameState';
+import type { RHIUploadBatch, RHIUploadBatchParticipant } from './frame/RHIUploadBatch';
+import type { RHISubmission } from './rhi/core';
+import { getTransformHistoryRevision } from '../core/TransformHistory';
 
 interface RendererSize {
     width: number;
     height: number;
+    cameraRelative?: boolean;
     getViewport?(): RendererViewport;
 }
 
@@ -59,10 +64,43 @@ interface FrameCachedBuffer {
     frameIndex: number;
 }
 
+interface ModelFrameCachedBuffer extends FrameCachedBuffer {
+    readonly normal: Matrix3;
+    revision: number;
+}
+
 interface MorphFrameCachedBuffer extends FrameCachedBuffer {
     readonly weights: Float32Array;
     readonly weights0: Float32Array;
     readonly weights1: Float32Array;
+}
+
+interface CameraHistoryRecord {
+    readonly committedView: Float32Array;
+    readonly committedProjection: Float32Array;
+    readonly committedViewProjection: Float32Array;
+    readonly committedViewInverse: Float32Array;
+    readonly committedOrigin: Float32Array;
+    readonly pendingView: Float32Array;
+    readonly pendingProjection: Float32Array;
+    readonly pendingViewProjection: Float32Array;
+    readonly pendingViewInverse: Float32Array;
+    readonly pendingOrigin: Float32Array;
+    committedRevision: number;
+    pendingRevision: number;
+    committedDepthMode: Camera['depthMode'];
+    pendingDepthMode: Camera['depthMode'];
+    committedGeneration: number;
+    pendingFrame: number;
+}
+
+interface TransformHistoryRecord {
+    readonly committed: Float32Array;
+    readonly pending: Float32Array;
+    committedRevision: number;
+    pendingRevision: number;
+    committedGeneration: number;
+    pendingFrame: number;
 }
 
 type OwnedBufferRegistration =
@@ -74,6 +112,9 @@ type OwnedBufferRegistration =
 
 const tempInverseProjection = new Matrix4();
 const tempViewNormal = new Matrix3();
+const tempRelativeViewInverse = new Matrix4();
+const tempRelativeView = new Matrix4();
+const tempRelativeViewProjection = new Matrix4();
 const std140WriteResult: Std140WriteResult = { byteOffset: 0, byteLength: 0 };
 const semanticBlockScratch = new WeakMap<UniformBuffer, Uint8Array>();
 const uniformBufferByteViews = new WeakMap<UniformBuffer, Uint8Array>();
@@ -265,6 +306,54 @@ function bytesEqual(
     return true;
 }
 
+function copyRelativeMatrix(
+    target: Float32Array,
+    source: ArrayLike<number>,
+    origin: ArrayLike<number>
+): void {
+    target.set(source);
+    target[12] = (source[12] ?? 0) - (origin[0] ?? 0);
+    target[13] = (source[13] ?? 0) - (origin[1] ?? 0);
+    target[14] = (source[14] ?? 0) - (origin[2] ?? 0);
+}
+
+function updateModelTransformBlock(
+    buffer: UniformBuffer,
+    mesh: Mesh,
+    current: Float32Array,
+    previous: Float32Array,
+    normal: Matrix3
+): void {
+    let candidate = semanticBlockScratch.get(buffer);
+    if (candidate?.byteLength !== modelBlockLayout.byteLength) {
+        candidate = new Uint8Array(modelBlockLayout.byteLength);
+        semanticBlockScratch.set(buffer, candidate);
+    } else {
+        candidate.fill(0);
+    }
+    const target = candidate.buffer;
+    if (!(target instanceof ArrayBuffer)) {
+        throw new TypeError('ModelBlock scratch storage must use an ArrayBuffer');
+    }
+    modelBlockLayout.writeInto(target, 'u_modelMatrix', current, std140WriteResult);
+    modelBlockLayout.writeInto(target, 'u_previousModelMatrix', previous, std140WriteResult);
+    modelBlockLayout.writeInto(
+        target,
+        'u_normalWorldMatrix',
+        normal.normalFromMat4(mesh.worldMatrix).elements,
+        std140WriteResult
+    );
+    modelBlockLayout.writeInto(
+        target,
+        'u_objectIdColor',
+        getMeshPickingIdentity(mesh).color,
+        std140WriteResult
+    );
+    if (!bytesEqual(bytesOf(buffer), candidate, 0, candidate.byteLength)) {
+        buffer.write(0, candidate);
+    }
+}
+
 /**
  * Commit only fields whose packed std140 bytes changed. Comparing the final ABI bytes catches
  * scalar assignments, in-place Color/Matrix edits and texture-derived numeric values without
@@ -298,7 +387,7 @@ function synchronizeMaterialBlock(cached: MaterialCachedBuffer): void {
 }
 
 /** Owns the canonical cross-backend uniform blocks and updates each at its natural frequency. */
-class BuiltInUniformBlockManager {
+class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
     private readonly renderer: RendererSize;
     private readonly ownedBuffers = new Set<UniformBuffer>();
     private readonly frameUniformBuffer: UniformBuffer;
@@ -320,13 +409,23 @@ class BuiltInUniformBlockManager {
     private readonly rendererSizeScratch = new Float32Array(2);
     private readonly cameraPositionNearScratch = new Float32Array(4);
     private readonly cameraParamsScratch = new Float32Array(4);
+    private readonly renderOriginScratch = new Float32Array(4);
+    private readonly historyParamsScratch = new Float32Array(4);
     /** Canonical semantic bindings for pass-global blocks, independent of draw order/material. */
     private readonly globalSemanticMaterial = new Material();
     private readonly materialBuffers = new WeakMap<Material, MaterialCachedBuffer>();
-    private readonly modelBuffers = new WeakMap<Mesh, RevisionCachedBuffer>();
+    private readonly modelBuffers = new WeakMap<Mesh, ModelFrameCachedBuffer>();
     private readonly geometryBuffers = new WeakMap<Geometry, RevisionCachedBuffer>();
     private readonly skinningBuffers = new WeakMap<Mesh, FrameCachedBuffer>();
     private readonly morphBuffers = new WeakMap<Mesh, MorphFrameCachedBuffer>();
+    private readonly cameraHistory = new WeakMap<Camera, CameraHistoryRecord>();
+    private readonly modelHistory = new WeakMap<Mesh, TransformHistoryRecord>();
+    private readonly skinningHistory = new WeakMap<Mesh, TransformHistoryRecord>();
+    private readonly morphHistory = new WeakMap<Mesh, TransformHistoryRecord>();
+    private readonly stagedCameras: CameraHistoryRecord[] = [];
+    private readonly stagedModels: TransformHistoryRecord[] = [];
+    private readonly stagedSkinning: TransformHistoryRecord[] = [];
+    private readonly stagedMorphs: TransformHistoryRecord[] = [];
     private readonly bufferOwners = new WeakMap<UniformBuffer, OwnedBufferRegistration>();
     private camera: Camera | null = null;
     private semanticFrame: SemanticFrameState | null = null;
@@ -334,6 +433,7 @@ class BuiltInUniformBlockManager {
     private readonly startTime = performance.now();
     private sceneRevision = -1;
     private lightRevision = -1;
+    private historyGeneration = 1;
 
     constructor(renderer: RendererSize) {
         this.renderer = renderer;
@@ -351,29 +451,105 @@ class BuiltInUniformBlockManager {
         });
     }
 
-    beginFrame(camera: Camera, viewport: RendererViewport = this.defaultViewport()): void {
+    beginFrame(
+        camera: Camera,
+        viewport: RendererViewport = this.defaultViewport(),
+        uploads?: RHIUploadBatch
+    ): void {
         this.semanticFrame = null;
-        this.beginApplicationFrame();
+        this.beginApplicationFrame(camera, uploads);
         this.beginPass(camera, viewport);
     }
 
     /** Begin one shared-renderer frame with explicit semantic ownership. */
-    beginSemanticFrame(frame: SemanticFrameState): void {
+    beginSemanticFrame(frame: SemanticFrameState, uploads?: RHIUploadBatch): void {
         this.semanticFrame = frame;
-        this.beginApplicationFrame();
+        this.beginApplicationFrame(frame.camera, uploads);
         this.beginSemanticPass(frame);
     }
 
     /** Advance frame-frequency semantics once, independently of the number of render passes. */
-    beginApplicationFrame(): void {
+    beginApplicationFrame(camera?: Camera, uploads?: RHIUploadBatch): void {
         this.frameIndex++;
+        uploads?.enlist(this);
         this.semanticPassCursor = 0;
+        this.renderOriginScratch.fill(0);
+        if (this.renderer.cameraRelative === true && camera !== undefined) {
+            this.renderOriginScratch[0] = camera.worldMatrix.elements[12];
+            this.renderOriginScratch[1] = camera.worldMatrix.elements[13];
+            this.renderOriginScratch[2] = camera.worldMatrix.elements[14];
+        }
         this.rendererSizeScratch[0] = this.renderer.width;
         this.rendererSizeScratch[1] = this.renderer.height;
         this.frameUniformBuffer
             .set('u_rendererSize', this.rendererSizeScratch)
             .set('u_time', (performance.now() - this.startTime) * 0.001)
             .set('u_frameIndex', this.frameIndex);
+    }
+
+    prepareCommit(_submission: RHISubmission): void {
+        // History snapshots are CPU-side and require no pre-submission work.
+    }
+
+    commit(_submission: RHISubmission): void {
+        for (const record of this.stagedCameras) {
+            record.committedView.set(record.pendingView);
+            record.committedProjection.set(record.pendingProjection);
+            record.committedViewProjection.set(record.pendingViewProjection);
+            record.committedViewInverse.set(record.pendingViewInverse);
+            record.committedOrigin.set(record.pendingOrigin);
+            record.committedRevision = record.pendingRevision;
+            record.committedDepthMode = record.pendingDepthMode;
+            record.committedGeneration = this.historyGeneration;
+            record.pendingFrame = -1;
+        }
+        this.commitTransformRecords(this.stagedModels);
+        this.commitTransformRecords(this.stagedSkinning);
+        this.commitTransformRecords(this.stagedMorphs);
+        this.clearStagedHistory();
+    }
+
+    rollback(): void {
+        for (const record of this.stagedCameras) record.pendingFrame = -1;
+        for (const record of this.stagedModels) record.pendingFrame = -1;
+        for (const record of this.stagedSkinning) record.pendingFrame = -1;
+        for (const record of this.stagedMorphs) record.pendingFrame = -1;
+        this.clearStagedHistory();
+    }
+
+    /** Invalidate every previous transform at a device-generation boundary. */
+    synchronizeAfterRecovery(): void {
+        this.historyGeneration += 1;
+    }
+
+    /** @internal Frame-wide origin used by instanced GPU transforms. */
+    get renderOrigin(): Readonly<Float32Array> {
+        return this.renderOriginScratch;
+    }
+
+    /** @internal Stage and write one current/previous camera-relative instance transform. */
+    writeInstanceModelMatrices(
+        mesh: Mesh,
+        current: Float32Array,
+        previous: Float32Array,
+        offset: number
+    ): void {
+        const history = this.transformHistoryRecord(this.modelHistory, mesh, 16);
+        if (history.pendingFrame !== this.frameIndex) {
+            copyRelativeMatrix(
+                history.pending,
+                mesh.worldMatrix.elements,
+                this.renderOriginScratch
+            );
+            history.pendingRevision = getTransformHistoryRevision(mesh);
+            history.pendingFrame = this.frameIndex;
+            this.stagedModels.push(history);
+        }
+        current.set(history.pending, offset);
+        const valid =
+            history.committedGeneration === this.historyGeneration &&
+            history.committedRevision === getTransformHistoryRevision(mesh);
+        previous.set(valid ? history.committed : history.pending, offset);
     }
 
     /** Start a camera/render pass without advancing animation-frame scoped buffers. */
@@ -452,21 +628,62 @@ class BuiltInUniformBlockManager {
             }
         }
         this.activeCameraBuffer = cameraBuffer;
-        this.cameraPositionNearScratch[0] = camera.worldMatrix.elements[12];
-        this.cameraPositionNearScratch[1] = camera.worldMatrix.elements[13];
-        this.cameraPositionNearScratch[2] = camera.worldMatrix.elements[14];
+        const history = this.cameraHistoryRecord(camera);
+        const firstCameraStage = history.pendingFrame !== this.frameIndex;
+        copyRelativeMatrix(
+            history.pendingViewInverse,
+            camera.worldMatrix.elements,
+            this.renderOriginScratch
+        );
+        tempRelativeViewInverse.fromArray(history.pendingViewInverse);
+        tempRelativeView.invert(tempRelativeViewInverse);
+        history.pendingView.set(tempRelativeView.elements);
+        history.pendingProjection.set(camera.projectionMatrix.elements);
+        tempRelativeViewProjection.multiply(camera.projectionMatrix, tempRelativeView);
+        history.pendingViewProjection.set(tempRelativeViewProjection.elements);
+        history.pendingOrigin.set(this.renderOriginScratch);
+        history.pendingRevision = getTransformHistoryRevision(camera);
+        history.pendingDepthMode = camera.depthMode;
+        if (firstCameraStage) {
+            history.pendingFrame = this.frameIndex;
+            this.stagedCameras.push(history);
+        }
+        const historyValid =
+            history.committedGeneration === this.historyGeneration &&
+            history.committedRevision === getTransformHistoryRevision(camera) &&
+            history.committedDepthMode === camera.depthMode;
+        const previousView = historyValid ? history.committedView : history.pendingView;
+        const previousProjection = historyValid
+            ? history.committedProjection
+            : history.pendingProjection;
+        const previousViewProjection = historyValid
+            ? history.committedViewProjection
+            : history.pendingViewProjection;
+        const previousViewInverse = historyValid
+            ? history.committedViewInverse
+            : history.pendingViewInverse;
+        const previousOrigin = historyValid ? history.committedOrigin : history.pendingOrigin;
+        this.cameraPositionNearScratch[0] = history.pendingViewInverse[12] ?? 0;
+        this.cameraPositionNearScratch[1] = history.pendingViewInverse[13] ?? 0;
+        this.cameraPositionNearScratch[2] = history.pendingViewInverse[14] ?? 0;
         this.cameraPositionNearScratch[3] = numericCameraProperty(camera, 'near', 0);
         this.cameraParamsScratch[0] = numericCameraProperty(camera, 'far', 0);
         this.cameraParamsScratch[1] = camera.isPerspectiveCamera ? 1 : 0;
         this.cameraParamsScratch[2] = camera.isPerspectiveCamera
             ? 2 / Math.log2(numericCameraProperty(camera, 'far', 1) + 1)
             : 0;
-        this.cameraParamsScratch[3] = 0;
+        this.cameraParamsScratch[3] = camera.depthMode === 'reversed' ? 1 : 0;
+        this.historyParamsScratch.fill(0);
+        this.historyParamsScratch[0] = historyValid ? 1 : 0;
         cameraBuffer
-            .set('u_viewMatrix', camera.viewMatrix.elements)
-            .set('u_projectionMatrix', camera.projectionMatrix.elements)
-            .set('u_viewProjectionMatrix', camera.viewProjectionMatrix.elements)
-            .set('u_viewInverseMatrix', camera.worldMatrix.elements)
+            .set('u_viewMatrix', history.pendingView)
+            .set('u_projectionMatrix', history.pendingProjection)
+            .set('u_viewProjectionMatrix', history.pendingViewProjection)
+            .set('u_previousViewMatrix', previousView)
+            .set('u_previousProjectionMatrix', previousProjection)
+            .set('u_previousViewProjectionMatrix', previousViewProjection)
+            .set('u_viewInverseMatrix', history.pendingViewInverse)
+            .set('u_previousViewInverseMatrix', previousViewInverse)
             .set(
                 'u_projectionInverseMatrix',
                 tempInverseProjection.invert(camera.projectionMatrix).elements
@@ -476,7 +693,10 @@ class BuiltInUniformBlockManager {
                 tempViewNormal.normalFromMat4(camera.worldMatrix).elements
             )
             .set('u_cameraPositionNear', this.cameraPositionNearScratch)
-            .set('u_cameraParams', this.cameraParamsScratch);
+            .set('u_cameraParams', this.cameraParamsScratch)
+            .set('u_renderOrigin', history.pendingOrigin)
+            .set('u_previousRenderOrigin', previousOrigin)
+            .set('u_historyParams', this.historyParamsScratch);
         this.setViewport(viewport);
     }
 
@@ -649,8 +869,8 @@ class BuiltInUniformBlockManager {
 
     private getModelBuffer(
         mesh: Mesh,
-        material: Material,
-        semanticFrame?: SemanticFrameState
+        _material: Material,
+        _semanticFrame?: SemanticFrameState
     ): UniformBuffer {
         let cached = this.modelBuffers.get(mesh);
         if (!cached) {
@@ -659,12 +879,36 @@ class BuiltInUniformBlockManager {
                     kind: 'model',
                     owner: mesh
                 }),
+                frameIndex: -1,
+                normal: new Matrix3(),
                 revision: -1
             };
             this.modelBuffers.set(mesh, cached);
         }
-        if (cached.revision !== mesh.worldMatrixVersion) {
-            updateSemanticBlock(cached.buffer, 'ModelBlock', mesh, material, semanticFrame);
+        if (cached.frameIndex !== this.frameIndex || cached.revision !== mesh.worldMatrixVersion) {
+            const history = this.transformHistoryRecord(this.modelHistory, mesh, 16);
+            const firstModelStage = history.pendingFrame !== this.frameIndex;
+            copyRelativeMatrix(
+                history.pending,
+                mesh.worldMatrix.elements,
+                this.renderOriginScratch
+            );
+            history.pendingRevision = getTransformHistoryRevision(mesh);
+            if (firstModelStage) {
+                history.pendingFrame = this.frameIndex;
+                this.stagedModels.push(history);
+            }
+            const historyValid =
+                history.committedGeneration === this.historyGeneration &&
+                history.committedRevision === getTransformHistoryRevision(mesh);
+            updateModelTransformBlock(
+                cached.buffer,
+                mesh,
+                history.pending,
+                historyValid ? history.committed : history.pending,
+                cached.normal
+            );
+            cached.frameIndex = this.frameIndex;
             cached.revision = mesh.worldMatrixVersion;
         }
         return cached.buffer;
@@ -712,7 +956,39 @@ class BuiltInUniformBlockManager {
             this.skinningBuffers.set(mesh, cached);
         }
         if (cached.frameIndex !== this.frameIndex) {
-            updateSemanticBlock(cached.buffer, 'SkinningBlock', mesh, material, semanticFrame);
+            const value = material.getUniformData(
+                'u_jointMat',
+                mesh,
+                programBindingInfoFor(semanticFrame)
+            );
+            const values =
+                Array.isArray(value) || (ArrayBuffer.isView(value) && !(value instanceof DataView))
+                    ? (value as ArrayLike<unknown>)
+                    : EMPTY_NUMERIC_VALUES;
+            const capacity = MAX_SKIN_JOINTS * 16;
+            if (values.length > capacity) {
+                throw new RangeError(
+                    `SkinningBlock supports at most ${String(MAX_SKIN_JOINTS)} joints`
+                );
+            }
+            const history = this.transformHistoryRecord(this.skinningHistory, mesh, capacity);
+            history.pending.fill(0);
+            for (let index = 0; index < values.length; index += 1) {
+                const component = values[index];
+                if (typeof component !== 'number' || !Number.isFinite(component)) {
+                    throw new TypeError(`Joint matrix component ${String(index)} must be finite`);
+                }
+                history.pending[index] = component;
+            }
+            history.pendingRevision = getTransformHistoryRevision(mesh);
+            history.pendingFrame = this.frameIndex;
+            this.stagedSkinning.push(history);
+            const historyValid =
+                history.committedGeneration === this.historyGeneration &&
+                history.committedRevision === history.pendingRevision;
+            cached.buffer
+                .set('u_jointMat', history.pending)
+                .set('u_previousJointMat', historyValid ? history.committed : history.pending);
             cached.frameIndex = this.frameIndex;
         }
         return cached.buffer;
@@ -760,8 +1036,20 @@ class BuiltInUniformBlockManager {
             }
             cached.weights[index] = value;
         }
-        cached.buffer.set('u_morphWeights0', cached.weights0);
-        cached.buffer.set('u_morphWeights1', cached.weights1);
+        const history = this.transformHistoryRecord(this.morphHistory, mesh, cached.weights.length);
+        history.pending.set(cached.weights);
+        history.pendingRevision = getTransformHistoryRevision(mesh);
+        history.pendingFrame = this.frameIndex;
+        this.stagedMorphs.push(history);
+        const historyValid =
+            history.committedGeneration === this.historyGeneration &&
+            history.committedRevision === history.pendingRevision;
+        const previous = historyValid ? history.committed : history.pending;
+        cached.buffer
+            .set('u_morphWeights0', cached.weights0)
+            .set('u_morphWeights1', cached.weights1)
+            .set('u_previousMorphWeights0', previous.subarray(0, 4))
+            .set('u_previousMorphWeights1', previous.subarray(4, 8));
         cached.frameIndex = this.frameIndex;
         return cached.buffer;
     }
@@ -814,6 +1102,68 @@ class BuiltInUniformBlockManager {
             default:
                 return undefined;
         }
+    }
+
+    private cameraHistoryRecord(camera: Camera): CameraHistoryRecord {
+        let record = this.cameraHistory.get(camera);
+        if (record !== undefined) return record;
+        const matrix = (): Float32Array => new Float32Array(16);
+        const origin = (): Float32Array => new Float32Array(4);
+        record = {
+            committedView: matrix(),
+            committedProjection: matrix(),
+            committedViewProjection: matrix(),
+            committedViewInverse: matrix(),
+            committedOrigin: origin(),
+            pendingView: matrix(),
+            pendingProjection: matrix(),
+            pendingViewProjection: matrix(),
+            pendingViewInverse: matrix(),
+            pendingOrigin: origin(),
+            committedRevision: -1,
+            pendingRevision: -1,
+            committedDepthMode: 'standard',
+            pendingDepthMode: 'standard',
+            committedGeneration: 0,
+            pendingFrame: -1
+        };
+        this.cameraHistory.set(camera, record);
+        return record;
+    }
+
+    private transformHistoryRecord(
+        records: WeakMap<Mesh, TransformHistoryRecord>,
+        mesh: Mesh,
+        length: number
+    ): TransformHistoryRecord {
+        let record = records.get(mesh);
+        if (record !== undefined) return record;
+        record = {
+            committed: new Float32Array(length),
+            pending: new Float32Array(length),
+            committedRevision: -1,
+            pendingRevision: -1,
+            committedGeneration: 0,
+            pendingFrame: -1
+        };
+        records.set(mesh, record);
+        return record;
+    }
+
+    private commitTransformRecords(records: readonly TransformHistoryRecord[]): void {
+        for (const record of records) {
+            record.committed.set(record.pending);
+            record.committedRevision = record.pendingRevision;
+            record.committedGeneration = this.historyGeneration;
+            record.pendingFrame = -1;
+        }
+    }
+
+    private clearStagedHistory(): void {
+        this.stagedCameras.length = 0;
+        this.stagedModels.length = 0;
+        this.stagedSkinning.length = 0;
+        this.stagedMorphs.length = 0;
     }
 
     private createBuffer(layout: Std140Layout): UniformBuffer {

--- a/src/render/RenderTarget.ts
+++ b/src/render/RenderTarget.ts
@@ -1,5 +1,6 @@
 import type Texture from '../texture/Texture';
 import type { RendererBackend } from './Renderer';
+import type { CameraDepthMode } from '../camera/Camera';
 
 export type RenderTargetSampleCount = 1 | 4;
 
@@ -45,6 +46,8 @@ export interface RenderTargetDepthStencilAttachmentOptions {
     readonly format?: RenderTargetDepthStencilFormat;
     /** Expose the depth aspect as an engine Texture. Multisampled depth cannot be sampled. */
     readonly sampled?: boolean;
+    /** Projection/depth-buffer convention. Defaults to `standard`. */
+    readonly depthMode?: CameraDepthMode;
     readonly compare?: RenderTargetCompareFunction;
     readonly depthClearValue?: number;
     readonly depthLoadOp?: RenderTargetLoadOp;
@@ -127,6 +130,7 @@ export interface NormalizedRenderTargetColorAttachment {
 export interface NormalizedRenderTargetDepthStencilAttachment {
     readonly format: RenderTargetDepthStencilFormat;
     readonly sampled: boolean;
+    readonly depthMode: CameraDepthMode;
     readonly compare: RenderTargetCompareFunction;
     readonly depthClearValue: number;
     readonly depthLoadOp: RenderTargetLoadOp;
@@ -208,6 +212,10 @@ export function normalizeRenderTargetParameters(
                   const options = depthOptions ?? {};
                   const format = options.format ?? 'depth24plus-stencil8';
                   const sampled = options.sampled ?? false;
+                  const depthMode: unknown = options.depthMode ?? 'standard';
+                  if (depthMode !== 'standard' && depthMode !== 'reversed') {
+                      throw new TypeError('Depth mode must be "standard" or "reversed"');
+                  }
                   if (sampled && sampleCount > 1) {
                       throw new TypeError(
                           'A multisampled depth attachment cannot be resolved into a sampleable depth texture'
@@ -216,7 +224,8 @@ export function normalizeRenderTargetParameters(
                   if (!sampled && options.compare !== undefined) {
                       throw new TypeError('Depth comparison sampling requires sampled: true');
                   }
-                  const depthClearValue = options.depthClearValue ?? 1;
+                  const depthClearValue =
+                      options.depthClearValue ?? (depthMode === 'reversed' ? 0 : 1);
                   const stencilClearValue = options.stencilClearValue ?? 0;
                   if (
                       !Number.isFinite(depthClearValue) ||
@@ -254,7 +263,10 @@ export function normalizeRenderTargetParameters(
                   return Object.freeze({
                       format,
                       sampled,
-                      compare: options.compare ?? 'less-equal',
+                      depthMode,
+                      compare:
+                          options.compare ??
+                          (depthMode === 'reversed' ? 'greater-equal' : 'less-equal'),
                       depthClearValue,
                       depthLoadOp,
                       depthStoreOp,

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -20,6 +20,7 @@ import type {
     RendererFeatureName,
     RendererOptions,
     RendererOptionsMap,
+    RendererRenderingProfile,
     RendererSupportOptions,
     RendererWebGL2Options,
     RendererWebGPUOptions
@@ -42,6 +43,8 @@ export class Renderer<
     declare readonly lightManager: RendererContract['lightManager'];
     declare readonly resourceManager: RendererContract['resourceManager'];
     declare readonly renderTarget: RendererContract['renderTarget'];
+    declare readonly cameraRelative: RendererContract['cameraRelative'];
+    declare readonly renderingProfile: RendererContract['renderingProfile'];
     declare width: RendererContract['width'];
     declare height: RendererContract['height'];
     declare pixelRatio: RendererContract['pixelRatio'];
@@ -116,6 +119,7 @@ export type {
     RendererFeatureName,
     RendererOptions,
     RendererOptionsMap,
+    RendererRenderingProfile,
     RendererSupportOptions,
     RendererWebGL2Options,
     RendererWebGPUOptions

--- a/src/render/RendererCore.ts
+++ b/src/render/RendererCore.ts
@@ -137,6 +137,8 @@ export interface RendererContract {
     pixelRatio: number;
     domElement: HTMLCanvasElement | null;
     useInstanced: boolean;
+    readonly cameraRelative: boolean;
+    readonly renderingProfile: 'portable' | 'high-end';
     forceMaterial: Material | null;
     clearColor: Color;
     resize(width: number, height: number, force?: boolean): void;
@@ -197,6 +199,9 @@ export abstract class RendererCore extends EventDispatcher implements RendererCo
     premultipliedAlpha = true;
     failIfMajorPerformanceCaveat = false;
     useLogDepth = false;
+    /** Use frame-wide camera-relative GPU transforms without changing CPU world coordinates. */
+    cameraRelative = false;
+    readonly renderingProfile: 'portable' | 'high-end' = 'portable';
     vertexPrecision: ShaderPrecision = 'highp';
     fragmentPrecision: ShaderPrecision = 'highp';
     fog: Fog | null = null;

--- a/src/render/RendererOptions.ts
+++ b/src/render/RendererOptions.ts
@@ -11,6 +11,9 @@ export type RendererAdapterPowerPreference = 'low-power' | 'high-performance';
 /** Backend-neutral context power policy; `default` is accepted by WebGL2 contexts. */
 export type RendererContextPowerPreference = 'default' | RendererAdapterPowerPreference;
 
+/** Shared renderer policy bundle. `high-end` enables reversed-Z cameras and camera-relative GPU transforms. */
+export type RendererRenderingProfile = 'portable' | 'high-end';
+
 /** Optional device capabilities that the renderer can request through the portable RHI. */
 export type RendererFeatureName =
     | 'texture-compression-bc'
@@ -37,6 +40,13 @@ export interface RendererCommonOptions {
     premultipliedAlpha?: boolean;
     failIfMajorPerformanceCaveat?: boolean;
     useLogDepth?: boolean;
+    /**
+     * Subtract one frame-wide camera origin from GPU camera/model transforms while preserving CPU
+     * world coordinates. This improves large-world precision and enables stable temporal inputs.
+     */
+    cameraRelative?: boolean;
+    /** Renderer policy bundle. Defaults to `portable`. */
+    renderingProfile?: RendererRenderingProfile;
     vertexPrecision?: ShaderPrecision;
     fragmentPrecision?: ShaderPrecision;
     fog?: Fog | null;

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -146,6 +146,7 @@ import {
 import { importSurfaceColor, importSurfaceDepthStencil } from '../renderer/SurfaceGraphBridge';
 import { SharedDrawPassParameters } from '../renderer/passes/SharedDrawPass';
 import { refreshShadowAtlasSceneBinding } from '../renderer/ShadowAtlasTextureBinding';
+import { depthClearValue } from '../renderer/DepthConvention';
 
 type TextureAccess =
     | 'attachment'
@@ -4003,7 +4004,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 this.#outputState.depthStencilFormat === null
                     ? null
                     : {
-                          depthClearValue: 1,
+                          depthClearValue: depthClearValue(camera.depthMode),
                           depthLoadOp: 'clear',
                           depthStoreOp: 'discard',
                           stencilClearValue: 0,
@@ -4026,6 +4027,12 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
             this.#outputState.colorAttachmentCount = resolved.colorAttachmentCount;
             this.#outputColorFormats.length = resolved.colorFormats.length;
             const normalized = resolved.normalizedParameters;
+            const normalizedDepth = normalized.depthStencilAttachment;
+            if (normalizedDepth !== null && normalizedDepth.depthMode !== camera.depthMode) {
+                throw new TypeError(
+                    `Render target depth mode ${normalizedDepth.depthMode} does not match camera depth mode ${camera.depthMode}`
+                );
+            }
             for (let index = 0; index < resolved.colorFormats.length; index += 1) {
                 const format = resolved.colorFormats[index];
                 if (format !== undefined) this.#outputColorFormats[index] = format;
@@ -4041,7 +4048,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 );
             }
             this.#outputState.depthStencilFormat = resolved.depthStencilFormat;
-            this.configureOutputDepthStencilAttachment(normalized.depthStencilAttachment);
+            this.configureOutputDepthStencilAttachment(normalizedDepth);
             this.setViewport(0, 0, resolved.width, resolved.height);
         }
         const lease = Object.freeze({});
@@ -5094,7 +5101,15 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         );
         this.services.beginScriptableMeshPass(context);
         const draw = retained ?? new ScriptableGPUDrivenDraw();
-        draw.configure(pass, parameters, this, services, target, this.frameIndex);
+        draw.configure(
+            pass,
+            parameters,
+            this,
+            services,
+            target,
+            this.frameIndex,
+            this.camera.depthMode
+        );
         return draw;
     }
 

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -100,6 +100,7 @@ import { WgslComputeShaderCompiler } from '../shader/WgslComputeCompiler';
 import { StorageGraphicsShaderCompiler } from '../shader/StorageGraphicsShaderCompiler';
 import { RenderPipelineHost, type RenderPipelineHostLifecycle } from './RenderPipelineHost';
 import { cameraCompositionRequiresSingleSample } from './CameraCompositionPolicy';
+import { depthClearValue } from '../renderer/DepthConvention';
 import {
     ScriptableRenderPipelineContextImpl,
     ScriptableRenderPipelineResources,
@@ -129,10 +130,11 @@ interface RenderingResources {
     readonly shadowBinding: ShadowAtlasTextureBinding;
     readonly shadowOwner: object;
     readonly shadowPrepareOptions: { width: number; height: number };
-    readonly shadowRenderOptions: Readonly<{
+    readonly shadowRenderOptions: {
         label: string;
         preparer: ShadowAtlasMeshPreparer;
-    }>;
+        depthClearValue: number;
+    };
     readonly shadowViewport: {
         x: number;
         y: number;
@@ -281,6 +283,7 @@ class SharedRendererDriver
     #meshFrameStarted = false;
     #fullscreenFrameStarted = false;
     #surfaceRequested = false;
+    #surfaceDepthMode: Camera['depthMode'] | null = null;
     #shadowBindingAttachedThisFrame = false;
     #applicationPassCount = 0;
     #applicationFaceCount = 0;
@@ -319,6 +322,11 @@ class SharedRendererDriver
             );
         }
         Object.assign(this, options);
+        const renderingProfile: unknown = this.renderingProfile;
+        if (renderingProfile !== 'portable' && renderingProfile !== 'high-end') {
+            throw new TypeError('Renderer renderingProfile must be "portable" or "high-end"');
+        }
+        if (this.renderingProfile === 'high-end') this.cameraRelative = true;
         const optionRequiredFeatures =
             'requiredFeatures' in options ? options.requiredFeatures : undefined;
         const optionRequiredLimits =
@@ -503,6 +511,7 @@ class SharedRendererDriver
         this.#meshFrameStarted = false;
         this.#fullscreenFrameStarted = false;
         this.#surfaceRequested = false;
+        this.#surfaceDepthMode = null;
         this.#shadowBindingAttachedThisFrame = false;
         this.#applicationPassCount = 0;
         this.#applicationFaceCount = 0;
@@ -661,6 +670,7 @@ class SharedRendererDriver
         capabilities: RenderPipelineCapabilities,
         runtimeOwner: object
     ): RenderPipelineContext {
+        this.configureCameraProfile(camera);
         const resources = this.requireResources();
         if (!this.#scriptableResourcesFrameStarted) {
             const frameIndex = this.#pipelineHost.activeFrameIndex;
@@ -882,7 +892,17 @@ class SharedRendererDriver
     override createRenderTarget(parameters: RenderTargetParameters): RHIRenderTarget {
         this.assertReadyForRender();
         this.assertNoFrameMutation('createRenderTarget');
-        const target = new RHIRenderTarget(this, parameters);
+        const depth = parameters.depthStencilAttachment;
+        const resolvedParameters =
+            this.renderingProfile === 'high-end' &&
+            depth !== false &&
+            depth?.depthMode === undefined
+                ? {
+                      ...parameters,
+                      depthStencilAttachment: { ...(depth ?? {}), depthMode: 'reversed' as const }
+                  }
+                : parameters;
+        const target = new RHIRenderTarget(this, resolvedParameters);
         this.#renderTargets.add(target);
         return target;
     }
@@ -1340,10 +1360,11 @@ class SharedRendererDriver
         const shadowBinding = new ShadowAtlasTextureBinding();
         const shadowOwner = Object.freeze({ renderer: this });
         const shadowPrepareOptions = { width: 1, height: 1 };
-        const shadowRenderOptions = Object.freeze({
+        const shadowRenderOptions = {
             label: 'Shadow atlas',
-            preparer: shadowPreparer
-        });
+            preparer: shadowPreparer,
+            depthClearValue: 1
+        };
         const shadowViewport = {
             x: 0,
             y: 0,
@@ -1362,6 +1383,7 @@ class SharedRendererDriver
         recovery.registerSubmissionTracker(shadowRenderer.submissions);
         recovery.registerSynchronizer(processor.buffers);
         recovery.registerSynchronizer(processor.textures);
+        recovery.registerSynchronizer(processor.uniformBlocks);
         recovery.registerSynchronizer(postProcess.fullscreen);
         recovery.registerSynchronizer(storageBuffers);
         recovery.registerSynchronizer({
@@ -1629,6 +1651,16 @@ class SharedRendererDriver
         const viewport = this.surfaceViewport();
         const context = this.createContext(camera, viewport);
         const isOverlayCamera = this.#surfaceRequested;
+        if (
+            isOverlayCamera &&
+            !camera.clearDepth &&
+            this.#surfaceDepthMode !== null &&
+            this.#surfaceDepthMode !== camera.depthMode
+        ) {
+            throw new TypeError(
+                'Composed cameras may preserve surface depth only when their depth modes match.'
+            );
+        }
         const preservePreviousColor = isOverlayCamera && !camera.clearColor;
         const forceSingleSample = cameraCompositionRequiresSingleSample(camera);
         this.ensureMeshFrame(context);
@@ -1662,12 +1694,14 @@ class SharedRendererDriver
                         : null,
                 depthLoadOp: isOverlayCamera && !camera.clearDepth ? 'load' : 'clear',
                 depthStoreOp: 'store',
+                clearDepth: depthClearValue(camera.depthMode),
                 stencilLoadOp: isOverlayCamera && !camera.clearStencil ? 'load' : 'clear',
                 stencilStoreOp: 'store'
             },
             true
         );
         this.#surfaceRequested = true;
+        this.#surfaceDepthMode = camera.depthMode;
         this.recordSceneBuild(visible, fireEvent, shadowPassCount);
         this.#pendingPresentationStage = stage;
         this.#pendingPresentationCamera = camera;
@@ -1699,6 +1733,11 @@ class SharedRendererDriver
         );
         const normalized = target.normalizedParameters;
         const depth = normalized.depthStencilAttachment;
+        if (depth !== null && depth.depthMode !== camera.depthMode) {
+            throw new TypeError(
+                `Render target depth mode ${depth.depthMode} does not match camera depth mode ${camera.depthMode}`
+            );
+        }
         this.fireBeforeSceneEvents(visible, fireEvent);
         const record = resources.offscreen.build(
             this.#pipelineHost.requireActiveScope(),
@@ -1762,7 +1801,12 @@ class SharedRendererDriver
             return 0;
         }
 
-        const atlas = resources.shadowResources.prepare(resources.shadowOwner, plan.atlas);
+        const atlas = resources.shadowResources.prepare(
+            resources.shadowOwner,
+            plan.atlas,
+            context.camera.depthMode
+        );
+        resources.shadowRenderOptions.depthClearValue = depthClearValue(context.camera.depthMode);
         resources.shadowPreparer.configure(plan, meshes);
         const viewport = resources.shadowViewport;
         viewport.width = atlas.width;
@@ -1784,6 +1828,7 @@ class SharedRendererDriver
 
     private prepareScene(stage: RendererScene, camera: Camera): readonly Mesh[] {
         if (!this.#pipelineHost.recording) this.resetDiagnosticsFrame();
+        this.configureCameraProfile(camera);
         this.fog = stage.fog ?? null;
         stage.updateMatrixWorld();
         camera.updateViewProjectionMatrix();
@@ -1792,6 +1837,10 @@ class SharedRendererDriver
         visible.length = 0;
         this.renderList.traverse(this.#collectVisibleMesh);
         return visible;
+    }
+
+    private configureCameraProfile(camera: Camera): void {
+        if (this.renderingProfile === 'high-end') camera.depthMode = 'reversed';
     }
 
     private executeRetainedPresentation(): void {

--- a/src/render/pipeline/ForwardRenderPipeline.ts
+++ b/src/render/pipeline/ForwardRenderPipeline.ts
@@ -37,6 +37,7 @@ import type {
     RenderPipelineExtent,
     RenderPipelineTextureDescriptor
 } from './ScriptableRenderGraph';
+import { depthClearValue } from '../renderer/DepthConvention';
 
 /** Stable stages at which a forward feature may synchronously record graph work. */
 export type ForwardRenderInjectionPoint =
@@ -1013,7 +1014,8 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
     ): void {
         const operations = this.#depthOperations;
         const selected = context.output.depthStencilAttachment;
-        operations.depthClearValue = selected?.depthClearValue ?? 1;
+        operations.depthClearValue =
+            selected?.depthClearValue ?? depthClearValue(context.camera.depthMode);
         operations.stencilClearValue = selected?.stencilClearValue ?? 0;
         const writesOutput = depth !== null && depth === outputDepth;
         if (writesOutput) {

--- a/src/render/renderer/DepthConvention.ts
+++ b/src/render/renderer/DepthConvention.ts
@@ -1,0 +1,29 @@
+import type { CameraDepthMode } from '../../camera/Camera';
+import type { RHICompareFunction } from '../rhi/core';
+
+export function depthClearValue(mode: CameraDepthMode): 0 | 1 {
+    return mode === 'reversed' ? 0 : 1;
+}
+
+export function depthComparison(mode: CameraDepthMode): 'greater-equal' | 'less-equal' {
+    return mode === 'reversed' ? 'greater-equal' : 'less-equal';
+}
+
+export function applyDepthModeToComparison(
+    comparison: RHICompareFunction,
+    mode: CameraDepthMode
+): RHICompareFunction {
+    if (mode !== 'reversed') return comparison;
+    switch (comparison) {
+        case 'less':
+            return 'greater';
+        case 'less-equal':
+            return 'greater-equal';
+        case 'greater':
+            return 'less';
+        case 'greater-equal':
+            return 'less-equal';
+        default:
+            return comparison;
+    }
+}

--- a/src/render/renderer/GPUDrivenPipelineResourceCache.ts
+++ b/src/render/renderer/GPUDrivenPipelineResourceCache.ts
@@ -1,4 +1,5 @@
 import { TRIANGLES } from '../../constants/webgl';
+import type { CameraDepthMode } from '../../camera/Camera';
 import type Material from '../../material/Material';
 import type { ShaderReadBinding } from '../compute/ComputeShader';
 import type StorageGraphicsShader from '../compute/StorageGraphicsShader';
@@ -78,6 +79,7 @@ interface CompiledShaderMemo {
 }
 
 interface PipelineStateMemo {
+    readonly depthMode: CameraDepthMode;
     readonly material: Material;
     readonly primitiveMode: number;
     readonly stripIndexFormat: RHIIndexFormat | undefined;
@@ -118,10 +120,12 @@ function samePipelineStateMemo(
     material: Material,
     target: RHIMeshDrawTargetDescriptor,
     primitiveMode: number,
-    stripIndexFormat: RHIIndexFormat | undefined
+    stripIndexFormat: RHIIndexFormat | undefined,
+    depthMode: CameraDepthMode
 ): boolean {
     if (
         memo.material !== material ||
+        memo.depthMode !== depthMode ||
         memo.primitiveMode !== primitiveMode ||
         memo.stripIndexFormat !== stripIndexFormat ||
         memo.colorFormats.length !== target.colorFormats.length ||
@@ -168,9 +172,11 @@ function createPipelineStateMemo(
     target: RHIMeshDrawTargetDescriptor,
     primitiveMode: number,
     stripIndexFormat: RHIIndexFormat | undefined,
-    record: Readonly<GPUDrivenPipelineResourceRecord>
+    record: Readonly<GPUDrivenPipelineResourceRecord>,
+    depthMode: CameraDepthMode
 ): PipelineStateMemo {
     return {
+        depthMode,
         material,
         primitiveMode,
         stripIndexFormat,
@@ -475,7 +481,8 @@ export class GPUDrivenPipelineResourceCache {
         shader: StorageGraphicsShader,
         material: Material,
         publicVertexLayouts: readonly Readonly<GPUDrivenVertexBufferLayout>[],
-        target: RHIMeshDrawTargetDescriptor
+        target: RHIMeshDrawTargetDescriptor,
+        depthMode: CameraDepthMode = 'standard'
     ): Readonly<GPUDrivenPipelineResourceRecord> {
         return this.prepareLayoutIdentity(
             shader,
@@ -483,7 +490,9 @@ export class GPUDrivenPipelineResourceCache {
             publicVertexLayouts,
             'procedural',
             target,
-            TRIANGLES
+            TRIANGLES,
+            undefined,
+            depthMode
         );
     }
 
@@ -510,7 +519,8 @@ export class GPUDrivenPipelineResourceCache {
         vertexLayouts: readonly Readonly<RHIVertexBufferLayout>[],
         target: RHIMeshDrawTargetDescriptor,
         primitiveMode: number,
-        stripIndexFormat?: RHIIndexFormat
+        stripIndexFormat?: RHIIndexFormat,
+        depthMode: CameraDepthMode = 'standard'
     ): Readonly<GPUDrivenPipelineResourceRecord> {
         return this.prepareLayoutIdentity(
             shader,
@@ -519,7 +529,8 @@ export class GPUDrivenPipelineResourceCache {
             'scene',
             target,
             primitiveMode,
-            stripIndexFormat
+            stripIndexFormat,
+            depthMode
         );
     }
 
@@ -532,7 +543,8 @@ export class GPUDrivenPipelineResourceCache {
         layoutKind: 'procedural' | 'scene',
         target: RHIMeshDrawTargetDescriptor,
         primitiveMode: number,
-        stripIndexFormat?: RHIIndexFormat
+        stripIndexFormat?: RHIIndexFormat,
+        depthMode: CameraDepthMode = 'standard'
     ): Readonly<GPUDrivenPipelineResourceRecord> {
         this.assertAlive();
         if (this.registry.deviceBackend !== 'webgpu') {
@@ -546,7 +558,14 @@ export class GPUDrivenPipelineResourceCache {
         if (layoutMemo !== undefined) {
             for (const memo of layoutMemo.states) {
                 if (
-                    samePipelineStateMemo(memo, material, target, primitiveMode, stripIndexFormat)
+                    samePipelineStateMemo(
+                        memo,
+                        material,
+                        target,
+                        primitiveMode,
+                        stripIndexFormat,
+                        depthMode
+                    )
                 ) {
                     return memo.record;
                 }
@@ -572,7 +591,8 @@ export class GPUDrivenPipelineResourceCache {
             this.registry.deviceCapabilities,
             'color',
             stripIndexFormat,
-            compiled.metadata.fragmentOutputs
+            compiled.metadata.fragmentOutputs,
+            depthMode
         );
         const signature = pipelineSignature(vertexLayouts, pipelineState);
         const createdBucket = bucket === undefined;
@@ -590,7 +610,14 @@ export class GPUDrivenPipelineResourceCache {
         const cached = bucket.recordsBySignature.get(signature);
         if (cached !== undefined) {
             layoutMemo.states.push(
-                createPipelineStateMemo(material, target, primitiveMode, stripIndexFormat, cached)
+                createPipelineStateMemo(
+                    material,
+                    target,
+                    primitiveMode,
+                    stripIndexFormat,
+                    cached,
+                    depthMode
+                )
             );
             return cached;
         }
@@ -646,7 +673,14 @@ export class GPUDrivenPipelineResourceCache {
         bucket.records.add(record);
         this.#bucketByRecord.set(record, bucket);
         layoutMemo.states.push(
-            createPipelineStateMemo(material, target, primitiveMode, stripIndexFormat, record)
+            createPipelineStateMemo(
+                material,
+                target,
+                primitiveMode,
+                stripIndexFormat,
+                record,
+                depthMode
+            )
         );
         return record;
     }

--- a/src/render/renderer/InstanceBatchCompiler.ts
+++ b/src/render/renderer/InstanceBatchCompiler.ts
@@ -29,6 +29,17 @@ export interface InstanceBatchCompilerCapabilities {
     >;
 }
 
+/** Internal bridge to the submission-transactional current/previous transform store. */
+export interface InstanceTransformHistory {
+    readonly renderOrigin: Readonly<Float32Array>;
+    writeInstanceModelMatrices(
+        mesh: Mesh,
+        current: Float32Array,
+        previous: Float32Array,
+        offset: number
+    ): void;
+}
+
 /** One interleaved, high-water CPU stream appended after the per-vertex streams. */
 export interface InstanceBatchVertexStreamPlan {
     readonly source: GeometryData;
@@ -610,6 +621,7 @@ class BatchRecord {
     private uniformBuffer: UniformBuffer | null = null;
     private uniformBufferFloats: Float32Array | null = null;
     private modelScratch: Float32Array | null = null;
+    private previousModelScratch: Float32Array | null = null;
     private normalScratch: Float32Array | null = null;
     private readonly normalMatrix3 = new Matrix3();
     private readonly normalMatrix4 = new Matrix4();
@@ -694,7 +706,8 @@ class BatchRecord {
         material: Material,
         inputs: readonly InstanceBatchVertexInputReflection[],
         capabilities: InstanceBatchCompilerCapabilities,
-        programInfo: ProgramBindingInfo
+        programInfo: ProgramBindingInfo,
+        transformHistory?: InstanceTransformHistory
     ): Readonly<InstanceBatchPlan> {
         this.classify(
             inputs,
@@ -808,7 +821,8 @@ class BatchRecord {
                 requirePresent(candidateStagingView, 'instance staging view'),
                 meshes,
                 material,
-                programInfo
+                programInfo,
+                transformHistory?.renderOrigin
             );
         }
 
@@ -817,21 +831,34 @@ class BatchRecord {
         if (this.backend === 'webgpu') {
             this.ensureUniformScratch();
             const modelScratch = requirePresent(this.modelScratch, 'model-matrix staging storage');
+            const previousModelScratch = requirePresent(
+                this.previousModelScratch,
+                'previous model-matrix staging storage'
+            );
             const normalScratch = requirePresent(
                 this.normalScratch,
                 'normal-matrix staging storage'
             );
             modelScratch.fill(0);
+            previousModelScratch.fill(0);
             normalScratch.fill(0);
             for (let meshIndex = 0; meshIndex < meshes.length; meshIndex += 1) {
                 const mesh = requirePresent(meshes[meshIndex], 'instance mesh');
-                const world = validateWorldMatrix(mesh);
                 const matrixOffset = meshIndex * 16;
-                for (let component = 0; component < 16; component += 1) {
-                    modelScratch[matrixOffset + component] = requirePresent(
-                        world[component],
-                        'world-matrix component'
+                if (transformHistory !== undefined) {
+                    transformHistory.writeInstanceModelMatrices(
+                        mesh,
+                        modelScratch,
+                        previousModelScratch,
+                        matrixOffset
                     );
+                } else {
+                    const world = validateWorldMatrix(mesh);
+                    for (let component = 0; component < 16; component += 1) {
+                        const value = requirePresent(world[component], 'world-matrix component');
+                        modelScratch[matrixOffset + component] = value;
+                        previousModelScratch[matrixOffset + component] = value;
+                    }
                 }
                 requireInvertibleWorldMatrix(mesh);
                 this.normalMatrix4.invert(mesh.worldMatrix).transpose();
@@ -854,12 +881,21 @@ class BatchRecord {
                     instanceBlockLayout.fields.u_instanceModelMatrices.offset / FLOAT_BYTES;
                 const normalOffset =
                     instanceBlockLayout.fields.u_instanceNormalMatrices.offset / FLOAT_BYTES;
-                modelChanged = !arraysEqual(
-                    modelScratch,
-                    this.uniformBufferFloats,
-                    modelScratch.length,
-                    modelOffset
-                );
+                const previousModelOffset =
+                    instanceBlockLayout.fields.u_previousInstanceModelMatrices.offset / FLOAT_BYTES;
+                modelChanged =
+                    !arraysEqual(
+                        modelScratch,
+                        this.uniformBufferFloats,
+                        modelScratch.length,
+                        modelOffset
+                    ) ||
+                    !arraysEqual(
+                        previousModelScratch,
+                        this.uniformBufferFloats,
+                        previousModelScratch.length,
+                        previousModelOffset
+                    );
                 normalChanged = !arraysEqual(
                     normalScratch,
                     this.uniformBufferFloats,
@@ -943,6 +979,13 @@ class BatchRecord {
                     'u_instanceModelMatrices',
                     requirePresent(this.modelScratch, 'model-matrix staging storage')
                 );
+                this.uniformBuffer.set(
+                    'u_previousInstanceModelMatrices',
+                    requirePresent(
+                        this.previousModelScratch,
+                        'previous model-matrix staging storage'
+                    )
+                );
             }
             if (normalChanged) {
                 this.uniformBuffer.set(
@@ -997,6 +1040,7 @@ class BatchRecord {
         this.uniformBuffer = null;
         this.uniformBufferFloats = null;
         this.modelScratch = null;
+        this.previousModelScratch = null;
         this.normalScratch = null;
     }
 
@@ -1168,7 +1212,8 @@ class BatchRecord {
         target: Float32Array,
         meshes: readonly Mesh[],
         material: Material,
-        programInfo: ProgramBindingInfo
+        programInfo: ProgramBindingInfo,
+        renderOrigin?: Readonly<Float32Array>
     ): void {
         let componentsPerInstance = 0;
         const last = this.instanceScratch.at(-1);
@@ -1179,10 +1224,17 @@ class BatchRecord {
             for (const input of this.instanceScratch) {
                 const targetOffset = instanceOffset + input.componentOffset;
                 if (input.builtIn === 1) {
+                    const world = validateWorldMatrix(mesh);
+                    if (renderOrigin !== undefined) {
+                        this.normalMatrix4.fromArray(world);
+                        this.normalMatrix4.elements[12] -= renderOrigin[0] ?? 0;
+                        this.normalMatrix4.elements[13] -= renderOrigin[1] ?? 0;
+                        this.normalMatrix4.elements[14] -= renderOrigin[2] ?? 0;
+                    }
                     copyResolvedValue(
                         target,
                         targetOffset,
-                        validateWorldMatrix(mesh),
+                        renderOrigin === undefined ? world : this.normalMatrix4.elements,
                         16,
                         input.name,
                         mesh
@@ -1215,11 +1267,17 @@ class BatchRecord {
     }
 
     private ensureUniformScratch(): void {
-        if (this.modelScratch !== null && this.normalScratch !== null) return;
+        if (
+            this.modelScratch !== null &&
+            this.previousModelScratch !== null &&
+            this.normalScratch !== null
+        )
+            return;
         const componentCount = MAX_INSTANCES_PER_DRAW * 16;
         this.modelScratch = new Float32Array(componentCount);
+        this.previousModelScratch = new Float32Array(componentCount);
         this.normalScratch = new Float32Array(componentCount);
-        this.diagnostics.storageAllocationCount += 2;
+        this.diagnostics.storageAllocationCount += 3;
     }
 
     private buildStreamLayout(stride: number): Readonly<RHIVertexBufferLayout> {
@@ -1330,7 +1388,8 @@ export class InstanceBatchCompiler {
         backend: RHIBackend,
         capabilities: InstanceBatchCompilerCapabilities,
         programInfo: ProgramBindingInfo = EMPTY_PROGRAM_INFO,
-        allowMaterialOverride = false
+        allowMaterialOverride = false,
+        transformHistory?: InstanceTransformHistory
     ): Readonly<InstanceBatchPlan> {
         validateBatch(owner, meshes, material, allowMaterialOverride);
         requireBackend(backend);
@@ -1348,7 +1407,15 @@ export class InstanceBatchCompiler {
             this.diagnosticState.planCapacity++;
         }
         try {
-            const plan = record.compile(owner, meshes, material, inputs, capabilities, programInfo);
+            const plan = record.compile(
+                owner,
+                meshes,
+                material,
+                inputs,
+                capabilities,
+                programInfo,
+                transformHistory
+            );
             if (createdRecord) {
                 records[backend] = record;
                 this.diagnosticState.activePlanCount++;

--- a/src/render/renderer/MeshDrawProcessor.ts
+++ b/src/render/renderer/MeshDrawProcessor.ts
@@ -535,7 +535,7 @@ export class MeshDrawProcessor {
             throw new Error('Mesh draw processor frame is already active');
         }
         this.validateContext(context);
-        this.activateContext(context, true);
+        this.activateContext(context, true, uploads);
         this.buffers.beginFrame(context.frameIndex, uploads);
         this.textures.beginFrame(context.frameIndex, uploads);
         this.resourceUses.beginFrame(context.frameIndex, uploads);
@@ -586,16 +586,29 @@ export class MeshDrawProcessor {
         if (!(context.lightManager instanceof LightManager)) {
             throw new TypeError('Mesh draw lighting requires a real LightManager instance');
         }
+        if (context.renderer.useLogDepth) {
+            const far: unknown = Reflect.get(context.camera, 'far');
+            if (context.camera.depthMode === 'reversed') {
+                throw new TypeError('Logarithmic depth cannot be combined with reversed-Z.');
+            }
+            if (typeof far !== 'number' || !Number.isFinite(far)) {
+                throw new TypeError('Logarithmic depth requires a finite camera far plane.');
+            }
+        }
     }
 
-    private activateContext(context: RenderGraphFrameContext, applicationFrame: boolean): void {
+    private activateContext(
+        context: RenderGraphFrameContext,
+        applicationFrame: boolean,
+        uploads?: RHIUploadBatch
+    ): void {
         context.lightManager.updateInfo(context.camera);
         refreshShadowAtlasSceneBinding(context.lightManager);
         this.#validatedLightingFrame = -1;
         this.#validatedLightManager = null;
         this.#hasShadowSamplerDependency = false;
         this.#sampledGraphDependencies.length = 0;
-        if (applicationFrame) this.uniformBlocks.beginSemanticFrame(context.semantic);
+        if (applicationFrame) this.uniformBlocks.beginSemanticFrame(context.semantic, uploads);
         else this.uniformBlocks.beginSemanticPass(context.semantic);
         this.#programBindingInfo.semanticFrame = context.semantic;
         this.#passSemanticFrame = context.semantic;
@@ -667,7 +680,8 @@ export class MeshDrawProcessor {
             fragmentOutputMode,
             geometry.mode,
             stripIndexFormat,
-            numericDepthSamplerMask
+            numericDepthSamplerMask,
+            context.camera.depthMode
         );
 
         const uniformHandles = this.prepareUniformBuffers(
@@ -834,7 +848,8 @@ export class MeshDrawProcessor {
             vertexPlan.vertexBuffers,
             target,
             geometry.mode,
-            stripIndexFormat
+            stripIndexFormat,
+            context.camera.depthMode
         );
         const globalLayout = pipeline.bindGroupLayouts[SCENE_STORAGE_BIND_GROUP];
         if (globalLayout === undefined) {
@@ -1012,7 +1027,8 @@ export class MeshDrawProcessor {
             'depth-only',
             geometry.mode,
             stripIndexFormat,
-            numericDepthSamplerMask
+            numericDepthSamplerMask,
+            context.camera.depthMode
         );
         const uniformHandles = this.prepareUniformBuffers(
             owner,
@@ -1198,7 +1214,8 @@ export class MeshDrawProcessor {
             this.registry.deviceBackend,
             this.registry.deviceCapabilities,
             this.#programBindingInfo,
-            forcedMaterial !== null
+            forcedMaterial !== null,
+            this.uniformBlocks
         );
         const vertexPlan = this.vertexInputs.compile(
             instancePlan.perVertexInputs,
@@ -1243,7 +1260,8 @@ export class MeshDrawProcessor {
             fragmentOutputMode,
             geometry.mode,
             stripIndexFormat,
-            numericDepthSamplerMask
+            numericDepthSamplerMask,
+            context.camera.depthMode
         );
         const instanceBlock = instancePlan.webGPUInstanceBlock;
         const uniformHandles = this.prepareUniformBuffers(

--- a/src/render/renderer/PipelineResourceCache.ts
+++ b/src/render/renderer/PipelineResourceCache.ts
@@ -1,4 +1,5 @@
 import type Shader from '../../shader/Shader';
+import type { CameraDepthMode } from '../../camera/Camera';
 import { TRIANGLES } from '../../constants/webgl';
 import {
     RHICacheCounter,
@@ -120,6 +121,7 @@ interface MutableVertexLayoutsMemo {
 type VertexLayoutsMemo = Readonly<PipelineResourceRecord> | MutableVertexLayoutsMemo;
 
 interface PipelineRequestVariant {
+    readonly depthMode: CameraDepthMode;
     readonly primitiveMode: number;
     readonly stripIndexFormat: RHIIndexFormat | undefined;
     readonly wireframe: boolean;
@@ -161,7 +163,8 @@ function samePipelineRequestVariant(
     material: RHIMeshDrawMaterialState,
     target: RHIMeshDrawTargetDescriptor,
     primitiveMode: number,
-    stripIndexFormat: RHIIndexFormat | undefined
+    stripIndexFormat: RHIIndexFormat | undefined,
+    depthMode: CameraDepthMode
 ): boolean {
     if (
         variant.colorFormats.length !== target.colorFormats.length ||
@@ -175,6 +178,7 @@ function samePipelineRequestVariant(
     }
     return (
         variant.primitiveMode === primitiveMode &&
+        variant.depthMode === depthMode &&
         variant.stripIndexFormat === stripIndexFormat &&
         variant.wireframe === material.wireframe &&
         variant.frontFace === material.frontFace &&
@@ -211,9 +215,11 @@ function createPipelineRequestVariant(
     primitiveMode: number,
     stripIndexFormat: RHIIndexFormat | undefined,
     pipelineState: Readonly<RHIMeshDrawPipelineState>,
-    stateSignature: string
+    stateSignature: string,
+    depthMode: CameraDepthMode
 ): PipelineRequestVariant {
     return {
+        depthMode,
         primitiveMode,
         stripIndexFormat,
         wireframe: material.wireframe,
@@ -442,7 +448,8 @@ export class PipelineResourceCache {
         fragmentOutputMode: ShaderFragmentOutputMode = 'color',
         primitiveMode = TRIANGLES,
         stripIndexFormat?: RHIIndexFormat,
-        numericDepthSamplerMask = 0
+        numericDepthSamplerMask = 0,
+        depthMode: CameraDepthMode = 'standard'
     ): Readonly<PipelineResourceRecord> {
         this.assertAlive();
         const vertexLayouts = this.normalizeVertexLayouts(vertexLayout);
@@ -491,7 +498,8 @@ export class PipelineResourceCache {
                             material,
                             target,
                             primitiveMode,
-                            stripIndexFormat
+                            stripIndexFormat,
+                            depthMode
                         )
                     ) {
                         requestVariant = candidate;
@@ -525,7 +533,8 @@ export class PipelineResourceCache {
                 this.registry.deviceCapabilities,
                 fragmentOutputMode,
                 stripIndexFormat,
-                compiled.metadata.fragmentOutputs
+                compiled.metadata.fragmentOutputs,
+                depthMode
             );
             requestVariant = createPipelineRequestVariant(
                 material,
@@ -533,7 +542,8 @@ export class PipelineResourceCache {
                 primitiveMode,
                 stripIndexFormat,
                 pipelineState,
-                pipelineStateSignature(pipelineState)
+                pipelineStateSignature(pipelineState),
+                depthMode
             );
         }
         const signature = `${vertexLayoutsSignature(vertexLayoutSnapshot)}#${requestVariant.pipelineStateSignature}`;

--- a/src/render/renderer/RHIDescriptorMapping.ts
+++ b/src/render/renderer/RHIDescriptorMapping.ts
@@ -1,5 +1,6 @@
 import type GeometryData from '../../geometry/GeometryData';
 import type Material from '../../material/Material';
+import type { CameraDepthMode } from '../../camera/Camera';
 import {
     ALWAYS,
     BACK,
@@ -74,6 +75,7 @@ import {
     type RHIVertexFormat,
     type RHICapabilities
 } from '../rhi/core';
+import { applyDepthModeToComparison } from './DepthConvention';
 
 /** Render-target identity required to create the first production mesh-draw pipeline. */
 export interface RHIMeshDrawTargetDescriptor {
@@ -454,7 +456,8 @@ export function mapRHIDefaultBlendState(
 
 export function mapRHIDepthStencilState(
     material: RHIMeshDrawMaterialState,
-    format: RHITextureFormat | null | undefined
+    format: RHITextureFormat | null | undefined,
+    depthMode: CameraDepthMode = 'standard'
 ): Readonly<RHIDepthStencilState> | undefined {
     mapRHIMeshDrawDynamicState(material);
     if (format === null || format === undefined) {
@@ -498,7 +501,9 @@ export function mapRHIDepthStencilState(
     return Object.freeze({
         format,
         depthCompare:
-            hasDepth && material.depthTest ? mapRHICompareFunction(material.depthFunc) : 'always',
+            hasDepth && material.depthTest
+                ? applyDepthModeToComparison(mapRHICompareFunction(material.depthFunc), depthMode)
+                : 'always',
         depthWriteEnabled: hasDepth && material.depthTest && material.depthMask,
         ...stencilState
     });
@@ -663,11 +668,12 @@ export function createRHIMeshDrawPipelineState(
     capabilities?: RHIMeshDrawTargetCapabilities,
     fragmentOutputMode: RHIMeshDrawFragmentOutputMode = 'color',
     stripIndexFormat?: RHIIndexFormat,
-    fragmentOutputs?: readonly Readonly<RHIShaderFragmentOutputReflection>[]
+    fragmentOutputs?: readonly Readonly<RHIShaderFragmentOutputReflection>[],
+    depthMode: CameraDepthMode = 'standard'
 ): Readonly<RHIMeshDrawPipelineState> {
     if (fragmentOutputMode === 'depth-only') {
         const depthFormat = validateRHIMeshDepthOnlyTarget(target, capabilities);
-        const mappedDepth = mapRHIDepthStencilState(material, depthFormat);
+        const mappedDepth = mapRHIDepthStencilState(material, depthFormat, depthMode);
         if (mappedDepth === undefined) {
             throw new Error('Depth-only mesh state could not be created');
         }
@@ -677,7 +683,10 @@ export function createRHIMeshDrawPipelineState(
             colorTargets: Object.freeze([]),
             depthStencil: Object.freeze({
                 ...mappedDepth,
-                depthCompare: mapRHICompareFunction(material.depthFunc),
+                depthCompare: applyDepthModeToComparison(
+                    mapRHICompareFunction(material.depthFunc),
+                    depthMode
+                ),
                 depthWriteEnabled: true
             }),
             multisample: mapRHIMultisampleState(target.sampleCount, material.sampleAlphaToCoverage)
@@ -714,7 +723,7 @@ export function createRHIMeshDrawPipelineState(
             });
         })
     );
-    const depthStencil = mapRHIDepthStencilState(material, target.depthStencilFormat);
+    const depthStencil = mapRHIDepthStencilState(material, target.depthStencilFormat, depthMode);
     const multisample = mapRHIMultisampleState(target.sampleCount, material.sampleAlphaToCoverage);
 
     return Object.freeze({

--- a/src/render/renderer/ScriptableGPUDrivenDraw.ts
+++ b/src/render/renderer/ScriptableGPUDrivenDraw.ts
@@ -3,6 +3,7 @@ import type { ShaderReadBinding } from '../compute/ComputeShader';
 import ComputeSampler from '../compute/ComputeSampler';
 import type { RGBufferHandle, RGTextureAccessHandle } from '../graph/RenderGraphResource';
 import type { RGPrepareContext } from '../graph/RenderGraphExecutor';
+import type { CameraDepthMode } from '../../camera/Camera';
 import type {
     GPUDrivenRenderPassParameters,
     GPUDrivenRenderPass
@@ -257,6 +258,7 @@ export class ScriptableGPUDrivenDraw {
     #indirectOffset = 0;
     #frameIndex = -1;
     #configured = false;
+    #depthMode: CameraDepthMode = 'standard';
 
     get draw(): PreparedDraw {
         const draw = this.#draw;
@@ -270,7 +272,8 @@ export class ScriptableGPUDrivenDraw {
         resolver: ScriptableGPUDrivenGraphResolver,
         services: ScriptableGPUDrivenDrawServices,
         target: RHIMeshDrawTargetDescriptor,
-        frameIndex: number
+        frameIndex: number,
+        depthMode: CameraDepthMode = 'standard'
     ): void {
         if (!Number.isSafeInteger(frameIndex) || frameIndex < 0) {
             throw new RangeError('GPU-driven frame index must be non-negative');
@@ -282,6 +285,7 @@ export class ScriptableGPUDrivenDraw {
         this.#services = services;
         this.#pipeline = null;
         this.#frameIndex = frameIndex;
+        this.#depthMode = depthMode;
         this.#configured = false;
         this.snapshotTarget(target);
 
@@ -444,7 +448,8 @@ export class ScriptableGPUDrivenDraw {
                 pass.shader,
                 pass.material,
                 pass.vertexLayouts,
-                this.#target
+                this.#target,
+                this.#depthMode
             );
             services.resourceUses.use(record.pipeline);
             this.#pipeline = services.pipelines.resolvePipeline(record);

--- a/src/render/renderer/ShadowAtlasRenderer.ts
+++ b/src/render/renderer/ShadowAtlasRenderer.ts
@@ -31,6 +31,8 @@ export interface ShadowAtlasRenderOptions<Owner extends object = object> {
     /** Prebuilt queues in `plan.slices` order. Mutually exclusive with `preparer`. */
     readonly sliceDraws?: readonly (readonly PreparedDraw[])[];
     readonly preparer?: ShadowAtlasSlicePreparer<Owner>;
+    /** Clear value matching the shadow cameras' depth convention. */
+    readonly depthClearValue?: number;
 }
 
 /**
@@ -140,7 +142,7 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
                 pass.label = `${options.label ?? 'Shadow atlas'} ${slice.kind} ${String(slice.sliceIndex)}`;
                 pass.setDepthStencilAttachment({
                     texture: atlasTexture,
-                    ...(index === 0 ? { depthClearValue: 1 } : {}),
+                    ...(index === 0 ? { depthClearValue: options.depthClearValue ?? 1 } : {}),
                     depthLoadOp: index === 0 ? 'clear' : 'load',
                     depthStoreOp: 'store'
                 });

--- a/src/render/renderer/ShadowAtlasResourceCache.ts
+++ b/src/render/renderer/ShadowAtlasResourceCache.ts
@@ -9,12 +9,15 @@ import {
 } from '../rhi/core';
 import type { ResourceRegistry, ResourceRegistryHandle } from './ResourceRegistry';
 import { assertShadowAtlasFormatSupported, type ShadowAtlasPlan } from './ShadowAtlasPlanner';
+import type { CameraDepthMode } from '../../camera/Camera';
+import { depthComparison } from './DepthConvention';
 
 export interface ShadowAtlasResourceRecord {
     readonly token: number;
     readonly width: number;
     readonly height: number;
     readonly format: RHITextureFormat;
+    readonly depthMode: CameraDepthMode;
     readonly texture: ResourceRegistryHandle<RHITexture>;
     readonly textureDescriptor: Readonly<RHINormalizedTextureDescriptor>;
     /** Persistent depth view consumed by reflected comparison-sampler bind groups. */
@@ -41,7 +44,11 @@ export class ShadowAtlasResourceCache {
 
     constructor(readonly registry: ResourceRegistry) {}
 
-    prepare(owner: object, plan: Readonly<ShadowAtlasPlan>): Readonly<ShadowAtlasResourceRecord> {
+    prepare(
+        owner: object,
+        plan: Readonly<ShadowAtlasPlan>,
+        depthMode: CameraDepthMode = 'standard'
+    ): Readonly<ShadowAtlasResourceRecord> {
         this.assertAlive();
         requireOwner(owner);
         this.validatePlanShape(plan);
@@ -49,7 +56,8 @@ export class ShadowAtlasResourceCache {
         if (
             current?.resource.width === plan.width &&
             current.resource.height === plan.height &&
-            current.resource.format === plan.format
+            current.resource.format === plan.format &&
+            current.resource.depthMode === depthMode
         ) {
             return current.resource;
         }
@@ -99,7 +107,7 @@ export class ShadowAtlasResourceCache {
                 mipmapFilter: 'nearest',
                 lodMinClamp: 0,
                 lodMaxClamp: 0,
-                compare: 'less-equal',
+                compare: depthComparison(depthMode),
                 maxAnisotropy: 1
             });
         } catch (error) {
@@ -116,6 +124,7 @@ export class ShadowAtlasResourceCache {
                 width: plan.width,
                 height: plan.height,
                 format: plan.format,
+                depthMode,
                 texture,
                 textureDescriptor,
                 view,

--- a/src/render/renderer/ShadowAtlasSceneAdapter.ts
+++ b/src/render/renderer/ShadowAtlasSceneAdapter.ts
@@ -391,6 +391,7 @@ function stageDirectionalCamera(
     light: DirectionalLight,
     mainCamera: Camera
 ): void {
+    camera.depthMode = mainCamera.depthMode;
     resetCameraTransform(camera);
     camera.left = -1;
     camera.right = 1;
@@ -521,6 +522,7 @@ function stageDirectionalCascadeCamera(
     tileHeight: number,
     stabilize: boolean
 ): void {
+    camera.depthMode = mainCamera.depthMode;
     resetCameraTransform(camera);
     camera.left = -1;
     camera.right = 1;
@@ -642,6 +644,7 @@ function stageSpotCamera(
     mainCamera: Camera,
     tileAspect: number
 ): void {
+    camera.depthMode = mainCamera.depthMode;
     resetCameraTransform(camera);
     camera.fov = 50;
     camera.near = 0.1;
@@ -1218,6 +1221,7 @@ export class ShadowAtlasSceneAdapter {
                 const camera = staged.cameras[face];
                 const matrix = staged.lightSpaceMatrices[face];
                 if (!camera || !matrix) throw new Error('Point shadow face staging is incomplete');
+                camera.depthMode = mainCamera.depthMode;
                 stagePointCamera(camera, light, face, planes.near, planes.far);
                 matrix.multiply(camera.viewProjectionMatrix, mainCamera.worldMatrix);
                 finiteMatrix(matrix, `Point shadow face ${String(face)} lightSpaceMatrix`);

--- a/src/render/ubo/BuiltInUniformBlocks.ts
+++ b/src/render/ubo/BuiltInUniformBlocks.ts
@@ -23,11 +23,18 @@ export const cameraBlockLayout = createStd140Layout({
     u_viewMatrix: 'mat4',
     u_projectionMatrix: 'mat4',
     u_viewProjectionMatrix: 'mat4',
+    u_previousViewMatrix: 'mat4',
+    u_previousProjectionMatrix: 'mat4',
+    u_previousViewProjectionMatrix: 'mat4',
     u_viewInverseMatrix: 'mat4',
+    u_previousViewInverseMatrix: 'mat4',
     u_projectionInverseMatrix: 'mat4',
     u_viewInverseNormalMatrix: 'mat3',
     u_cameraPositionNear: 'vec4',
     u_cameraParams: 'vec4',
+    u_renderOrigin: 'vec4',
+    u_previousRenderOrigin: 'vec4',
+    u_historyParams: 'vec4',
     u_viewport: 'vec4'
 });
 
@@ -119,6 +126,7 @@ export const materialBlockLayout = createStd140Layout({
 
 export const modelBlockLayout = createStd140Layout({
     u_modelMatrix: 'mat4',
+    u_previousModelMatrix: 'mat4',
     u_normalWorldMatrix: 'mat3',
     u_objectIdColor: 'vec4'
 });
@@ -131,16 +139,20 @@ export const geometryBlockLayout = createStd140Layout({
 });
 
 export const skinningBlockLayout = createStd140Layout({
-    u_jointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS }
+    u_jointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS },
+    u_previousJointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS }
 });
 
 export const morphBlockLayout = createStd140Layout({
     u_morphWeights0: 'vec4',
-    u_morphWeights1: 'vec4'
+    u_morphWeights1: 'vec4',
+    u_previousMorphWeights0: 'vec4',
+    u_previousMorphWeights1: 'vec4'
 });
 
 export const instanceBlockLayout = createStd140Layout({
     u_instanceModelMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW },
+    u_previousInstanceModelMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW },
     u_instanceNormalMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW }
 });
 

--- a/src/shader/chunk/cameraBlock.glsl
+++ b/src/shader/chunk/cameraBlock.glsl
@@ -1,0 +1,26 @@
+layout(std140) uniform CameraBlock {
+    mat4 u_viewMatrix;
+    mat4 u_projectionMatrix;
+    mat4 u_viewProjectionMatrix;
+    mat4 u_previousViewMatrix;
+    mat4 u_previousProjectionMatrix;
+    mat4 u_previousViewProjectionMatrix;
+    mat4 u_viewInverseMatrix;
+    mat4 u_previousViewInverseMatrix;
+    mat4 u_projectionInverseMatrix;
+    mat3 u_viewInverseNormalMatrix;
+    vec4 u_cameraPositionNear;
+    vec4 u_cameraParams;
+    vec4 u_renderOrigin;
+    vec4 u_previousRenderOrigin;
+    vec4 u_historyParams;
+    vec4 u_viewport;
+};
+
+#define u_cameraPosition u_cameraPositionNear.xyz
+#define u_cameraNear u_cameraPositionNear.w
+#define u_cameraFar u_cameraParams.x
+#define u_cameraType u_cameraParams.y
+#define u_logDepth u_cameraParams.z
+#define u_reversedDepth u_cameraParams.w
+#define u_cameraHistoryValid u_historyParams.x

--- a/src/shader/chunk/uniformBlocks.glsl
+++ b/src/shader/chunk/uniformBlocks.glsl
@@ -17,11 +17,18 @@ layout(std140) uniform CameraBlock {
     mat4 u_viewMatrix;
     mat4 u_projectionMatrix;
     mat4 u_viewProjectionMatrix;
+    mat4 u_previousViewMatrix;
+    mat4 u_previousProjectionMatrix;
+    mat4 u_previousViewProjectionMatrix;
     mat4 u_viewInverseMatrix;
+    mat4 u_previousViewInverseMatrix;
     mat4 u_projectionInverseMatrix;
     mat3 u_viewInverseNormalMatrix;
     vec4 u_cameraPositionNear;
     vec4 u_cameraParams;
+    vec4 u_renderOrigin;
+    vec4 u_previousRenderOrigin;
+    vec4 u_historyParams;
     vec4 u_viewport;
 };
 
@@ -30,6 +37,8 @@ layout(std140) uniform CameraBlock {
 #define u_cameraFar u_cameraParams.x
 #define u_cameraType u_cameraParams.y
 #define u_logDepth u_cameraParams.z
+#define u_reversedDepth u_cameraParams.w
+#define u_cameraHistoryValid u_historyParams.x
 
 layout(std140) uniform SceneBlock {
     vec4 u_fogColor;
@@ -121,17 +130,21 @@ layout(std140) uniform MaterialBlock {
     #ifdef HILO_WEBGPU
         layout(std140) uniform InstanceBlock {
             mat4 u_instanceModelMatrices[HILO_MAX_INSTANCES_PER_DRAW];
+            mat4 u_previousInstanceModelMatrices[HILO_MAX_INSTANCES_PER_DRAW];
             mat4 u_instanceNormalMatrices[HILO_MAX_INSTANCES_PER_DRAW];
         };
         #define u_modelMatrix u_instanceModelMatrices[gl_InstanceIndex]
+        #define u_previousModelMatrix u_previousInstanceModelMatrices[gl_InstanceIndex]
         #define u_normalWorldMatrix mat3(u_instanceNormalMatrices[gl_InstanceIndex])
     #else
         in mat4 u_modelMatrix;
         in mat3 u_normalWorldMatrix;
+        #define u_previousModelMatrix u_modelMatrix
     #endif
 #else
     layout(std140) uniform ModelBlock {
         mat4 u_modelMatrix;
+        mat4 u_previousModelMatrix;
         mat3 u_normalWorldMatrix;
         vec4 u_objectIdColor;
     };
@@ -147,6 +160,7 @@ layout(std140) uniform GeometryBlock {
 #ifdef HILO_JOINT_COUNT
     layout(std140) uniform SkinningBlock {
         mat4 u_jointMat[HILO_MAX_SKIN_JOINTS];
+        mat4 u_previousJointMat[HILO_MAX_SKIN_JOINTS];
     };
 #endif
 
@@ -154,6 +168,8 @@ layout(std140) uniform GeometryBlock {
     layout(std140) uniform MorphBlock {
         vec4 u_morphWeights0;
         vec4 u_morphWeights1;
+        vec4 u_previousMorphWeights0;
+        vec4 u_previousMorphWeights1;
     };
 
     float hiloMorphWeight(int index) {

--- a/src/shader/chunk/uniformBlocks.glsl
+++ b/src/shader/chunk/uniformBlocks.glsl
@@ -13,32 +13,7 @@ layout(std140) uniform FrameBlock {
     float u_frameIndex;
 };
 
-layout(std140) uniform CameraBlock {
-    mat4 u_viewMatrix;
-    mat4 u_projectionMatrix;
-    mat4 u_viewProjectionMatrix;
-    mat4 u_previousViewMatrix;
-    mat4 u_previousProjectionMatrix;
-    mat4 u_previousViewProjectionMatrix;
-    mat4 u_viewInverseMatrix;
-    mat4 u_previousViewInverseMatrix;
-    mat4 u_projectionInverseMatrix;
-    mat3 u_viewInverseNormalMatrix;
-    vec4 u_cameraPositionNear;
-    vec4 u_cameraParams;
-    vec4 u_renderOrigin;
-    vec4 u_previousRenderOrigin;
-    vec4 u_historyParams;
-    vec4 u_viewport;
-};
-
-#define u_cameraPosition u_cameraPositionNear.xyz
-#define u_cameraNear u_cameraPositionNear.w
-#define u_cameraFar u_cameraParams.x
-#define u_cameraType u_cameraParams.y
-#define u_logDepth u_cameraParams.z
-#define u_reversedDepth u_cameraParams.w
-#define u_cameraHistoryValid u_historyParams.x
+#include "./cameraBlock.glsl"
 
 layout(std140) uniform SceneBlock {
     vec4 u_fogColor;

--- a/src/shader/method/getShadow.glsl
+++ b/src/shader/method/getShadow.glsl
@@ -35,7 +35,7 @@ float getShadowAtlas(int sliceIndex, float bias, vec3 fragPos, mat4 lightSpaceMa
             );
             visibility += textureLod(
                 u_shadowAtlas,
-                vec3(sampleUV, projection.z - bias),
+                vec3(sampleUV, projection.z + (u_reversedDepth > 0.5 ? bias : -bias)),
                 0.0
             );
         }

--- a/src/utils/MeshPicker.ts
+++ b/src/utils/MeshPicker.ts
@@ -6,6 +6,7 @@ import type { Renderer } from '../render/Renderer';
 import type { RenderTarget } from '../render/RenderTarget';
 import { decodeMeshPickingId, getMeshPickingIdentity } from '../render/PickingIdentity';
 import type { ShaderOptions } from '../render/types';
+import type { CameraDepthMode } from '../camera/Camera';
 
 class MeshPickerMaterial extends BasicMaterial {
     constructor() {
@@ -53,6 +54,7 @@ class MeshPicker {
     /** Active renderer owned by this picker's Stage. */
     readonly renderer: Renderer;
     private renderTarget: RenderTarget | null = null;
+    private renderTargetDepthMode: CameraDepthMode | null = null;
     private readonly idMeshMap = new Map<number, Mesh>();
     private operation = Promise.resolve();
     private destroyed = false;
@@ -84,7 +86,7 @@ class MeshPicker {
         if (!camera) throw new Error('MeshPicker requires its Stage to have an active camera.');
 
         this.validateSelectionRectangle(x, y, width, height);
-        const target = this.requireRenderTarget();
+        const target = this.requireRenderTarget(camera.depthMode);
         const region = this.resolveReadbackRegion(x, y, width, height, target);
         if (!region) return [];
         this.collectMeshIdentities();
@@ -113,10 +115,14 @@ class MeshPicker {
         return [...meshes];
     }
 
-    private requireRenderTarget(): RenderTarget {
+    private requireRenderTarget(depthMode: CameraDepthMode): RenderTarget {
         const { renderer } = this;
         const width = renderer.width;
         const height = renderer.height;
+        if (this.renderTarget !== null && this.renderTargetDepthMode !== depthMode) {
+            this.renderTarget.destroy();
+            this.renderTarget = null;
+        }
         if (!this.renderTarget) {
             this.renderTarget = renderer.createRenderTarget({
                 width,
@@ -132,13 +138,14 @@ class MeshPicker {
                 ],
                 depthStencilAttachment: {
                     format: 'depth24plus',
-                    depthClearValue: 1,
+                    depthMode,
                     depthLoadOp: 'clear',
                     depthStoreOp: 'discard'
                 },
                 sampleCount: 1,
                 label: 'MeshPicker'
             });
+            this.renderTargetDepthMode = depthMode;
         } else if (this.renderTarget.width !== width || this.renderTarget.height !== height) {
             this.renderTarget.resize(width, height);
         }
@@ -194,6 +201,7 @@ class MeshPicker {
         this.destroyed = true;
         const target = this.renderTarget;
         this.renderTarget = null;
+        this.renderTargetDepthMode = null;
         this.idMeshMap.clear();
         if (target) {
             void this.operation.then(() => {

--- a/test/spec/camera/OrthographicCamera.test.ts
+++ b/test/spec/camera/OrthographicCamera.test.ts
@@ -9,4 +9,12 @@ describe('OrthographicCamera', () => {
         expect(camera.isOrthographicCamera).toBe(true);
         expect(camera.className).toBe('OrthographicCamera');
     });
+
+    it('reverses near/far depth while retaining OpenGL clip coordinates', () => {
+        const camera = new OrthographicCamera({ near: 1, far: 101, depthMode: 'reversed' });
+        const elements = camera.projectionMatrix.elements;
+        const depth = (distance: number): number => elements[10] * -distance + elements[14];
+        expect(depth(1)).toBeCloseTo(1, 6);
+        expect(depth(101)).toBeCloseTo(-1, 6);
+    });
 });

--- a/test/spec/camera/PerspectiveCamera.test.ts
+++ b/test/spec/camera/PerspectiveCamera.test.ts
@@ -9,4 +9,40 @@ describe('PerspectiveCamera', () => {
         expect(camera.isPerspectiveCamera).toBe(true);
         expect(camera.className).toBe('PerspectiveCamera');
     });
+
+    it('maps finite and infinite reversed-Z depth without changing the shared clip convention', () => {
+        const camera = new PerspectiveCamera({
+            near: 0.25,
+            far: 1_000_000,
+            depthMode: 'reversed'
+        });
+        const projectDepth = (distance: number): number => {
+            const elements = camera.projectionMatrix.elements;
+            const z = -distance;
+            return (elements[10] * z + elements[14]) / (elements[11] * z + elements[15]);
+        };
+
+        expect(projectDepth(camera.near)).toBeCloseTo(1, 6);
+        expect(projectDepth(camera.far ?? 0)).toBeCloseTo(-1, 5);
+
+        camera.far = null;
+        camera.updateProjectionMatrix();
+        expect(projectDepth(camera.near)).toBeCloseTo(1, 6);
+        expect(projectDepth(1e12)).toBeCloseTo(-1, 6);
+        expect(camera.far).toBeNull();
+    });
+
+    it('keeps standard depth as the compatibility default and validates projection bounds', () => {
+        const camera = new PerspectiveCamera({ near: 0.5, far: 50 });
+        const elements = camera.projectionMatrix.elements;
+        const depth = (distance: number): number => {
+            const z = -distance;
+            return (elements[10] * z + elements[14]) / (elements[11] * z + elements[15]);
+        };
+        expect(camera.depthMode).toBe('standard');
+        expect(depth(0.5)).toBeCloseTo(-1, 6);
+        expect(depth(50)).toBeCloseTo(1, 6);
+        expect(() => new PerspectiveCamera({ near: 0 })).toThrow(/near/);
+        expect(() => new PerspectiveCamera({ near: 2, far: 1 })).toThrow(/far/);
+    });
 });

--- a/test/spec/renderer/BuiltInUniformBlockManager.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlockManager.test.ts
@@ -606,6 +606,60 @@ describe('BuiltInUniformBlockManager', () => {
         );
     });
 
+    it('keeps CPU world coordinates while packing camera-relative current transforms', () => {
+        const manager = new BuiltInUniformBlockManager({
+            width: 320,
+            height: 180,
+            cameraRelative: true
+        });
+        const camera = new PerspectiveCamera({ x: 100_000 });
+        camera.updateMatrixWorld(true).updateViewProjectionMatrix();
+        const mesh = testEnv.mesh.clone();
+        mesh.setPosition(100_004, 2, -3).updateMatrixWorld(true);
+        const worldX = mesh.worldMatrix.elements[12];
+
+        manager.beginFrame(camera);
+        const model = manager.resolveUniformBlock('ModelBlock', mesh, testEnv.material, camera);
+        const cameraBlock = manager.resolveUniformBlock(
+            'CameraBlock',
+            mesh,
+            testEnv.material,
+            camera
+        );
+
+        expect(readFloatField(model, 'u_modelMatrix', 16).slice(12, 15)).toEqualishValues(4, 2, -3);
+        expect(readFloatField(cameraBlock, 'u_renderOrigin', 3)).toEqualishValues(100_000, 0, 0);
+        expect(readFloatField(cameraBlock, 'u_cameraPositionNear', 3)).toEqualishValues(0, 0, 0);
+        expect(mesh.worldMatrix.elements[12]).toBe(worldX);
+    });
+
+    it('commits previous transforms only on success and resets them after invalidation', () => {
+        const manager = new BuiltInUniformBlockManager({ width: 320, height: 180 });
+        const mesh = testEnv.mesh.clone();
+        const render = (x: number): UniformBuffer => {
+            mesh.setPosition(x, 0, 0).updateMatrixWorld(true);
+            manager.beginFrame(testEnv.camera);
+            return manager.resolveUniformBlock('ModelBlock', mesh, testEnv.material);
+        };
+
+        let block = render(2);
+        expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(2);
+        manager.commit({} as never);
+
+        block = render(3);
+        expect(readFloatField(block, 'u_modelMatrix', 16)[12]).toBe(3);
+        expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(2);
+        manager.rollback();
+
+        block = render(4);
+        expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(2);
+        manager.commit({} as never);
+
+        mesh.invalidateTransformHistory();
+        block = render(20);
+        expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(20);
+    });
+
     it('packs ambient and directional lighting into LightBlock for every render pass', () => {
         const manager = new BuiltInUniformBlockManager({ width: 320, height: 180 });
         const lightManager = new LightManager();

--- a/test/spec/renderer/BuiltInUniformBlocks.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlocks.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../src/render/ubo/BuiltInUniformBlocks';
 
 describe('built-in std140 ABI', () => {
-    it('keeps every canonical block byte size stable', () => {
+    it('locks the canonical block byte sizes including the D0 history ABI', () => {
         expect({
             FrameBlock: frameBlockLayout.byteLength,
             CameraBlock: cameraBlockLayout.byteLength,
@@ -28,15 +28,15 @@ describe('built-in std140 ABI', () => {
             InstanceBlock: instanceBlockLayout.byteLength
         }).toEqual({
             FrameBlock: 16,
-            CameraBlock: 416,
+            CameraBlock: 720,
             SceneBlock: 32,
             LightBlock: 16288,
             MaterialBlock: 544,
-            ModelBlock: 128,
+            ModelBlock: 192,
             GeometryBlock: 224,
-            SkinningBlock: 8192,
-            MorphBlock: 32,
-            InstanceBlock: 16384
+            SkinningBlock: 16384,
+            MorphBlock: 64,
+            InstanceBlock: 24576
         });
     });
 
@@ -45,11 +45,19 @@ describe('built-in std140 ABI', () => {
         expect(frameBlockLayout.fields.u_time.offset).toBe(8);
         expect(frameBlockLayout.fields.u_frameIndex.offset).toBe(12);
 
-        expect(cameraBlockLayout.fields.u_projectionInverseMatrix.offset).toBe(256);
-        expect(cameraBlockLayout.fields.u_viewInverseNormalMatrix.offset).toBe(320);
-        expect(cameraBlockLayout.fields.u_cameraPositionNear.offset).toBe(368);
-        expect(cameraBlockLayout.fields.u_cameraParams.offset).toBe(384);
-        expect(cameraBlockLayout.fields.u_viewport.offset).toBe(400);
+        expect(cameraBlockLayout.fields.u_previousViewMatrix.offset).toBe(192);
+        expect(cameraBlockLayout.fields.u_previousProjectionMatrix.offset).toBe(256);
+        expect(cameraBlockLayout.fields.u_previousViewProjectionMatrix.offset).toBe(320);
+        expect(cameraBlockLayout.fields.u_viewInverseMatrix.offset).toBe(384);
+        expect(cameraBlockLayout.fields.u_previousViewInverseMatrix.offset).toBe(448);
+        expect(cameraBlockLayout.fields.u_projectionInverseMatrix.offset).toBe(512);
+        expect(cameraBlockLayout.fields.u_viewInverseNormalMatrix.offset).toBe(576);
+        expect(cameraBlockLayout.fields.u_cameraPositionNear.offset).toBe(624);
+        expect(cameraBlockLayout.fields.u_cameraParams.offset).toBe(640);
+        expect(cameraBlockLayout.fields.u_renderOrigin.offset).toBe(656);
+        expect(cameraBlockLayout.fields.u_previousRenderOrigin.offset).toBe(672);
+        expect(cameraBlockLayout.fields.u_historyParams.offset).toBe(688);
+        expect(cameraBlockLayout.fields.u_viewport.offset).toBe(704);
 
         expect(materialBlockLayout.fields.u_diffuseEnvSphereHarmonics3.offset).toBe(96);
         expect(materialBlockLayout.fields.u_diffuseEnvSphereHarmonics3.arrayStride).toBe(16);
@@ -63,8 +71,9 @@ describe('built-in std140 ABI', () => {
         expect(materialBlockLayout.fields.u_attenuationColor.offset).toBe(528);
 
         expect(modelBlockLayout.fields.u_modelMatrix.offset).toBe(0);
-        expect(modelBlockLayout.fields.u_normalWorldMatrix.offset).toBe(64);
-        expect(modelBlockLayout.fields.u_objectIdColor.offset).toBe(112);
+        expect(modelBlockLayout.fields.u_previousModelMatrix.offset).toBe(64);
+        expect(modelBlockLayout.fields.u_normalWorldMatrix.offset).toBe(128);
+        expect(modelBlockLayout.fields.u_objectIdColor.offset).toBe(176);
         expect(geometryBlockLayout.fields.u_positionDecodeMat.offset).toBe(0);
         expect(geometryBlockLayout.fields.u_uvDecodeMat.offset).toBe(128);
         expect(geometryBlockLayout.fields.u_uv1DecodeMat.offset).toBe(176);
@@ -86,8 +95,12 @@ describe('built-in std140 ABI', () => {
         expect(lightBlockLayout.fields.u_areaLightsHeight.offset).toBe(16160);
 
         expect(skinningBlockLayout.fields.u_jointMat.arrayStride).toBe(64);
+        expect(skinningBlockLayout.fields.u_previousJointMat.offset).toBe(8192);
         expect(morphBlockLayout.fields.u_morphWeights1.offset).toBe(16);
-        expect(instanceBlockLayout.fields.u_instanceNormalMatrices.offset).toBe(8192);
+        expect(morphBlockLayout.fields.u_previousMorphWeights0.offset).toBe(32);
+        expect(morphBlockLayout.fields.u_previousMorphWeights1.offset).toBe(48);
+        expect(instanceBlockLayout.fields.u_previousInstanceModelMatrices.offset).toBe(8192);
+        expect(instanceBlockLayout.fields.u_instanceNormalMatrices.offset).toBe(16384);
     });
 
     it('pads dynamic semantic arrays to the fixed ABI capacity and rejects overflow', () => {

--- a/test/spec/renderer/GPUDrivenPipelineResourceCache.test.ts
+++ b/test/spec/renderer/GPUDrivenPipelineResourceCache.test.ts
@@ -109,6 +109,38 @@ function compilerFixture(source: StorageGraphicsShader): {
 }
 
 describe('GPUDrivenPipelineResourceCache', () => {
+    it('keeps reversed-Z storage-graphics pipeline state distinct', () => {
+        const backend = new FakeWebGPURHIBackend();
+        const registry = new ResourceRegistry(backend.createDevice());
+        const source = shader();
+        const fixture = compilerFixture(source);
+        const cache = new GPUDrivenPipelineResourceCache(registry, fixture.compiler);
+        const material = new Material({ cullFace: false });
+        const layouts: never[] = [];
+        const target = {
+            colorFormats: ['rgba8unorm' as const],
+            depthStencilFormat: 'depth24plus' as const,
+            sampleCount: 1
+        };
+        const standard = cache.prepareScene(source, material, layouts, target, 4);
+        const reversed = cache.prepareScene(
+            source,
+            material,
+            layouts,
+            target,
+            4,
+            undefined,
+            'reversed'
+        );
+        expect(reversed).not.toBe(standard);
+        expect(registry.resolve(reversed.pipeline).descriptor.depthStencil?.depthCompare).toBe(
+            'greater-equal'
+        );
+        cache.destroy();
+        registry.destroy();
+        backend.destroy();
+    });
+
     it('memoizes ordinary scene layouts by stable vertex-layout identity', () => {
         const backend = new FakeWebGPURHIBackend();
         const device = backend.createDevice();

--- a/test/spec/renderer/InstanceBatchCompiler.test.ts
+++ b/test/spec/renderer/InstanceBatchCompiler.test.ts
@@ -344,6 +344,8 @@ describe('InstanceBatchCompiler WebGPU planning', () => {
         expect(block?.layout).toBe(instanceBlockLayout);
         const packed = blockFloats(required(block, 'WebGPU InstanceBlock'));
         const modelOffset = instanceBlockLayout.fields.u_instanceModelMatrices.offset / 4;
+        const previousModelOffset =
+            instanceBlockLayout.fields.u_previousInstanceModelMatrices.offset / 4;
         const normalOffset = instanceBlockLayout.fields.u_instanceNormalMatrices.offset / 4;
         expect(Array.from(packed.slice(modelOffset, modelOffset + 16))).toEqual([
             1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1
@@ -357,8 +359,14 @@ describe('InstanceBatchCompiler WebGPU planning', () => {
         expect(Array.from(packed.slice(normalOffset + 16, normalOffset + 32))).toEqual([
             0.5, 0, 0, 0, 0, 0.25, 0, 0, 0, 0, 0.20000000298023224, 0, 0, 0, 0, 1
         ]);
-        expect(Array.from(packed.slice(modelOffset + 32, normalOffset))).toEqual(
-            new Array(normalOffset - modelOffset - 32).fill(0)
+        expect(Array.from(packed.slice(modelOffset + 32, previousModelOffset))).toEqual(
+            new Array(previousModelOffset - modelOffset - 32).fill(0)
+        );
+        expect(Array.from(packed.slice(previousModelOffset, previousModelOffset + 32))).toEqual(
+            Array.from(packed.slice(modelOffset, modelOffset + 32))
+        );
+        expect(Array.from(packed.slice(previousModelOffset + 32, normalOffset))).toEqual(
+            new Array(normalOffset - previousModelOffset - 32).fill(0)
         );
         expect(Array.from(packed.slice(normalOffset + 32))).toEqual(
             new Array(packed.length - normalOffset - 32).fill(0)

--- a/test/spec/renderer/PipelineResourceCache.test.ts
+++ b/test/spec/renderer/PipelineResourceCache.test.ts
@@ -103,6 +103,35 @@ function target(colorFormat: RHITextureFormat = 'rgba8unorm'): RHIMeshDrawTarget
 }
 
 describe('PipelineResourceCache', () => {
+    it('keys otherwise identical pipelines by depth convention', () => {
+        const fixture = createFixture();
+        const source = shader(fragmentSource);
+        const layout = vertexLayout();
+        const material = new Material();
+        const drawTarget = target();
+        const standard = fixture.pipelines.prepare(source, layout, material, drawTarget);
+        const reversed = fixture.pipelines.prepare(
+            source,
+            layout,
+            material,
+            drawTarget,
+            'color',
+            TRIANGLES,
+            undefined,
+            0,
+            'reversed'
+        );
+        expect(reversed).not.toBe(standard);
+        expect(
+            fixture.pipelines.resolve(reversed).pipeline.descriptor.depthStencil?.depthCompare
+        ).toBe('greater-equal');
+        fixture.pipelines.destroy();
+        fixture.shaders.destroy();
+        fixture.registry.collect(0);
+        fixture.registry.destroy();
+        fixture.backend.destroy();
+    });
+
     it('shares the pass-global opaque texture layout across material shader variants', () => {
         const fixture = createFixture();
         const first = fixture.pipelines.prepare(

--- a/test/spec/renderer/RHIDescriptorMapping.test.ts
+++ b/test/spec/renderer/RHIDescriptorMapping.test.ts
@@ -238,6 +238,11 @@ describe('RHIDescriptorMapping material state', () => {
             depthCompare: 'less-equal',
             depthWriteEnabled: true
         });
+        expect(mapRHIDepthStencilState(new Material(), 'depth24plus', 'reversed')).toEqual({
+            format: 'depth24plus',
+            depthCompare: 'greater-equal',
+            depthWriteEnabled: true
+        });
         expect(
             mapRHIDepthStencilState(
                 new Material({ depthTest: false, depthMask: true }),

--- a/test/spec/renderer/RenderTargetDepthConvention.test.ts
+++ b/test/spec/renderer/RenderTargetDepthConvention.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRenderTargetParameters } from '../../../src/render/RenderTarget';
+
+describe('RenderTarget depth convention', () => {
+    it('derives clear and comparison defaults from reversed-Z', () => {
+        const normalized = normalizeRenderTargetParameters({
+            width: 16,
+            height: 8,
+            depthStencilAttachment: { sampled: true, depthMode: 'reversed' }
+        });
+        expect(normalized.depthStencilAttachment).toMatchObject({
+            depthMode: 'reversed',
+            depthClearValue: 0,
+            compare: 'greater-equal'
+        });
+    });
+
+    it('retains standard depth defaults for compatibility', () => {
+        const normalized = normalizeRenderTargetParameters({ width: 4, height: 4 });
+        expect(normalized.depthStencilAttachment).toMatchObject({
+            depthMode: 'standard',
+            depthClearValue: 1,
+            compare: 'less-equal'
+        });
+    });
+});

--- a/test/spec/renderer/Renderer.test.ts
+++ b/test/spec/renderer/Renderer.test.ts
@@ -135,6 +135,38 @@ describe('Renderer public entry point', () => {
         expect(renderer.isReady).toBe(true);
     });
 
+    it('applies the high-end depth and coordinate profile across cameras and targets', async () => {
+        const renderer = await Renderer.create({
+            backend: 'webgl2',
+            domElement: document.createElement('canvas'),
+            width: 12,
+            height: 6,
+            antialias: false,
+            renderingProfile: 'high-end'
+        });
+        activeRenderers.push(renderer);
+        const camera = new PerspectiveCamera({ near: 0.1, far: null });
+        const stage = new Node();
+        const derivedTarget = renderer.createRenderTarget({ width: 12, height: 6 });
+
+        renderer.renderToTarget(derivedTarget, stage, camera);
+
+        expect(renderer.renderingProfile).toBe('high-end');
+        expect(renderer.cameraRelative).toBe(true);
+        expect(camera.depthMode).toBe('reversed');
+
+        const incompatibleTarget = renderer.createRenderTarget({
+            width: 12,
+            height: 6,
+            depthStencilAttachment: { depthMode: 'standard' }
+        });
+        expect(() => {
+            renderer.renderToTarget(incompatibleTarget, stage, camera);
+        }).toThrow(/depth mode standard does not match camera depth mode reversed/u);
+        derivedTarget.destroy();
+        incompatibleTarget.destroy();
+    });
+
     it('probes auto once and falls back to WebGL2 without a facade', async () => {
         rhiSupportControl.override = () => Promise.resolve(false);
         const renderer = await Renderer.create({

--- a/test/spec/renderer/ShadowAtlasResourceCache.test.ts
+++ b/test/spec/renderer/ShadowAtlasResourceCache.test.ts
@@ -59,6 +59,29 @@ describe('ShadowAtlasResourceCache', () => {
         backend.destroy();
     });
 
+    it('keys comparison samplers by the atlas depth convention', () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+        const registry = new ResourceRegistry(device);
+        const cache = new ShadowAtlasResourceCache(registry);
+        const plan = new ShadowAtlasPlanner().build(
+            { directional: [{ owner: {}, width: 16, height: 16 }], spot: [], point: [] },
+            device.capabilities
+        );
+        const owner = {};
+        const standard = cache.prepare(owner, plan);
+        const reversed = cache.prepare(owner, plan, 'reversed');
+        expect(reversed).not.toBe(standard);
+        expect(reversed.depthMode).toBe('reversed');
+        expect(registry.resolve(reversed.comparisonSampler).descriptor.compare).toBe(
+            'greater-equal'
+        );
+        cache.destroy();
+        registry.collect(0);
+        registry.destroy();
+        backend.destroy();
+    });
+
     it('atomically replaces resized atlases and defers each release to last use', () => {
         const backend = new FakeWebGLRHIBackend();
         const device = backend.createDevice();

--- a/test/spec/shader/ShaderModernity.test.ts
+++ b/test/spec/shader/ShaderModernity.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import {
+    cameraBlockLayout,
+    instanceBlockLayout,
+    modelBlockLayout,
+    morphBlockLayout,
+    skinningBlockLayout
+} from '../../../src/render/ubo/BuiltInUniformBlocks';
 
 const engineShaderSources = import.meta.glob<string>('../../../src/shader/**/*.{vert,frag,glsl}', {
     eager: true,
@@ -15,14 +22,56 @@ const exampleShaderSources = import.meta.glob<string>(
     }
 );
 
+const engineShaderContainerSources = import.meta.glob<string>(
+    '../../../src/**/*.{ts,vert,frag,glsl}',
+    {
+        eager: true,
+        query: '?raw',
+        import: 'default'
+    }
+);
+
+const uiFixtureShaderSources = import.meta.glob<string>('../../../test/ui/fixtures/**/*.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default'
+});
+
 const shaderSources = { ...engineShaderSources, ...exampleShaderSources };
+const builtInBlockSources = {
+    ...engineShaderContainerSources,
+    ...exampleShaderSources,
+    ...uiFixtureShaderSources
+};
+const builtInBlockLayouts = {
+    CameraBlock: cameraBlockLayout,
+    ModelBlock: modelBlockLayout,
+    SkinningBlock: skinningBlockLayout,
+    MorphBlock: morphBlockLayout,
+    InstanceBlock: instanceBlockLayout
+} as const;
 const glslDeclarationType = '(?:float|int|uint|bool|[biu]?vec[2-4]|mat[2-4](?:x[2-4])?)';
+const builtInBlockPattern = new RegExp(
+    `layout\\s*\\(\\s*std140\\s*\\)\\s*uniform\\s+(${Object.keys(builtInBlockLayouts).join('|')})\\s*\\{([\\s\\S]*?)\\}\\s*;`,
+    'gu'
+);
+const std140FieldPattern = new RegExp(
+    `\\b(${glslDeclarationType})\\s+([A-Za-z_]\\w*)\\s*(?:\\[[^\\]]+\\])?\\s*;`,
+    'gu'
+);
 
 interface ShaderViolation {
     path: string;
     line: number;
     rule: string;
     source: string;
+}
+
+interface BuiltInBlockViolation {
+    path: string;
+    block: keyof typeof builtInBlockLayouts;
+    declared: string[];
+    expectedPrefix: string[];
 }
 
 const legacySyntaxRules: readonly (readonly [string, RegExp])[] = [
@@ -87,6 +136,33 @@ function collectViolations(): ShaderViolation[] {
     return violations;
 }
 
+function isBuiltInBlockName(value: string): value is keyof typeof builtInBlockLayouts {
+    return Object.hasOwn(builtInBlockLayouts, value);
+}
+
+function collectBuiltInBlockViolations(): BuiltInBlockViolation[] {
+    const violations: BuiltInBlockViolation[] = [];
+    for (const [path, source] of Object.entries(builtInBlockSources)) {
+        builtInBlockPattern.lastIndex = 0;
+        for (const blockMatch of source.matchAll(builtInBlockPattern)) {
+            const block = blockMatch[1] ?? '';
+            if (!isBuiltInBlockName(block)) continue;
+            const body = blockMatch[2] ?? '';
+            const declared = [...body.matchAll(std140FieldPattern)].map(
+                match => `${match[1] ?? ''} ${match[2] ?? ''}`
+            );
+            const canonical = Object.values(builtInBlockLayouts[block].fields).map(
+                field => `${field.type} ${field.name}`
+            );
+            const expectedPrefix = canonical.slice(0, declared.length);
+            if (declared.some((field, index) => field !== expectedPrefix[index])) {
+                violations.push({ path, block, declared, expectedPrefix });
+            }
+        }
+    }
+    return violations;
+}
+
 describe('WebGL 2 shader contract', () => {
     it('keeps engine and example shaders on native GLSL ES 3.00 with UBO numeric data', () => {
         expect(Object.keys(engineShaderSources).length).toBeGreaterThan(0);
@@ -98,6 +174,19 @@ describe('WebGL 2 shader contract', () => {
         expect(Object.keys(engineShaderSources).some(path => path.includes('GLSL300Define'))).toBe(
             false
         );
+    });
+
+    it('keeps hand-authored history uniform blocks on canonical ABI prefixes', () => {
+        expect(collectBuiltInBlockViolations()).toEqual([]);
+    });
+
+    it('uses the canonical CameraBlock source for viewport ABI diagnostics', () => {
+        const visualFixture = Object.entries(uiFixtureShaderSources).find(([path]) =>
+            path.endsWith('/ui/fixtures/visual.ts')
+        )?.[1];
+        expect(visualFixture).toBeTypeOf('string');
+        expect(visualFixture ?? '').toContain("cameraBlock.glsl?raw';");
+        expect(visualFixture ?? '').toContain('${cameraBlockSource}');
     });
 
     it('renders snow as instanced billboard triangles with built-in frame and camera blocks', () => {

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -29,6 +29,7 @@ import {
     GPUDrivenRenderPass,
     version,
     type BasicLoadRequest,
+    type CameraDepthMode,
     type BasicMaterialParameters,
     type AreaLightParameters,
     type DispatchEvent,
@@ -45,6 +46,7 @@ import {
     type ComputeTextureViewDimension,
     type RendererBackend,
     type RendererResourceDiagnostics,
+    type RendererRenderingProfile,
     type RendererSupportOptions,
     type RendererWebGL2Options,
     type RendererWebGPUOptions,
@@ -85,7 +87,15 @@ const orderedNodeParameters = {
 const orderedNode = new Node(orderedNodeParameters);
 orderedNode.zIndex = 21;
 
-const camera = new PerspectiveCamera({ aspect: 16 / 9, near: 0.1, far: 1_000, z: 4 });
+const depthMode: CameraDepthMode = 'reversed';
+const camera = new PerspectiveCamera({
+    aspect: 16 / 9,
+    near: 0.1,
+    far: null,
+    depthMode,
+    z: 4
+});
+camera.invalidateTransformHistory();
 const rendererParameters = {
     backend: 'webgl2',
     width: 640,
@@ -115,8 +125,10 @@ const webgpuRendererParameters = {
     domElement: document.createElement('canvas'),
     width: 640,
     height: 360,
-    pixelRatio: 1
+    pixelRatio: 1,
+    renderingProfile: 'high-end'
 } satisfies RendererWebGPUOptions;
+const renderingProfile: RendererRenderingProfile = webgpuRendererParameters.renderingProfile;
 const webgpuRendererPromise: Promise<Renderer<'webgpu'>> =
     Renderer.create(webgpuRendererParameters);
 const webgpuRenderer = await webgpuRendererPromise;
@@ -189,7 +201,8 @@ const renderTargetParameters = {
     width: 320,
     height: 180,
     sampleCount: 4,
-    colorAttachments: [{ format: 'rgba16float' }, { format: 'rgba8unorm' }]
+    colorAttachments: [{ format: 'rgba16float' }, { format: 'rgba8unorm' }],
+    depthStencilAttachment: { depthMode: 'reversed', sampled: true }
 } satisfies RenderTargetParameters;
 const renderers: readonly Renderer[] = [renderer, webgpuRenderer];
 const compressionFormat: TextureCompressionFormat = 'bc';
@@ -464,6 +477,7 @@ version satisfies string;
 void renderer;
 void stage;
 void webgpuRenderer;
+void renderingProfile;
 void webglRendererPromise;
 void webgpuRendererPromise;
 void webgpuRendererPreserveDrawingBufferIsNever;

--- a/test/ui/fixtures/visual.ts
+++ b/test/ui/fixtures/visual.ts
@@ -13,6 +13,7 @@ import {
     Stage,
     Vector3
 } from '../../../src/Hilo3d';
+import cameraBlockSource from '../../../src/shader/chunk/cameraBlock.glsl?raw';
 
 const container = document.querySelector<HTMLElement>('#stage');
 if (!container) throw new Error('Visual fixture container is missing.');
@@ -143,17 +144,7 @@ async function runReadbackDiagnostics(): Promise<void> {
                     `,
                     fs: `#version 300 es
                         precision highp float;
-                        layout(std140) uniform CameraBlock {
-                            mat4 u_viewMatrix;
-                            mat4 u_projectionMatrix;
-                            mat4 u_viewProjectionMatrix;
-                            mat4 u_viewInverseMatrix;
-                            mat4 u_projectionInverseMatrix;
-                            mat3 u_viewInverseNormalMatrix;
-                            vec4 u_cameraPositionNear;
-                            vec4 u_cameraParams;
-                            vec4 u_viewport;
-                        };
+                        ${cameraBlockSource}
                         layout(location = 0) out vec4 fragmentColor;
                         void main(void) {
                             fragmentColor = u_viewport / 255.0;

--- a/website/index.html
+++ b/website/index.html
@@ -44,8 +44,8 @@
                 </a>
                 <nav class="mainNavigation" aria-label="Main navigation">
                     <a href="#examples">Examples</a>
-                    <a href="#showcase">Showcase</a>
                     <a href="#why">Architecture</a>
+                    <a href="#showcase">Showcase</a>
                     <a href="./docs/">Docs</a>
                     <a href="./docs/modules/Hilo3d.html">API</a>
                 </nav>
@@ -69,9 +69,9 @@
                         <em>Own every frame.</em>
                     </h1>
                     <p class="heroDescription">
-                        One RHI runs the same scene on WebGPU and WebGL 2. The Render Graph
-                        validates work before submission. The Scriptable Render Pipeline lets you
-                        customize passes without forking the engine.
+                        Build high-performance 2D and 3D experiences with a modern TypeScript
+                        graphics engine. Run the same scene on WebGPU and WebGL 2, customize every
+                        render pass, and stay in control from scene to screen.
                     </p>
                     <div class="heroCapabilities" aria-label="Rendering capabilities">
                         <span>2D + 3D</span>
@@ -121,12 +121,21 @@
             </section>
 
             <section class="proofBar sectionShell" aria-label="Hilo3D project highlights">
-                <div><strong>RHI</strong><span>one renderer for WebGPU + WebGL 2</span></div>
-                <div><strong>Render Graph</strong><span>validate passes before GPU work</span></div>
                 <div>
-                    <strong>SRP</strong><span>customize the frame without an engine fork</span>
+                    <strong>One frontend</strong><span>one scene across WebGPU and WebGL 2</span>
                 </div>
-                <div><strong>PBR</strong><span>glTF · HDR · Bloom · compute</span></div>
+                <div>
+                    <strong>Validated frames</strong
+                    ><span>validate passes before GPU submission</span>
+                </div>
+                <div>
+                    <strong>Your pipeline</strong
+                    ><span>compose and customize without an engine fork</span>
+                </div>
+                <div>
+                    <strong>Modern rendering</strong
+                    ><span>PBR · glTF · HDR · Bloom · GPU Compute</span>
+                </div>
             </section>
 
             <section class="examples sectionShell" id="examples">
@@ -213,84 +222,101 @@
             </section>
 
             <section class="why sectionShell" id="why">
-                <div class="sectionIntro">
+                <div class="sectionIntro architectureIntro">
                     <p class="eyebrow"><span></span> Rendering architecture</p>
-                    <h2>Modern graphics architecture, end to end.</h2>
+                    <h2>
+                        <span>One rendering path.</span>
+                        <span>Native on both backends.</span>
+                    </h2>
                     <p>
-                        The RHI keeps rendering portable, the Render Graph keeps every frame
-                        predictable, and the Scriptable Render Pipeline keeps the engine extensible.
+                        Scene processing, draw preparation, shadows, post-processing, and resource
+                        lifecycle stay in one shared frontend. Every frame is compiled through a
+                        validated Render Graph and executed through native WebGPU or WebGL 2
+                        backends.
                     </p>
                 </div>
 
-                <div class="advantageGrid">
-                    <article class="advantageCard advantageCardPrimary">
-                        <span class="cardNumber">01</span>
-                        <div class="miniPipeline" aria-hidden="true">
-                            <div class="miniPipelineSource">
-                                <small>Shared frontend</small>
-                                <span>Renderer</span>
-                                <b>Scene · Passes</b>
-                            </div>
-                            <i>→</i>
-                            <div class="miniPipelineCore">
-                                <small>Unified contract</small>
-                                <span>Portable RHI</span>
-                                <b>Resources · Pipelines · Commands</b>
-                            </div>
-                            <i>→</i>
-                            <div class="miniOutputs">
-                                <small>Native backends</small>
+                <div class="architectureDiagram">
+                    <div class="architectureDiagramHeader">
+                        <span><b></b>Production frame path</span>
+                        <small>One shared frontend · two native backends</small>
+                    </div>
+                    <div class="architecturePath">
+                        <div class="architectureNode">
+                            <small>Public scene</small>
+                            <strong>Stage</strong>
+                            <span>Nodes · Cameras · Lights</span>
+                        </div>
+                        <i class="architectureConnector" aria-hidden="true">→</i>
+                        <div class="architectureNode architectureNodeShared">
+                            <small>Shared frontend</small>
+                            <strong>Renderer</strong>
+                            <span>Collect · Cull · Sort · Instance</span>
+                        </div>
+                        <i class="architectureConnector" aria-hidden="true">→</i>
+                        <div class="architectureNode architectureNodePipeline">
+                            <small>Extension layer</small>
+                            <strong>Pipeline Host + SRP</strong>
+                            <span>Default path · Custom passes</span>
+                        </div>
+                        <i class="architectureConnector" aria-hidden="true">→</i>
+                        <div class="architectureNode architectureNodeGraph">
+                            <small>Frame compiler</small>
+                            <strong>Render Graph</strong>
+                            <span>Setup · Compile · Prepare · Execute</span>
+                        </div>
+                        <i class="architectureConnector" aria-hidden="true">→</i>
+                        <div class="architectureNode architectureNodeRhi">
+                            <small>Portable contract</small>
+                            <strong>RHI</strong>
+                            <span>Resources · Pipelines · Commands</span>
+                        </div>
+                        <i class="architectureConnector" aria-hidden="true">→</i>
+                        <div class="architectureNode architectureBackends">
+                            <small>Native backends</small>
+                            <div>
                                 <span><b></b>WebGPU</span>
                                 <span><b></b>WebGL 2</span>
                             </div>
                         </div>
-                        <div class="advantageCopy">
-                            <p class="cardKicker">01 · Rendering Hardware Interface · RHI</p>
-                            <h3>One renderer. Two native backends.</h3>
-                            <p>
-                                One resource, pipeline, and command contract keeps scene code
-                                portable while WebGPU and WebGL 2 stay native to their own APIs.
-                            </p>
+                    </div>
+                    <div class="architectureServices">
+                        <small>Shared frame state &amp; lifecycle</small>
+                        <div>
+                            <span>Frame Arena</span>
+                            <span>Upload Batch</span>
+                            <span>Resource Registry</span>
+                            <span>Persistent Resources</span>
+                            <span>Submission Tracking</span>
+                            <span>Device Recovery</span>
                         </div>
-                    </article>
+                    </div>
+                </div>
 
-                    <article class="advantageCard">
-                        <span class="cardNumber">02</span>
-                        <div class="graphGraphic" aria-hidden="true">
-                            <span><b>01</b>Setup</span><i>→</i><span><b>02</b>Compile</span><i>→</i
-                            ><span><b>03</b>Prepare</span><i>→</i><span><b>04</b>Execute</span>
-                        </div>
-                        <div class="advantageCardCopy">
-                            <p class="cardKicker">02 · Validated Render Graph</p>
-                            <h3>Validate first.<br />Execute with confidence.</h3>
-                            <p>
-                                Resource dependencies, descriptors and pass ordering are validated
-                                before GPU work begins, so an invalid frame stops before partial
-                                submission.
-                            </p>
-                        </div>
+                <div class="architecturePrinciples">
+                    <article>
+                        <span>01 · Shared frontend</span>
+                        <h3>One renderer owns the frame.</h3>
+                        <p>
+                            Scene collection, culling, sorting, instancing, shadows and
+                            post-processing stay backend-neutral.
+                        </p>
                     </article>
-
-                    <article class="advantageCard">
-                        <span class="cardNumber">03</span>
-                        <div class="scriptPipelineGraphic" aria-hidden="true">
-                            <div>
-                                <span><b>Default</b> Forward Pipeline</span>
-                                <small>Production path</small>
-                            </div>
-                            <div>
-                                <span><b>Custom</b> Your Pipeline</span>
-                                <small>Scriptable features</small>
-                            </div>
-                        </div>
-                        <div class="advantageCardCopy">
-                            <p class="cardKicker">03 · Scriptable Render Pipeline</p>
-                            <h3>Shape the frame.<br />Keep the engine.</h3>
-                            <p>
-                                Add or replace shadow, scene, post-processing and output stages
-                                without forking the renderer or bypassing engine lifecycle.
-                            </p>
-                        </div>
+                    <article>
+                        <span>02 · Transactional graph</span>
+                        <h3>Validate, submit, then commit.</h3>
+                        <p>
+                            Invalid dependencies stop before GPU work. Frame-local state commits
+                            only after a valid submission and rolls back on failure.
+                        </p>
+                    </article>
+                    <article>
+                        <span>03 · Portable execution</span>
+                        <h3>Native APIs behind one contract.</h3>
+                        <p>
+                            Resources, pipelines, bindings, commands and recovery cross the RHI
+                            while native access stays inside backend boundaries.
+                        </p>
                     </article>
                 </div>
             </section>
@@ -391,7 +417,7 @@
             <section class="quickStart sectionShell">
                 <div class="quickStartCopy">
                     <p class="eyebrow"><span></span> Start building</p>
-                    <h2>From install to<br />first frame.</h2>
+                    <h2>From install to <br />first frame.</h2>
                     <p>
                         Create one asynchronous stage. Auto mode selects a compatible WebGPU adapter
                         first and uses WebGL 2 when WebGPU is unavailable.
@@ -435,7 +461,7 @@
             <section class="finalCta sectionShell">
                 <div>
                     <p class="eyebrow"><span></span> Open source · MIT</p>
-                    <h2>Ship your next<br />realtime world.</h2>
+                    <h2>Ship your next <br />realtime world.</h2>
                 </div>
                 <div class="finalActions">
                     <a class="button buttonPrimary" href="./docs/">Read the docs →</a>

--- a/website/styles.css
+++ b/website/styles.css
@@ -89,7 +89,7 @@ video {
 .ambientGlow {
     position: absolute;
     z-index: -2;
-    width: 620px;
+    width: min(620px, 100vw);
     height: 620px;
     border-radius: 50%;
     filter: blur(140px);
@@ -99,13 +99,13 @@ video {
 
 .ambientGlowMint {
     top: -310px;
-    left: -260px;
+    left: 0;
     background: var(--mint);
 }
 
 .ambientGlowBlue {
     top: 120px;
-    right: -350px;
+    right: 0;
     background: var(--blue);
 }
 
@@ -542,6 +542,7 @@ video {
 
 .proofBar > div {
     display: flex;
+    min-width: 0;
     min-height: 122px;
     flex-direction: column;
     justify-content: center;
@@ -555,9 +556,10 @@ video {
 
 .proofBar strong {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 27px;
+    font-size: clamp(21px, 1.5vw, 27px);
     font-weight: 520;
     letter-spacing: -0.04em;
+    white-space: nowrap;
 }
 
 .proofBar span {
@@ -758,54 +760,30 @@ video {
     max-width: 680px;
 }
 
-.advantageGrid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-    margin-top: 58px;
+.architectureIntro {
+    max-width: 1000px;
 }
 
-.advantageCard {
+.architectureIntro h2 span {
+    display: block;
+}
+
+.architectureIntro > p:last-child {
+    max-width: 820px;
+}
+
+.architectureDiagram {
     position: relative;
-    display: flex;
-    min-height: 500px;
     overflow: hidden;
-    flex-direction: column;
-    padding: 30px;
+    margin-top: 58px;
+    padding: 26px;
     border: 1px solid var(--line);
-    border-radius: 17px;
-    background:
-        radial-gradient(circle at 100% 0%, rgba(107, 140, 255, 0.08), transparent 45%), var(--panel);
-}
-
-.advantageCard::before {
-    position: absolute;
-    top: 0;
-    right: 18%;
-    left: 18%;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(110, 231, 196, 0.7), transparent);
-    content: '';
-    opacity: 0.65;
-}
-
-.advantageCard:nth-child(3)::before {
-    background: linear-gradient(90deg, transparent, rgba(183, 147, 255, 0.8), transparent);
-}
-
-.advantageCardPrimary {
-    display: grid;
-    min-height: 430px;
-    grid-column: 1 / -1;
-    grid-template-columns: minmax(310px, 0.78fr) minmax(520px, 1.22fr);
-    align-items: center;
-    gap: 54px;
-    padding: 44px;
+    border-radius: 18px;
     background:
         linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
         linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px),
-        radial-gradient(circle at 70% 50%, rgba(110, 231, 196, 0.12), transparent 34%),
-        linear-gradient(145deg, #111824, #0b1018);
+        radial-gradient(circle at 66% 36%, rgba(110, 231, 196, 0.1), transparent 28%),
+        linear-gradient(145deg, #101722, #0a0f17);
     background-size:
         40px 40px,
         40px 40px,
@@ -813,133 +791,147 @@ video {
         auto;
 }
 
-.cardNumber {
+.architectureDiagram::before {
     position: absolute;
-    top: 27px;
-    right: 28px;
-    color: #465164;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 9px;
+    top: 0;
+    right: 22%;
+    left: 22%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(110, 231, 196, 0.75), transparent);
+    content: '';
 }
 
-.cardKicker {
-    display: inline-flex;
-    width: fit-content;
-    margin: 0 0 17px;
-    padding: 7px 10px;
-    border: 1px solid rgba(110, 231, 196, 0.18);
-    border-radius: 999px;
-    background: rgba(110, 231, 196, 0.055);
-    color: var(--mint);
+.architectureDiagramHeader {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: #697589;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 9px;
-    font-weight: 750;
-    letter-spacing: 0.12em;
+    font-size: 8px;
+    font-weight: 720;
+    letter-spacing: 0.11em;
     text-transform: uppercase;
 }
 
-.advantageCard h3 {
-    margin: 0;
-    color: #f4f7fb;
-    font-size: clamp(31px, 3.4vw, 46px);
-    font-weight: 670;
-    letter-spacing: -0.055em;
-    line-height: 1.04;
-    text-wrap: balance;
+.architectureDiagramHeader > span {
+    display: flex;
+    align-items: center;
+    gap: 9px;
 }
 
-.advantageCard > p:last-child,
-.advantageCopy > p:last-child,
-.advantageCardCopy > p:last-child {
-    max-width: 580px;
-    margin: 17px 0 0;
-    color: var(--muted);
-    font-size: 12px;
-    line-height: 1.7;
+.architectureDiagramHeader b {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--mint);
+    box-shadow: 0 0 12px var(--mint);
 }
 
-.miniPipeline {
+.architectureDiagramHeader small {
+    color: #596477;
+    font-size: inherit;
+}
+
+.architecturePath {
     position: relative;
     z-index: 1;
     display: grid;
-    width: 100%;
-    grid-column: 2;
-    grid-row: 1;
-    grid-template-columns: 0.8fr auto 1.25fr auto 0.9fr;
-    align-items: center;
-    gap: 12px;
+    grid-template-columns:
+        minmax(100px, 0.68fr) auto minmax(130px, 0.95fr) auto minmax(150px, 1.08fr) auto
+        minmax(150px, 1.08fr) auto minmax(120px, 0.8fr) auto minmax(125px, 0.84fr);
+    align-items: stretch;
+    gap: 8px;
+    margin-top: 24px;
 }
 
-.miniPipeline > div,
-.miniOutputs {
+.architectureNode {
     display: grid;
-    min-height: 132px;
+    min-width: 0;
+    min-height: 148px;
     align-content: center;
     gap: 11px;
-    padding: 20px;
+    padding: 17px;
     border: 1px solid var(--line);
-    border-radius: 12px;
-    background: rgba(255, 255, 255, 0.025);
-    color: #b8c1ce;
+    border-radius: 11px;
+    background: rgba(255, 255, 255, 0.028);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 9px;
-    font-weight: 700;
+}
+
+.architectureNode small,
+.architectureServices small {
+    color: #697589;
+    font-size: 7px;
+    font-weight: 750;
+    letter-spacing: 0.11em;
     text-transform: uppercase;
 }
 
-.miniPipeline > div > small {
-    color: #657084;
-    font-size: 7px;
-    letter-spacing: 0.12em;
-}
-
-.miniPipeline > div > span {
-    color: #c9d1dc;
-    font-size: 10px;
-}
-
-.miniPipeline > div > b {
-    color: #647084;
-    font-size: 7px;
-    font-weight: 650;
-    letter-spacing: 0.03em;
-    text-transform: none;
-}
-
-.miniPipeline .miniPipelineCore {
-    min-height: 174px;
-    border-color: rgba(110, 231, 196, 0.32);
-    background: linear-gradient(145deg, rgba(110, 231, 196, 0.1), rgba(107, 140, 255, 0.08));
-    box-shadow: 0 0 44px rgba(110, 231, 196, 0.08);
-    color: var(--mint);
-}
-
-.miniPipeline .miniPipelineCore > span {
-    color: var(--mint);
+.architectureNode strong {
+    color: #dce2eb;
     font-size: 12px;
+    line-height: 1.35;
 }
 
-.miniPipeline > i {
-    color: #4c5769;
+.architectureNode > span {
+    color: #788498;
+    font-size: 7px;
+    line-height: 1.6;
+}
+
+.architectureNodeShared {
+    border-color: rgba(110, 231, 196, 0.2);
+    background: rgba(110, 231, 196, 0.045);
+}
+
+.architectureNodePipeline {
+    border-color: rgba(183, 147, 255, 0.23);
+    background: rgba(183, 147, 255, 0.05);
+}
+
+.architectureNodeGraph {
+    border-color: rgba(110, 231, 196, 0.36);
+    background: linear-gradient(145deg, rgba(110, 231, 196, 0.11), rgba(107, 140, 255, 0.07));
+    box-shadow: 0 0 42px rgba(110, 231, 196, 0.07);
+}
+
+.architectureNodeGraph strong {
+    color: var(--mint);
+}
+
+.architectureNodeRhi {
+    border-color: rgba(107, 140, 255, 0.3);
+    background: rgba(107, 140, 255, 0.07);
+}
+
+.architectureNodeRhi strong {
+    color: #91a7ff;
+}
+
+.architectureConnector {
+    display: grid;
+    align-items: center;
+    color: #536073;
     font-style: normal;
+    font-size: 15px;
 }
 
-.miniOutputs {
-    min-height: 174px;
-    align-content: center;
-    justify-items: start;
-    gap: 14px;
+.architectureBackends > div {
+    display: grid;
+    gap: 8px;
 }
 
-.miniOutputs span {
+.architectureBackends span {
     display: flex;
     align-items: center;
     gap: 8px;
-    color: #c9d1dc;
+    color: #c8d0dc;
     font-size: 9px;
+    font-weight: 720;
 }
 
-.miniOutputs b {
+.architectureBackends span b {
     width: 5px;
     height: 5px;
     border-radius: 50%;
@@ -947,111 +939,80 @@ video {
     box-shadow: 0 0 9px var(--blue);
 }
 
-.miniOutputs span:last-child b {
+.architectureBackends span:last-child b {
     background: var(--purple);
     box-shadow: 0 0 9px var(--purple);
 }
 
-.advantageCopy {
+.architectureServices {
     position: relative;
-    z-index: 2;
-    grid-column: 1;
-    grid-row: 1;
-}
-
-.advantageCardCopy {
-    position: relative;
-    z-index: 2;
-    margin-top: auto;
-}
-
-.graphGraphic {
-    display: flex;
-    min-height: 158px;
-    align-items: center;
-    justify-content: space-between;
-    gap: 7px;
-    margin: 26px 0 42px;
-    padding: 18px;
-    border: 1px solid var(--line);
+    z-index: 1;
+    margin-top: 14px;
+    padding: 16px 17px;
+    border: 1px solid rgba(110, 231, 196, 0.16);
     border-radius: 11px;
-    background: rgba(4, 7, 12, 0.46);
-    color: #9ea9b8;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 8px;
-    font-weight: 700;
+    background: rgba(4, 8, 13, 0.5);
 }
 
-.graphGraphic span {
+.architectureServices > div {
     display: grid;
-    min-height: 76px;
-    flex: 1;
-    align-content: center;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: 8px;
-    padding: 11px 9px;
-    border: 1px solid rgba(110, 231, 196, 0.13);
-    border-radius: 6px;
-    background: rgba(110, 231, 196, 0.04);
-    color: #c4cdd9;
+    margin-top: 11px;
+}
+
+.architectureServices span {
+    padding: 9px 8px;
+    border: 1px solid rgba(110, 231, 196, 0.11);
+    border-radius: 7px;
+    background: rgba(110, 231, 196, 0.035);
+    color: #8c98aa;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 7px;
+    font-weight: 680;
     text-align: center;
 }
 
-.graphGraphic span b {
-    color: var(--mint);
-    font-size: 7px;
-    font-weight: 750;
-}
-
-.graphGraphic i {
-    color: #4e596b;
-    font-style: normal;
-}
-
-.scriptPipelineGraphic {
+.architecturePrinciples {
     display: grid;
-    min-height: 158px;
-    gap: 10px;
-    margin: 26px 0 42px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+    margin-top: 16px;
 }
 
-.scriptPipelineGraphic > div {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: center;
-    padding: 0 18px;
+.architecturePrinciples article {
+    min-height: 230px;
+    padding: 28px;
     border: 1px solid var(--line);
-    border-radius: 9px;
-    background: rgba(255, 255, 255, 0.025);
+    border-radius: 16px;
+    background:
+        radial-gradient(circle at 100% 0%, rgba(107, 140, 255, 0.07), transparent 48%), var(--panel);
 }
 
-.scriptPipelineGraphic > div:last-child {
-    border-color: rgba(183, 147, 255, 0.2);
-    background: rgba(183, 147, 255, 0.045);
-}
-
-.scriptPipelineGraphic span {
-    color: #b9c2cf;
+.architecturePrinciples article > span {
+    color: var(--mint);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 10px;
-    font-weight: 720;
+    font-size: 8px;
+    font-weight: 750;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
 }
 
-.scriptPipelineGraphic span b {
-    display: block;
-    margin-bottom: 5px;
-    color: var(--mint);
-    font-size: 7px;
-    letter-spacing: 0.12em;
+.architecturePrinciples h3 {
+    margin: 48px 0 0;
+    color: #f4f7fb;
+    font-size: clamp(24px, 2.35vw, 31px);
+    font-weight: 660;
+    letter-spacing: -0.05em;
+    line-height: 1.08;
+    text-wrap: balance;
 }
 
-.scriptPipelineGraphic > div:last-child span b {
-    color: var(--purple);
-}
-
-.scriptPipelineGraphic small {
-    color: #657084;
-    font-size: 8px;
+.architecturePrinciples p {
+    margin: 15px 0 0;
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.7;
 }
 
 .sectionIntroRow {
@@ -1141,7 +1102,13 @@ video {
 }
 
 .exampleCardGltf .exampleMedia img {
-    object-position: 59% center;
+    object-position: 72% center;
+}
+
+.exampleCardGltf::after {
+    background:
+        linear-gradient(90deg, rgba(5, 8, 13, 0.9), rgba(5, 8, 13, 0.3) 48%, transparent 72%),
+        linear-gradient(180deg, rgba(5, 8, 13, 0.08) 25%, rgba(5, 8, 13, 0.92) 100%);
 }
 
 .exampleCardRaytracing .exampleMedia img {
@@ -1424,6 +1391,23 @@ video {
         transform: none;
     }
 
+    .proofBar {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .proofBar > div {
+        border-bottom: 1px solid var(--line);
+    }
+
+    .proofBar > div:nth-child(odd) {
+        border-left: 0;
+    }
+
+    .proofBar > div:nth-child(3),
+    .proofBar > div:nth-child(4) {
+        border-bottom: 0;
+    }
+
     .why {
         grid-template-columns: 1fr;
     }
@@ -1432,16 +1416,17 @@ video {
         position: static;
     }
 
-    .advantageCardPrimary {
-        min-height: auto;
-        grid-template-columns: 1fr;
-        gap: 38px;
+    .architecturePath {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
     }
 
-    .advantageCardPrimary .miniPipeline,
-    .advantageCardPrimary .advantageCopy {
-        grid-column: 1;
-        grid-row: auto;
+    .architectureConnector {
+        display: none;
+    }
+
+    .architectureNode {
+        min-height: 132px;
     }
 
     .exampleGrid {
@@ -1555,22 +1540,34 @@ video {
         padding: 30px;
     }
 
-    .advantageGrid {
+    .architectureDiagram {
+        padding: 22px;
+    }
+
+    .architectureDiagramHeader {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .architecturePath {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .architectureServices > div {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .architecturePrinciples {
         grid-template-columns: 1fr;
     }
 
-    .advantageCardPrimary {
+    .architecturePrinciples article {
         min-height: auto;
-        grid-column: auto;
-        grid-template-columns: 1fr;
-        gap: 38px;
-        padding: 36px 30px;
     }
 
-    .advantageCardPrimary .miniPipeline,
-    .advantageCardPrimary .advantageCopy {
-        grid-column: 1;
-        grid-row: auto;
+    .architecturePrinciples h3 {
+        margin-top: 32px;
     }
 
     .sectionIntroRow {
@@ -1620,6 +1617,18 @@ video {
 @media (max-width: 560px) {
     .headerAction {
         padding: 0 12px;
+    }
+
+    .proofBar {
+        grid-template-columns: 1fr;
+    }
+
+    .proofBar > div {
+        border-left: 0;
+    }
+
+    .proofBar > div:nth-child(3) {
+        border-bottom: 1px solid var(--line);
     }
 
     .installLine {
@@ -1679,47 +1688,32 @@ video {
         font-size: 34px;
     }
 
-    .advantageCard {
-        min-height: 310px;
-        padding: 26px 23px;
+    .architectureIntro h2 span {
+        display: inline;
     }
 
-    .advantageCardPrimary {
-        min-height: auto;
+    .architectureIntro h2 span + span::before {
+        content: ' ';
     }
 
-    .miniPipeline {
-        width: 100%;
+    .architectureDiagram {
+        padding: 19px;
+    }
+
+    .architecturePath {
         grid-template-columns: 1fr;
-        gap: 8px;
     }
 
-    .miniPipeline > i {
-        display: none;
+    .architectureNode {
+        min-height: 104px;
     }
 
-    .miniPipeline > div,
-    .miniPipeline .miniPipelineCore,
-    .miniOutputs {
-        min-height: 74px;
-    }
-
-    .miniOutputs {
-        grid-template-columns: 1fr 1fr;
-        justify-items: center;
-    }
-
-    .miniOutputs small {
-        grid-column: 1 / -1;
-    }
-
-    .graphGraphic {
-        display: grid;
+    .architectureServices > div {
         grid-template-columns: 1fr 1fr;
     }
 
-    .graphGraphic i {
-        display: none;
+    .architecturePrinciples article {
+        padding: 24px;
     }
 
     .codeWindow pre {


### PR DESCRIPTION
## Summary

- complete roadmap D0 with reversed-Z depth conventions, finite/infinite perspective support, and camera-relative GPU transforms
- add submission-aware current/previous transform history across camera, model, skinning, morph, and GPU-driven instance data
- propagate the selected depth convention through render targets, pipeline caches, shadows, descriptor mapping, and mesh picking
- update the public API report, changelog, rendering documentation, modernization notes, and roadmap status
- refresh the homepage value proposition, proof points, responsive rendering architecture diagram, examples presentation, and navigation flow

## Why

D0 is the foundation for motion vectors, TAA/TAAU, GPU Scene, Hi-Z, and large-world rendering. The homepage changes explain the same shared-renderer, Render Graph, SRP, and portable RHI architecture in a clearer progression for experienced 3D developers without duplicating the hero proof points.

## Developer impact

- the portable profile keeps standard depth by default
- the high-end rendering profile enables reversed-Z and camera-relative rendering
- cameras can select a depth mode explicitly, and perspective cameras support an infinite far plane
- previous-frame state advances only after a successful submission and rolls back on failed frames
- the homepage remains responsive and accessible without relying on a rasterized architecture diagram

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:render:architecture` — 135 tests passed
- `npm run test:rhi` — 216 tests passed, 1 native test skipped
- `npm run site:build` — 67,559 internal references validated
- browser review at 1440×1000 and 390×844 — no horizontal overflow, broken images, or console warnings/errors
