### PR TITLE
fix(render): make presentation encoding explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Make forward feature color encoding explicit. `replaceColor()` now requires `linear` or `srgb`,
   and the default Forward pipeline always routes surface presentation through the Render Graph so
   the final output transfer is owned by the output stage rather than individual materials.
+- Replace the Forward-specific color-encoding type with the shared `RenderColorEncoding`. Manual
+  RenderTarget presentation now accepts an explicit `colorEncoding`; linear inputs receive the final
+  sRGB transfer, while display-transformed `srgb` inputs are preserved without a second conversion.
 
 ### Changes
 
@@ -34,6 +37,10 @@
   Uber output is presented without a second conversion. Single-camera MSAA resolves into the
   persistent single-sample composition target; multi-camera stacks use one single-sample
   color/depth/stencil composition contract so later cameras can load prior contents exactly.
+- Keep ShaderMaterial scene output linear and make custom pipeline presentation encoding explicit.
+  ShaderToy now relies on the shared Forward output transfer, while the compute particle field and
+  crystal path tracer declare their display-referred output so their authored grading is not
+  transferred twice.
 - Advance the RHI benchmark manifest to schema 4 and model fixed surface-output draws separately
   from primary scene and post-process draws; immutable snapshots from earlier schemas remain
   historical evidence and are not rewritten.

--- a/documentation/ENGINEERING_MODERNIZATION.md
+++ b/documentation/ENGINEERING_MODERNIZATION.md
@@ -533,6 +533,12 @@ texture、resize、所有权、显式 present 选择与异步区域 readback；�
 target、非法 attachment、MSAA depth sampling、无附件 target、销毁后复用和 depth-only
 present 均直接报错。
 
+RenderTarget attachment format 与其当前内容的颜色编码是两个独立合同。`present()` 或
+`setRenderTarget(..., { present: true })` 默认把 attachment
+zero 解释为线性颜色，并只在写入浏览器 surface 时执行一次 linear-to-sRGB transfer。已经自行完成 tone
+mapping/display transform 的自定义 pipeline 必须通过 `colorEncoding: 'srgb'`
+显式声明；该路径只做原样采样呈现，不会再次提亮。
+
 WebGPU MRT pipeline target 与 attachment location 一一对应，支持中间为 `null` 的 sparse color
 slot；depth-only target 不声明颜色输出。resize 在新 color/depth/MSAA
 allocation 全部成功后才提交，失败会销毁新资源并保留旧 target

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -131,7 +131,9 @@ Graph 分配和回收。
 Uber 之前，不能在 sRGB/tone-mapped 结果上模糊。Forward feature 资源显式携带 `linear`/`srgb`
 编码；Color Uber 将结果标记为 `srgb`，最终 surface output 因而不会再次转换。未启用 Color
 Uber 时，默认 Forward output pass 负责唯一一次准确的 linear-to-sRGB
-transfer；RenderTarget 仍保留调用方选择的线性或 sRGB 格式语义。
+transfer。手动呈现 RenderTarget 时同样默认输入为线性；自定义 pipeline 若已输出 display-referred
+sRGB，必须在 `present()` 或 `setRenderTarget()` 的 presentation options 中声明
+`colorEncoding: 'srgb'`，从而使用无二次转换的 passthrough。
 
 当前 `exposure` 是固定的手动 EV compensation；运行时尚未提供 scene luminance histogram、eye
 adaptation、GPU exposure

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -541,6 +541,11 @@ pass，不创建这些原生对象。
   `hiloBottomLeftFragCoord()`。不依赖方向的随机 dither 可以继续直接使用 native fragment position。
 - compute/storage image 的 row 0 是顶部；compute presenter 只在 storage-row 到 fullscreen native
   UV 的边界转换一次。CPU readback 仍返回 top-to-bottom rows。
+- 普通 Forward/ShaderMaterial scene color 必须保持线性，surface
+  output 负责唯一一次 linear-to-sRGB。自定义 RenderTarget pipeline 若已经完成 display
+  transform，必须在 presentation options 中声明
+  `colorEncoding: 'srgb'`；未声明时按线性输入处理，不能依赖 backend 或 attachment
+  format 猜测内容编码。
 
 这套合同覆盖 ShaderToy、Life Game、Bloom/Color Uber、opaque scene texture transmission、Shadow
 Atlas、compute particles、compute path tracer、普通 glTF 材质与 cube

