### PR TITLE
feat(examples): upgrade glTF viewer

### DIFF
--- a/examples/glTFViewer/app/ViewerPostProcess.ts
+++ b/examples/glTFViewer/app/ViewerPostProcess.ts
@@ -1,0 +1,359 @@
+import * as Hilo3d from '../../../src/Hilo3d';
+
+const FULLSCREEN_VERTEX_SOURCE = `#version 300 es
+out vec2 v_uv;
+void main() {
+    v_uv = vec2(float((gl_VertexID << 1) & 2), float(gl_VertexID & 2));
+    gl_Position = vec4(v_uv * 2.0 - 1.0, 0.0, 1.0);
+}`;
+
+const COLOR_GRADE_FRAGMENT_SOURCE = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_sceneColor;
+layout(std140) uniform ViewerColorGradeBlock {
+    float u_exposure;
+    float u_contrast;
+    float u_saturation;
+    float u_vignette;
+    float u_toneMapping;
+};
+layout(location = 0) out vec4 color;
+
+vec3 linearToSRGB(vec3 value) {
+    vec3 low = value * 12.92;
+    vec3 high = 1.055 * pow(max(value, vec3(0.0)), vec3(1.0 / 2.4)) - 0.055;
+    return mix(high, low, lessThanEqual(value, vec3(0.0031308)));
+}
+
+vec3 pbrNeutral(vec3 value) {
+    const float startCompression = 0.76;
+    const float desaturation = 0.15;
+    float x = min(value.r, min(value.g, value.b));
+    float offset = x < 0.08 ? x - 6.25 * x * x : 0.04;
+    value -= offset;
+    float peak = max(value.r, max(value.g, value.b));
+    if (peak < startCompression) return value;
+    float d = 1.0 - startCompression;
+    float newPeak = 1.0 - d * d / (peak + d - startCompression);
+    value *= newPeak / peak;
+    float g = 1.0 - 1.0 / (desaturation * (peak - newPeak) + 1.0);
+    return mix(value, vec3(newPeak), g);
+}
+
+vec3 acesFitted(vec3 value) {
+    return clamp(
+        (value * (2.51 * value + 0.03)) /
+            (value * (2.43 * value + 0.59) + 0.14),
+        0.0,
+        1.0
+    );
+}
+
+float interleavedGradientNoise(vec2 pixel) {
+    return fract(52.9829189 * fract(dot(pixel, vec2(0.06711056, 0.00583715))));
+}
+
+void main() {
+    vec4 source = texture(u_sceneColor, v_uv);
+    vec3 result = source.rgb * exp2(u_exposure);
+    result = (result - vec3(0.18)) * u_contrast + vec3(0.18);
+    float luminance = dot(result, vec3(0.2126, 0.7152, 0.0722));
+    result = mix(vec3(luminance), result, u_saturation);
+
+    if (u_toneMapping < 0.5) {
+        result = pbrNeutral(result);
+    } else if (u_toneMapping < 1.5) {
+        result = acesFitted(result);
+    } else if (u_toneMapping < 2.5) {
+        result = result / (vec3(1.0) + result);
+    }
+
+    vec2 dimensions = vec2(textureSize(u_sceneColor, 0));
+    vec2 centered = v_uv * 2.0 - 1.0;
+    centered.x *= dimensions.x / max(dimensions.y, 1.0);
+    float vignette = smoothstep(0.25, 1.2, length(centered)) * u_vignette;
+    result *= 1.0 - vignette * 0.72;
+    result = linearToSRGB(max(result, vec3(0.0)));
+    result += (interleavedGradientNoise(gl_FragCoord.xy) - 0.5) / 255.0;
+    color = vec4(result, source.a);
+}`;
+
+Hilo3d.registerUniformBlockBinding('ViewerColorGradeBlock');
+
+const colorGradeLayout = Hilo3d.createStd140Layout({
+    u_exposure: 'float',
+    u_contrast: 'float',
+    u_saturation: 'float',
+    u_vignette: 'float',
+    u_toneMapping: 'float'
+});
+
+export type ViewerToneMappingMode = 'pbr-neutral' | 'aces' | 'reinhard' | 'none';
+export type ViewerLookPreset = 'neutral' | 'studio' | 'cinematic';
+
+export interface ViewerPostProcessState {
+    readonly exposure: number;
+    readonly contrast: number;
+    readonly saturation: number;
+    readonly vignette: number;
+    readonly toneMapping: ViewerToneMappingMode;
+}
+
+class ToggleableBloomRuntime implements Hilo3d.ForwardRenderPipelineFeatureRuntime {
+    readonly #controller: ViewerBloomController;
+    readonly #runtime: Hilo3d.ForwardRenderPipelineFeatureRuntime;
+
+    constructor(
+        controller: ViewerBloomController,
+        runtime: Hilo3d.ForwardRenderPipelineFeatureRuntime
+    ) {
+        this.#controller = controller;
+        this.#runtime = runtime;
+    }
+
+    record(context: Hilo3d.ForwardRenderFeatureContext): void {
+        if (this.#controller.enabled) this.#runtime.record(context);
+    }
+
+    destroy(): void {
+        this.#runtime.destroy();
+    }
+}
+
+export class ViewerBloomController implements Hilo3d.ForwardRenderPipelineFeature {
+    readonly name = 'gltf-viewer-bloom';
+    readonly injectionPoint = 'after-transparent' as const;
+    readonly requirements: Hilo3d.ForwardRenderPipelineFeature['requirements'];
+    readonly #feature: Hilo3d.Bloom;
+    #enabled = true;
+
+    constructor(options: Readonly<Hilo3d.BloomOptions>) {
+        this.#feature = new Hilo3d.Bloom(options);
+        this.requirements = this.#feature.requirements;
+    }
+
+    get enabled(): boolean {
+        return this.#enabled;
+    }
+
+    setEnabled(enabled: boolean): void {
+        this.#enabled = enabled;
+    }
+
+    create(): Hilo3d.ForwardRenderPipelineFeatureRuntime {
+        return new ToggleableBloomRuntime(this, this.#feature.create());
+    }
+}
+
+interface MutableColorAttachment extends Hilo3d.RenderPipelineColorAttachment {
+    texture: Hilo3d.RenderGraphTextureHandle;
+}
+
+class ViewerColorGradeParameters implements Hilo3d.FullscreenRenderPassParameters {
+    readonly inputTextures: Hilo3d.RenderGraphTextureHandle[] = [];
+    readonly colorAttachments: MutableColorAttachment[] = [];
+    readonly #attachment: MutableColorAttachment = {
+        texture: 0 as Hilo3d.RenderGraphTextureHandle,
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: 0, g: 0, b: 0, a: 1 }
+    };
+
+    configure(
+        source: Hilo3d.RenderGraphTextureHandle,
+        destination: Hilo3d.RenderGraphTextureHandle
+    ): void {
+        this.inputTextures[0] = source;
+        this.inputTextures.length = 1;
+        this.#attachment.texture = destination;
+        this.colorAttachments[0] = this.#attachment;
+        this.colorAttachments.length = 1;
+    }
+
+    reset(): void {
+        this.inputTextures.length = 0;
+        this.colorAttachments.length = 0;
+    }
+}
+
+class ViewerColorGradeRuntime implements Hilo3d.ForwardRenderPipelineFeatureRuntime {
+    readonly #pass: Hilo3d.FullscreenRenderPass;
+    readonly #parameters = new Hilo3d.RenderPassParameterPool(
+        () => new ViewerColorGradeParameters(),
+        parameters => {
+            parameters.reset();
+        }
+    );
+    readonly #descriptor = {
+        format: 'rgba8unorm' as const,
+        extent: Object.freeze({ relativeTo: 'output' as const, scale: 1 })
+    };
+
+    constructor(block: Hilo3d.UniformBuffer<typeof colorGradeLayout.schema>) {
+        this.#pass = new Hilo3d.FullscreenRenderPass({
+            name: 'glTF Viewer color grade',
+            shader: new Hilo3d.Shader({
+                vs: FULLSCREEN_VERTEX_SOURCE,
+                fs: COLOR_GRADE_FRAGMENT_SOURCE
+            }),
+            pipelineState: {
+                ...Hilo3d.DEFAULT_MATERIAL_PIPELINE_STATE,
+                depthTest: false,
+                depthWrite: false,
+                cullMode: 'none'
+            },
+            uniformBuffers: [block]
+        });
+    }
+
+    record(context: Hilo3d.ForwardRenderFeatureContext): void {
+        const source = context.resources.color;
+        if (source === null) throw new Error('glTF Viewer color grade requires scene color');
+        const destination = context.pipeline.graph.createTexture(
+            'glTF Viewer color grade output',
+            this.#descriptor
+        );
+        const parameters = context.pipeline.acquirePassParameters(this.#parameters);
+        parameters.configure(source, destination);
+        context.pipeline.graph.addPass(this.#pass, parameters);
+        context.resources.replaceColor(destination, 'srgb');
+    }
+
+    destroy(): void {
+        // The renderer owns the pipeline objects; the controller retains only CPU-side UBO data.
+    }
+}
+
+class ViewerColorGradeFeature implements Hilo3d.ForwardRenderPipelineFeature {
+    readonly name = 'gltf-viewer-color-grade';
+    readonly injectionPoint = 'after-post-process' as const;
+    readonly requirements = Object.freeze({
+        sampledSceneColor: true,
+        sampledDepth: false,
+        requiredTextureFormats: Object.freeze([
+            Object.freeze({
+                format: 'rgba8unorm' as const,
+                use: 'color-attachment' as const
+            }),
+            Object.freeze({
+                format: 'rgba8unorm' as const,
+                use: 'filterable-sampled' as const
+            })
+        ])
+    });
+
+    constructor(readonly block: Hilo3d.UniformBuffer<typeof colorGradeLayout.schema>) {}
+
+    create(): Hilo3d.ForwardRenderPipelineFeatureRuntime {
+        return new ViewerColorGradeRuntime(this.block);
+    }
+}
+
+function toneMappingValue(mode: ViewerToneMappingMode): number {
+    switch (mode) {
+        case 'pbr-neutral':
+            return 0;
+        case 'aces':
+            return 1;
+        case 'reinhard':
+            return 2;
+        case 'none':
+            return 3;
+    }
+}
+
+function finiteRange(value: number, minimum: number, maximum: number, label: string): number {
+    if (!Number.isFinite(value) || value < minimum || value > maximum) {
+        throw new RangeError(`${label} must be between ${String(minimum)} and ${String(maximum)}`);
+    }
+    return value;
+}
+
+const DEFAULT_STATE: ViewerPostProcessState = Object.freeze({
+    exposure: -0.3,
+    contrast: 0.04,
+    saturation: 0,
+    vignette: 0.12,
+    toneMapping: 'pbr-neutral'
+});
+
+const PRESETS: Readonly<Record<ViewerLookPreset, ViewerPostProcessState>> = Object.freeze({
+    neutral: DEFAULT_STATE,
+    studio: Object.freeze({
+        exposure: -0.18,
+        contrast: 0.12,
+        saturation: -0.04,
+        vignette: 0.18,
+        toneMapping: 'pbr-neutral'
+    }),
+    cinematic: Object.freeze({
+        exposure: -0.42,
+        contrast: 0.22,
+        saturation: -0.12,
+        vignette: 0.34,
+        toneMapping: 'aces'
+    })
+});
+
+export class ViewerPostProcessController {
+    readonly feature: Hilo3d.ForwardRenderPipelineFeature;
+    readonly #block = Hilo3d.UniformBuffer.fromSchema(colorGradeLayout, {
+        u_exposure: DEFAULT_STATE.exposure,
+        u_contrast: 1 + DEFAULT_STATE.contrast,
+        u_saturation: 1 + DEFAULT_STATE.saturation,
+        u_vignette: DEFAULT_STATE.vignette,
+        u_toneMapping: toneMappingValue(DEFAULT_STATE.toneMapping)
+    });
+    #state: ViewerPostProcessState = DEFAULT_STATE;
+
+    constructor() {
+        this.feature = new ViewerColorGradeFeature(this.#block);
+    }
+
+    get state(): ViewerPostProcessState {
+        return this.#state;
+    }
+
+    setExposure(value: number): void {
+        value = finiteRange(value, -3, 3, 'Viewer exposure');
+        this.#state = Object.freeze({ ...this.#state, exposure: value });
+        this.#block.set('u_exposure', value);
+    }
+
+    setContrast(value: number): void {
+        value = finiteRange(value, -0.75, 1, 'Viewer contrast');
+        this.#state = Object.freeze({ ...this.#state, contrast: value });
+        this.#block.set('u_contrast', 1 + value);
+    }
+
+    setSaturation(value: number): void {
+        value = finiteRange(value, -1, 1, 'Viewer saturation');
+        this.#state = Object.freeze({ ...this.#state, saturation: value });
+        this.#block.set('u_saturation', 1 + value);
+    }
+
+    setVignette(value: number): void {
+        value = finiteRange(value, 0, 1, 'Viewer vignette');
+        this.#state = Object.freeze({ ...this.#state, vignette: value });
+        this.#block.set('u_vignette', value);
+    }
+
+    setToneMapping(value: ViewerToneMappingMode): void {
+        this.#state = Object.freeze({ ...this.#state, toneMapping: value });
+        this.#block.set('u_toneMapping', toneMappingValue(value));
+    }
+
+    applyPreset(preset: ViewerLookPreset): void {
+        const state = PRESETS[preset];
+        this.setExposure(state.exposure);
+        this.setContrast(state.contrast);
+        this.setSaturation(state.saturation);
+        this.setVignette(state.vignette);
+        this.setToneMapping(state.toneMapping);
+    }
+
+    reset(): void {
+        this.applyPreset('neutral');
+    }
+}

--- a/examples/glTFViewer/app/index.ts
+++ b/examples/glTFViewer/app/index.ts
@@ -8,6 +8,26 @@ import {
 } from '../../shared/init';
 import { environmentMaterialDefaults } from '../../shared/environment';
 import { hashReadback } from '../../shared/readbackDiagnostics';
+import {
+    ViewerBloomController,
+    ViewerPostProcessController,
+    type ViewerLookPreset,
+    type ViewerToneMappingMode
+} from './ViewerPostProcess';
+
+type ViewerState = 'empty' | 'error' | 'loading' | 'ready';
+type InspectorSection = 'scene' | 'material' | 'post';
+
+interface MaterialSnapshot {
+    readonly baseColor: readonly [number, number, number, number];
+    readonly ior: number;
+    readonly iridescenceFactor: number;
+    readonly metallic: number;
+    readonly normalScale: number;
+    readonly opacity: number;
+    readonly roughness: number;
+    readonly transmissionFactor: number;
+}
 
 function requireElement<ElementType extends Element>(
     element: ElementType | null,
@@ -27,8 +47,12 @@ const stageContainer = requireElement(
     '#stageContainer'
 );
 const uploadButton = requireElement(
-    document.querySelector<HTMLElement>('#uploadIcon'),
+    document.querySelector<HTMLButtonElement>('#uploadIcon'),
     '#uploadIcon'
+);
+const openFileButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#openFileButton'),
+    '#openFileButton'
 );
 const showLinkButton = requireElement(
     document.querySelector<HTMLButtonElement>('#showLinkBtn'),
@@ -38,7 +62,287 @@ const linkInput = requireElement(
     document.querySelector<HTMLInputElement>('#linkInput'),
     '#linkInput'
 );
+const importerStatus = requireElement(
+    document.querySelector<HTMLElement>('.dropCopy .info'),
+    '.dropCopy .info'
+);
+const loadSampleButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#loadSampleButton'),
+    '#loadSampleButton'
+);
+const loadingSource = requireElement(
+    document.querySelector<HTMLElement>('#loadingSource'),
+    '#loadingSource'
+);
+const modelName = requireElement(document.querySelector<HTMLElement>('#modelName'), '#modelName');
+const modelFormat = requireElement(
+    document.querySelector<HTMLElement>('#modelFormat'),
+    '#modelFormat'
+);
+const panelModelName = requireElement(
+    document.querySelector<HTMLElement>('#panelModelName'),
+    '#panelModelName'
+);
+const sourceValue = requireElement(
+    document.querySelector<HTMLElement>('#sourceValue'),
+    '#sourceValue'
+);
+const backendBadge = requireElement(
+    document.querySelector<HTMLElement>('#backendBadge'),
+    '#backendBadge'
+);
+const viewportStatusText = requireElement(
+    document.querySelector<HTMLElement>('#viewportStatusText'),
+    '#viewportStatusText'
+);
+const meshCount = requireElement(document.querySelector<HTMLElement>('#meshCount'), '#meshCount');
+const materialCount = requireElement(
+    document.querySelector<HTMLElement>('#materialCount'),
+    '#materialCount'
+);
+const textureCount = requireElement(
+    document.querySelector<HTMLElement>('#textureCount'),
+    '#textureCount'
+);
+const animationCount = requireElement(
+    document.querySelector<HTMLElement>('#animationCount'),
+    '#animationCount'
+);
+const versionValue = requireElement(
+    document.querySelector<HTMLElement>('#versionValue'),
+    '#versionValue'
+);
+const generatorValue = requireElement(
+    document.querySelector<HTMLElement>('#generatorValue'),
+    '#generatorValue'
+);
+const sceneCount = requireElement(
+    document.querySelector<HTMLElement>('#sceneCount'),
+    '#sceneCount'
+);
+const cameraSection = requireElement(
+    document.querySelector<HTMLElement>('#cameraSection'),
+    '#cameraSection'
+);
+const cameraSelect = requireElement(
+    document.querySelector<HTMLSelectElement>('#cameraSelect'),
+    '#cameraSelect'
+);
+const cameraHint = requireElement(
+    document.querySelector<HTMLElement>('#cameraHint'),
+    '#cameraHint'
+);
+const dimensionsValue = requireElement(
+    document.querySelector<HTMLElement>('#dimensionsValue'),
+    '#dimensionsValue'
+);
+const extensionList = requireElement(
+    document.querySelector<HTMLElement>('#extensionList'),
+    '#extensionList'
+);
+const inspectorTabButtons = [
+    ...document.querySelectorAll<HTMLButtonElement>('[data-inspector-tab]')
+];
+const scenePanel = requireElement(
+    document.querySelector<HTMLElement>('#scenePanel'),
+    '#scenePanel'
+);
+const materialPanel = requireElement(
+    document.querySelector<HTMLElement>('#materialPanel'),
+    '#materialPanel'
+);
+const postPanel = requireElement(document.querySelector<HTMLElement>('#postPanel'), '#postPanel');
+const materialSelect = requireElement(
+    document.querySelector<HTMLSelectElement>('#materialSelect'),
+    '#materialSelect'
+);
+const materialModeBadge = requireElement(
+    document.querySelector<HTMLElement>('#materialModeBadge'),
+    '#materialModeBadge'
+);
+const materialCountLabel = requireElement(
+    document.querySelector<HTMLElement>('#materialCountLabel'),
+    '#materialCountLabel'
+);
+const baseColorInput = requireElement(
+    document.querySelector<HTMLInputElement>('#baseColorInput'),
+    '#baseColorInput'
+);
+const metallicInput = requireElement(
+    document.querySelector<HTMLInputElement>('#metallicInput'),
+    '#metallicInput'
+);
+const metallicValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#metallicValue'),
+    '#metallicValue'
+);
+const roughnessInput = requireElement(
+    document.querySelector<HTMLInputElement>('#roughnessInput'),
+    '#roughnessInput'
+);
+const roughnessValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#roughnessValue'),
+    '#roughnessValue'
+);
+const normalScaleInput = requireElement(
+    document.querySelector<HTMLInputElement>('#normalScaleInput'),
+    '#normalScaleInput'
+);
+const normalScaleValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#normalScaleValue'),
+    '#normalScaleValue'
+);
+const opacityInput = requireElement(
+    document.querySelector<HTMLInputElement>('#opacityInput'),
+    '#opacityInput'
+);
+const opacityValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#opacityValue'),
+    '#opacityValue'
+);
+const opacityHint = requireElement(
+    document.querySelector<HTMLElement>('#opacityHint'),
+    '#opacityHint'
+);
+const transmissionInput = requireElement(
+    document.querySelector<HTMLInputElement>('#transmissionInput'),
+    '#transmissionInput'
+);
+const transmissionValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#transmissionValue'),
+    '#transmissionValue'
+);
+const iridescenceInput = requireElement(
+    document.querySelector<HTMLInputElement>('#iridescenceInput'),
+    '#iridescenceInput'
+);
+const iridescenceValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#iridescenceValue'),
+    '#iridescenceValue'
+);
+const iorInput = requireElement(document.querySelector<HTMLInputElement>('#iorInput'), '#iorInput');
+const iorValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#iorValue'),
+    '#iorValue'
+);
+const resetMaterialButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#resetMaterialButton'),
+    '#resetMaterialButton'
+);
+const lookPresetButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-look-preset]')];
+const toneMappingSelect = requireElement(
+    document.querySelector<HTMLSelectElement>('#toneMappingSelect'),
+    '#toneMappingSelect'
+);
+const exposureInput = requireElement(
+    document.querySelector<HTMLInputElement>('#exposureInput'),
+    '#exposureInput'
+);
+const exposureValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#exposureValue'),
+    '#exposureValue'
+);
+const contrastInput = requireElement(
+    document.querySelector<HTMLInputElement>('#contrastInput'),
+    '#contrastInput'
+);
+const contrastValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#contrastValue'),
+    '#contrastValue'
+);
+const saturationInput = requireElement(
+    document.querySelector<HTMLInputElement>('#saturationInput'),
+    '#saturationInput'
+);
+const saturationValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#saturationValue'),
+    '#saturationValue'
+);
+const vignetteInput = requireElement(
+    document.querySelector<HTMLInputElement>('#vignetteInput'),
+    '#vignetteInput'
+);
+const vignetteValue = requireElement(
+    document.querySelector<HTMLOutputElement>('#vignetteValue'),
+    '#vignetteValue'
+);
+const resetPostButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#resetPostButton'),
+    '#resetPostButton'
+);
+const bloomFeatureStatus = requireElement(
+    document.querySelector<HTMLElement>('#bloomFeatureStatus'),
+    '#bloomFeatureStatus'
+);
+const bloomEnabledInput = requireElement(
+    document.querySelector<HTMLInputElement>('#bloomEnabledInput'),
+    '#bloomEnabledInput'
+);
+const bloomStateLabel = requireElement(
+    document.querySelector<HTMLElement>('#bloomStateLabel'),
+    '#bloomStateLabel'
+);
+const inspectorPanel = requireElement(
+    document.querySelector<HTMLElement>('#inspectorPanel'),
+    '#inspectorPanel'
+);
+const toggleInspectorButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#toggleInspectorButton'),
+    '#toggleInspectorButton'
+);
+const closeInspectorButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#closeInspectorButton'),
+    '#closeInspectorButton'
+);
+const zoomOutButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#zoomOutButton'),
+    '#zoomOutButton'
+);
+const zoomInButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#zoomInButton'),
+    '#zoomInButton'
+);
+const resetViewButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#resetViewButton'),
+    '#resetViewButton'
+);
+const fullscreenButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#fullscreenButton'),
+    '#fullscreenButton'
+);
+const sourceDialog = requireElement(
+    document.querySelector<HTMLDialogElement>('#sourceDialog'),
+    '#sourceDialog'
+);
+const openUrlDialogButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#openUrlDialogButton'),
+    '#openUrlDialogButton'
+);
+const closeSourceDialogButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#closeSourceDialogButton'),
+    '#closeSourceDialogButton'
+);
+const cancelSourceDialogButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#cancelSourceDialogButton'),
+    '#cancelSourceDialogButton'
+);
+const dialogLinkInput = requireElement(
+    document.querySelector<HTMLInputElement>('#dialogLinkInput'),
+    '#dialogLinkInput'
+);
+const dialogShowLinkButton = requireElement(
+    document.querySelector<HTMLButtonElement>('#dialogShowLinkBtn'),
+    '#dialogShowLinkBtn'
+);
 const query = parseQuery();
+const viewerPostProcess = new ViewerPostProcessController();
+const viewerBloom = new ViewerBloomController({
+    threshold: 1.15,
+    knee: 0.58,
+    intensity: 0.16,
+    scatter: 0.58,
+    maxLevels: 6
+});
 
 const camera = new Hilo3d.PerspectiveCamera({
     aspect: innerWidth / innerHeight,
@@ -50,7 +354,12 @@ const stage = await Hilo3d.Stage.create<Hilo3d.RendererBackend>({
     backend: resolveExampleBackend(),
     container: stageContainer,
     camera,
-    clearColor: new Hilo3d.Color(0.4, 0.4, 0.4),
+    clearColor: new Hilo3d.Color(0.032, 0.04, 0.06),
+    renderPipeline: new Hilo3d.ForwardRenderPipelineFactory({
+        sceneColorFormat: 'rgba16float',
+        opaqueTexture: true,
+        features: [viewerBloom, viewerPostProcess.feature]
+    }),
     width: innerWidth,
     height: innerHeight
 });
@@ -60,7 +369,7 @@ ticker.addTick(Hilo3d.Tween);
 ticker.addTick(Hilo3d.Animation);
 ticker.start();
 const stats = new Stats(ticker, stage.renderer);
-const orbitControls = new Hilo3d.OrbitControls(stage, { enablePan: false });
+const orbitControls = new Hilo3d.OrbitControls(stage, { enablePan: true });
 const loader = new Hilo3d.GLTFLoader();
 const diagnosticTarget = stage.renderer.createRenderTarget({
     width: 320,
@@ -73,9 +382,52 @@ const diagnosticTarget = stage.renderer.createRenderTarget({
 let currentModel: Hilo3d.GLTFModel | null = null;
 let modelLoadGeneration = 0;
 let modelSourcePath = '';
+let currentSourceLabel = '';
+let dragDepth = 0;
 const objectUrls = new Map<string, string>();
 const viewerDecorations: Hilo3d.Node[] = [];
 const viewerOwnedTextures = new Set<Hilo3d.Texture<unknown>>();
+const materialDefaults = new Map<Hilo3d.PBRMaterial, MaterialSnapshot>();
+let pbrMaterials: Hilo3d.PBRMaterial[] = [];
+let modelCameras: Hilo3d.Camera[] = [];
+let activeInspectorSection: InspectorSection = 'scene';
+
+function setViewerState(state: ViewerState): void {
+    document.body.dataset['viewState'] = state;
+}
+
+function setInspectorOpen(open: boolean): void {
+    document.body.dataset['inspectorOpen'] = String(open);
+    inspectorPanel.setAttribute('aria-hidden', String(!open));
+    inspectorPanel.inert = !open;
+    toggleInspectorButton.setAttribute('aria-expanded', String(open));
+    toggleInspectorButton.setAttribute(
+        'aria-label',
+        open ? 'Hide model information' : 'Show model information'
+    );
+}
+
+function isInspectorSection(value: string | undefined): value is InspectorSection {
+    return value === 'scene' || value === 'material' || value === 'post';
+}
+
+function setInspectorSection(section: InspectorSection): void {
+    activeInspectorSection = section;
+    const panels: Readonly<Record<InspectorSection, HTMLElement>> = {
+        scene: scenePanel,
+        material: materialPanel,
+        post: postPanel
+    };
+    for (const [name, panel] of Object.entries(panels)) {
+        panel.hidden = name !== section;
+    }
+    for (const button of inspectorTabButtons) {
+        button.setAttribute(
+            'aria-selected',
+            String(button.dataset['inspectorTab'] === activeInspectorSection)
+        );
+    }
+}
 
 function destroyModel(model: Hilo3d.GLTFModel): void {
     model.node.destroy(stage.renderer);
@@ -102,6 +454,9 @@ function releaseCurrentModel(): void {
     modelLoadGeneration++;
     delete document.body.dataset['modelReady'];
     delete document.body.dataset['modelGeneration'];
+    stage.camera = camera;
+    orbitControls.reset();
+    syncCameraInteraction();
     if (currentModel) {
         destroyModel(currentModel);
         currentModel = null;
@@ -114,11 +469,17 @@ function releaseCurrentModel(): void {
     viewerOwnedTextures.clear();
     for (const url of objectUrls.values()) URL.revokeObjectURL(url);
     objectUrls.clear();
+    materialDefaults.clear();
+    pbrMaterials = [];
+    modelCameras = [];
+    cameraSection.hidden = true;
+    cameraSelect.replaceChildren();
     Hilo3d.BasicLoader.cache.clear();
 }
 
 function showInput(error?: unknown): void {
-    if (error !== undefined) {
+    const hasError = error !== undefined;
+    if (hasError) {
         const message =
             error instanceof Error
                 ? error.message
@@ -126,22 +487,388 @@ function showInput(error?: unknown): void {
                   ? error
                   : 'The glTF model could not be loaded.';
         inputContainer.dataset['error'] = message;
-        requireElement(document.querySelector<HTMLElement>('.info'), '.info').textContent = message;
+        importerStatus.textContent = message;
+    } else {
+        delete inputContainer.dataset['error'];
+        importerStatus.textContent = 'glTF, GLB, or a complete asset folder';
     }
+    setInspectorOpen(false);
+    setViewerState(hasError ? 'error' : 'empty');
     stats.container.style.display = 'none';
-    stageContainer.style.visibility = 'hidden';
-    inputContainer.style.display = 'block';
 }
 
-function showStage(): void {
-    stats.container.style.display = 'block';
-    stageContainer.style.visibility = 'visible';
-    inputContainer.style.display = 'none';
+function showLoading(sourceLabel: string): void {
+    currentSourceLabel = sourceLabel;
+    modelName.textContent = displayNameForSource(sourceLabel);
+    loadingSource.textContent = `Loading ${sourceLabel}…`;
+    setInspectorOpen(false);
+    setViewerState('loading');
+    stats.container.style.display = 'none';
 }
 
 function queryEnabled(name: string): boolean {
     const value = query[name];
     return value !== undefined && value !== 'false';
+}
+
+function collectionSize<Value>(collection: Hilo3d.GLTFCollection<Value> | undefined): number {
+    if (!collection) return 0;
+    return Array.isArray(collection) ? collection.length : Object.keys(collection).length;
+}
+
+function sourceLabelForUrl(source: string): string {
+    try {
+        const pathname = new URL(source, location.href).pathname;
+        const segment = pathname.split('/').filter(Boolean).at(-1);
+        return segment ? decodeURIComponent(segment) : 'Remote model';
+    } catch {
+        return 'Remote model';
+    }
+}
+
+function displayNameForSource(source: string): string {
+    const filename = source.split('/').at(-1) ?? source;
+    const decoded = decodeURIComponent(filename);
+    return decoded.replace(/\.(?:gltf|glb)$/iu, '') || 'Untitled model';
+}
+
+function formatDimension(value: number): string {
+    if (!Number.isFinite(value)) return '—';
+    if (value === 0) return '0';
+    if (Math.abs(value) >= 1000 || Math.abs(value) < 0.01) return value.toExponential(2);
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function updateExtensionList(extensions: readonly string[]): void {
+    if (extensions.length === 0) {
+        const empty = document.createElement('span');
+        empty.className = 'emptyExtension';
+        empty.textContent = 'No extensions declared';
+        extensionList.replaceChildren(empty);
+        return;
+    }
+    extensionList.replaceChildren(
+        ...extensions.map(extension => {
+            const badge = document.createElement('span');
+            badge.textContent = extension;
+            return badge;
+        })
+    );
+}
+
+function syncCameraInteraction(): void {
+    const usesViewerCamera = stage.camera === camera;
+    if (usesViewerCamera && !sourceDialog.open) orbitControls.enable();
+    else orbitControls.disable();
+    zoomOutButton.disabled = !usesViewerCamera;
+    resetViewButton.disabled = !usesViewerCamera;
+    zoomInButton.disabled = !usesViewerCamera;
+}
+
+function selectCamera(value: string): void {
+    if (value === 'viewer') {
+        stage.camera = camera;
+        cameraSelect.value = 'viewer';
+        cameraHint.textContent = 'Interactive viewer camera · orbit, zoom, and pan enabled';
+        syncCameraInteraction();
+        return;
+    }
+
+    const index = Number(value);
+    const modelCamera = Number.isSafeInteger(index) ? modelCameras[index] : undefined;
+    if (!modelCamera) throw new RangeError(`Unknown glTF camera: ${value}.`);
+    stage.camera = modelCamera;
+    cameraSelect.value = String(index);
+    cameraHint.textContent = 'Authored glTF framing · viewer navigation is locked';
+    syncCameraInteraction();
+}
+
+function populateCameraControls(cameras: readonly Hilo3d.Camera[]): void {
+    modelCameras = [...cameras];
+    cameraSection.hidden = modelCameras.length === 0;
+    if (modelCameras.length === 0) {
+        cameraSelect.replaceChildren();
+        stage.camera = camera;
+        syncCameraInteraction();
+        return;
+    }
+
+    const viewerOption = new Option('Viewer camera (default)', 'viewer');
+    const modelOptions = modelCameras.map((modelCamera, index) => {
+        const name = modelCamera.name.trim();
+        return new Option(name || `glTF camera ${String(index + 1)}`, String(index));
+    });
+    cameraSelect.replaceChildren(viewerOption, ...modelOptions);
+
+    const requestedCamera = query['camera'];
+    if (requestedCamera === undefined || requestedCamera === 'false') {
+        selectCamera('viewer');
+        return;
+    }
+    selectCamera(requestedCamera);
+}
+
+function averageMaterialValue(
+    materials: readonly Hilo3d.PBRMaterial[],
+    read: (material: Hilo3d.PBRMaterial) => number
+): number {
+    if (materials.length === 0) return 0;
+    return materials.reduce((sum, material) => sum + read(material), 0) / materials.length;
+}
+
+function selectedMaterials(): Hilo3d.PBRMaterial[] {
+    const selectedIndex = Number(materialSelect.value);
+    const material = Number.isSafeInteger(selectedIndex) ? pbrMaterials[selectedIndex] : undefined;
+    return material ? [material] : [];
+}
+
+function supportsFeature(material: Hilo3d.PBRMaterial, feature: string): boolean {
+    return material.definition.staticFeatures[feature] === 1;
+}
+
+function setRangeControl(
+    input: HTMLInputElement,
+    output: HTMLOutputElement,
+    value: number,
+    suffix = ''
+): void {
+    input.value = String(value);
+    output.textContent = `${value.toFixed(2)}${suffix}`;
+}
+
+function setMaterialControlsDisabled(disabled: boolean): void {
+    for (const input of [
+        baseColorInput,
+        metallicInput,
+        roughnessInput,
+        normalScaleInput,
+        opacityInput,
+        transmissionInput,
+        iridescenceInput,
+        iorInput
+    ]) {
+        input.disabled = disabled;
+    }
+    resetMaterialButton.disabled = disabled;
+}
+
+function materialModeLabel(materials: readonly Hilo3d.PBRMaterial[]): string {
+    const modes = new Set(
+        materials.map(material => {
+            if (material.requiresOpaqueSceneTexture) return 'Transmission';
+            if (material.compositing.mode === 'alpha-blend') return 'Alpha blend';
+            if (material.coverage.mode !== 'opaque') return 'Alpha mask';
+            return 'Opaque';
+        })
+    );
+    return modes.size === 1 ? ([...modes][0] ?? 'Opaque') : 'Mixed';
+}
+
+function syncMaterialControls(): void {
+    const materials = selectedMaterials();
+    const representative = materials[0];
+    setMaterialControlsDisabled(representative === undefined);
+    if (!representative) {
+        materialModeBadge.textContent = 'Unavailable';
+        materialCountLabel.textContent = 'No PBR materials in this asset';
+        return;
+    }
+
+    materialModeBadge.textContent = materialModeLabel(materials);
+    materialCountLabel.textContent =
+        materials.length === 1
+            ? (representative.name ?? '1 material selected')
+            : `${String(materials.length)} materials selected`;
+    baseColorInput.value = `#${representative.baseColor.toHEX()}`;
+    setRangeControl(
+        metallicInput,
+        metallicValue,
+        averageMaterialValue(materials, material => material.metallic)
+    );
+    setRangeControl(
+        roughnessInput,
+        roughnessValue,
+        averageMaterialValue(materials, material => material.roughness)
+    );
+    setRangeControl(
+        normalScaleInput,
+        normalScaleValue,
+        averageMaterialValue(materials, material => material.normalScale)
+    );
+
+    const alphaBlendMaterials = materials.filter(
+        material => material.compositing.mode === 'alpha-blend'
+    );
+    opacityInput.disabled = alphaBlendMaterials.length === 0;
+    opacityHint.textContent =
+        alphaBlendMaterials.length === 0
+            ? 'This asset uses opaque, masked, or physical transmission surfaces.'
+            : `Editing ${String(alphaBlendMaterials.length)} alpha-blend ${alphaBlendMaterials.length === 1 ? 'material' : 'materials'}.`;
+    setRangeControl(
+        opacityInput,
+        opacityValue,
+        alphaBlendMaterials.length > 0
+            ? averageMaterialValue(alphaBlendMaterials, material => material.opacity)
+            : 1
+    );
+
+    const transmissiveMaterials = materials.filter(material =>
+        supportsFeature(material, 'HAS_TRANSMISSION')
+    );
+    transmissionInput.disabled = transmissiveMaterials.length === 0;
+    setRangeControl(
+        transmissionInput,
+        transmissionValue,
+        transmissiveMaterials.length > 0
+            ? averageMaterialValue(transmissiveMaterials, material => material.transmissionFactor)
+            : 0
+    );
+
+    const iridescentMaterials = materials.filter(material =>
+        supportsFeature(material, 'HAS_IRIDESCENCE')
+    );
+    iridescenceInput.disabled = iridescentMaterials.length === 0;
+    setRangeControl(
+        iridescenceInput,
+        iridescenceValue,
+        iridescentMaterials.length > 0
+            ? averageMaterialValue(iridescentMaterials, material => material.iridescenceFactor)
+            : 0
+    );
+    setRangeControl(
+        iorInput,
+        iorValue,
+        averageMaterialValue(materials, material => material.ior)
+    );
+}
+
+function captureMaterialDefaults(model: Hilo3d.GLTFModel): void {
+    materialDefaults.clear();
+    pbrMaterials = model.materials.filter(
+        (material): material is Hilo3d.PBRMaterial => material instanceof Hilo3d.PBRMaterial
+    );
+    for (const material of pbrMaterials) {
+        materialDefaults.set(material, {
+            baseColor: [
+                material.baseColor.r,
+                material.baseColor.g,
+                material.baseColor.b,
+                material.baseColor.a
+            ],
+            ior: material.ior,
+            iridescenceFactor: material.iridescenceFactor,
+            metallic: material.metallic,
+            normalScale: material.normalScale,
+            opacity: material.opacity,
+            roughness: material.roughness,
+            transmissionFactor: material.transmissionFactor
+        });
+    }
+
+    const options = pbrMaterials.map((material, index) => {
+        const option = document.createElement('option');
+        option.value = String(index);
+        option.textContent = material.name ?? `Material ${String(index + 1)}`;
+        return option;
+    });
+    if (options.length > 0) {
+        materialSelect.replaceChildren(...options);
+        materialSelect.value = '0';
+    } else {
+        const emptyOption = document.createElement('option');
+        emptyOption.value = '';
+        emptyOption.textContent = 'No PBR materials';
+        materialSelect.replaceChildren(emptyOption);
+        materialSelect.value = '';
+    }
+    materialSelect.disabled = pbrMaterials.length === 0;
+    syncMaterialControls();
+}
+
+function applyToSelectedMaterials(
+    update: (material: Hilo3d.PBRMaterial) => void,
+    filter?: (material: Hilo3d.PBRMaterial) => boolean
+): void {
+    for (const material of selectedMaterials()) {
+        if (!filter || filter(material)) update(material);
+    }
+}
+
+function resetSelectedMaterials(): void {
+    applyToSelectedMaterials(material => {
+        const snapshot = materialDefaults.get(material);
+        if (!snapshot) return;
+        material.baseColor.set(...snapshot.baseColor);
+        material.ior = snapshot.ior;
+        material.iridescenceFactor = snapshot.iridescenceFactor;
+        material.metallic = snapshot.metallic;
+        material.normalScale = snapshot.normalScale;
+        material.opacity = snapshot.opacity;
+        material.roughness = snapshot.roughness;
+        material.transmissionFactor = snapshot.transmissionFactor;
+        material.invalidateData();
+    });
+    syncMaterialControls();
+}
+
+function setLookPresetSelection(preset: ViewerLookPreset | null): void {
+    for (const button of lookPresetButtons) {
+        button.setAttribute('aria-pressed', String(button.dataset['lookPreset'] === preset));
+    }
+}
+
+function syncPostProcessControls(preset: ViewerLookPreset | null = null): void {
+    const state = viewerPostProcess.state;
+    toneMappingSelect.value = state.toneMapping;
+    setRangeControl(exposureInput, exposureValue, state.exposure, ' EV');
+    setRangeControl(contrastInput, contrastValue, state.contrast);
+    setRangeControl(saturationInput, saturationValue, state.saturation);
+    setRangeControl(vignetteInput, vignetteValue, state.vignette);
+    setLookPresetSelection(preset);
+}
+
+function syncBloomControl(): void {
+    const enabled = viewerBloom.enabled;
+    bloomEnabledInput.checked = enabled;
+    bloomStateLabel.textContent = enabled ? 'On' : 'Off';
+    bloomFeatureStatus.dataset['enabled'] = String(enabled);
+}
+
+function isToneMappingMode(value: string): value is ViewerToneMappingMode {
+    return value === 'pbr-neutral' || value === 'aces' || value === 'reinhard' || value === 'none';
+}
+
+function updateModelInterface(model: Hilo3d.GLTFModel, bounds: Hilo3d.Bounds): void {
+    const sourceName = displayNameForSource(currentSourceLabel);
+    const assetName = model.json.asset.name?.trim();
+    const resolvedName = assetName && assetName.length > 0 ? assetName : sourceName;
+    const sourceFormat = currentSourceLabel.toLowerCase().endsWith('.glb') ? 'GLB' : 'glTF';
+    const version = model.json.asset.version;
+    const meshTotal = model.meshes.length;
+    const generator = model.json.asset.generator?.trim();
+    const transmissionTotal = model.materials.filter(
+        material => material.requiresOpaqueSceneTexture
+    ).length;
+
+    modelName.textContent = resolvedName;
+    panelModelName.textContent = resolvedName;
+    modelFormat.textContent = `${sourceFormat} · glTF ${version}`;
+    sourceValue.textContent = currentSourceLabel;
+    sourceValue.title = currentSourceLabel;
+    backendBadge.textContent = stage.renderer.backend === 'webgpu' ? 'WebGPU' : 'WebGL 2';
+    viewportStatusText.textContent = `${String(meshTotal)} ${meshTotal === 1 ? 'mesh' : 'meshes'} · ${transmissionTotal > 0 ? `${String(transmissionTotal)} transmission` : 'Ready'}`;
+    meshCount.textContent = String(meshTotal);
+    materialCount.textContent = String(model.materials.length);
+    textureCount.textContent = String(model.textures.length);
+    animationCount.textContent = String(collectionSize(model.json.animations));
+    versionValue.textContent = `glTF ${version}`;
+    generatorValue.textContent = generator && generator.length > 0 ? generator : 'Unknown';
+    generatorValue.title = generatorValue.textContent;
+    sceneCount.textContent = String(collectionSize(model.json.scenes));
+    dimensionsValue.textContent = [bounds.width, bounds.height, bounds.depth]
+        .map(formatDimension)
+        .join(' × ');
+    updateExtensionList(model.json.extensionsUsed ?? []);
 }
 
 function initializeModel(
@@ -156,8 +883,8 @@ function initializeModel(
     currentModel = model;
     stage.addChild(model.node);
     const bounds = model.node.getBounds();
+    if (!bounds) throw new Error('The glTF model has no renderable bounds.');
     if (!queryEnabled('noResize')) {
-        if (!bounds) throw new Error('The glTF model has no renderable bounds.');
         const largestDimension = Math.max(bounds.width, bounds.height, bounds.depth);
         if (largestDimension > 0) {
             const scale = 1.5 / largestDimension;
@@ -175,15 +902,7 @@ function initializeModel(
         model.node.setScale(scale);
     }
 
-    const requestedCamera = query['camera'];
-    if (requestedCamera !== 'false' && model.cameras.length > 0) {
-        const cameraIndex = requestedCamera === undefined ? 0 : Number(requestedCamera);
-        const modelCamera = Number.isSafeInteger(cameraIndex)
-            ? model.cameras[cameraIndex]
-            : undefined;
-        if (!modelCamera) throw new RangeError(`Unknown glTF camera: ${requestedCamera ?? '0'}.`);
-        stage.camera = modelCamera;
-    }
+    populateCameraControls(model.cameras);
 
     if (query['addLight'] !== undefined || model.lights.length === 0) {
         const skybox = new Hilo3d.Mesh({
@@ -202,13 +921,22 @@ function initializeModel(
         viewerDecorations.push(skybox, light);
     }
     if (generation === modelLoadGeneration) {
+        captureMaterialDefaults(model);
+        updateModelInterface(model, bounds);
+        setViewerState('ready');
+        stats.container.style.display = 'block';
         document.body.dataset['modelReady'] = 'true';
         document.body.dataset['modelGeneration'] = String(generation);
     }
 }
 
-async function loadModel(source: string, fromLocalFiles = false): Promise<void> {
+async function loadModel(
+    source: string,
+    fromLocalFiles = false,
+    sourceLabel = sourceLabelForUrl(source)
+): Promise<void> {
     const generation = ++modelLoadGeneration;
+    showLoading(sourceLabel);
     const resolveImage = (uri: string): string => resolveModelResource(uri, modelSourcePath);
     const resolveBuffer = (uri: string): string => resolveModelResource(uri, modelSourcePath);
     const resolveShader = (uri: string): string => resolveModelResource(uri, modelSourcePath);
@@ -250,12 +978,12 @@ async function loadModel(source: string, fromLocalFiles = false): Promise<void> 
 }
 
 function reportLoadFailure(error: unknown): void {
+    console.error('Failed to load glTF model.', error);
     showInput(error);
 }
 
 function loadFiles(files: FileList): void {
     releaseCurrentModel();
-    showStage();
     const selectedFiles = [...files];
     const modelFile = selectedFiles.find(file => {
         const extension = (Hilo3d.util.getExtension(file.name) ?? '').toLowerCase();
@@ -273,34 +1001,277 @@ function loadFiles(files: FileList): void {
     modelSourcePath = normalizeFilePath(modelFile.webkitRelativePath || modelFile.name);
     const source = objectUrls.get(modelSourcePath);
     if (!source) throw new Error('Selected glTF file has no object URL.');
-    loadModel(source, true).catch(reportLoadFailure);
+    loadModel(source, true, modelFile.name).catch(reportLoadFailure);
 }
 
-uploadButton.addEventListener('click', () => {
+function navigateToSource(source: string): void {
+    const url = source.trim();
+    if (!url) return;
+    const next = new URL(location.href);
+    next.searchParams.set('url', url);
+    location.assign(next);
+}
+
+function openFilePicker(): void {
     fileInput.click();
-});
+}
+
+function closeSourceDialog(): void {
+    if (sourceDialog.open) sourceDialog.close();
+}
+
+function openSourceDialog(): void {
+    dialogLinkInput.value = query['url'] ?? '';
+    sourceDialog.showModal();
+    orbitControls.disable();
+    dialogLinkInput.focus();
+}
+
+async function toggleFullscreen(): Promise<void> {
+    if (document.fullscreenElement) {
+        await document.exitFullscreen();
+        return;
+    }
+    await document.documentElement.requestFullscreen();
+}
+
+function updateFullscreenButton(): void {
+    const isFullscreen = document.fullscreenElement !== null;
+    fullscreenButton.setAttribute(
+        'aria-label',
+        isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'
+    );
+    fullscreenButton.dataset['tooltip'] = isFullscreen ? 'Exit fullscreen' : 'Fullscreen';
+}
+
+uploadButton.addEventListener('click', openFilePicker);
+openFileButton.addEventListener('click', openFilePicker);
 fileInput.addEventListener('change', () => {
     if (fileInput.files) loadFiles(fileInput.files);
+    fileInput.value = '';
+});
+
+document.body.addEventListener('dragenter', event => {
+    event.preventDefault();
+    if (!event.dataTransfer?.types.includes('Files')) return;
+    dragDepth++;
+    document.body.dataset['dragActive'] = 'true';
 });
 document.body.addEventListener('dragover', event => {
     event.preventDefault();
     if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
 });
+document.body.addEventListener('dragleave', event => {
+    event.preventDefault();
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) delete document.body.dataset['dragActive'];
+});
 document.body.addEventListener('drop', event => {
     event.preventDefault();
+    dragDepth = 0;
+    delete document.body.dataset['dragActive'];
     if (event.dataTransfer?.files.length) loadFiles(event.dataTransfer.files);
 });
+
 showLinkButton.addEventListener('click', () => {
-    const url = linkInput.value.trim();
-    if (!url) return;
-    const next = new URL(location.href);
-    next.searchParams.set('url', url);
-    location.assign(next);
+    navigateToSource(linkInput.value);
 });
+linkInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter') navigateToSource(linkInput.value);
+});
+loadSampleButton.addEventListener('click', () => {
+    navigateToSource('../models/KhronosPBR/IridescentDishWithOlives.glb');
+});
+
+toggleInspectorButton.addEventListener('click', () => {
+    setInspectorOpen(document.body.dataset['inspectorOpen'] !== 'true');
+});
+closeInspectorButton.addEventListener('click', () => {
+    setInspectorOpen(false);
+    toggleInspectorButton.focus();
+});
+for (const button of inspectorTabButtons) {
+    button.addEventListener('click', () => {
+        const section = button.dataset['inspectorTab'];
+        if (isInspectorSection(section)) setInspectorSection(section);
+    });
+}
+cameraSelect.addEventListener('change', () => {
+    selectCamera(cameraSelect.value);
+});
+materialSelect.addEventListener('change', syncMaterialControls);
+baseColorInput.addEventListener('input', () => {
+    applyToSelectedMaterials(material => {
+        const alpha = material.baseColor.a;
+        material.baseColor.fromHEX(baseColorInput.value);
+        material.baseColor.a = alpha;
+        material.invalidateData();
+    });
+});
+metallicInput.addEventListener('input', () => {
+    const value = Number(metallicInput.value);
+    applyToSelectedMaterials(material => {
+        material.metallic = value;
+    });
+    metallicValue.textContent = value.toFixed(2);
+});
+roughnessInput.addEventListener('input', () => {
+    const value = Number(roughnessInput.value);
+    applyToSelectedMaterials(material => {
+        material.roughness = value;
+    });
+    roughnessValue.textContent = value.toFixed(2);
+});
+normalScaleInput.addEventListener('input', () => {
+    const value = Number(normalScaleInput.value);
+    applyToSelectedMaterials(material => {
+        material.normalScale = value;
+    });
+    normalScaleValue.textContent = value.toFixed(2);
+});
+opacityInput.addEventListener('input', () => {
+    const value = Number(opacityInput.value);
+    applyToSelectedMaterials(
+        material => {
+            material.opacity = value;
+        },
+        material => material.compositing.mode === 'alpha-blend'
+    );
+    opacityValue.textContent = value.toFixed(2);
+});
+transmissionInput.addEventListener('input', () => {
+    const value = Number(transmissionInput.value);
+    applyToSelectedMaterials(
+        material => {
+            material.transmissionFactor = value;
+        },
+        material => supportsFeature(material, 'HAS_TRANSMISSION')
+    );
+    transmissionValue.textContent = value.toFixed(2);
+});
+iridescenceInput.addEventListener('input', () => {
+    const value = Number(iridescenceInput.value);
+    applyToSelectedMaterials(
+        material => {
+            material.iridescenceFactor = value;
+        },
+        material => supportsFeature(material, 'HAS_IRIDESCENCE')
+    );
+    iridescenceValue.textContent = value.toFixed(2);
+});
+iorInput.addEventListener('input', () => {
+    const value = Number(iorInput.value);
+    applyToSelectedMaterials(material => {
+        material.ior = value;
+    });
+    iorValue.textContent = value.toFixed(2);
+});
+resetMaterialButton.addEventListener('click', resetSelectedMaterials);
+
+for (const button of lookPresetButtons) {
+    button.addEventListener('click', () => {
+        const preset = button.dataset['lookPreset'];
+        if (preset !== 'neutral' && preset !== 'studio' && preset !== 'cinematic') return;
+        viewerPostProcess.applyPreset(preset);
+        syncPostProcessControls(preset);
+    });
+}
+bloomEnabledInput.addEventListener('change', () => {
+    viewerBloom.setEnabled(bloomEnabledInput.checked);
+    syncBloomControl();
+});
+toneMappingSelect.addEventListener('change', () => {
+    if (!isToneMappingMode(toneMappingSelect.value)) return;
+    viewerPostProcess.setToneMapping(toneMappingSelect.value);
+    setLookPresetSelection(null);
+});
+exposureInput.addEventListener('input', () => {
+    const value = Number(exposureInput.value);
+    viewerPostProcess.setExposure(value);
+    exposureValue.textContent = `${value.toFixed(2)} EV`;
+    setLookPresetSelection(null);
+});
+contrastInput.addEventListener('input', () => {
+    const value = Number(contrastInput.value);
+    viewerPostProcess.setContrast(value);
+    contrastValue.textContent = value.toFixed(2);
+    setLookPresetSelection(null);
+});
+saturationInput.addEventListener('input', () => {
+    const value = Number(saturationInput.value);
+    viewerPostProcess.setSaturation(value);
+    saturationValue.textContent = value.toFixed(2);
+    setLookPresetSelection(null);
+});
+vignetteInput.addEventListener('input', () => {
+    const value = Number(vignetteInput.value);
+    viewerPostProcess.setVignette(value);
+    vignetteValue.textContent = value.toFixed(2);
+    setLookPresetSelection(null);
+});
+resetPostButton.addEventListener('click', () => {
+    viewerBloom.setEnabled(true);
+    viewerPostProcess.reset();
+    syncBloomControl();
+    syncPostProcessControls('neutral');
+});
+zoomOutButton.addEventListener('click', () => {
+    orbitControls.dolly(1 / 1.18);
+});
+zoomInButton.addEventListener('click', () => {
+    orbitControls.dolly(1.18);
+});
+resetViewButton.addEventListener('click', () => {
+    orbitControls.reset();
+});
+fullscreenButton.addEventListener('click', () => {
+    void toggleFullscreen().catch((error: unknown) => {
+        console.error('Unable to change fullscreen state.', error);
+    });
+});
+document.addEventListener('fullscreenchange', updateFullscreenButton);
+
+openUrlDialogButton.addEventListener('click', openSourceDialog);
+closeSourceDialogButton.addEventListener('click', closeSourceDialog);
+cancelSourceDialogButton.addEventListener('click', closeSourceDialog);
+dialogShowLinkButton.addEventListener('click', () => {
+    closeSourceDialog();
+    navigateToSource(dialogLinkInput.value);
+});
+dialogLinkInput.addEventListener('keydown', event => {
+    if (event.key !== 'Enter') return;
+    closeSourceDialog();
+    navigateToSource(dialogLinkInput.value);
+});
+sourceDialog.addEventListener('close', () => {
+    syncCameraInteraction();
+});
+sourceDialog.addEventListener('click', event => {
+    if (!(event instanceof MouseEvent) || event.target !== sourceDialog) return;
+    const bounds = sourceDialog.getBoundingClientRect();
+    const isOutside =
+        event.clientX < bounds.left ||
+        event.clientX > bounds.right ||
+        event.clientY < bounds.top ||
+        event.clientY > bounds.bottom;
+    if (isOutside) closeSourceDialog();
+});
+
+setInspectorSection('scene');
+syncBloomControl();
+syncPostProcessControls('neutral');
+
+const handleResize = (): void => {
+    camera.aspect = innerWidth / innerHeight;
+    if (stage.camera instanceof Hilo3d.PerspectiveCamera) {
+        stage.camera.aspect = innerWidth / innerHeight;
+    }
+    stage.resize(innerWidth, innerHeight);
+};
+window.addEventListener('resize', handleResize);
 
 const sourceFromQuery = query['url'];
 if (sourceFromQuery) {
-    showStage();
     loadModel(sourceFromQuery).catch(reportLoadFailure);
 } else {
     showInput();
@@ -340,6 +1311,7 @@ window.__HILO3D_GLTF_VIEWER_DIAGNOSTICS__ = {
 };
 
 window.addEventListener('beforeunload', () => {
+    window.removeEventListener('resize', handleResize);
     diagnosticTarget.destroy();
     releaseCurrentModel();
     orbitControls.dispose();

--- a/examples/glTFViewer/app/index.ts
+++ b/examples/glTFViewer/app/index.ts
@@ -18,6 +18,11 @@ import {
 type ViewerState = 'empty' | 'error' | 'loading' | 'ready';
 type InspectorSection = 'scene' | 'material' | 'post';
 
+const BACKEND_LABELS: Readonly<Record<Hilo3d.RendererBackend, string>> = Object.freeze({
+    webgl2: 'WebGL 2',
+    webgpu: 'WebGPU'
+});
+
 interface MaterialSnapshot {
     readonly baseColor: readonly [number, number, number, number];
     readonly ior: number;
@@ -855,7 +860,7 @@ function updateModelInterface(model: Hilo3d.GLTFModel, bounds: Hilo3d.Bounds): v
     modelFormat.textContent = `${sourceFormat} · glTF ${version}`;
     sourceValue.textContent = currentSourceLabel;
     sourceValue.title = currentSourceLabel;
-    backendBadge.textContent = stage.renderer.backend === 'webgpu' ? 'WebGPU' : 'WebGL 2';
+    backendBadge.textContent = BACKEND_LABELS[stage.renderer.backend];
     viewportStatusText.textContent = `${String(meshTotal)} ${meshTotal === 1 ? 'mesh' : 'meshes'} · ${transmissionTotal > 0 ? `${String(transmissionTotal)} transmission` : 'Ready'}`;
     meshCount.textContent = String(meshTotal);
     materialCount.textContent = String(model.materials.length);

--- a/examples/glTFViewer/css/index.css
+++ b/examples/glTFViewer/css/index.css
@@ -1,17 +1,31 @@
-.iconfont {
-    font-family: system-ui, sans-serif;
-    font-size: 16px;
-    font-style: normal;
-    -webkit-font-smoothing: antialiased;
-    -webkit-text-stroke-width: 0.2px;
-    -moz-osx-font-smoothing: grayscale;
+:root {
+    color-scheme: dark;
+    --viewer-bg: #080a0f;
+    --viewer-panel: rgba(15, 18, 27, 0.86);
+    --viewer-panel-solid: #11141d;
+    --viewer-border: rgba(205, 218, 255, 0.13);
+    --viewer-border-strong: rgba(205, 218, 255, 0.22);
+    --viewer-text: #f6f7fb;
+    --viewer-muted: #9299aa;
+    --viewer-subtle: #686f80;
+    --viewer-accent: #63e4d4;
+    --viewer-accent-blue: #5794ff;
+    --viewer-accent-violet: #8568ff;
+    --viewer-danger: #ff7d86;
+    --viewer-radius: 16px;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
 }
 
-html,
-body,
-div {
-    padding: 0;
-    margin: 0;
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
 }
 
 html,
@@ -20,69 +34,1724 @@ body {
     height: 100%;
 }
 
-#stageContainer {
-    width: 100%;
-    height: 100%;
-    visibility: hidden;
+body {
+    margin: 0;
+    overflow: hidden;
+    background: var(--viewer-bg);
+    color: var(--viewer-text);
+    font-family: inherit;
+    -webkit-font-smoothing: antialiased;
 }
 
-#inputContainer {
+button,
+input {
+    font: inherit;
+}
+
+button,
+a {
+    -webkit-tap-highlight-color: transparent;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+    outline: 2px solid rgba(99, 228, 212, 0.78);
+    outline-offset: 3px;
+}
+
+svg {
+    display: block;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.75;
+}
+
+.srOnly {
     position: absolute;
-    width: 500px;
-    height: 280px;
-    left: 50%;
-    top: 50%;
-    margin-left: -250px;
-    margin-top: -250px;
-    text-align: center;
-}
-
-#inputContainer .title {
-    padding: 20px 0px;
-    font-size: 16px;
-}
-
-#inputContainer .dropArea {
-    border: 4px dashed #666;
-    height: 80%;
-    padding: 5px;
-    border-radius: 10px;
-}
-
-#inputContainer .dropArea .info {
-    font-size: 24px;
-    padding: 25px 5px;
-}
-
-#inputContainer .dropArea #uploadIcon {
-    width: 160px;
-    display: inline-block;
-    height: 100px;
-    text-align: center;
-    font-size: 90px;
-    cursor: pointer;
-    padding: 15px;
-    color: #111;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 #input {
     display: none;
 }
 
-.linkInputArea {
-    padding-top: 15px;
+.viewerBackdrop,
+.viewerShell,
+#stageContainer {
+    position: absolute;
+    inset: 0;
+}
+
+.viewerBackdrop {
+    z-index: 0;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at 50% 45%, rgba(30, 38, 56, 0.55), transparent 38%),
+        linear-gradient(145deg, #0e1119 0%, #080a0f 56%, #07080c 100%);
+}
+
+.viewerGlow {
+    position: absolute;
+    width: min(54vw, 760px);
+    aspect-ratio: 1;
+    border-radius: 50%;
+    filter: blur(4px);
+    opacity: 0.18;
+}
+
+.viewerGlowPrimary {
+    top: -34%;
+    right: -13%;
+    background: radial-gradient(circle, rgba(73, 154, 255, 0.72), transparent 68%);
+}
+
+.viewerGlowSecondary {
+    bottom: -45%;
+    left: -18%;
+    background: radial-gradient(circle, rgba(101, 232, 205, 0.42), transparent 66%);
+}
+
+.viewerGrid {
+    position: absolute;
+    inset: 0;
+    opacity: 0.22;
+    background-image:
+        linear-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: radial-gradient(circle at 50% 46%, black, transparent 74%);
+}
+
+.viewerShell {
+    z-index: 1;
+    isolation: isolate;
+}
+
+#stageContainer {
+    z-index: -1;
+    width: 100%;
+    height: 100%;
+    background: var(--viewer-bg);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 420ms ease;
+}
+
+#stageContainer canvas {
+    display: block;
+}
+
+body[data-view-state='loading'] #stageContainer,
+body[data-view-state='ready'] #stageContainer {
+    opacity: 1;
+    visibility: visible;
+}
+
+.viewerTopbar {
+    position: fixed;
+    z-index: 40;
+    top: 0;
+    right: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    min-height: 68px;
+    padding: 0 20px;
+    border-bottom: 1px solid transparent;
+    pointer-events: none;
+    transition:
+        background 220ms ease,
+        border-color 220ms ease;
+}
+
+body[data-view-state='ready'] .viewerTopbar,
+body[data-view-state='loading'] .viewerTopbar {
+    border-color: rgba(228, 235, 255, 0.1);
+    background: linear-gradient(180deg, rgba(7, 9, 14, 0.88), rgba(7, 9, 14, 0.6));
+    backdrop-filter: blur(18px) saturate(1.2);
+}
+
+.brand,
+.topbarActions,
+.modelIdentity {
+    pointer-events: auto;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    flex: none;
+    gap: 9px;
+    color: var(--viewer-text);
+    text-decoration: none;
+}
+
+.brandMark {
+    position: relative;
+    display: grid;
+    width: 34px;
+    height: 34px;
+    place-items: center;
+    border: 1px solid rgba(150, 220, 255, 0.35);
+    border-radius: 10px;
+    background: linear-gradient(145deg, rgba(83, 224, 209, 0.19), rgba(100, 91, 255, 0.2));
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.18),
+        0 8px 30px rgba(60, 137, 255, 0.16);
+    overflow: hidden;
+}
+
+.brandMark::before {
+    position: absolute;
+    inset: -35%;
+    background: conic-gradient(from 160deg, transparent, rgba(98, 229, 211, 0.6), transparent 38%);
+    content: '';
+    transform: rotate(20deg);
+}
+
+.brandMark span {
+    position: relative;
+    background: linear-gradient(135deg, #75efdb, #6d82ff);
+    background-clip: text;
+    color: transparent;
+    font-size: 16px;
+    font-weight: 900;
+    letter-spacing: -0.06em;
+}
+
+.brandType {
+    font-size: 15px;
+    font-weight: 720;
+    letter-spacing: -0.035em;
+}
+
+.brandType span {
+    background: linear-gradient(90deg, var(--viewer-accent), #7192ff 58%, #9a6dff);
+    background-clip: text;
+    color: transparent;
+}
+
+.brandProduct {
+    padding-left: 10px;
+    border-left: 1px solid var(--viewer-border-strong);
+    color: var(--viewer-muted);
+    font-size: 13px;
+    font-weight: 520;
+}
+
+.modelIdentity {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    align-items: center;
+    gap: 9px;
+    margin-left: 28px;
+}
+
+.modelName {
+    max-width: min(34vw, 420px);
+    overflow: hidden;
+    font-size: 13px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.modelMeta {
+    color: var(--viewer-subtle);
+    font-size: 11px;
+}
+
+.topbarActions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+}
+
+.modelOnly {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 180ms ease;
+}
+
+body[data-view-state='ready'] .modelOnly {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.backendBadge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 30px;
+    padding: 0 10px;
+    border: 1px solid rgba(109, 214, 210, 0.2);
+    border-radius: 999px;
+    background: rgba(74, 175, 174, 0.08);
+    color: #a9dcd7;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 9px;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.primaryButton,
+.secondaryButton,
+.iconButton,
+.toolButton,
+.sampleButton,
+#showLinkBtn {
+    appearance: none;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+}
+
+.primaryButton {
+    display: inline-flex;
+    min-height: 42px;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 17px;
+    border-radius: 11px;
+    background: linear-gradient(135deg, #69e5d3 0%, #5db6ed 54%, #7287ff 100%);
+    box-shadow:
+        0 10px 28px rgba(64, 156, 214, 0.2),
+        inset 0 1px 0 rgba(255, 255, 255, 0.32);
+    color: #061015;
+    font-size: 12px;
+    font-weight: 760;
+    transition:
+        filter 160ms ease,
+        transform 160ms ease,
+        box-shadow 160ms ease;
+}
+
+.primaryButton:hover {
+    box-shadow:
+        0 14px 34px rgba(64, 156, 214, 0.28),
+        inset 0 1px 0 rgba(255, 255, 255, 0.38);
+    filter: brightness(1.08);
+    transform: translateY(-1px);
+}
+
+.primaryButton:active {
+    transform: translateY(0);
+}
+
+.compactButton {
+    min-height: 36px;
+    padding: 0 13px;
+    border-radius: 10px;
+}
+
+.compactButton svg {
+    width: 16px;
+    height: 16px;
+    stroke-width: 1.9;
+}
+
+.secondaryButton {
+    min-height: 42px;
+    padding: 0 17px;
+    border: 1px solid var(--viewer-border-strong);
+    border-radius: 11px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--viewer-text);
+    font-size: 12px;
+    font-weight: 650;
+}
+
+.iconButton,
+.toolButton {
+    position: relative;
+    display: grid;
+    width: 36px;
+    height: 36px;
+    flex: none;
+    place-items: center;
+    border: 1px solid var(--viewer-border);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.045);
+    color: #c8cdd8;
+    transition:
+        background 150ms ease,
+        border-color 150ms ease,
+        color 150ms ease,
+        transform 150ms ease;
+}
+
+.iconButton:hover,
+.toolButton:hover,
+.iconButton[aria-expanded='true'] {
+    border-color: rgba(125, 214, 220, 0.38);
+    background: rgba(112, 192, 211, 0.11);
+    color: #fff;
+    transform: translateY(-1px);
+}
+
+.iconButton svg,
+.toolButton svg {
+    width: 18px;
+    height: 18px;
+}
+
+.importer {
+    position: absolute;
+    z-index: 10;
+    top: 50%;
+    left: 50%;
+    width: min(590px, calc(100vw - 40px));
+    max-height: calc(100vh - 106px);
+    padding: 34px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 24px;
+    background:
+        linear-gradient(145deg, rgba(20, 24, 35, 0.9), rgba(12, 15, 23, 0.82)), var(--viewer-panel);
+    box-shadow:
+        0 36px 110px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.055);
+    overflow: auto;
+    transform: translate(-50%, -47%);
+    transition:
+        opacity 200ms ease,
+        transform 240ms ease,
+        visibility 0s linear 240ms;
+    backdrop-filter: blur(24px) saturate(1.16);
+}
+
+body[data-view-state='loading'] .importer,
+body[data-view-state='ready'] .importer {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -44%) scale(0.98);
+}
+
+.importerEyebrow,
+.panelEyebrow {
+    color: #8bcfc9;
+    font-size: 9px;
+    font-weight: 760;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.importerEyebrow {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+}
+
+.eyebrowLine {
+    width: 24px;
+    height: 1px;
+    background: linear-gradient(90deg, var(--viewer-accent), transparent);
+}
+
+.importer h1 {
+    margin: 13px 0 0;
+    font-size: clamp(34px, 5vw, 52px);
+    font-weight: 660;
+    letter-spacing: -0.055em;
+    line-height: 0.98;
+}
+
+.importer h1 span {
+    background: linear-gradient(92deg, #fff 0%, #aad6e5 55%, #9a8aff 100%);
+    background-clip: text;
+    color: transparent;
+}
+
+.importerIntro {
+    max-width: 460px;
+    margin: 17px 0 22px;
+    color: var(--viewer-muted);
+    font-size: 13px;
+    line-height: 1.65;
+}
+
+.dropArea {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 15px;
+    align-items: center;
+    padding: 17px;
+    border: 1px dashed rgba(141, 177, 216, 0.28);
+    border-radius: var(--viewer-radius);
+    background:
+        linear-gradient(100deg, rgba(98, 220, 208, 0.035), rgba(104, 116, 255, 0.045)),
+        rgba(255, 255, 255, 0.018);
+    transition:
+        border-color 160ms ease,
+        background 160ms ease;
+}
+
+.dropArea:hover,
+body[data-drag-active='true'] .dropArea {
+    border-color: rgba(104, 226, 213, 0.58);
+    background: rgba(81, 181, 184, 0.075);
+}
+
+body[data-view-state='error'] .dropArea {
+    border-color: rgba(255, 125, 134, 0.46);
+}
+
+.dropIcon {
+    display: grid;
+    width: 50px;
+    height: 50px;
+    place-items: center;
+    border: 1px solid rgba(131, 213, 226, 0.18);
+    border-radius: 14px;
+    background: rgba(85, 180, 194, 0.07);
+    color: #8edbd4;
+}
+
+.dropIcon svg {
+    width: 26px;
+    height: 26px;
+}
+
+.dropCopy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.dropCopy strong {
+    font-size: 13px;
+    font-weight: 670;
+}
+
+.dropCopy .info {
+    color: var(--viewer-subtle);
+    font-size: 10px;
+    line-height: 1.4;
+}
+
+body[data-view-state='error'] .dropCopy .info {
+    color: #ff9ca3;
+}
+
+.importDivider {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 19px 0 15px;
+    color: var(--viewer-subtle);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.importDivider::before,
+.importDivider::after {
+    height: 1px;
+    flex: 1;
+    background: var(--viewer-border);
+    content: '';
+}
+
+.importDivider span {
+    padding: 0 12px;
+}
+
+.urlField {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    min-height: 44px;
+    padding-left: 13px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 12px;
+    background: rgba(5, 7, 12, 0.4);
+    color: var(--viewer-subtle);
+    transition:
+        border-color 160ms ease,
+        box-shadow 160ms ease;
+}
+
+.urlField:focus-within {
+    border-color: rgba(100, 218, 211, 0.44);
+    box-shadow: 0 0 0 3px rgba(99, 228, 212, 0.06);
+}
+
+.urlField > svg {
+    width: 17px;
+    height: 17px;
 }
 
 #linkInput {
-    width: 380px;
+    min-width: 0;
+    height: 42px;
+    padding: 0 10px;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--viewer-text);
+    font-size: 11px;
+}
+
+#linkInput::placeholder,
+#dialogLinkInput::placeholder {
+    color: #5c6371;
 }
 
 #showLinkBtn {
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border-radius: 10px;
+    background: transparent;
+    color: #95a0b1;
+}
+
+#showLinkBtn:hover {
+    color: var(--viewer-accent);
+}
+
+#showLinkBtn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.sampleButton {
+    display: grid;
+    width: 100%;
+    grid-template-columns: auto 1fr auto;
+    gap: 11px;
+    align-items: center;
+    margin-top: 13px;
+    padding: 9px 11px;
+    border: 1px solid transparent;
+    border-radius: 12px;
+    background: transparent;
+    color: #737b8b;
+    text-align: left;
+    transition:
+        background 150ms ease,
+        border-color 150ms ease,
+        color 150ms ease;
+}
+
+.sampleButton:hover {
+    border-color: var(--viewer-border);
+    background: rgba(255, 255, 255, 0.025);
+    color: #b5bbc7;
+}
+
+.samplePreview {
+    display: grid;
+    width: 31px;
+    height: 31px;
+    place-items: center;
+    border-radius: 9px;
+    background: linear-gradient(145deg, rgba(90, 215, 205, 0.13), rgba(119, 103, 255, 0.12));
+    color: #74cac6;
+}
+
+.samplePreview svg {
+    width: 24px;
+    height: 24px;
+    stroke-width: 1.35;
+}
+
+.sampleButton > span:nth-child(2) {
+    font-size: 10px;
+    line-height: 1.45;
+}
+
+.sampleButton strong {
+    color: #aeb5c2;
+    font-weight: 650;
+}
+
+.sampleArrow {
+    width: 16px;
+    height: 16px;
+}
+
+.loadingOverlay {
+    position: absolute;
+    z-index: 12;
+    top: 50%;
+    left: 50%;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -45%);
+    transition: opacity 180ms ease;
+}
+
+body[data-view-state='loading'] .loadingOverlay {
+    visibility: visible;
+    opacity: 1;
+}
+
+.loadingMark {
+    position: relative;
+    display: grid;
+    width: 58px;
+    height: 58px;
+    place-items: center;
+    margin-bottom: 18px;
+}
+
+.loadingMark::before {
+    position: absolute;
+    inset: 0;
+    border: 1px solid rgba(102, 224, 211, 0.18);
+    border-radius: 18px;
+    background: rgba(87, 182, 191, 0.06);
+    box-shadow: 0 14px 50px rgba(66, 169, 242, 0.16);
+    content: '';
+    transform: rotate(45deg);
+}
+
+.loadingMark span {
+    position: absolute;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--viewer-accent);
+    animation: loadingPulse 1.2s ease-in-out infinite;
+}
+
+.loadingMark span:first-child {
+    margin-left: -19px;
+    animation-delay: -0.22s;
+}
+
+.loadingMark span:last-child {
+    margin-left: 19px;
+    animation-delay: 0.22s;
+}
+
+.loadingOverlay strong {
+    font-size: 13px;
+    font-weight: 670;
+}
+
+.loadingOverlay > span {
+    max-width: min(360px, calc(100vw - 50px));
+    margin-top: 6px;
+    overflow: hidden;
+    color: var(--viewer-muted);
+    font-size: 10px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+@keyframes loadingPulse {
+    0%,
+    100% {
+        opacity: 0.28;
+        transform: scale(0.72);
+    }
+    50% {
+        opacity: 1;
+        transform: scale(1.1);
+    }
+}
+
+.dropOverlay {
+    position: fixed;
+    z-index: 80;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    border: 2px solid transparent;
+    background: rgba(5, 8, 14, 0.24);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 130ms ease;
+    backdrop-filter: blur(8px);
+}
+
+body[data-drag-active='true'] .dropOverlay {
+    border-color: rgba(105, 229, 211, 0.52);
+    opacity: 1;
+}
+
+.dropOverlayCard {
+    display: flex;
+    min-width: min(360px, calc(100vw - 40px));
+    align-items: center;
+    flex-direction: column;
+    padding: 32px;
+    border: 1px solid rgba(137, 227, 222, 0.26);
+    border-radius: 22px;
+    background: rgba(11, 15, 23, 0.9);
+    box-shadow: 0 28px 100px rgba(0, 0, 0, 0.52);
+}
+
+.dropOverlayCard svg {
+    width: 30px;
+    height: 30px;
+    margin-bottom: 14px;
+    color: var(--viewer-accent);
+}
+
+.dropOverlayCard strong {
+    font-size: 14px;
+}
+
+.dropOverlayCard span {
+    margin-top: 6px;
+    color: var(--viewer-muted);
+    font-size: 10px;
+}
+
+.inspectorPanel {
+    position: fixed;
+    z-index: 35;
+    top: 84px;
+    right: 16px;
+    bottom: 16px;
+    width: min(332px, calc(100vw - 32px));
+    padding: 20px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 18px;
+    background: var(--viewer-panel);
+    box-shadow:
+        0 28px 90px rgba(0, 0, 0, 0.38),
+        inset 0 1px 0 rgba(255, 255, 255, 0.045);
+    opacity: 0;
+    overflow-y: auto;
+    pointer-events: none;
+    transform: translateX(calc(100% + 28px));
+    transition:
+        opacity 200ms ease,
+        transform 260ms cubic-bezier(0.2, 0.7, 0.2, 1);
+    backdrop-filter: blur(24px) saturate(1.15);
+}
+
+body[data-view-state='ready'][data-inspector-open='true'] .inspectorPanel {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0);
+}
+
+.inspectorHeader,
+.dialogHeader {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 15px;
+}
+
+.inspectorHeader h2,
+.dialogHeader h2 {
+    margin: 5px 0 0;
+    font-size: 17px;
+    font-weight: 660;
+    letter-spacing: -0.025em;
+}
+
+.inspectorTabs {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+    margin-top: 19px;
+    padding: 4px;
+    border: 1px solid rgba(210, 222, 255, 0.08);
+    border-radius: 11px;
+    background: rgba(3, 5, 9, 0.26);
+}
+
+.inspectorTabs button {
+    min-height: 32px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--viewer-subtle);
     cursor: pointer;