--- a/documentation/SCRIPTABLE_RENDER_PIPELINE_PLAN.md
+++ b/documentation/SCRIPTABLE_RENDER_PIPELINE_PLAN.md
@@ -1280,8 +1280,9 @@ compatibility layer 掩盖。
 - 省略 `renderPipeline` 时仍得到当前 forward 行为。
 - `Renderer.create()` / `Stage.create()` 仍是唯一创建入口；省略 backend 的 WebGPU-first `auto`
   策略、显式 backend fail-closed 和选中后的不回退规则不变。
-- `render()`、`renderToTarget()`、`renderFrame()`、`setRenderTarget()`、`present()`
-  和 readback 签名不变。
+- `render()`、`renderToTarget()`、`renderFrame()` 和 readback 的职责不变；`setRenderTarget()` 与
+  `present()` 的 presentation options 显式携带 attachment-zero
+  `colorEncoding`，不再从自定义 shader 或 attachment format 猜测显示语义。
 - clear、MSAA、depth/stencil、events、diagnostics、resource manager 和 recovery 可观察语义不变。
 - 已使用 async `create()` 的应用无需为默认 SRP 迁移；`renderPipeline` 本身是 additive public API。
 

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -1932,9 +1932,6 @@ export interface FogParameters {
 }
 
 // @public