-    width: 100px;
-    padding: 1px 0px 2px 0px;
+    font-size: 9px;
+    font-weight: 650;
+    transition:
+        background 150ms ease,
+        color 150ms ease,
+        box-shadow 150ms ease;
+}
+
+.inspectorTabs button:hover {
+    color: #c5cad4;
+}
+
+.inspectorTabs button[aria-selected='true'] {
+    background: rgba(255, 255, 255, 0.075);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.06),
+        0 5px 14px rgba(0, 0, 0, 0.15);
+    color: #fff;
+}
+
+.inspectorContent {
+    min-height: 0;
+}
+
+.inspectorContent [hidden] {
+    display: none;
+}
+
+.panelLead {
+    margin: 21px 1px 17px;
+}
+
+.panelLead h3 {
+    margin: 6px 0 0;
+    font-size: 16px;
+    font-weight: 660;
+    letter-spacing: -0.025em;
+}
+
+.panelLead p {
+    margin: 7px 0 0;
+    color: var(--viewer-subtle);
+    font-size: 9px;
+    line-height: 1.55;
+}
+
+.modelCard {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 12px;
+    margin-top: 22px;
+    padding: 13px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.025);
+}
+
+.modelGlyph {
+    display: grid;
+    width: 45px;
+    height: 45px;
+    flex: none;
+    place-items: center;
+    border-radius: 12px;
+    background: linear-gradient(145deg, rgba(98, 229, 211, 0.13), rgba(113, 100, 255, 0.16));
+    color: #7edbd2;
+}
+
+.modelGlyph svg {
+    width: 31px;
+    height: 31px;
+    stroke-width: 1.3;
+}
+
+.modelCard > div:last-child {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.modelCard strong,
+.modelCard span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.modelCard strong {
+    font-size: 12px;
+}
+
+.modelCard span {
+    color: var(--viewer-subtle);
+    font-size: 9px;
+}
+
+.statGrid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.statGrid > div {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    flex-direction: column;
+    padding: 11px 4px 9px;
+    border: 1px solid rgba(210, 222, 255, 0.085);
+    border-radius: 11px;
+    background: rgba(255, 255, 255, 0.018);
+}
+
+.statGrid strong {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.statGrid span {
+    margin-top: 4px;
+    color: var(--viewer-subtle);
+    font-size: 8px;
+    text-transform: uppercase;
+}
+
+.detailSection {
+    margin-top: 21px;
+}
+
+.detailSection h3 {
+    margin: 0 0 10px;
+    color: #a7aeba;
+    font-size: 9px;
+    font-weight: 720;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.detailSection dl {
+    margin: 0;
+}
+
+.detailSection dl > div {
+    display: grid;
+    grid-template-columns: 86px minmax(0, 1fr);
+    gap: 10px;
+    padding: 9px 0;
+    border-bottom: 1px solid rgba(211, 222, 255, 0.07);
+    font-size: 10px;
+}
+
+.detailSection dt {
+    color: var(--viewer-subtle);
+}
+
+.detailSection dd {
+    margin: 0;
+    overflow: hidden;
+    color: #bdc3cf;
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.cameraSection {
+    padding: 13px;
+    border: 1px solid rgba(151, 168, 255, 0.1);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.018);
+}
+
+.cameraSection h3 {
+    margin-bottom: 12px;
+}
+
+.cameraHint {
+    margin: 8px 0 0;
+    color: var(--viewer-subtle);
+    font-size: 8px;
+    line-height: 1.5;
+}
+
+.extensionList {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.extensionList span {
+    padding: 5px 7px;
+    border: 1px solid rgba(110, 200, 213, 0.14);
+    border-radius: 7px;
+    background: rgba(76, 181, 192, 0.055);
+    color: #9bc2c2;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 8px;
+}
+
+.extensionList .emptyExtension {
+    border-color: transparent;
+    background: transparent;
+    color: var(--viewer-subtle);
+    font-family: inherit;
+}
+
+.controlRows {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 7px;
+}
+
+.controlRows span {
+    color: var(--viewer-subtle);
+    font-size: 9px;
+}
+
+.selectControl {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    color: #a7aeba;
+    font-size: 9px;
+    font-weight: 620;
+}
+
+.selectWrap {
+    position: relative;
+    display: block;
+}
+
+.selectWrap select {
+    width: 100%;
+    height: 39px;
+    padding: 0 35px 0 11px;
+    appearance: none;
+    border: 1px solid var(--viewer-border);
+    border-radius: 10px;
+    outline: 0;
+    background: rgba(5, 7, 12, 0.42);
+    color: #d3d7df;
+    cursor: pointer;
+    font-size: 10px;
+}
+
+.selectWrap select:focus {
+    border-color: rgba(104, 218, 211, 0.44);
+}
+
+.selectWrap svg {
+    position: absolute;
+    top: 50%;
+    right: 11px;
+    width: 15px;
+    height: 15px;
+    color: var(--viewer-subtle);
+    pointer-events: none;
+    transform: translateY(-50%);
+}
+
+.materialSummary {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin-top: 9px;
+}
+
+#materialModeBadge,
+.activePill {
+    padding: 4px 7px;
+    border: 1px solid rgba(101, 219, 208, 0.17);
+    border-radius: 999px;
+    background: rgba(78, 185, 178, 0.07);
+    color: #9ad5cf;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 7px;
+    font-weight: 650;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+#materialCountLabel {
+    color: var(--viewer-subtle);
+    font-size: 8px;
+}
+
+.propertyGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    margin-top: 19px;
+}
+
+.colorControl,
+.rangeControl {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.colorControl {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-bottom: 14px;
+    border-bottom: 1px solid rgba(211, 222, 255, 0.07);
+}
+
+.colorControl > span {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.colorControl strong,
+.rangeControl strong {
+    color: #bfc4ce;
+    font-size: 9px;
+    font-weight: 610;
+}
+
+.colorControl small,
+.rangeControl small {
+    color: var(--viewer-subtle);
+    font-size: 8px;
+    font-weight: 450;
+}
+
+.colorControl input {
+    width: 39px;
+    height: 29px;
+    padding: 3px;
+    border: 1px solid var(--viewer-border-strong);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.04);
+    cursor: pointer;
+}
+
+.colorControl input::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+.colorControl input::-webkit-color-swatch {
+    border: 0;
+    border-radius: 5px;
+}
+
+.rangeControl > span {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.rangeControl output {
+    color: #8fa3ac;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 8px;
+}
+
+.rangeControl input[type='range'] {
+    width: 100%;
+    height: 4px;
+    margin: 1px 0 0;
+    appearance: none;
+    border-radius: 999px;
+    outline: 0;
+    background: linear-gradient(90deg, rgba(91, 220, 207, 0.78), rgba(117, 116, 255, 0.78));
+    cursor: pointer;
+}
+
+.rangeControl input[type='range']::-webkit-slider-thumb {
+    width: 14px;
+    height: 14px;
+    appearance: none;
+    border: 2px solid #10141c;
+    border-radius: 50%;
+    background: #d9fbf5;
+    box-shadow: 0 0 0 1px rgba(111, 225, 213, 0.55);
+}
+
+.rangeControl input[type='range']::-moz-range-thumb {
+    width: 11px;
+    height: 11px;
+    border: 2px solid #10141c;
+    border-radius: 50%;
+    background: #d9fbf5;
+    box-shadow: 0 0 0 1px rgba(111, 225, 213, 0.55);
+}
+
+.rangeControl input:disabled,
+.colorControl input:disabled,
+.selectWrap select:disabled {
+    cursor: not-allowed;
+    filter: grayscale(1);
+    opacity: 0.35;
+}
+
+.panelResetButton {
+    width: 100%;
+    min-height: 37px;
+    margin-top: 21px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.025);
+    color: #9ba2af;
+    cursor: pointer;
+    font-size: 9px;
+    font-weight: 610;
+    transition:
+        border-color 150ms ease,
+        background 150ms ease,
+        color 150ms ease;
+}
+
+.panelResetButton:hover {
+    border-color: rgba(116, 213, 216, 0.3);
+    background: rgba(94, 190, 196, 0.07);
+    color: #dce0e7;
+}
+
+.lookPresets {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+}
+
+.lookPresets button {
+    min-height: 34px;
+    padding: 0 8px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--viewer-subtle);
+    cursor: pointer;
+    font-size: 8px;
+    font-weight: 620;
+}
+
+.lookPresets button:hover,
+.lookPresets button[aria-pressed='true'] {
+    border-color: rgba(108, 216, 212, 0.3);
+    background: rgba(88, 184, 190, 0.08);
+    color: #d9e7e6;
+}
+
+.featureStatus {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 13px;
+    padding: 11px;
+    border: 1px solid rgba(151, 168, 255, 0.12);
+    border-radius: 11px;
+    background: linear-gradient(105deg, rgba(83, 216, 205, 0.045), rgba(111, 100, 255, 0.055));
+}
+
+.featureIcon {
+    display: grid;
+    width: 27px;
+    height: 27px;
+    flex: none;
+    place-items: center;
+    border-radius: 8px;
+    background: rgba(102, 213, 209, 0.09);
+    color: #78ddd2;
+    font-size: 13px;
+}
+
+.featureStatus > span:nth-child(2) {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.featureStatus strong {
+    color: #c5cbd5;
+    font-size: 9px;
+}
+
+.featureStatus small {
+    color: var(--viewer-subtle);
+    font-size: 7px;
+}
+
+.featureSwitch {
+    position: relative;
+    display: grid;
+    min-width: 48px;
+    flex: none;
+    cursor: pointer;
+    gap: 4px;
+    justify-items: center;
+}
+
+.featureSwitch input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+}
+
+.switchTrack {
+    position: relative;
+    width: 31px;
+    height: 17px;
+    border: 1px solid rgba(191, 200, 224, 0.17);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.065);
+    transition:
+        border-color 150ms ease,
+        background 150ms ease;
+}
+
+.switchTrack::after {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: #8d96a7;
+    content: '';
+    transition:
+        background 150ms ease,
+        box-shadow 150ms ease,
+        transform 150ms ease;
+}
+
+.featureSwitch input:checked + .switchTrack {
+    border-color: rgba(101, 219, 208, 0.3);
+    background: rgba(78, 185, 178, 0.18);
+}
+
+.featureSwitch input:checked + .switchTrack::after {
+    background: #84e7dc;
+    box-shadow: 0 0 9px rgba(101, 219, 208, 0.4);
+    transform: translateX(14px);
+}
+
+.featureSwitch input:focus-visible + .switchTrack {
+    outline: 2px solid rgba(111, 207, 226, 0.7);
+    outline-offset: 2px;
+}
+
+.featureSwitch > span:last-child {
+    color: #9ad5cf;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 7px;
+    font-weight: 650;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.featureStatus[data-enabled='false'] {
+    filter: saturate(0.55);
+    opacity: 0.72;
+}
+
+.featureStatus[data-enabled='false'] .featureSwitch > span:last-child {
+    color: var(--viewer-subtle);
+}
+
+kbd {
+    display: inline-flex;
+    min-height: 21px;
+    align-items: center;
+    margin-right: 4px;
+    padding: 0 6px;
+    border: 1px solid var(--viewer-border);
+    border-bottom-color: rgba(214, 223, 250, 0.25);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.045);
+    color: #bfc5d1;
+    font-family: inherit;
+    font-size: 8px;
+}
+
+.viewportStatus {
+    position: fixed;
+    z-index: 25;
+    bottom: 20px;
+    left: 20px;
+    display: flex;
+    min-height: 32px;
+    align-items: center;
+    gap: 7px;
+    padding: 0 11px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 999px;
+    background: rgba(10, 13, 19, 0.7);
+    color: #aeb5c1;
+    font-size: 9px;
+    backdrop-filter: blur(12px);
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--viewer-accent);
+    box-shadow: 0 0 0 3px rgba(99, 228, 212, 0.1);
+}
+
+.viewportToolbar {
+    position: fixed;
+    z-index: 25;
+    bottom: 18px;
+    left: 50%;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 14px;
+    background: rgba(10, 13, 20, 0.78);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.26);
+    transform: translateX(-50%);
+    backdrop-filter: blur(18px) saturate(1.16);
+}
+
+.toolButton {
+    width: 35px;
+    height: 35px;
+    border-color: transparent;
+    background: transparent;
+}
+
+.toolButton:disabled {
+    cursor: not-allowed;
+    opacity: 0.3;
+}
+
+.toolButton:disabled:hover {
+    border-color: transparent;
+    background: transparent;
+    color: #c8cdd8;
+    transform: none;
+}
+
+.toolbarDivider {
+    width: 1px;
+    height: 20px;
+    margin: 0 3px;
+    background: var(--viewer-border);
+}
+
+[data-tooltip]::after {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    padding: 5px 7px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 6px;
+    background: #171a22;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    color: #d9dce3;
+    content: attr(data-tooltip);
+    font-size: 8px;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -2px);
+    transition:
+        opacity 120ms ease,
+        transform 120ms ease;
+    white-space: nowrap;
+}
+
+.viewportToolbar [data-tooltip]::after {
+    top: auto;
+    bottom: calc(100% + 9px);
+}
+
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
+.sourceDialog {
+    width: min(430px, calc(100vw - 32px));
+    padding: 22px;
+    border: 1px solid var(--viewer-border-strong);
+    border-radius: 19px;
+    background: var(--viewer-panel-solid);
+    box-shadow: 0 32px 110px rgba(0, 0, 0, 0.64);
+    color: var(--viewer-text);
+}
+
+.sourceDialog::backdrop {
+    background: rgba(3, 5, 9, 0.65);
+    backdrop-filter: blur(8px);
+}
+
+.sourceDialog p {
+    margin: 18px 0;
+    color: var(--viewer-muted);
+    font-size: 11px;
+    line-height: 1.55;
+}
+
+.sourceDialog > label {
+    display: block;
+    margin-bottom: 7px;
+    color: #abb2bf;
+    font-size: 10px;
+    font-weight: 620;
+}
+
+#dialogLinkInput {
+    width: 100%;
+    height: 44px;
+    padding: 0 13px;
+    border: 1px solid var(--viewer-border);
+    border-radius: 11px;
+    outline: 0;
+    background: rgba(4, 6, 10, 0.5);
+    color: var(--viewer-text);
+    font-size: 11px;
+}
+
+#dialogLinkInput:focus {
+    border-color: rgba(102, 224, 212, 0.48);
+}
+
+.dialogActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 19px;
 }
 
 .hilo3dStats {
-    display: none;
+    z-index: 24;
+    top: 84px;
+    bottom: auto;
+    left: 20px;
+    min-width: 142px;
+    padding: 8px 10px;
+    border-color: var(--viewer-border);
+    border-radius: 10px;
+    background: rgba(8, 11, 17, 0.62);
+    box-shadow: none;
+    color: #a8afbb !important;
+    font-size: 9px;
+    line-height: 1.5;
+    backdrop-filter: blur(12px);
+}
+
+@media (max-width: 800px) {
+    .viewerTopbar {
+        min-height: 60px;
+        padding: 0 13px;
+    }
+
+    .brandProduct,
+    .backendBadge,
+    .modelIdentity,
+    .hilo3dStats {
+        display: none;
+    }
+
+    .importer {
+        width: min(560px, calc(100vw - 24px));
+        max-height: calc(100vh - 78px);
+        padding: 25px;
+        transform: translate(-50%, -46%);
+    }
+
+    .importer h1 {
+        font-size: clamp(32px, 10vw, 46px);
+    }
+
+    .inspectorPanel {
+        top: auto;
+        right: 10px;
+        bottom: 10px;
+        left: 10px;
+        width: auto;
+        max-height: min(70vh, 620px);
+        transform: translateY(calc(100% + 22px));
+    }
+
+    body[data-view-state='ready'][data-inspector-open='true'] .inspectorPanel {
+        transform: translateY(0);
+    }
+
+    .viewportStatus {
+        display: none;
+    }
+}
+
+@media (max-width: 560px) {
+    .brandType {
+        display: none;
+    }
+
+    .compactButton {
+        width: 36px;
+        padding: 0;
+        font-size: 0;
+    }
+
+    .compactButton svg {
+        width: 18px;
+        height: 18px;
+    }
+
+    .importer {
+        top: 58px;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        max-height: none;
+        padding: 25px 18px 24px;
+        border-right: 0;
+        border-bottom: 0;
+        border-left: 0;
+        border-radius: 22px 22px 0 0;
+        transform: none;
+    }
+
+    body[data-view-state='loading'] .importer,
+    body[data-view-state='ready'] .importer {
+        transform: translateY(10px);
+    }
+
+    .importerIntro {
+        margin-bottom: 18px;
+    }
+
+    .dropArea {
+        grid-template-columns: auto 1fr;
+    }
+
+    .dropArea .primaryButton {
+        min-height: 38px;
+        grid-column: 1 / -1;
+    }
+
+    .sampleButton > span:nth-child(2) {
+        line-height: 1.35;
+    }
+
+    .viewportToolbar {
+        bottom: 12px;
+    }
+
+    .controlRows {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
 }

--- a/examples/glTFViewer/index.html
+++ b/examples/glTFViewer/index.html
@@ -3,27 +3,671 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>glTF Viewer - rendered by Hilo3d</title>
+        <meta name="theme-color" content="#080a0f" />
+        <title>glTF Viewer · Hilo3D</title>
         <link rel="stylesheet" href="../example.css" />
         <link rel="stylesheet" href="./css/index.css" />
     </head>
-    <body>
-        <input type="file" multiple id="input" />
-        <div id="inputContainer">
-            <div class="title">
-                It's a glTF Viewer rendered by
-                <a href="https://github.com/hiloteam/Hilo3d">Hilo3d</a>.
-            </div>
-            <div class="dropArea">
-                <div class="info">Drag glTF 2.0 files or folder here</div>
-                <div class="iconfont" id="uploadIcon" aria-label="Choose glTF files">⇧</div>
-            </div>
-            <div class="linkInputArea">
-                <input id="linkInput" type="text" placeholder="Copy the glTF model url here!" />
-                <button id="showLinkBtn">show the model</button>
-            </div>
+    <body data-view-state="empty" data-inspector-open="false">
+        <input
+            id="input"
+            type="file"
+            accept=".gltf,.glb,model/gltf+json,model/gltf-binary"
+            multiple
+        />
+
+        <div class="viewerBackdrop" aria-hidden="true">
+            <div class="viewerGlow viewerGlowPrimary"></div>
+            <div class="viewerGlow viewerGlowSecondary"></div>
+            <div class="viewerGrid"></div>
         </div>
-        <div id="stageContainer"></div>
+
+        <main class="viewerShell">
+            <div id="stageContainer" role="img" aria-label="Interactive 3D model viewport"></div>
+
+            <header class="viewerTopbar">
+                <a
+                    class="brand"
+                    href="https://github.com/hiloteam/Hilo3d"
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="Hilo3D on GitHub"
+                >
+                    <span class="brandMark" aria-hidden="true">
+                        <span>H</span>
+                    </span>
+                    <span class="brandType">Hilo<span>3D</span></span>
+                    <span class="brandProduct">Viewer</span>
+                </a>
+
+                <div class="modelIdentity modelOnly" aria-live="polite">
+                    <span class="modelName" id="modelName">Untitled model</span>
+                    <span class="modelMeta" id="modelFormat">glTF 2.0</span>
+                </div>
+
+                <div class="topbarActions">
+                    <span class="backendBadge modelOnly" id="backendBadge">WebGL 2</span>
+                    <button
+                        class="iconButton modelOnly"
+                        id="openUrlDialogButton"
+                        type="button"
+                        aria-label="Load model from URL"
+                        data-tooltip="Open URL"
+                    >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path
+                                d="M10.4 13.6a4 4 0 0 0 5.66 0l2.12-2.12a4 4 0 0 0-5.66-5.66l-1.2 1.2"
+                            />
+                            <path
+                                d="M13.6 10.4a4 4 0 0 0-5.66 0l-2.12 2.12a4 4 0 0 0 5.66 5.66l1.2-1.2"
+                            />
+                        </svg>
+                    </button>
+                    <button
+                        class="primaryButton compactButton modelOnly"
+                        id="openFileButton"
+                        type="button"
+                    >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M12 16V4m0 0L7.5 8.5M12 4l4.5 4.5" />
+                            <path d="M5 14v4a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4" />
+                        </svg>
+                        Open model
+                    </button>
+                    <button
+                        class="iconButton modelOnly"
+                        id="toggleInspectorButton"
+                        type="button"
+                        aria-label="Show model information"
+                        aria-controls="inspectorPanel"
+                        aria-expanded="false"
+                        data-tooltip="Model info"
+                    >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <circle cx="12" cy="12" r="9" />
+                            <path d="M12 10.5V17m0-10v.2" />
+                        </svg>
+                    </button>
+                </div>
+            </header>
+
+            <section id="inputContainer" class="importer" aria-labelledby="importerTitle">
+                <div class="importerEyebrow">
+                    <span class="eyebrowLine"></span>
+                    Browser-based 3D inspection
+                </div>
+                <h1 id="importerTitle">Put your model<br /><span>in the spotlight.</span></h1>
+                <p class="importerIntro">
+                    Review glTF assets in a focused, physically based viewport powered by Hilo3D.
+                </p>
+
+                <div class="dropArea">
+                    <div class="dropIcon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <path d="m12 3 7 4v8l-7 4-7-4V7l7-4Z" />
+                            <path d="m5.4 7.2 6.6 3.9 6.6-3.9M12 11v8" />
+                        </svg>
+                    </div>
+                    <div class="dropCopy">
+                        <strong>Drop your model here</strong>
+                        <span class="info">glTF, GLB, or a complete asset folder</span>
+                    </div>
+                    <button class="primaryButton" id="uploadIcon" type="button">
+                        Browse files
+                    </button>
+                </div>
+
+                <div class="importDivider"><span>or load from the web</span></div>
+                <div class="linkInputArea">
+                    <label class="srOnly" for="linkInput">glTF model URL</label>
+                    <div class="urlField">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path
+                                d="M10.4 13.6a4 4 0 0 0 5.66 0l2.12-2.12a4 4 0 0 0-5.66-5.66l-1.2 1.2"
+                            />
+                            <path
+                                d="M13.6 10.4a4 4 0 0 0-5.66 0l-2.12 2.12a4 4 0 0 0 5.66 5.66l1.2-1.2"
+                            />
+                        </svg>
+                        <input
+                            id="linkInput"
+                            type="url"
+                            inputmode="url"
+                            placeholder="https://example.com/model.glb"
+                            autocomplete="url"
+                        />
+                        <button id="showLinkBtn" type="button" aria-label="Load model URL">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="m9 18 6-6-6-6" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+
+                <button class="sampleButton" id="loadSampleButton" type="button">
+                    <span class="samplePreview" aria-hidden="true">
+                        <svg viewBox="0 0 40 40">
+                            <path d="M20 7 31 13.5v13L20 33 9 26.5v-13L20 7Z" />
+                            <path d="m9.7 13.8 10.3 6 10.3-6M20 19.8V33" />
+                        </svg>
+                    </span>
+                    <span
+                        ><strong>No model handy?</strong> Explore the iridescent glass sample</span
+                    >
+                    <svg class="sampleArrow" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="m9 18 6-6-6-6" />
+                    </svg>
+                </button>
+            </section>
+
+            <div class="loadingOverlay" role="status" aria-live="polite">
+                <div class="loadingMark"><span></span><span></span><span></span></div>
+                <strong>Preparing your model</strong>
+                <span id="loadingSource">Loading geometry, materials, and textures…</span>
+            </div>
+
+            <div class="dropOverlay" aria-hidden="true">
+                <div class="dropOverlayCard">
+                    <svg viewBox="0 0 24 24">
+                        <path d="M12 16V4m0 0L7.5 8.5M12 4l4.5 4.5" />
+                        <path d="M5 14v4a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4" />
+                    </svg>
+                    <strong>Drop to replace model</strong>
+                    <span>All linked files will be resolved locally</span>
+                </div>
+            </div>
+
+            <aside id="inspectorPanel" class="inspectorPanel" aria-hidden="true">
+                <div class="inspectorHeader">
+                    <div>
+                        <span class="panelEyebrow">Workspace</span>
+                        <h2>Model inspector</h2>
+                    </div>
+                    <button
+                        class="iconButton"
+                        id="closeInspectorButton"
+                        type="button"
+                        aria-label="Close model information"
+                    >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="m7 7 10 10M17 7 7 17" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div class="inspectorTabs" role="tablist" aria-label="Inspector sections">
+                    <button
+                        id="sceneTab"
+                        type="button"
+                        role="tab"
+                        aria-selected="true"
+                        aria-controls="scenePanel"
+                        data-inspector-tab="scene"
+                    >
+                        Scene
+                    </button>
+                    <button
+                        id="materialTab"
+                        type="button"
+                        role="tab"
+                        aria-selected="false"
+                        aria-controls="materialPanel"
+                        data-inspector-tab="material"
+                    >
+                        Material
+                    </button>
+                    <button
+                        id="postTab"
+                        type="button"
+                        role="tab"
+                        aria-selected="false"
+                        aria-controls="postPanel"
+                        data-inspector-tab="post"
+                    >
+                        Post
+                    </button>
+                </div>
+
+                <div class="inspectorContent">
+                    <section id="scenePanel" role="tabpanel" aria-labelledby="sceneTab">
+                        <div class="modelCard">
+                            <div class="modelGlyph" aria-hidden="true">
+                                <svg viewBox="0 0 48 48">
+                                    <path d="M24 6 40 15v18l-16 9-16-9V15L24 6Z" />
+                                    <path d="m8.9 15.4 15.1 9 15.1-9M24 24.4V42" />
+                                </svg>
+                            </div>
+                            <div>
+                                <strong id="panelModelName">Untitled model</strong>
+                                <span id="sourceValue">Local asset</span>
+                            </div>
+                        </div>
+
+                        <div class="statGrid" aria-label="Model statistics">
+                            <div><strong id="meshCount">0</strong><span>Meshes</span></div>
+                            <div><strong id="materialCount">0</strong><span>Materials</span></div>
+                            <div><strong id="textureCount">0</strong><span>Textures</span></div>
+                            <div><strong id="animationCount">0</strong><span>Animations</span></div>
+                        </div>
+
+                        <section class="detailSection">
+                            <h3>Asset</h3>
+                            <dl>
+                                <div>
+                                    <dt>Version</dt>
+                                    <dd id="versionValue">glTF 2.0</dd>
+                                </div>
+                                <div>
+                                    <dt>Generator</dt>
+                                    <dd id="generatorValue">Unknown</dd>
+                                </div>
+                                <div>
+                                    <dt>Scenes</dt>
+                                    <dd id="sceneCount">0</dd>
+                                </div>
+                                <div>
+                                    <dt>Dimensions</dt>
+                                    <dd id="dimensionsValue">—</dd>
+                                </div>
+                            </dl>
+                        </section>
+
+                        <section class="detailSection cameraSection" id="cameraSection" hidden>
+                            <h3>Camera</h3>
+                            <label class="selectControl" for="cameraSelect">
+                                <span>Active camera</span>
+                                <span class="selectWrap">
+                                    <select id="cameraSelect"></select>
+                                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="m8 10 4 4 4-4" />
+                                    </svg>
+                                </span>
+                            </label>
+                            <p class="cameraHint" id="cameraHint">Interactive viewer camera</p>
+                        </section>
+
+                        <section class="detailSection extensionSection">
+                            <h3>Extensions</h3>
+                            <div class="extensionList" id="extensionList">
+                                <span class="emptyExtension">No extensions declared</span>
+                            </div>
+                        </section>
+
+                        <section class="detailSection controlSection">
+                            <h3>Navigation</h3>
+                            <div class="controlRows">
+                                <span><kbd>Drag</kbd> Orbit</span>
+                                <span><kbd>Scroll</kbd> Zoom</span>
+                                <span><kbd>Shift + drag</kbd> Pan</span>
+                            </div>
+                        </section>
+                    </section>
+
+                    <section
+                        id="materialPanel"
+                        role="tabpanel"
+                        aria-labelledby="materialTab"
+                        hidden
+                    >
+                        <div class="panelLead">
+                            <span class="panelEyebrow">Surface controls</span>
+                            <h3>Material properties</h3>
+                            <p>Factors multiply the asset textures and update live.</p>
+                        </div>
+
+                        <label class="selectControl" for="materialSelect">
+                            <span>Target material</span>
+                            <span class="selectWrap">
+                                <select id="materialSelect">
+                                    <option value="">No PBR materials</option>
+                                </select>
+                                <svg viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="m8 10 4 4 4-4" />
+                                </svg>
+                            </span>
+                        </label>
+
+                        <div class="materialSummary">
+                            <span id="materialModeBadge">Opaque</span>
+                            <span id="materialCountLabel">No material selected</span>
+                        </div>
+
+                        <div class="propertyGroup">
+                            <label class="colorControl" for="baseColorInput">
+                                <span>
+                                    <strong>Base color</strong>
+                                    <small>Texture tint</small>
+                                </span>
+                                <input id="baseColorInput" type="color" value="#ffffff" />
+                            </label>
+
+                            <label class="rangeControl" for="metallicInput">
+                                <span
+                                    ><strong>Metallic</strong
+                                    ><output id="metallicValue">1.00</output></span
+                                >
+                                <input
+                                    id="metallicInput"
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value="1"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="roughnessInput">
+                                <span
+                                    ><strong>Roughness</strong
+                                    ><output id="roughnessValue">1.00</output></span
+                                >
+                                <input
+                                    id="roughnessInput"
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value="1"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="normalScaleInput">
+                                <span
+                                    ><strong>Normal strength</strong
+                                    ><output id="normalScaleValue">1.00</output></span
+                                >
+                                <input
+                                    id="normalScaleInput"
+                                    type="range"
+                                    min="0"
+                                    max="2"
+                                    step="0.01"
+                                    value="1"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="opacityInput">
+                                <span
+                                    ><strong>Opacity</strong
+                                    ><output id="opacityValue">1.00</output></span
+                                >
+                                <input
+                                    id="opacityInput"
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value="1"
+                                />
+                                <small id="opacityHint">Available for alpha-blend materials.</small>
+                            </label>
+
+                            <label class="rangeControl" for="transmissionInput">
+                                <span
+                                    ><strong>Transmission</strong
+                                    ><output id="transmissionValue">0.00</output></span
+                                >
+                                <input
+                                    id="transmissionInput"
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value="0"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="iridescenceInput">
+                                <span
+                                    ><strong>Iridescence</strong
+                                    ><output id="iridescenceValue">0.00</output></span
+                                >
+                                <input
+                                    id="iridescenceInput"
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value="0"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="iorInput">
+                                <span
+                                    ><strong>Index of refraction</strong
+                                    ><output id="iorValue">1.50</output></span
+                                >
+                                <input
+                                    id="iorInput"
+                                    type="range"
+                                    min="1"
+                                    max="2.5"
+                                    step="0.01"
+                                    value="1.5"
+                                />
+                            </label>
+                        </div>
+
+                        <button class="panelResetButton" id="resetMaterialButton" type="button">
+                            Reset material values
+                        </button>
+                    </section>
+
+                    <section id="postPanel" role="tabpanel" aria-labelledby="postTab" hidden>
+                        <div class="panelLead">
+                            <span class="panelEyebrow">Display pipeline</span>
+                            <h3>Post processing</h3>
+                            <p>HDR grading runs after transparent and transmission rendering.</p>
+                        </div>
+
+                        <div class="lookPresets" role="group" aria-label="Color look preset">
+                            <button type="button" data-look-preset="neutral" aria-pressed="true">
+                                Neutral
+                            </button>
+                            <button type="button" data-look-preset="studio" aria-pressed="false">
+                                Studio
+                            </button>
+                            <button type="button" data-look-preset="cinematic" aria-pressed="false">
+                                Film
+                            </button>
+                        </div>
+
+                        <div class="featureStatus" id="bloomFeatureStatus" data-enabled="true">
+                            <span class="featureIcon" aria-hidden="true">✦</span>
+                            <span
+                                ><strong>HDR bloom</strong><small>Soft-knee · 6 levels</small></span
+                            >
+                            <label class="featureSwitch" for="bloomEnabledInput">
+                                <input
+                                    id="bloomEnabledInput"
+                                    type="checkbox"
+                                    aria-label="Enable HDR bloom"
+                                    checked
+                                />
+                                <span class="switchTrack" aria-hidden="true"></span>
+                                <span id="bloomStateLabel">On</span>
+                            </label>
+                        </div>
+
+                        <div class="propertyGroup">
+                            <label class="selectControl" for="toneMappingSelect">
+                                <span>Tone mapping</span>
+                                <span class="selectWrap">
+                                    <select id="toneMappingSelect">
+                                        <option value="pbr-neutral">PBR Neutral</option>
+                                        <option value="aces">ACES</option>
+                                        <option value="reinhard">Reinhard</option>
+                                        <option value="none">None</option>
+                                    </select>
+                                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="m8 10 4 4 4-4" />
+                                    </svg>
+                                </span>
+                            </label>
+
+                            <label class="rangeControl" for="exposureInput">
+                                <span
+                                    ><strong>Exposure</strong
+                                    ><output id="exposureValue">-0.30 EV</output></span
+                                >
+                                <input
+                                    id="exposureInput"
+                                    type="range"
+                                    min="-2"
+                                    max="2"
+                                    step="0.01"
+                                    value="-0.3"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="contrastInput">
+                                <span
+                                    ><strong>Contrast</strong
+                                    ><output id="contrastValue">+0.04</output></span
+                                >
+                                <input
+                                    id="contrastInput"
+                                    type="range"
+                                    min="-0.5"
+                                    max="0.5"
+                                    step="0.01"
+                                    value="0.04"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="saturationInput">
+                                <span
+                                    ><strong>Saturation</strong
+                                    ><output id="saturationValue">0.00</output></span
+                                >
+                                <input
+                                    id="saturationInput"
+                                    type="range"
+                                    min="-1"
+                                    max="1"
+                                    step="0.01"
+                                    value="0"
+                                />
+                            </label>
+
+                            <label class="rangeControl" for="vignetteInput">
+                                <span
+                                    ><strong>Vignette</strong
+                                    ><output id="vignetteValue">0.12</output></span
+                                >
+                                <input
+                                    id="vignetteInput"
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    value="0.12"
+                                />
+                            </label>
+                        </div>
+
+                        <button class="panelResetButton" id="resetPostButton" type="button">
+                            Reset post processing
+                        </button>
+                    </section>
+                </div>
+            </aside>
+
+            <div class="viewportStatus modelOnly" aria-live="polite">
+                <span class="statusDot"></span>
+                <span id="viewportStatusText">Model ready</span>
+            </div>
+
+            <nav class="viewportToolbar modelOnly" aria-label="Viewport controls">
+                <button
+                    class="toolButton"
+                    id="zoomOutButton"
+                    type="button"
+                    aria-label="Zoom out"
+                    data-tooltip="Zoom out"
+                >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <circle cx="10.5" cy="10.5" r="6.5" />
+                        <path d="M6.5 10.5h8M15.5 15.5 20 20" />
+                    </svg>
+                </button>
+                <button
+                    class="toolButton"
+                    id="resetViewButton"
+                    type="button"
+                    aria-label="Reset view"
+                    data-tooltip="Reset view"
+                >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M4 12a8 8 0 1 0 2.3-5.65L4 8.65" />
+                        <path d="M4 4v4.65h4.65" />
+                    </svg>
+                </button>
+                <button
+                    class="toolButton"
+                    id="zoomInButton"
+                    type="button"
+                    aria-label="Zoom in"
+                    data-tooltip="Zoom in"
+                >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <circle cx="10.5" cy="10.5" r="6.5" />
+                        <path d="M6.5 10.5h8m-4-4v8M15.5 15.5 20 20" />
+                    </svg>
+                </button>
+                <span class="toolbarDivider"></span>
+                <button
+                    class="toolButton"
+                    id="fullscreenButton"
+                    type="button"
+                    aria-label="Enter fullscreen"
+                    data-tooltip="Fullscreen"
+                >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M8.5 4H4v4.5M15.5 4H20v4.5M20 15.5V20h-4.5M4 15.5V20h4.5" />
+                    </svg>
+                </button>
+            </nav>
+        </main>
+
+        <dialog id="sourceDialog" class="sourceDialog" aria-labelledby="sourceDialogTitle">
+            <div class="dialogHeader">
+                <div>
+                    <span class="panelEyebrow">Remote asset</span>
+                    <h2 id="sourceDialogTitle">Open model URL</h2>
+                </div>
+                <button
+                    class="iconButton"
+                    id="closeSourceDialogButton"
+                    type="button"
+                    aria-label="Close dialog"
+                >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="m7 7 10 10M17 7 7 17" />
+                    </svg>
+                </button>
+            </div>
+            <p>
+                Paste a public URL to a .gltf or .glb file. Cross-origin assets must allow access.
+            </p>
+            <label for="dialogLinkInput">Model URL</label>
+            <input
+                id="dialogLinkInput"
+                type="url"
+                inputmode="url"
+                placeholder="https://example.com/model.glb"
+                autocomplete="url"
+            />
+            <div class="dialogActions">
+                <button class="secondaryButton" id="cancelSourceDialogButton" type="button">
+                    Cancel
+                </button>
+                <button class="primaryButton" id="dialogShowLinkBtn" type="button">
+                    Open model
+                </button>
+            </div>
+        </dialog>
+
         <script type="module" src="./app/index.ts"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary

- redesign the glTF Viewer with a low-chrome, Sketchfab-inspired responsive interface
- add per-material PBR editing for base color, metallic, roughness, normal strength, opacity, transmission, iridescence, and IOR
- add conditional camera selection between the interactive viewer camera and cameras authored in the glTF asset
- add HDR bloom, live bloom enable/disable, tone mapping, exposure, contrast, saturation, vignette, and display presets
- make the iridescent dish asset the built-in viewer sample

## Why

The previous viewer did not provide an inspection workflow for materials, cameras, or post-processing. It also rendered physical transmission without an opaque scene-color texture, so assets using `KHR_materials_transmission` and `KHR_materials_volume` could appear white or otherwise incorrect.

The updated forward pipeline keeps an HDR scene color target, captures opaque scene color for transmission, and applies bloom plus a graph-native display transform after transparent rendering.

## User impact

Users can inspect a model without leaving the viewport, edit one material at a time, select authored cameras when present, and compare post-processing settings live. Models without glTF cameras do not show the camera card.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:ui:contract` (12 tests)
- `npx vitest run test/spec/renderer/PostProcessing.test.ts test/spec/renderer/PostProcessRenderer.test.ts` (13 tests)
- `npm run test:render:architecture` (135 tests)
- `npm run examples:build`
- manually verified `IridescentDishWithOlives.glb` on WebGL2 and WebGPU with no browser errors
- manually verified single-material selection, authored/default camera switching, hidden camera UI for camera-less assets, and the bloom toggle

Full `npm run validate` and physical native-GPU coverage were not run.