-export type ForwardRenderColorEncoding = 'linear' | 'srgb';
-
-// @public
 export interface ForwardRenderFeatureContext {
     readonly cullingResults: CullingResultsHandle;
     readonly pipeline: RenderPipelineContext;
@@ -1985,9 +1982,9 @@ export interface ForwardRenderPipelineFeatureRuntime {
 // @public
 export interface ForwardRenderPipelineResources {
     readonly color: RenderGraphTextureHandle | null;
-    readonly colorEncoding: ForwardRenderColorEncoding;
+    readonly colorEncoding: RenderColorEncoding;
     readonly depth: RenderGraphTextureHandle | null;
-    replaceColor(texture: RenderGraphTextureHandle, encoding: ForwardRenderColorEncoding): void;
+    replaceColor(texture: RenderGraphTextureHandle, encoding: RenderColorEncoding): void;
 }
 
 // @public
@@ -5697,6 +5694,9 @@ type RegistryLoadMethod = {
 }['load'];
 
 // @public
+export type RenderColorEncoding = 'linear' | 'srgb';
+
+// @public
 export class Renderer<Backend extends RendererBackend = RendererBackend> implements RendererContract {
     // (undocumented)
     static [Symbol.hasInstance](value: unknown): boolean;
@@ -5878,7 +5878,7 @@ export interface RendererContract {
     onInit(callback: (renderer: this) => void): void;
     // (undocumented)
     pixelRatio: number;
-    present(target?: RenderTarget): void;
+    present(target?: RenderTarget, options?: RenderTargetPresentationOptions): void;
     // (undocumented)
     readonly ready: Promise<void>;
     // (undocumented)
@@ -5925,7 +5925,7 @@ export interface RendererFrame {
     // (undocumented)
     readonly backend: RendererBackend;
     // (undocumented)
-    present(target?: RenderTarget): void;
+    present(target?: RenderTarget, options?: RenderTargetPresentationOptions): void;
     // (undocumented)
     render(stage: RendererScene, camera: Camera, fireEvent?: boolean): void;
     // (undocumented)
@@ -6477,6 +6477,11 @@ export interface RenderTargetParameters {
     readonly width: number;
 }
 
+// @public
+export interface RenderTargetPresentationOptions {
+    readonly colorEncoding?: RenderColorEncoding;
+}
+
 // @public (undocumented)
 export interface RenderTargetReadColorAttachmentOptions {
     // (undocumented)
@@ -6494,7 +6499,7 @@ export interface RenderTargetReadColorAttachmentOptions {
 export type RenderTargetSampleCount = 1 | 4;
 
 // @public (undocumented)
-export interface RenderTargetSelectionOptions {
+export interface RenderTargetSelectionOptions extends RenderTargetPresentationOptions {
     readonly present?: boolean;
     readonly takeOwnership?: boolean;
 }

--- a/examples/compute_particles.ts
+++ b/examples/compute_particles.ts
@@ -1858,7 +1858,12 @@ const particles = stage.renderer.createStorageBuffer({
     recovery: 'cpu-shadow'
 });
 factory.runtime.attachResources({ particles });
-stage.renderer.setRenderTarget(target, { present: true, takeOwnership: true });
+stage.renderer.setRenderTarget(target, {
+    present: true,
+    takeOwnership: true,
+    // The custom pipeline authors and blends its final field in display-referred space.
+    colorEncoding: 'srgb'
+});
 
 const controller = new InteractionController();
 controller.attach(stage.canvas);

--- a/examples/compute_raytracing.ts
+++ b/examples/compute_raytracing.ts
@@ -1350,7 +1350,12 @@ const accumulation = stage.renderer.createStorageBuffer({
     recovery: 'cpu-shadow'
 });
 factory.runtime.attachResources({ accumulation });
-stage.renderer.setRenderTarget(target, { present: true, takeOwnership: true });
+stage.renderer.setRenderTarget(target, {
+    present: true,
+    takeOwnership: true,
+    // PRESENT_PASS already applies ACES and its display transfer.
+    colorEncoding: 'srgb'
+});
 
 const controller = new OrbitController(sampleElement);
 controller.attach(stage.canvas);

--- a/examples/shaderToy.ts
+++ b/examples/shaderToy.ts
@@ -536,9 +536,6 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
         // render   
         vec3 col = render( ro, rd );
 
-        // gamma
-        col = pow( col, vec3(0.4545) );
-
         tot += col;
 #if AA>1
     }

--- a/src/Hilo3d.ts
+++ b/src/Hilo3d.ts
@@ -119,6 +119,7 @@ export {
 } from './2d/UiButton';
 
 export { default as RenderInfo } from './render/RenderInfo';
+export type { RenderColorEncoding } from './render/RenderColorEncoding';
 export type {
     StorageBuffer,
     StorageBufferDescriptor,
@@ -138,6 +139,7 @@ export type {
     RenderTargetDepthStencilFormat,
     RenderTargetLoadOp,
     RenderTargetParameters,
+    RenderTargetPresentationOptions,
     RenderTargetReadColorAttachmentOptions,
     RenderTargetSampleCount,
     RenderTargetSelectionOptions,

--- a/src/render/RenderColorEncoding.ts
+++ b/src/render/RenderColorEncoding.ts
@@ -1,0 +1,2 @@
+/** Encoding carried by render-pipeline color values at a presentation boundary. */
+export type RenderColorEncoding = 'linear' | 'srgb';

--- a/src/render/RenderTarget.ts
+++ b/src/render/RenderTarget.ts
@@ -1,6 +1,7 @@
 import type Texture from '../texture/Texture';
 import type { RendererBackend } from './Renderer';
 import type { CameraDepthMode } from '../camera/Camera';
+import type { RenderColorEncoding } from './RenderColorEncoding';
 
 export type RenderTargetSampleCount = 1 | 4;
 
@@ -71,7 +72,16 @@ export interface RenderTargetParameters {
     readonly label?: string;
 }
 
-export interface RenderTargetSelectionOptions {
+/** Color contract used when attachment zero is copied to the browser presentation surface. */
+export interface RenderTargetPresentationOptions {
+    /**
+     * Encoding stored in attachment zero. Linear input receives the final sRGB transfer. Defaults
+     * to `linear`; a selection's value is reused by `present()` when that target is implicit.
+     */
+    readonly colorEncoding?: RenderColorEncoding;
+}
+
+export interface RenderTargetSelectionOptions extends RenderTargetPresentationOptions {
     /** Present attachment zero after each render. */
     readonly present?: boolean;
     /** Destroy the target when it is replaced or when the renderer is destroyed. */

--- a/src/render/RendererCore.ts
+++ b/src/render/RendererCore.ts
@@ -17,6 +17,7 @@ import { getRegisteredRendererDiagnostics } from './diagnostics/RendererDiagnost
 import type {
     RenderTarget,
     RenderTargetParameters,
+    RenderTargetPresentationOptions,
     RenderTargetSelectionOptions
 } from './RenderTarget';
 import type { StorageBuffer, StorageBufferDescriptor } from './StorageBuffer';
@@ -60,7 +61,7 @@ export interface RendererFrame {
         camera: Camera,
         fireEvent?: boolean
     ): void;
-    present(target?: RenderTarget): void;
+    present(target?: RenderTarget, options?: RenderTargetPresentationOptions): void;
 }
 
 /** Synchronous frame recorder. Returning a Promise is rejected at runtime. */
@@ -95,10 +96,9 @@ export function createRendererFrame(
             assertActive();
             renderer.renderToTarget(target, stage, camera, fireEvent);
         },
-        present(target?: RenderTarget) {
+        present(target?: RenderTarget, options?: RenderTargetPresentationOptions) {
             assertActive();
-            if (target) renderer.present(target);
-            else renderer.present();
+            renderer.present(target, options);
         }
     });
 }
@@ -154,7 +154,7 @@ export interface RendererContract {
     createRenderTarget(parameters: RenderTargetParameters): RenderTarget;
     setRenderTarget(target: RenderTarget | null, options?: RenderTargetSelectionOptions): this;
     /** Present the first color attachment of a renderer-owned target to the canvas. */
-    present(target?: RenderTarget): void;
+    present(target?: RenderTarget, options?: RenderTargetPresentationOptions): void;
     renderToTarget(
         target: RenderTarget,
         stage: RendererScene,
@@ -273,7 +273,7 @@ export abstract class RendererCore extends EventDispatcher implements RendererCo
         target: RenderTarget | null,
         options?: RenderTargetSelectionOptions
     ): this;
-    abstract present(target?: RenderTarget): void;
+    abstract present(target?: RenderTarget, options?: RenderTargetPresentationOptions): void;
     abstract renderToTarget(
         target: RenderTarget,
         stage: RendererScene,

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -31,9 +31,11 @@ import type {
     RenderTargetColorAttachmentReadback,
     RenderTargetCompareFunction,
     RenderTargetParameters,
+    RenderTargetPresentationOptions,
     RenderTargetReadColorAttachmentOptions,
     RenderTargetSelectionOptions
 } from '../RenderTarget';
+import type { RenderColorEncoding } from '../RenderColorEncoding';
 import {
     RendererStorageBuffer,
     type StorageBuffer,
@@ -203,6 +205,14 @@ function countMeshFaces(mesh: Mesh): number {
     return 0;
 }
 
+function resolvePresentationColorEncoding(value: unknown): RenderColorEncoding {
+    const encoding = value ?? 'linear';
+    if (encoding !== 'linear' && encoding !== 'srgb') {
+        throw new TypeError('Render-target presentation color encoding must be linear or srgb');
+    }
+    return encoding;
+}
+
 function reportListenerFailure(reason: unknown): void {
     const error = asError(reason, 'Renderer lifecycle listener failed');
     queueMicrotask(() => {
@@ -292,6 +302,7 @@ class SharedRendererDriver
     #afterSceneEventCount = 0;
     #ownsRenderTarget = false;
     #autoPresentRenderTarget = false;
+    #selectedTargetColorEncoding: RenderColorEncoding = 'linear';
     #pipelineCacheMetrics: RHICacheCounterContinuation | null = null;
     #bindGroupCacheMetrics: RHICacheCounterContinuation | null = null;
     #vertexInputCacheMetrics: RHICacheCounterContinuation | null = null;
@@ -467,7 +478,7 @@ class SharedRendererDriver
             const selected = this.renderTarget;
             this.#pipelineHost.recordPipeline(stage, camera, selected, fireEvent);
             if (selected !== null && this.#autoPresentRenderTarget) {
-                this.presentInternal(selected);
+                this.presentInternal(selected, this.#selectedTargetColorEncoding);
             }
         });
     }
@@ -940,17 +951,28 @@ class SharedRendererDriver
         this.renderTarget = resolved;
         this.#ownsRenderTarget = resolved !== null && options.takeOwnership === true;
         this.#autoPresentRenderTarget = resolved !== null && options.present === true;
+        this.#selectedTargetColorEncoding = resolvePresentationColorEncoding(options.colorEncoding);
         if (destroyPrevious) previous.destroy();
         return this;
     }
 
-    override present(target?: RenderTarget): void {
+    override present(target?: RenderTarget, options: RenderTargetPresentationOptions = {}): void {
+        const explicitColorEncoding =
+            options.colorEncoding === undefined
+                ? null
+                : resolvePresentationColorEncoding(options.colorEncoding);
         this.recordFrameCommand(() => {
-            this.presentInternal(target ?? this.requireSelectedRenderTarget());
+            const resolvedTarget = target ?? this.requireSelectedRenderTarget();
+            const colorEncoding =
+                explicitColorEncoding ??
+                (resolvedTarget === this.renderTarget
+                    ? this.#selectedTargetColorEncoding
+                    : 'linear');
+            this.presentInternal(resolvedTarget, colorEncoding);
         });
     }
 
-    private presentInternal(target: RenderTarget): void {
+    private presentInternal(target: RenderTarget, colorEncoding: RenderColorEncoding): void {
         const resolved = this.requireOwnedTarget(target);
         if (resolved.colorAttachmentCount === 0) {
             throw new TypeError('A depth-only render target cannot be presented');
@@ -965,7 +987,7 @@ class SharedRendererDriver
             context,
             this.requireSurface(),
             resolved.resourceRecord,
-            { clearColor: this.clearColor },
+            { clearColor: this.clearColor, colorEncoding },
             this.#fullscreenFrameStarted
         );
         this.#fullscreenFrameStarted = true;
@@ -1264,6 +1286,7 @@ class SharedRendererDriver
         this.renderTarget = null;
         this.#ownsRenderTarget = false;
         this.#autoPresentRenderTarget = false;
+        this.#selectedTargetColorEncoding = 'linear';
     }
 
     private async initializeWebGL2(): Promise<void> {
@@ -2046,6 +2069,7 @@ class SharedRendererDriver
         this.renderTarget = null;
         this.#ownsRenderTarget = false;
         this.#autoPresentRenderTarget = false;
+        this.#selectedTargetColorEncoding = 'linear';
     }
 
     private destroyAllStorageBuffers(): void {

--- a/src/render/pipeline/ForwardRenderPipeline.ts
+++ b/src/render/pipeline/ForwardRenderPipeline.ts
@@ -7,6 +7,7 @@ import {
     type RenderTargetSampleCount,
     type RenderTargetStoreOp
 } from '../RenderTarget';
+import type { RenderColorEncoding } from '../RenderColorEncoding';
 import type {
     CullingResultsHandle,
     RendererListDescriptor,
@@ -95,19 +96,16 @@ export interface ForwardRenderPipelineFeature {
     create(context: RenderPipelineCreateContext): ForwardRenderPipelineFeatureRuntime;
 }
 
-/** Color encoding carried by the current forward scene-color resource. */
-export type ForwardRenderColorEncoding = 'linear' | 'srgb';
-
 /** Callback-scoped forward resources visible only during one synchronous feature record call. */
 export interface ForwardRenderPipelineResources {
     /** Current attachment-zero scene color, or null for a depth-only output. */
     readonly color: RenderGraphTextureHandle | null;
     /** Encoding of the current scene color. Lighting and HDR effects require `linear`. */
-    readonly colorEncoding: ForwardRenderColorEncoding;
+    readonly colorEncoding: RenderColorEncoding;
     /** Current scene depth, or null when no depth resource was requested or configured. */
     readonly depth: RenderGraphTextureHandle | null;
     /** Replace attachment-zero scene color for subsequent features and final output. */
-    replaceColor(texture: RenderGraphTextureHandle, encoding: ForwardRenderColorEncoding): void;
+    replaceColor(texture: RenderGraphTextureHandle, encoding: RenderColorEncoding): void;
 }
 
 /** Callback-scoped inputs passed to one forward feature runtime. */
@@ -336,7 +334,7 @@ class ForwardFeatureState {
     #pipeline: RenderPipelineContext | null = null;
     #cullingResults = INVALID_CULLING_RESULTS_HANDLE;
     #color: RenderGraphTextureHandle | null = null;
-    #colorEncoding: ForwardRenderColorEncoding = 'linear';
+    #colorEncoding: RenderColorEncoding = 'linear';
     #depth: RenderGraphTextureHandle | null = null;
     #replacementAllowed = false;
     #activeCallbackLease: ForwardFeatureCallbackLease | null = null;
@@ -390,7 +388,7 @@ class ForwardFeatureState {
         return this.#color;
     }
 
-    get currentColorEncoding(): ForwardRenderColorEncoding {
+    get currentColorEncoding(): RenderColorEncoding {
         this.assertFrameActive();
         return this.#colorEncoding;
     }
@@ -418,7 +416,7 @@ class ForwardFeatureState {
         return this.#depth;
     }
 
-    readColorEncoding(lease: ForwardFeatureCallbackLease): ForwardRenderColorEncoding {
+    readColorEncoding(lease: ForwardFeatureCallbackLease): RenderColorEncoding {
         this.assertCallbackActive(lease);
         return this.#colorEncoding;
     }
@@ -426,7 +424,7 @@ class ForwardFeatureState {
     replaceColor(
         lease: ForwardFeatureCallbackLease,
         texture: RenderGraphTextureHandle,
-        encoding: ForwardRenderColorEncoding
+        encoding: RenderColorEncoding
     ): void {
         this.assertCallbackActive(lease);
         if (!this.#replacementAllowed) {
@@ -479,11 +477,11 @@ class ForwardFeatureResourcesLease implements ForwardRenderPipelineResources {
         return this.#state.readDepth(this.#lease);
     }
 
-    get colorEncoding(): ForwardRenderColorEncoding {
+    get colorEncoding(): RenderColorEncoding {
         return this.#state.readColorEncoding(this.#lease);
     }
 
-    replaceColor(texture: RenderGraphTextureHandle, encoding: ForwardRenderColorEncoding): void {
+    replaceColor(texture: RenderGraphTextureHandle, encoding: RenderColorEncoding): void {
         this.#state.replaceColor(this.#lease, texture, encoding);
     }
 }

--- a/src/render/pipeline/index.ts
+++ b/src/render/pipeline/index.ts
@@ -7,7 +7,6 @@ export {
 } from './ClusteredForwardPlus';
 export {
     ForwardRenderPipelineFactory,
-    type ForwardRenderColorEncoding,
     type ForwardRenderFeatureContext,
     type ForwardRenderFeatureRequirements,
     type ForwardRenderInjectionPoint,

--- a/src/render/pipeline/passes/internal/OutputTransferShader.ts
+++ b/src/render/pipeline/passes/internal/OutputTransferShader.ts
@@ -15,3 +15,13 @@ void main() {
     vec4 source = texture(u_source, v_uv);
     color = vec4(linearToSRGB(max(source.rgb, vec3(0.0))), source.a);
 }`;
+
+/** @internal Preserve display-encoded values that already underwent a display transform. */
+export const SRGB_PASSTHROUGH_FRAGMENT_SOURCE = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_source;
+layout(location = 0) out vec4 color;
+void main() {
+    color = texture(u_source, v_uv);
+}`;

--- a/src/render/renderer/PostProcessRenderer.ts
+++ b/src/render/renderer/PostProcessRenderer.ts
@@ -8,7 +8,11 @@ import type { RenderGraphFrameContext } from '../frame/RenderGraphFrameContext';
 import type { RenderGraphBuilder } from '../graph/RenderGraphBuilder';
 import type { RGExecutionResult } from '../graph/RenderGraphExecutor';
 import { PORTABLE_FULLSCREEN_VERTEX_SOURCE } from '../pipeline/passes/internal/PortableFullscreenShader';
-import { LINEAR_TO_SRGB_FRAGMENT_SOURCE } from '../pipeline/passes/internal/OutputTransferShader';
+import {
+    LINEAR_TO_SRGB_FRAGMENT_SOURCE,
+    SRGB_PASSTHROUGH_FRAGMENT_SOURCE
+} from '../pipeline/passes/internal/OutputTransferShader';
+import type { RenderColorEncoding } from '../RenderColorEncoding';
 import {
     RHITextureUsage,
     type RHIBuffer,
@@ -51,6 +55,8 @@ export interface PostProcessFrameOptions {
     readonly steps?: readonly Readonly<PostProcessStep>[];
     readonly label?: string;
     readonly clearColor?: RHIColor;
+    /** Encoding of the final source color presented to the browser surface. Defaults to linear. */
+    readonly colorEncoding?: RenderColorEncoding;
 }
 
 export interface PostProcessFrameResult {
@@ -77,6 +83,14 @@ function surfaceHasAcquiredTexture(surface: RHISurface): boolean {
     return surface.state === 'acquired';
 }
 
+function resolveColorEncoding(value: unknown): RenderColorEncoding {
+    const encoding = value ?? 'linear';
+    if (encoding !== 'linear' && encoding !== 'srgb') {
+        throw new TypeError('Post-process source color encoding must be linear or srgb');
+    }
+    return encoding;
+}
+
 /** Shared post-process chain followed by an explicit fullscreen present pass. */
 export class PostProcessRenderer {
     readonly frame: RenderGraphFrame;
@@ -89,9 +103,13 @@ export class PostProcessRenderer {
         readTextures: 1
     });
     readonly #presentOwner = {};
-    readonly #presentShader = new ShaderClass({
+    readonly #linearPresentShader = new ShaderClass({
         vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE,
         fs: LINEAR_TO_SRGB_FRAGMENT_SOURCE
+    });
+    readonly #srgbPresentShader = new ShaderClass({
+        vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE,
+        fs: SRGB_PASSTHROUGH_FRAGMENT_SOURCE
     });
     readonly #presentPipelineState: Readonly<MaterialPipelineState> = Object.freeze({
         ...DEFAULT_MATERIAL_PIPELINE_STATE,
@@ -168,6 +186,7 @@ export class PostProcessRenderer {
             throw new TypeError('Composed post-process effects require explicit output scheduling');
         }
         const configuration = this.validateInputs(context, surface, input, options);
+        const colorEncoding = resolveColorEncoding(options.colorEncoding);
         if (!fullscreenFrameStarted) this.fullscreen.beginFrame(context, scope.uploads);
         const currentImport = this.bridge.import(scope.graph, input);
         const surfaceTexture = importSurfaceColor(scope.graph, surface, 'post-process surface');
@@ -200,7 +219,10 @@ export class PostProcessRenderer {
         present.addDraw(
             this.fullscreen.prepare({
                 owner: slot.owner,
-                shader: this.#presentShader,
+                shader:
+                    colorEncoding === 'linear'
+                        ? this.#linearPresentShader
+                        : this.#srgbPresentShader,
                 pipelineState: this.#presentPipelineState,
                 target: { colorFormats: [configuration.format], sampleCount: 1 },
                 sampledResources: this.sampledResources(slot.owner, sourceColor.record.readableView)
@@ -220,6 +242,7 @@ export class PostProcessRenderer {
         this.assertAlive();
         if (this.#active) throw new Error('Nested PostProcessRenderer execution is not allowed');
         const configuration = this.validateInputs(context, surface, input, options);
+        const colorEncoding = resolveColorEncoding(options.colorEncoding);
         const steps = options.steps ?? [];
         this.prepareOutputTargets(input, steps);
         this.#active = true;
@@ -281,7 +304,10 @@ export class PostProcessRenderer {
                 present.addDraw(
                     this.fullscreen.prepare({
                         owner: this.#presentOwner,
-                        shader: this.#presentShader,
+                        shader:
+                            colorEncoding === 'linear'
+                                ? this.#linearPresentShader
+                                : this.#srgbPresentShader,
                         pipelineState: this.#presentPipelineState,
                         target: { colorFormats: [configuration.format], sampleCount: 1 },
                         sampledResources: this.sampledResources(

--- a/test/spec/renderer/GlslToWgsl.test.ts
+++ b/test/spec/renderer/GlslToWgsl.test.ts
@@ -1250,6 +1250,7 @@ describe('modern example WebGPU shader corpus', () => {
         registerUniformBlockBinding('ShaderToyBlock');
         const source = Object.values(shaderToyExampleModules)[0];
         if (!source) throw new Error('ShaderToy example source was not loaded');
+        expect(source).not.toContain('col = pow( col, vec3(0.4545) )');
         const translator = new NagaShaderTranslator();
         await translator.initialize();
         const translated = translator.translate(screenVertexSource, shaderToyFragment(source));

--- a/test/spec/renderer/PostProcessRenderer.test.ts
+++ b/test/spec/renderer/PostProcessRenderer.test.ts
@@ -10,6 +10,10 @@ import {
 import { RenderTargetResourceCache } from '../../../src/render/renderer/RenderTargetResourceCache';
 import { ResourceRegistry } from '../../../src/render/renderer/ResourceRegistry';
 import { RHITextureUsage } from '../../../src/render/rhi/core';
+import {
+    LINEAR_TO_SRGB_FRAGMENT_SOURCE,
+    SRGB_PASSTHROUGH_FRAGMENT_SOURCE
+} from '../../../src/render/pipeline/passes/internal/OutputTransferShader';
 import Shader from '../../../src/shader/Shader';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -215,5 +219,44 @@ describe.each([
         expect(renderer.fullscreen.active).toBe(false);
 
         destroyFixture(backend, registry, resources, renderer, 1);
+    });
+
+    it('transfers linear presentation input once and preserves display-encoded input', async () => {
+        const backend = createBackend();
+        const device = backend.createDevice();
+        const registry = new ResourceRegistry(device);
+        const resources = new RenderTargetResourceCache(registry);
+        const renderer = new PostProcessRenderer(resources);
+        await renderer.initialize();
+        const surface = configuredSurface(device);
+        const input = resources.prepare(
+            {},
+            {
+                width: 8,
+                height: 8,
+                colorFormats: ['rgba8unorm']
+            }
+        );
+        const compile = vi.spyOn(renderer.fullscreen.compiler, 'compile');
+
+        const linear = renderer.render(context(device, 1), surface, input, {
+            colorEncoding: 'linear'
+        });
+        await complete(backend, linear.tracking);
+        const srgb = renderer.render(context(device, 2), surface, input, {
+            colorEncoding: 'srgb'
+        });
+        await complete(backend, srgb.tracking);
+
+        const fragmentSources = compile.mock.calls.map(([shader]) => shader.fs);
+        expect(fragmentSources).toContain(LINEAR_TO_SRGB_FRAGMENT_SOURCE);
+        expect(fragmentSources).toContain(SRGB_PASSTHROUGH_FRAGMENT_SOURCE);
+        expect(() =>
+            renderer.render(context(device, 3), surface, input, {
+                colorEncoding: 'display-p3' as 'linear'
+            })
+        ).toThrow(/must be linear or srgb/u);
+
+        destroyFixture(backend, registry, resources, renderer, 3);
     });
 });

--- a/test/spec/renderer/Renderer.test.ts
+++ b/test/spec/renderer/Renderer.test.ts
@@ -500,7 +500,7 @@ describe('Renderer public entry point', () => {
             frame.renderToTarget(firstTarget, stage, camera);
             frame.renderToTarget(secondTarget, stage, camera);
             frame.present(firstTarget);
-            frame.present(firstTarget);
+            frame.present(firstTarget, { colorEncoding: 'srgb' });
         });
 
         expect(beginFrame).toHaveBeenCalledOnce();

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -51,6 +51,7 @@ import {
     type RendererSupportOptions,
     type RendererWebGL2Options,
     type RendererWebGPUOptions,
+    type RenderColorEncoding,
     type RenderTarget,
     type RenderTargetColorAttachmentReadback,
     type RenderTargetParameters,
@@ -217,13 +218,19 @@ const compressionSupport: readonly boolean[] = renderers.map(currentRenderer =>
 );
 const webglRenderTarget: RenderTarget = renderer.createRenderTarget(renderTargetParameters);
 const webgpuRenderTarget: RenderTarget = webgpuRenderer.createRenderTarget(renderTargetParameters);
-renderer.setRenderTarget(webglRenderTarget, { present: true, takeOwnership: true });
+const displayEncoding: RenderColorEncoding = 'srgb';
+renderer.setRenderTarget(webglRenderTarget, {
+    present: true,
+    takeOwnership: true,
+    colorEncoding: displayEncoding
+});
 webgpuRenderer.setRenderTarget(webgpuRenderTarget, { present: true, takeOwnership: true });
 renderer.renderToTarget(webglRenderTarget, stage, camera);
 webgpuRenderer.renderToTarget(webgpuRenderTarget, webgpuStage, camera);
 renderers.forEach(currentRenderer => {
     currentRenderer.present(
-        currentRenderer.backend === 'webgl2' ? webglRenderTarget : webgpuRenderTarget
+        currentRenderer.backend === 'webgl2' ? webglRenderTarget : webgpuRenderTarget,
+        { colorEncoding: 'linear' }
     );
 });
 const colorReadbacks: readonly Promise<RenderTargetColorAttachmentReadback>[] = [

--- a/test/ui/compute-particles.spec.ts
+++ b/test/ui/compute-particles.spec.ts
@@ -171,6 +171,7 @@ test('keeps the interactive particle simulation and rendering on public GPU APIs
     expect(source).toContain('context.graph.importStorageBuffer');
     expect(source).toContain("recovery: 'cpu-shadow'");
     expect(source).toContain('blend: Hilo3d.MaterialBlendPreset.STRAIGHT_ALPHA_ADDITIVE');
+    expect(source).toContain("colorEncoding: 'srgb'");
 });
 
 declare global {

--- a/test/ui/compute-raytracing.spec.ts
+++ b/test/ui/compute-raytracing.spec.ts
@@ -135,6 +135,7 @@ test('keeps path tracing on the public compute and Render Graph APIs', () => {
     expect(source).toContain('accumulation[radianceIndex] =');
     expect(source).toContain("recovery: 'cpu-shadow'");
     expect(source).toContain('new Hilo3d.RenderPassParameterPool');
+    expect(source).toContain("colorEncoding: 'srgb'");
 });
 
 declare global {


### PR DESCRIPTION
## Summary

- introduce a shared `RenderColorEncoding` contract for manual RenderTarget presentation
- apply the linear-to-sRGB transfer exactly once and preserve explicitly display-encoded output
- remove ShaderToy's duplicate gamma transfer and mark the compute particle/path-tracer outputs as `srgb`
- update renderer tests, browser contracts, public API report, changelog, and rendering documentation

## Root cause

The shared presentation pass began treating every manually presented RenderTarget as linear. ShaderToy already applied its own gamma transform, the path tracer already applied ACES plus display transfer, and the particle field was authored/blended in display-referred space. Those paths therefore received a second transfer and appeared washed out. The backend shader compiler was behaving consistently; the missing piece was an explicit content-encoding contract at the presentation boundary.

## Validation

- `npm run validate` (exit 0)
  - 180 test files / 1736 unit tests
  - 213 portable RHI tests; native adapter tests 3 passed / 1 skipped
  - 16 real-WebGPU browser tests
  - 178 UI tests
  - 3 visual tests, including exact WebGPU/WebGL2 first-frame parity
  - examples build, TypeDoc, API Extractor, package consumer and pack checks
- targeted WebGL2/WebGPU browser checks for ShaderToy, Compute Particle Field, and Crystal Compute Path Tracer
- manual browser inspection confirmed no clipped-white regression in the three reported examples

## Notes

The physical-GPU `test:webgpu:native` lane was not run locally; it remains separate from portable `npm run validate`.