### PR TITLE
feat: add motion vectors and temporal AA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
   1,920 bytes, WebGPU material textures begin at binding 2, and custom uniform block registrations
   begin after ten built-in WebGL2 binding points.
 - Expand the fixed Camera/Model/Skinning/Morph/Instance std140 ABI with current/previous transforms,
-  render origins, and history/depth flags. Custom shaders that redeclare built-in blocks must use
-  the updated field order and capacities.
+  stable and jittered camera projections, render origins, and per-domain history/depth flags. Custom
+  shaders that redeclare built-in blocks must use the updated field order and capacities.
 - Make forward feature color encoding explicit. `replaceColor()` now requires `linear` or `srgb`,
   and the default Forward pipeline always routes surface presentation through the Render Graph so
   the final output transfer is owned by the output stage rather than individual materials.
@@ -24,6 +24,15 @@
   sRGB transfer, while display-transformed `srgb` inputs are preserved without a second conversion.
 
 ### Changes
+
+- Add the native-resolution `TemporalAA` Forward feature. Built-in opaque/masked materials now
+  expose a strict single-sample `rg16float` motion-vector pass using submission-aware
+  current/previous camera, model, instance, skin, and morph state. TAA runs after opaque and before
+  transparent/Bloom, with `rgba16float` double-buffer color history, depth history, reprojection,
+  disocclusion, neighborhood clamp, camera-cut/resize/device-loss invalidation, and failed-frame
+  rollback. Add stable CPU projection matrices beside raster jitter and portable non-filtering depth
+  sampling for fullscreen passes. TAAU, dynamic resolution, reactive masks, and transparent history
+  remain deferred.
 
 - Add canonical built-in material definitions, stable material IDs and revisions, explicit
   forward/depth-only/shadow-caster/picking roles, role-aware shader variants, per-slot texture/UV
@@ -303,9 +312,10 @@
 - Expose the built-in forward culling results to features, reject feature runtimes shared across
   Renderers, and preserve selected RenderTarget color/depth/stencil clear/load/store operations
   across feature-enabled scene, intermediate-color, and output passes.
-- Reject pre-opaque scene-color sampling and keep the built-in forward feature's `sampledDepth`
-  option fail-closed; a custom SRP can explicitly compose depth prepass, compute culling, and a
-  storage-aware Scene pass for Forward+.
+- Reject pre-opaque scene-color sampling and support built-in Forward `sampledDepth` through
+  single-sample sampleable depth plus portable non-filtering fullscreen bindings. A custom SRP can
+  still explicitly compose depth prepass, compute culling, and a storage-aware Scene pass for
+  Forward+.
 - Add backend-neutral `Renderer.waitForIdle()` for application completion fences. Native WebGL 2 or
   WebGPU interoperability is opt-in through `Renderer.getExtension()` instead of public `gl` or
   `gpuDevice` fields.

--- a/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
+++ b/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
@@ -1,6 +1,6 @@
 # Hilo3D 材质系统现代化架构
 
-> 状态：当前架构文档，更新于 2026-08-09。本文描述已经进入生产路径的材质合同、明确的 breaking
+> 状态：当前架构文档，更新于 2026-08-10。本文描述已经进入生产路径的材质合同、明确的 breaking
 > changes，以及后续演进边界。源码、测试与 [`RENDERING_ARCHITECTURE.md`](./RENDERING_ARCHITECTURE.md)
 > 共同构成事实来源。
 
@@ -121,15 +121,15 @@ const material = new Hilo3d.ShaderMaterial({
 
 Pipeline 通过 role 请求材质，而不是读取 `material.passes[]` 并让材质控制执行顺序。
 
-| Role                  | 当前内置支持               | 合同                                                  |
-| --------------------- | -------------------------- | ----------------------------------------------------- |
-| `forward`             | 是                         | 普通 surface/unlit color 输出                         |
-| `depth-only`          | 是                         | 复用 deformation 与 coverage，无 color attachment     |
-| `shadow-caster`       | 是                         | 复用 deformation、coverage、cull 和 alpha cutoff      |
-| `picking`             | 是                         | 复用 geometry/coverage，输出稳定对象 ID               |
-| `motion-vector`       | 保留类型，未由内置材质声明 | 后续 TAA/TAAU 工作包实现 current/previous deformation |
-| `material-attributes` | 保留类型，未由内置材质声明 | 后续 GTAO/SSR/SSGI 工作包定义输出 ABI                 |
-| `user:*`              | 自定义 Definition 可声明   | 只有自定义 Pipeline 显式请求才运行                    |
+| Role                  | 当前内置支持 | 合同                                                                      |
+| --------------------- | ------------ | ------------------------------------------------------------------------- |
+| `forward`             | 是           | 普通 surface/unlit color 输出                                             |
+| `depth-only`          | 是           | 复用 deformation 与 coverage，无 color attachment                         |
+| `shadow-caster`       | 是           | 复用 deformation、coverage、cull 和 alpha cutoff                          |
+| `picking`             | 是           | 复用 geometry/coverage，输出稳定对象 ID                                   |
+| `motion-vector`       | 是           | opaque/masked 输出 single-sample `rg16float` current-to-previous velocity |
+| `material-attributes` | 保留类型     | 后续 GTAO/SSR/SSGI 工作包定义输出 ABI                                     |
+| `user:*`              | 自定义       | 只有自定义 Pipeline 显式请求才运行                                        |
 
 [`MaterialCompiler.ts`](../src/material/MaterialCompiler.ts) 负责 role 解析、target
 contract 验证和稳定 variant key。fallback 只有三种：
@@ -253,13 +253,13 @@ default 对象而发生串改。
 | 工作包                       | 状态          | 当前结果 / 下一步                                                               |
 | ---------------------------- | ------------- | ------------------------------------------------------------------------------- |
 | Definition / Instance        | 已完成        | 内置与自定义材质都使用不可变结构和实例数据                                      |
-| Semantic pass                | 已完成基础    | forward/depth/shadow/picking 已接生产路径；motion/attributes 待对应渲染功能实现 |
+| Semantic pass                | 已完成基础    | forward/depth/shadow/picking/motion 已接生产路径；attributes 待对应渲染功能实现 |
 | Texture slot                 | 已完成        | 每槽 UV/transform/encoding/channel，glTF extensions 共用 builder                |
 | Typed semantics              | 已完成        | attribute/uniform/texture/slot 常量与联合类型公开                               |
 | UBO lowering                 | 已完成        | scalar 与 slot block 分离，双后端固定 ABI                                       |
 | Shared GPU Material Database | 已完成（PBR） | 私有 PBR table 已抽取、共享、去重，并具备 dirty upload、提交回滚与 recovery     |
 | Variant manifest / warmup    | 未完成        | 增加资产收集、异步 warmup、预算与诊断                                           |
-| Motion vectors               | 未完成        | 定义 previous skin/morph/coverage 输出并接 TAA/TAAU                             |
+| Motion vectors               | 已完成首版    | opaque/masked、skin/morph/instance history 与原生分辨率 TAA；透明/TAAU 后续     |
 | Material attributes          | 未完成        | 定义 compact normal/roughness/flags ABI，按 feature 创建附件                    |
 | Advanced surface families    | 后续          | sheen/specular/dispersion、subsurface、hair 等按真实内容和预算推进              |
 

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -12,7 +12,7 @@ RHI、WebGPU/WebGL 2 双后端、Compute/Storage/Indirect
 Draw、HDR/PBR、设备丢失恢复和严格的帧事务都已经存在。当前主要缺口不在“能不能向 WebGPU 发命令”，而在以下六个生产级系统：
 
 1. **材质系统后续层**：`MaterialDefinition`/`MaterialInstance`、forward/depth/shadow/picking 语义 Pass、共享 surface/BRDF，以及 renderer-local、按 identity 去重且 submission-aware 的 PBR
-   GPU Material Database 已落地；motion/attributes role、更多 surface family、variant
+   GPU Material Database 与内置 motion role 已落地；attributes role、更多 surface family、variant
    manifest/warmup 与跨 shadow/时域消费者仍待完成。详见
    [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 2. **GPU Scene 与 GPU 可见性**：high-end profile 已让注册的普通不透明 `Mesh` 进入常驻 GPU
@@ -21,17 +21,16 @@ Draw、HDR/PBR、设备丢失恢复和严格的帧事务都已经存在。当前
 3. **生产级 Clustered Forward+**：high-end profile 已提供 depth-driven 3D cluster、GPU
    count/prefix/write allocator、有界 overflow 与 storage-aware GGX
    PBR；完整材质层、阴影、cookie/IES、精确 area-light 和透明路径仍需接入。
-4. **时域渲染框架**：已有 recovery-aware history owner、current/previous transform
-   ABI 与显式 invalidation，但仍没有 motion vector、projection
-   jitter、TAA/TAAU、动态分辨率和 reactive mask。
+4. **时域渲染框架**：recovery-aware history owner、current/previous transform、projection
+   jitter、opaque/masked motion vector 与原生分辨率 TAA 已落地；TAAU、动态分辨率、reactive
+   mask 和透明时域策略仍未完成。
 5. **自动曝光与可控显示变换**：已有手动 EV exposure、PBR Neutral、ACES fitted、Reinhard 和 Color
    Uber，但没有 GPU 亮度统计、eye adaptation、exposure history 或参数化 filmic toe/shoulder。
 6. **现代资源与几何虚拟化**：已有 mip/array/aspect subresource graph view，但仍没有 GPU
    meshlet/LOD、纹理流送、KTX 2/Basis、虚拟纹理或虚拟阴影页系统。
 
-最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 MAT0 前端与共享 PBR
-record 基础上推进 T0 原生分辨率 motion
-vector/TAA，同时继续完成 G0/L0 的剩余门禁。E0 是可独立交付的显示质量切片，可以复用已经完成的 F0/F1，但不能抢占或阻塞这些主线：
+最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 MAT0 与 T0 原生分辨率切片上推进 TAAU/reactive
+mask，同时继续完成 G0/L0 的剩余门禁。E0 是可独立交付的显示质量切片，可以复用已经完成的 F0/F1，但不能抢占或阻塞这些主线：
 
 ```mermaid
 flowchart LR
@@ -96,21 +95,21 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 
 ## 2. 当前渲染能力基线
 
-| 领域                                 | 当前状态      | 证据与边界                                                                                                  |
-| ------------------------------------ | ------------- | ----------------------------------------------------------------------------------------------------------- |
-| Shared Renderer / Render Graph / RHI | 生产可用      | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                   |
-| Raster PBR / HDR                     | 生产可用      | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径        |
-| Shadow                               | 可用基线      | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow 和 PCF；缺少缓存、receiver-driven 分配和虚拟页             |
-| Compute / Storage / Indirect         | 底座生产可用  | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环   |
-| Material architecture                | 生产基础      | Definition/Instance、基础语义 Pass 与共享 PBR GPU record 已落地；motion/attributes、更多 family/warmup 待补 |
-| GPU-driven ordinary scene            | high-end 切片 | 注册的不透明 indexed `Mesh` 走 dirty GPU database、Hi-Z/LOD/compact 与固定 bucket indirect；透明/变形待补   |
-| Forward+                             | high-end 切片 | 3D cluster count/prefix/write、有界预算和 storage GGX PBR 已闭环；阴影/完整 layered PBR/透明待补            |
-| Temporal rendering                   | 部分基础      | current/previous transform ABI 已完成；仍无 jitter、motion vector pass、temporal resolve 或 TAAU            |
-| Exposure / display transform         | 部分可用      | 有手动 EV、固定 tone mapper 与 Color Uber；无亮度统计、eye adaptation、exposure history 或 filmic 曲线控制  |
-| Screen-space lighting                | 缺失          | 无 depth pyramid、normal/roughness attribute buffer、GTAO、SSR、SSGI                                        |
-| Volumetrics / atmosphere             | 缺失          | 无 froxel volume、temporal reprojection、physical sky 或 volumetric cloud                                   |
-| Geometry / texture streaming         | 缺失          | 无 GPU LOD/meshlet/cluster streaming；KTX loader 仅支持 KTX 1.1 2D 容器                                     |
-| GPU profiling / graph debugging      | 生产基线      | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 时不创建 query     |
+| 领域                                 | 当前状态      | 证据与边界                                                                                                                        |
+| ------------------------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Shared Renderer / Render Graph / RHI | 生产可用      | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                         |
+| Raster PBR / HDR                     | 生产可用      | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                              |
+| Shadow                               | 可用基线      | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow 和 PCF；缺少缓存、receiver-driven 分配和虚拟页                                   |
+| Compute / Storage / Indirect         | 底座生产可用  | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                         |
+| Material architecture                | 生产基础      | Definition/Instance、基础语义 Pass 与共享 PBR GPU record 已落地；motion/attributes、更多 family/warmup 待补                       |
+| GPU-driven ordinary scene            | high-end 切片 | 注册的不透明 indexed `Mesh` 走 dirty GPU database、Hi-Z/LOD/compact 与固定 bucket indirect；透明/变形待补                         |
+| Forward+                             | high-end 切片 | 3D cluster count/prefix/write、有界预算和 storage GGX PBR 已闭环；阴影/完整 layered PBR/透明待补                                  |
+| Temporal rendering                   | 原生 TAA 切片 | jitter/non-jitter matrix、opaque/masked velocity、depth rejection、双缓冲 history 与 invalidation 已完成；TAAU/reactive mask 待补 |
+| Exposure / display transform         | 部分可用      | 有手动 EV、固定 tone mapper 与 Color Uber；无亮度统计、eye adaptation、exposure history 或 filmic 曲线控制                        |
+| Screen-space lighting                | 缺失          | 无 depth pyramid、normal/roughness attribute buffer、GTAO、SSR、SSGI                                                              |
+| Volumetrics / atmosphere             | 缺失          | 无 froxel volume、temporal reprojection、physical sky 或 volumetric cloud                                                         |
+| Geometry / texture streaming         | 缺失          | 无 GPU LOD/meshlet/cluster streaming；KTX loader 仅支持 KTX 1.1 2D 容器                                                           |
+| GPU profiling / graph debugging      | 生产基线      | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 时不创建 query                           |
 
 ### 2.1 现有实现中最关键的限制
 
@@ -130,11 +129,12 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
   `subgroup-size-control` feature，因此只记录 adapter 的 subgroup min/max，不虚构非标准 gate。
 - Render Graph 每帧 Build/Compile，已有 pass culling 和跨帧 transient pool，但没有 compiled graph
   reuse 或同帧物理 alias。
-- Camera/mesh current/previous transform 与 history-valid ABI 已完成；仍缺 projection
-  jitter、motion-vector material pass、temporal resolve 和 TAAU policy。
-- 当前 turnkey post-processing 只有 Bloom 与 Color Uber；exposure 是手动 EV compensation，固定 tone
-  mapper 没有参数化 filmic toe/shoulder，也没有 histogram、eye adaptation 或 GPU exposure
-  history。Opaque scene texture 只能支持最低边界的屏幕空间 transmission。
+- Camera/mesh/instance/skin/morph current/previous transform、history-valid ABI、projection
+  jitter、motion-vector material pass 与原生分辨率 temporal
+  resolve 已完成；仍缺 TAAU、动态分辨率和 reactive mask policy。
+- 当前 turnkey post-processing 提供可选 TemporalAA、Bloom 与 Color Uber；exposure 是手动 EV
+  compensation，固定 tone mapper 没有参数化 filmic toe/shoulder，也没有 histogram、eye
+  adaptation 或 GPU exposure history。Opaque scene texture 只能支持最低边界的屏幕空间 transmission。
 - RHI 已有 timestamp QuerySet、pass timestamp、debug group/marker 和 Render Graph
   timeline；occlusion query 仍不在当前合同内。
 - KTX loader 明确只解析 KTX 1.1、单 face 2D；没有 KTX 2、Basis Universal transcode、mip
@@ -442,6 +442,13 @@ light、transmission 和 device recovery 有真实 WebGPU 像素证据；overflo
 | 输入                                     | 核心处理                                                  | 输出                           | 首要验收                                  |
 | ---------------------------------------- | --------------------------------------------------------- | ------------------------------ | ----------------------------------------- |
 | 低分辨率当前帧、velocity、depth、history | reprojection、disocclusion、clamp、reactive mask、upscale | 稳定高分辨率画面与分辨率控制器 | camera cut 无旧帧闪回，运动物体不持续拖影 |
+
+当前已交付 T0 的原生分辨率首切片：内置 opaque/masked Basic/PBR/Geometry 输出 single-sample
+`rg16float` velocity；Camera 同时保留 jittered raster 与 non-jittered CPU projection； `TemporalAA`
+在 opaque 后、transparent/Bloom 前使用 `rgba16float` color history、`r16float` depth
+history、reprojection、depth disocclusion 和 3×3 neighborhood clamp。首次出现、camera
+cut、resize、失败帧和 device recovery 均进入提交事务与 history
+invalidation 验收。transparent、TAAU、动态分辨率和 reactive mask 保留到后续切片。
 
 - opaque/alpha-tested geometry 输出 motion vector；skinning/morph 必须有 previous pose；
 - camera jitter 不污染 CPU picking/frustum；提供 jittered 与 non-jittered matrix；

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -98,6 +98,20 @@ ray；volume 根据折射方向修正光程，再用 Beer-Lambert attenuation �
 
 这些限制是显式的最低实现边界，不会通过 backend 私有 framebuffer 抓取绕过 Render Graph。
 
+## 内置 TemporalAA
+
+`TemporalAA` 是可选的 `after-opaque` feature。它先用内置材质的 `motion-vector` semantic
+pass 把 opaque/masked velocity 写入 single-sample `rg16float`，再用当前 sampled depth、上一帧
+`rgba16float` color history 与 `r16float` depth history 做原生分辨率 reprojection、depth
+disocclusion 和 3×3 neighborhood clamp。history 双缓冲只在有效 submission 后轮换；camera
+cut、resize、显式 transform invalidation 和 device
+recovery 会让下一帧重新初始化，失败帧保留上一份已提交 history 和 jitter index。
+
+Camera 同时维护 jittered raster projection 与 non-jittered CPU
+projection；frustum、picking、project/unproject 不读取 jitter。TAA
+resolve 只处理 opaque 结果，transparent/transmission 在它之后合成，Bloom 再消费完整线性 HDR 颜色。TAAU、动态分辨率和 reactive
+mask 不属于当前首版。
+
 ## 内置 Bloom
 
 `Bloom` 是 `after-transparent` forward feature，在线性 `rgba16float` scene color 上执行：
@@ -151,6 +165,7 @@ const stage = await Hilo3d.Stage.create({
     camera,
     container,
     renderPipeline: new Hilo3d.PostProcessRenderPipelineFactory({
+        temporalAA: {},
         bloom: {
             threshold: 1,
             knee: 0.5,
@@ -168,8 +183,10 @@ const stage = await Hilo3d.Stage.create({
 ```
 
 该 factory 固定 attachment-zero scene color 为 `rgba16float`，默认启用 Bloom、Color Uber 和 opaque
-texture。需要自行组合时，也可以把 `Bloom`/`ColorUber` 作为 `ForwardRenderPipelineFactory.features`
-使用；调用方必须保证 Bloom 输入仍是线性 HDR 格式，并让 Color Uber 位于所有 HDR effect 之后。
+texture；`temporalAA` 需要显式提供配置启用。需要自行组合时，也可以把
+`TemporalAA`/`Bloom`/`ColorUber` 作为 `ForwardRenderPipelineFactory.features`
+使用；调用方必须保证 TemporalAA 位于 opaque 后和 transparent 前、Bloom 输入仍是线性 HDR 格式，并让 Color
+Uber 位于所有 HDR effect 之后。
 
 三个示例覆盖基础参数矩阵、直接 layered material API 和真实 glTF 资产路径：
 
@@ -193,7 +210,7 @@ reference，不替代应用在生产中提供经过正式卷积的 HDR IBL。
 
 ## 验证要求
 
-改动 PBR、Bloom、Color Uber 或 scene texture ABI 时至少需要：
+改动 PBR、TemporalAA、Bloom、Color Uber 或 scene texture ABI 时至少需要：
 
 - WebGL 2 GLSL compile/link；
 - Naga GLSL -> WGSL 转换；

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -99,10 +99,12 @@ texture/UV/transform/encoding/channel、stable material
 ID 和数据 revision。参数变化不改变 Definition 或 Shader resource
 layout，需要改变 topology 时构造另一个材质实例。
 
-Render Pipeline 请求 `forward`、`depth-only`、`shadow-caster` 或 `picking` role，材质不拥有 graph
-pass 顺序。Shadow Atlas 直接编译 `shadow-caster`，不创建 proxy material；role 缺失或 target
-output 不匹配会在 RHI frame 前失败。`motion-vector` 与 `material-attributes`
-已保留类型，但当前内置材质不声明，由后续时域和属性缓冲路线定义完整输出 ABI 后接入。
+Render Pipeline 请求 `forward`、`depth-only`、`shadow-caster`、`motion-vector` 或 `picking`
+role，材质不拥有 graph pass 顺序。Shadow Atlas 直接编译 `shadow-caster`，不创建 proxy
+material；role 缺失或 target output 不匹配会在 RHI frame 前失败。内置 Basic/PBR/Geometry 的
+`motion-vector` pass 只接受 single-sample `rg16float` target，复用 current/previous
+camera、model、instance、skin、morph 与 coverage ABI；首次出现或任一 transform
+history 失效时写零。`material-attributes` 仍保留给后续属性缓冲路线。
 
 portable material UBO 分为 432-byte `MaterialBlock` 与 1,920-byte
 `MaterialTextureBlock`，二者按最终 std140 bytes 独立更新。WebGPU material group 的 binding
@@ -173,7 +175,10 @@ transfer。
 
 内置 HDR 组合由 `PostProcessRenderPipelineFactory` 提供：attachment-zero scene color 使用
 `rgba16float`，opaque queue 完成后由 graph `TextureCopyPass` 捕获 opaque scene
-texture，再把该 texture 作为 pass-global binding 交给 transparent PBR transmission/volume draw。随后
+texture，再把该 texture 作为 pass-global binding 交给 transparent PBR transmission/volume draw。可选
+`TemporalAA` 在 opaque 后记录 `rg16float` velocity，并用 sampled depth、`rgba16float` 双缓冲 color
+history 和 `r16float` 双缓冲 depth history 完成原生分辨率 reprojection、disocclusion 与 neighborhood
+clamp。resolved opaque color 随后才接受 transparent composition，因此透明不写入 TAA history。之后
 `Bloom` 在 tone mapping 前记录 soft-knee/Karis prefilter、13-tap downsample pyramid、tent
 upsample 与线性 composite；`ColorUber` 最后统一完成 grading、tone
 mapping、linear-to-sRGB 与 dithering，并把输出编码标记为 `srgb`，避免 surface output
@@ -187,10 +192,9 @@ Pass；中间队列 Pass 强制 store/load 以保持内容。当 filterable samp
 color 需要中间纹理且 output 选择 `load`
 时，先把旧 output 搬入中间纹理；若中间 color 无法无损搬运 multisample/non-filterable 内容，则在 RHI
 frame 开始前明确失败。scene color sampling 只允许在 opaque writer 之后。内置
-`ForwardRenderPipelineFeature.requirements.sampledDepth`
-仍保持 fail-closed；需要完整 Forward+ 深度预处理/采样链路时，应使用自定义 `RenderPipeline`
-显式记录 depth Scene Pass、compute Pass 与最终 storage-aware Scene
-Pass，而不是假定内置 feature 已经自动改写 forward shader。
+`ForwardRenderPipelineFeature.requirements.sampledDepth` 会创建 single-sample、sampleable
+depth；公共 fullscreen ABI 对普通 depth `sampler2D` 自动选择 non-filtering sampler，并在 WebGPU
+lowering 中专门化为 numeric depth texture。comparison sampling 仍要求显式 comparison 合同。
 
 WebGPU high-end profile 现在提供公开的
 `ClusteredForwardPlusPipelineFactory`。应用注册稳定的 geometry/material/LOD
@@ -724,8 +728,9 @@ Renderer 的组合式 Pass，使未来加入新的图优化、调试可视化或
   instancing 的后续优化不能改变这个确定性正确性合同。
 - 自定义 SRP 可以直接使用 `ClusteredForwardPlusPipelineFactory` 获得已注册 opaque PBR bucket 的 GPU
   Scene、Hi-Z、3D cluster allocator 和共享 surface/BRDF 的 storage PBR；常用 metallic/roughness
-  PBR 贴图已原生进入 GPU path，clustered variant 只替换 light iteration。内置 Forward feature 的
-  `sampledDepth: true` 仍关闭，也不会把任意 layered/transparent material 自动改写为 clustered
+  PBR 贴图已原生进入 GPU path，clustered variant 只替换 light iteration。内置 Forward
+  feature 已支持 portable sampled depth，但不会把任意 layered/transparent
+  material 自动改写为 clustered
   variant。未注册、runtime-incompatible、deformed、transparent 或超过 GPU
   Scene 容量的 mesh 使用共享 Forward compatibility path；renderer list 的 identity
   exclusion 保证 GPU-managed mesh 不会被重复绘制。

--- a/documentation/SCRIPTABLE_RENDER_PIPELINE_PLAN.md
+++ b/documentation/SCRIPTABLE_RENDER_PIPELINE_PLAN.md
@@ -782,8 +782,9 @@ export interface ForwardRenderFeatureContext {
   policy。
 - `sampledSceneColor` 只允许 `after-opaque` 及更晚的 injection point，避免 feature 在 scene
   writer 之前读取未初始化资源。
-- `sampledDepth` 当前保持 fail-closed；公共 fullscreen binding ABI 尚未完成 non-filtering depth
-  sampling 的双后端垂直实现，声明 `true` 会在 factory 构造时明确失败。
+- `sampledDepth` 会让 Forward depth attachment 保持 single-sample/sampleable；fullscreen 普通 depth
+  `sampler2D` 使用 non-filtering sampler，并在 WebGPU artifact 中专门化为 numeric depth
+  texture。comparison sampler 仍需独立显式合同。
 - feature 未产生 terminal output 时，由默认 pipeline 继续写入原 output；重复 terminal
   writer 或悬空 output 由 graph validation 拒绝。
 - 动态禁用 feature 时其 pass 可被 graph culling 删除；feature set 和 attachment
@@ -1460,8 +1461,8 @@ GLSL 转换”和“先公开部分 storage binding”的实施顺序；本节�
    dispatch/draw、graph hazard、readback、device-loss recovery、真实 WebGPU 和负向 WebGL 2
    policy 原子开放。
 9. 首发 graph compute texture 只表达完整 2D subresource，storage texture 仅 transient
-   write-only；跨帧 state 使用 renderer-owned `StorageBuffer`。内置 Forward feature 的
-   `sampledDepth` 仍关闭，但完整自定义 SRP 可显式组合 depth prepass、compute 与 Scene group-3
+   write-only；跨帧 state 使用 renderer-owned `StorageBuffer`。内置 Forward feature 已支持 portable
+   non-filtering depth sampling；完整自定义 SRP 仍可显式组合 depth prepass、compute 与 Scene group-3
    storage。
 
 这样扩展不会重写 SRP：factory requirements、renderer-local runtime、同步 record、graph

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -600,6 +600,7 @@ export class Camera extends Node_2 {
     className: string;
     clearColor: boolean;
     clearDepth: boolean;
+    clearProjectionJitter(): this;
     clearStencil: boolean;
     get depthMode(): CameraDepthMode;
     set depthMode(value: CameraDepthMode);
@@ -621,22 +622,26 @@ export class Camera extends Node_2 {
     // (undocumented)
     isPerspectiveCamera: boolean;
     isPointVisible(point: Vector3): boolean;
+    readonly jitteredProjectionMatrix: Matrix4;
+    readonly jitteredViewProjectionMatrix: Matrix4;
     protected _needUpdateProjectionMatrix: boolean;
     get priority(): number;
     set priority(value: number);
-    // (undocumented)
+    get projectionJitterX(): number;
+    get projectionJitterY(): number;
     readonly projectionMatrix: Matrix4;
     projectVector(vector: Vector3, width?: number, height?: number): Vector3;
+    setProjectionJitter(x: number, y: number): this;
     // (undocumented)
     static readonly typeName: string;
     unprojectVector(vector: Vector3, width?: number, height?: number): Vector3;
     updateFrustum(matrix: Matrix4): this;
+    protected updateJitteredProjectionMatrix(): void;
     updateProjectionMatrix(): void;
     updateViewMatrix(): this;
     updateViewProjectionMatrix(): this;
     // (undocumented)
     readonly viewMatrix: Matrix4;
-    // (undocumented)
     readonly viewProjectionMatrix: Matrix4;
     visibility: number;
 }
@@ -1976,6 +1981,8 @@ export interface ForwardRenderPipelineFeature {
 // @public
 export interface ForwardRenderPipelineFeatureRuntime {
     destroy(): void;
+    frameDiscarded?(frameIndex: number): void;
+    frameSubmitted?(frameIndex: number): void;
     record(context: ForwardRenderFeatureContext): unknown;
 }
 
@@ -5481,6 +5488,7 @@ export interface PostProcessRenderPipelineOptions {
     readonly colorUber?: Readonly<ColorUberOptions>;
     readonly features?: readonly ForwardRenderPipelineFeature[];
     readonly opaqueTexture?: boolean;
+    readonly temporalAA?: Readonly<TemporalAAOptions> | false;
 }
 
 // @public (undocumented)
@@ -6284,6 +6292,7 @@ export type RenderPipelineOutputResources = RenderPipelineTargetResources;
 export interface RenderPipelinePersistentTargetDescriptor {
     readonly colorFormats: readonly RenderTargetColorFormat[];
     readonly depthStencilFormat?: RenderTargetDepthStencilFormat;
+    readonly depthStencilSampled?: boolean;
     readonly extent: RenderPipelineExtent;
     readonly label?: string;
     readonly sampleCount?: RenderTargetSampleCount;
@@ -8106,6 +8115,50 @@ export interface SubDataUpdate {
     readonly data: TypedArray;
     // (undocumented)
     readonly revision: number;
+}
+
+// @public
+export class TemporalAA implements ForwardRenderPipelineFeature {
+    constructor(options?: Readonly<TemporalAAOptions>);
+    // (undocumented)
+    create(): ForwardRenderPipelineFeatureRuntime;
+    // (undocumented)
+    readonly injectionPoint: "after-opaque";
+    // (undocumented)
+    readonly name = "temporal-aa";
+    // (undocumented)
+    readonly requirements: Readonly<{
+        sampledSceneColor: true;
+        sampledDepth: true;
+        requiredLimits: Readonly<{
+            maxColorAttachments: 3;
+        }>;
+        requiredTextureFormats: readonly (Readonly<{
+            format: "rgba16float";
+            use: "color-attachment";
+        }> | Readonly<{
+            format: "rgba16float";
+            use: "filterable-sampled";
+        }> | Readonly<{
+            format: "rg16float";
+            use: "color-attachment";
+        }> | Readonly<{
+            format: "rg16float";
+            use: "filterable-sampled";
+        }> | Readonly<{
+            format: "r16float";
+            use: "color-attachment";
+        }> | Readonly<{
+            format: "r16float";
+            use: "filterable-sampled";
+        }>)[];
+    }>;
+}
+
+// @public
+export interface TemporalAAOptions {
+    readonly depthThreshold?: number;
+    readonly historyWeight?: number;
 }
 
 // @public

--- a/src/camera/Camera.ts
+++ b/src/camera/Camera.ts
@@ -46,8 +46,14 @@ export interface CameraParameters extends NodeParameters {
 class Camera extends Node {
     static override readonly typeName: string = 'Camera';
     readonly viewMatrix = new Matrix4();
+    /** Stable non-jittered projection used by CPU culling, picking, and project/unproject. */
     readonly projectionMatrix = new Matrix4();
+    /** Raster projection with the current sub-pixel clip-space jitter applied. */
+    readonly jitteredProjectionMatrix = new Matrix4();
+    /** Stable non-jittered view-projection used by CPU visibility and interaction queries. */
     readonly viewProjectionMatrix = new Matrix4();
+    /** Raster view-projection with the current sub-pixel clip-space jitter applied. */
+    readonly jitteredViewProjectionMatrix = new Matrix4();
     protected readonly _frustum = new Frustum();
     protected _geometry: Geometry | null = null;
     override isCamera = true;
@@ -98,6 +104,8 @@ class Camera extends Node {
      */
     protected _needUpdateProjectionMatrix = true;
     protected _isGeometryDirty = false;
+    private projectionJitterXValue = 0;
+    private projectionJitterYValue = 0;
     /**
      * @param params - 创建对象的属性参数。可包含此类的所有属性。
      */
@@ -126,6 +134,40 @@ class Camera extends Node {
      */
     updateProjectionMatrix(): void {
         this.projectionMatrix.identity();
+        this.updateJitteredProjectionMatrix();
+    }
+    /** Horizontal raster jitter in normalized-device coordinates. */
+    get projectionJitterX(): number {
+        return this.projectionJitterXValue;
+    }
+    /** Vertical raster jitter in normalized-device coordinates. */
+    get projectionJitterY(): number {
+        return this.projectionJitterYValue;
+    }
+    /**
+     * Apply a sub-pixel raster offset without changing the stable CPU projection.
+     *
+     * Temporal render features use normalized-device coordinates, where one physical pixel is
+     * `2 / attachmentSize`. Culling, picking, project/unproject, and camera helpers continue to
+     * consume `projectionMatrix` and `viewProjectionMatrix`.
+     * @param x - Horizontal normalized-device offset.
+     * @param y - Vertical normalized-device offset.
+     * @returns this
+     */
+    setProjectionJitter(x: number, y: number): this {
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            throw new RangeError('Camera projection jitter must contain finite values.');
+        }
+        if (x === this.projectionJitterXValue && y === this.projectionJitterYValue) return this;
+        this.projectionJitterXValue = x;
+        this.projectionJitterYValue = y;
+        this.updateJitteredProjectionMatrix();
+        this.jitteredViewProjectionMatrix.multiply(this.jitteredProjectionMatrix, this.viewMatrix);
+        return this;
+    }
+    /** Clear the raster jitter while preserving transform history. */
+    clearProjectionJitter(): this {
+        return this.setProjectionJitter(0, 0);
     }
     /**
      * 获取几何体，子类必须重写
@@ -146,8 +188,25 @@ class Camera extends Node {
         }
         this.updateViewMatrix();
         this.viewProjectionMatrix.multiply(this.projectionMatrix, this.viewMatrix);
+        this.jitteredViewProjectionMatrix.multiply(this.jitteredProjectionMatrix, this.viewMatrix);
         this.updateFrustum(this.viewProjectionMatrix);
         return this;
+    }
+    /** Rebuild the raster projection by translating clip coordinates before perspective divide. */
+    protected updateJitteredProjectionMatrix(): void {
+        const source = this.projectionMatrix.elements;
+        this.jitteredProjectionMatrix.copy(this.projectionMatrix);
+        const destination = this.jitteredProjectionMatrix.elements;
+        const x = this.projectionJitterXValue;
+        const y = this.projectionJitterYValue;
+        destination[0] = source[0] + x * source[3];
+        destination[4] = source[4] + x * source[7];
+        destination[8] = source[8] + x * source[11];
+        destination[12] = source[12] + x * source[15];
+        destination[1] = source[1] + y * source[3];
+        destination[5] = source[5] + y * source[7];
+        destination[9] = source[9] + y * source[11];
+        destination[13] = source[13] + y * source[15];
     }
     /**
      * 获取元素相对于当前Camera的矩阵

--- a/src/camera/OrthographicCamera.ts
+++ b/src/camera/OrthographicCamera.ts
@@ -105,6 +105,7 @@ class OrthographicCamera extends Camera {
             this.depthMode === 'reversed' ? far : near,
             this.depthMode === 'reversed' ? near : far
         );
+        this.updateJitteredProjectionMatrix();
     }
     override getGeometry(forceUpdate = false): Geometry {
         if (forceUpdate || !this._geometry || this._isGeometryDirty) {

--- a/src/camera/PerspectiveCamera.ts
+++ b/src/camera/PerspectiveCamera.ts
@@ -121,6 +121,7 @@ class PerspectiveCamera extends Camera {
             elements[10] = this.depthMode === 'reversed' ? 1 : -1;
             elements[14] = this.depthMode === 'reversed' ? 2 * near : -2 * near;
         }
+        this.updateJitteredProjectionMatrix();
     }
     override getGeometry(forceUpdate = false): Geometry {
         if (forceUpdate || !this._geometry || this._isGeometryDirty) {

--- a/src/material/BuiltInMaterialDefinitions.ts
+++ b/src/material/BuiltInMaterialDefinitions.ts
@@ -101,6 +101,13 @@ function buildPasses(
         alphaToCoverage: false
     });
     const outputState: Readonly<MaterialPipelineState> = Object.freeze({ ...unblendedState });
+    const motionVectorState: Readonly<MaterialPipelineState> = Object.freeze({
+        ...unblendedState,
+        depthTest: true,
+        depthWrite: false,
+        depthCompare: 'equal',
+        alphaToCoverage: false
+    });
     return Object.freeze([
         Object.freeze({
             role: 'forward' as const,
@@ -121,6 +128,13 @@ function buildPasses(
             shader: module,
             fragmentOutput: 'depth-only' as const,
             state: depthState,
+            fallback: 'required' as const
+        }),
+        Object.freeze({
+            role: 'motion-vector' as const,
+            shader: module,
+            fragmentOutput: 'motion-vector' as const,
+            state: motionVectorState,
             fallback: 'required' as const
         }),
         Object.freeze({

--- a/src/material/MaterialCompiler.ts
+++ b/src/material/MaterialCompiler.ts
@@ -187,6 +187,16 @@ export class MaterialCompiler {
         if (pass.fragmentOutput !== 'depth-only' && request.target.colorFormats.length === 0) {
             throw new TypeError(`Material role ${role} requires at least one color target`);
         }
+        if (
+            pass.fragmentOutput === 'motion-vector' &&
+            (request.target.colorFormats.length !== 1 ||
+                request.target.colorFormats[0] !== 'rg16float' ||
+                request.target.sampleCount !== 1)
+        ) {
+            throw new TypeError(
+                'Material motion-vector role requires one single-sample rg16float color target'
+            );
+        }
         const state = role === 'forward' ? resolveForwardState(instance, pass) : pass.state;
         const sourceRevision =
             pass.shader.kind === 'glsl'

--- a/src/render/BuiltInUniformBlockManager.ts
+++ b/src/render/BuiltInUniformBlockManager.ts
@@ -118,6 +118,7 @@ const tempViewNormal = new Matrix3();
 const tempRelativeViewInverse = new Matrix4();
 const tempRelativeView = new Matrix4();
 const tempRelativeViewProjection = new Matrix4();
+const tempRelativeNonJitteredViewProjection = new Matrix4();
 const std140WriteResult: Std140WriteResult = { byteOffset: 0, byteLength: 0 };
 const semanticBlockScratch = new WeakMap<UniformBuffer, Uint8Array>();
 const uniformBufferByteViews = new WeakMap<UniformBuffer, Uint8Array>();
@@ -136,6 +137,8 @@ const MATERIAL_TEXTURE_BLOCK_FIELD_NAMES = Object.freeze(
         fieldName => !fieldName.endsWith('Padding')
     )
 );
+const MODEL_HISTORY_INVALID = new Float32Array(4);
+const MODEL_HISTORY_VALID = new Float32Array([1, 0, 0, 0]);
 
 function fieldNamesOf(layout: Std140Layout): readonly string[] {
     let names = layoutFieldNames.get(layout);
@@ -330,7 +333,8 @@ function updateModelTransformBlock(
     mesh: Mesh,
     current: Float32Array,
     previous: Float32Array,
-    normal: Matrix3
+    normal: Matrix3,
+    historyValid: boolean
 ): void {
     let candidate = semanticBlockScratch.get(buffer);
     if (candidate?.byteLength !== modelBlockLayout.byteLength) {
@@ -349,6 +353,12 @@ function updateModelTransformBlock(
         target,
         'u_normalWorldMatrix',
         normal.normalFromMat4(mesh.worldMatrix).elements,
+        std140WriteResult
+    );
+    modelBlockLayout.writeInto(
+        target,
+        'u_modelHistoryParams',
+        historyValid ? MODEL_HISTORY_VALID : MODEL_HISTORY_INVALID,
         std140WriteResult
     );
     modelBlockLayout.writeInto(
@@ -537,18 +547,13 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         this.historyGeneration += 1;
     }
 
-    /** @internal Frame-wide origin used by instanced GPU transforms. */
-    get renderOrigin(): Readonly<Float32Array> {
-        return this.renderOriginScratch;
-    }
-
     /** @internal Stage and write one current/previous camera-relative instance transform. */
     writeInstanceModelMatrices(
         mesh: Mesh,
         current: Float32Array,
         previous: Float32Array,
         offset: number
-    ): void {
+    ): boolean {
         const history = this.transformHistoryRecord(this.modelHistory, mesh, 16);
         if (history.pendingFrame !== this.frameIndex) {
             copyRelativeMatrix(
@@ -565,6 +570,7 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             history.committedGeneration === this.historyGeneration &&
             history.committedRevision === getTransformHistoryRevision(mesh);
         previous.set(valid ? history.committed : history.pending, offset);
+        return valid;
     }
 
     /** Start a camera/render pass without advancing animation-frame scoped buffers. */
@@ -653,8 +659,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         tempRelativeViewInverse.fromArray(history.pendingViewInverse);
         tempRelativeView.invert(tempRelativeViewInverse);
         history.pendingView.set(tempRelativeView.elements);
-        history.pendingProjection.set(camera.projectionMatrix.elements);
-        tempRelativeViewProjection.multiply(camera.projectionMatrix, tempRelativeView);
+        history.pendingProjection.set(camera.jitteredProjectionMatrix.elements);
+        tempRelativeViewProjection.multiply(camera.jitteredProjectionMatrix, tempRelativeView);
         history.pendingViewProjection.set(tempRelativeViewProjection.elements);
         history.pendingOrigin.set(this.renderOriginScratch);
         history.pendingRevision = getTransformHistoryRevision(camera);
@@ -694,6 +700,14 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             .set('u_viewMatrix', history.pendingView)
             .set('u_projectionMatrix', history.pendingProjection)
             .set('u_viewProjectionMatrix', history.pendingViewProjection)
+            .set('u_nonJitteredProjectionMatrix', camera.projectionMatrix.elements)
+            .set(
+                'u_nonJitteredViewProjectionMatrix',
+                tempRelativeNonJitteredViewProjection.multiply(
+                    camera.projectionMatrix,
+                    tempRelativeView
+                ).elements
+            )
             .set('u_previousViewMatrix', previousView)
             .set('u_previousProjectionMatrix', previousProjection)
             .set('u_previousViewProjectionMatrix', previousViewProjection)
@@ -701,7 +715,7 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             .set('u_previousViewInverseMatrix', previousViewInverse)
             .set(
                 'u_projectionInverseMatrix',
-                tempInverseProjection.invert(camera.projectionMatrix).elements
+                tempInverseProjection.invert(camera.jitteredProjectionMatrix).elements
             )
             .set(
                 'u_viewInverseNormalMatrix',
@@ -976,7 +990,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
                 mesh,
                 history.pending,
                 historyValid ? history.committed : history.pending,
-                cached.normal
+                cached.normal,
+                historyValid
             );
             cached.frameIndex = this.frameIndex;
             cached.revision = mesh.worldMatrixVersion;
@@ -1058,7 +1073,11 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
                 history.committedRevision === history.pendingRevision;
             cached.buffer
                 .set('u_jointMat', history.pending)
-                .set('u_previousJointMat', historyValid ? history.committed : history.pending);
+                .set('u_previousJointMat', historyValid ? history.committed : history.pending)
+                .set(
+                    'u_skinHistoryParams',
+                    historyValid ? MODEL_HISTORY_VALID : MODEL_HISTORY_INVALID
+                );
             cached.frameIndex = this.frameIndex;
         }
         return cached.buffer;
@@ -1119,7 +1138,11 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             .set('u_morphWeights0', cached.weights0)
             .set('u_morphWeights1', cached.weights1)
             .set('u_previousMorphWeights0', previous.subarray(0, 4))
-            .set('u_previousMorphWeights1', previous.subarray(4, 8));
+            .set('u_previousMorphWeights1', previous.subarray(4, 8))
+            .set(
+                'u_morphHistoryParams',
+                historyValid ? MODEL_HISTORY_VALID : MODEL_HISTORY_INVALID
+            );
         cached.frameIndex = this.frameIndex;
         return cached.buffer;
     }

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -232,7 +232,7 @@ interface MutablePersistentTargetResourceDescriptor extends RenderTargetResource
     sampleCount: 1 | 4;
     multisampleAttachmentLifetime: 'persistent';
     depthStencilFormat: RHITextureFormat | null;
-    depthStencilSampled: false;
+    depthStencilSampled: boolean;
 }
 
 interface TextureAccessRecordBase {
@@ -1601,8 +1601,6 @@ class ScriptableFullscreenDraw {
         if (pipeline === null) throw new Error('Fullscreen draw pipeline is not configured');
         const registry = fullscreen.registry;
         const plan = pipeline.bindingPlan;
-        const sampler = registry.resolve(fullscreen.defaultSampler);
-        fullscreen.resourceUses.use(fullscreen.defaultSampler);
         try {
             for (const groupIndex of plan.activeGroupIndices) {
                 const layoutHandle = pipeline.bindGroupLayouts[groupIndex];
@@ -1637,6 +1635,17 @@ class ScriptableFullscreenDraw {
                     if (context.getTexture(handle).sampleCount !== 1) {
                         throw new Error('Fullscreen sampled textures must be single-sample');
                     }
+                    if (sampled.samplerType === 'comparison') {
+                        throw new TypeError(
+                            'Fullscreen comparison sampling requires an explicit comparison contract'
+                        );
+                    }
+                    const samplerHandle =
+                        sampled.samplerType === 'non-filtering'
+                            ? fullscreen.nonFilteringSampler
+                            : fullscreen.defaultSampler;
+                    const sampler = registry.resolve(samplerHandle);
+                    fullscreen.resourceUses.use(samplerHandle);
                     this.addEntry(group, sampled.textureBinding, context.getTextureView(handle));
                     this.addEntry(group, sampled.samplerBinding, sampler);
                 }
@@ -4660,6 +4669,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         }
         targetDescriptor.sampleCount = descriptor.sampleCount ?? 1;
         targetDescriptor.depthStencilFormat = descriptor.depthStencilFormat ?? null;
+        targetDescriptor.depthStencilSampled = descriptor.depthStencilSampled ?? false;
         const record = this.resources.preparePersistentTarget(
             runtimeOwner,
             key,
@@ -5235,9 +5245,9 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         this.services.beginScriptableResourcePass(context);
         this.services.beginScriptableFullscreenPass(context);
         const fullscreen = this.services.getScriptableFullscreenProcessor();
-        const pipeline = fullscreen.prepareGraphPipeline(pass.shader, pass.pipelineState, target);
         const inputs = this.#fullscreenInputScratch;
         inputs.length = parameters.inputTextures.length;
+        let numericDepthSamplerMask = 0;
         for (let index = 0; index < parameters.inputTextures.length; index += 1) {
             const publicHandle = parameters.inputTextures[index];
             if (publicHandle === undefined) {
@@ -5248,13 +5258,31 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 throw new Error('Fullscreen input texture was not declared during setup');
             }
             const format = this.requireTexture(publicHandle).format;
-            if (!this.capabilities.supportsTextureFormat(format, 'filterable-sampled')) {
+            const numericDepth = rhiTextureFormatHasDepth(format);
+            const use = numericDepth ? 'sampled' : 'filterable-sampled';
+            if (!this.capabilities.supportsTextureFormat(format, use)) {
                 throw new Error(
-                    `Fullscreen input texture format ${format} does not support linear filtering`
+                    numericDepth
+                        ? `Fullscreen depth input texture format ${format} does not support sampling`
+                        : `Fullscreen input texture format ${format} does not support linear filtering`
                 );
+            }
+            if (numericDepth) {
+                if (index >= 52) {
+                    throw new RangeError(
+                        'Fullscreen numeric depth specialization supports at most 52 inputs'
+                    );
+                }
+                numericDepthSamplerMask += 2 ** index;
             }
             inputs[index] = internal;
         }
+        const pipeline = fullscreen.prepareGraphPipeline(
+            pass.shader,
+            pass.pipelineState,
+            target,
+            numericDepthSamplerMask
+        );
         const processor = this.services.getScriptableMeshProcessor();
         const uniformHandles = this.#fullscreenUniformScratch;
         uniformHandles.length = pass.uniformBuffers.length;

--- a/src/render/pipeline/ForwardRenderPipeline.ts
+++ b/src/render/pipeline/ForwardRenderPipeline.ts
@@ -77,6 +77,10 @@ export interface ForwardRenderPipelineFeatureRuntime {
      * @returns An ignored synchronous value. Promise-like values are rejected before RHI execution.
      */
     record(context: ForwardRenderFeatureContext): unknown;
+    /** Commit feature-owned temporal CPU state after a valid frame submission. */
+    frameSubmitted?(frameIndex: number): void;
+    /** Roll back feature-owned temporal CPU state when recording or submission is discarded. */
+    frameDiscarded?(frameIndex: number): void;
     /** Release renderer-local feature state exactly once. */
     destroy(): void;
 }
@@ -545,11 +549,6 @@ function snapshotFeature(feature: ForwardRenderPipelineFeature): FeatureSnapshot
             `Forward render feature ${feature.name} must declare sampledSceneColor and sampledDepth`
         );
     }
-    if (sampledDepth) {
-        throw new Error(
-            `Forward render feature ${feature.name} sampledDepth is not implemented end to end`
-        );
-    }
     if (
         sampledSceneColor &&
         injectionPointIndex(injectionPoint) < injectionPointIndex('after-opaque')
@@ -721,6 +720,7 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
         readonly extent: RenderPipelineExtent;
         readonly colorFormats: RenderTargetColorFormat[];
         depthStencilFormat?: RenderTargetDepthStencilFormat;
+        depthStencilSampled?: boolean;
         sampleCount: RenderTargetSampleCount;
     } = {
         label: 'Forward linear surface composition',
@@ -865,6 +865,18 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
             this.recordOutputPasses(context, output, colorCount);
         } finally {
             this.#featureState.endFrame();
+        }
+    }
+
+    frameSubmitted(frameIndex: number): void {
+        for (const feature of this.#compiledFeatures) {
+            feature.runtime.frameSubmitted?.(frameIndex);
+        }
+    }
+
+    frameDiscarded(frameIndex: number): void {
+        for (const feature of this.#compiledFeatures) {
+            feature.runtime.frameDiscarded?.(frameIndex);
         }
     }
 
@@ -1024,6 +1036,7 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
             this.#sceneColorFormat ?? context.output.colorFormat(0);
         this.#surfaceCompositionColorFormats.length = 1;
         descriptor.sampleCount = 1;
+        descriptor.depthStencilSampled = this.#requiresSampledDepth;
         const depthFormat = context.output.depthStencilFormat;
         if (depthFormat === null) delete descriptor.depthStencilFormat;
         else descriptor.depthStencilFormat = depthFormat;

--- a/src/render/pipeline/ScriptableRenderGraph.ts
+++ b/src/render/pipeline/ScriptableRenderGraph.ts
@@ -141,6 +141,8 @@ export interface RenderPipelinePersistentTargetDescriptor {
     readonly colorFormats: readonly RenderTargetColorFormat[];
     /** Optional depth/stencil attachment format. */
     readonly depthStencilFormat?: RenderTargetDepthStencilFormat;
+    /** Create a persistent depth-only sampled view for a single-sample depth attachment. */
+    readonly depthStencilSampled?: boolean;
     /** Raster sample count, defaulting to one. */
     readonly sampleCount?: RenderTargetSampleCount;
 }

--- a/src/render/pipeline/passes/FullscreenRenderPass.ts
+++ b/src/render/pipeline/passes/FullscreenRenderPass.ts
@@ -30,7 +30,7 @@ export interface FullscreenRenderPassOptions {
 
 /** Frame-scoped graph resources and dynamic state for one fullscreen draw. */
 export interface FullscreenRenderPassParameters {
-    /** Linear-filterable sampled textures in reflected sampler order. */
+    /** Sampled textures in reflected sampler order; numeric depth uses nearest sampling. */
     readonly inputTextures: readonly RenderGraphTextureAccessHandle[];
     /** Color attachments in fragment-output location order. */
     readonly colorAttachments: readonly Readonly<RenderPipelineColorAttachment>[];
@@ -48,8 +48,9 @@ export interface FullscreenRenderPassParameters {
  * Draws a `gl_VertexID` fullscreen triangle with graph textures resolved during prepare.
  *
  * The vertex shader must declare no vertex attributes. GLSL samplers and registered std140
- * blocks are matched to the fixed arrays captured by this pass instance. Input formats must
- * support filterable sampling because the shared fullscreen path uses one fixed linear sampler.
+ * blocks are matched to the fixed arrays captured by this pass instance. Color inputs use the
+ * shared linear sampler; ordinary depth inputs are specialized to numeric depth and use the
+ * shared non-filtering sampler on both rendering backends.
  */
 export class FullscreenRenderPass implements ScriptableRenderPass<FullscreenRenderPassParameters> {
     /** Stable diagnostic pass name. */

--- a/src/render/postprocessing/PostProcessRenderPipeline.ts
+++ b/src/render/postprocessing/PostProcessRenderPipeline.ts
@@ -10,9 +10,12 @@ import type {
 } from '../pipeline/RenderPipeline';
 import { Bloom, type BloomOptions } from './Bloom';
 import { ColorUber, type ColorUberOptions } from './ColorUber';
+import { TemporalAA, type TemporalAAOptions } from './TemporalAA';
 
 /** Turnkey HDR forward/post-processing pipeline configuration. */
 export interface PostProcessRenderPipelineOptions {
+    /** Native-resolution temporal anti-aliasing settings, or false to omit TAA. */
+    readonly temporalAA?: Readonly<TemporalAAOptions> | false;
     /** Bloom settings, or false to omit bloom. Bloom is enabled by default. */
     readonly bloom?: Readonly<BloomOptions> | false;
     /** Final color grading/tone mapping settings. */
@@ -24,7 +27,8 @@ export interface PostProcessRenderPipelineOptions {
 }
 
 /**
- * Turnkey linear-HDR forward pipeline with high-quality bloom, Color Uber, and opaque scene color.
+ * Turnkey linear-HDR forward pipeline with optional TAA, high-quality bloom, Color Uber, and
+ * opaque scene color.
  */
 export class PostProcessRenderPipelineFactory implements RenderPipelineFactory {
     readonly name = 'post-process-forward';
@@ -33,6 +37,9 @@ export class PostProcessRenderPipelineFactory implements RenderPipelineFactory {
 
     constructor(options: Readonly<PostProcessRenderPipelineOptions> = {}) {
         const features: ForwardRenderPipelineFeature[] = [];
+        if (options.temporalAA !== false && options.temporalAA !== undefined) {
+            features.push(new TemporalAA(options.temporalAA));
+        }
         if (options.bloom !== false) features.push(new Bloom(options.bloom ?? {}));
         features.push(new ColorUber(options.colorUber ?? {}));
         features.push(...(options.features ?? []));

--- a/src/render/postprocessing/TemporalAA.ts
+++ b/src/render/postprocessing/TemporalAA.ts
@@ -1,0 +1,511 @@
+import type Camera from '../../camera/Camera';
+import { getTransformHistoryRevision } from '../../core/TransformHistory';
+import { DEFAULT_MATERIAL_PIPELINE_STATE } from '../../material/MaterialDefinition';
+import Shader from '../../shader/Shader';
+import UniformBuffer from '../UniformBuffer';
+import { renderTargetFormatHasStencil } from '../RenderTarget';
+import type {
+    ForwardRenderFeatureContext,
+    ForwardRenderPipelineFeature,
+    ForwardRenderPipelineFeatureRuntime
+} from '../pipeline/ForwardRenderPipeline';
+import { RenderPassParameterPool } from '../pipeline/RenderPassParameterPool';
+import type { CullingResultsHandle } from '../pipeline/RendererList';
+import {
+    FullscreenRenderPass,
+    SceneRenderPass,
+    type FullscreenRenderPassParameters,
+    type SceneRenderPassParameters
+} from '../pipeline/passes';
+import { PORTABLE_FULLSCREEN_VERTEX_SOURCE } from '../pipeline/passes/internal/PortableFullscreenShader';
+import type {
+    RenderGraphTextureAccessHandle,
+    RenderGraphTextureHandle,
+    RenderPipelineColorAttachment,
+    RenderPipelineDepthStencilAttachment,
+    RenderPipelineHistoryTextureResources
+} from '../pipeline/ScriptableRenderGraph';
+import { createStd140Layout } from '../ubo/Std140Layout';
+import { registerUniformBlockBinding } from '../ubo/UniformBlockBindings';
+
+const TEMPORAL_AA_BLOCK = `layout(std140) uniform TemporalAABlock {
+    float u_historyWeight;
+    float u_depthThreshold;
+    vec2 u_temporalPadding;
+};`;
+
+const INITIALIZE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_depth;
+layout(location = 0) out vec4 historyColor;
+layout(location = 1) out vec4 resolvedColor;
+layout(location = 2) out float historyDepth;
+void main() {
+    vec4 current = texture(u_scene, v_uv);
+    historyColor = current;
+    resolvedColor = current;
+    historyDepth = texture(u_depth, v_uv).r;
+}`;
+
+const RESOLVE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_history;
+uniform sampler2D u_velocity;
+uniform sampler2D u_depth;
+uniform sampler2D u_historyDepth;
+${TEMPORAL_AA_BLOCK}
+layout(location = 0) out vec4 historyColor;
+layout(location = 1) out vec4 resolvedColor;
+layout(location = 2) out float historyDepth;
+
+void main() {
+    vec4 current = texture(u_scene, v_uv);
+    float currentDepth = texture(u_depth, v_uv).r;
+    vec2 velocity = texture(u_velocity, v_uv).xy;
+    vec2 historyUV = v_uv - velocity;
+    bool inside = all(greaterThanEqual(historyUV, vec2(0.0))) &&
+        all(lessThanEqual(historyUV, vec2(1.0)));
+
+    vec2 texel = 1.0 / vec2(textureSize(u_scene, 0));
+    vec3 neighborhoodMin = current.rgb;
+    vec3 neighborhoodMax = current.rgb;
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            vec3 sampleColor = texture(u_scene, v_uv + vec2(float(x), float(y)) * texel).rgb;
+            neighborhoodMin = min(neighborhoodMin, sampleColor);
+            neighborhoodMax = max(neighborhoodMax, sampleColor);
+        }
+    }
+
+    vec4 previous = inside ? texture(u_history, historyUV) : current;
+    float previousDepth = inside ? texture(u_historyDepth, historyUV).r : currentDepth;
+    float depthLimit = u_depthThreshold * max(1.0, abs(currentDepth));
+    float accepted = inside && abs(previousDepth - currentDepth) <= depthLimit ? 1.0 : 0.0;
+    vec3 clampedHistory = clamp(previous.rgb, neighborhoodMin, neighborhoodMax);
+    vec3 resolved = mix(current.rgb, clampedHistory, u_historyWeight * accepted);
+    vec4 result = vec4(resolved, current.a);
+    historyColor = result;
+    resolvedColor = result;
+    historyDepth = currentDepth;
+}`;
+
+registerUniformBlockBinding('TemporalAABlock');
+
+const temporalAALayout = createStd140Layout({
+    u_historyWeight: 'float',
+    u_depthThreshold: 'float',
+    u_temporalPadding: 'vec2'
+});
+
+const OUTPUT_EXTENT = Object.freeze({ relativeTo: 'output' as const, scale: 1 });
+const VELOCITY_DESCRIPTOR = Object.freeze({
+    format: 'rg16float' as const,
+    extent: OUTPUT_EXTENT
+});
+const RESOLVED_DESCRIPTOR = Object.freeze({
+    format: 'rgba16float' as const,
+    extent: OUTPUT_EXTENT
+});
+const COLOR_HISTORY_DESCRIPTOR = Object.freeze({
+    label: 'TemporalAA color history',
+    format: 'rgba16float' as const,
+    extent: OUTPUT_EXTENT,
+    usage: Object.freeze(['sampled' as const, 'attachment' as const]),
+    bufferCount: 2 as const
+});
+const DEPTH_HISTORY_DESCRIPTOR = Object.freeze({
+    label: 'TemporalAA depth history',
+    format: 'r16float' as const,
+    extent: OUTPUT_EXTENT,
+    usage: Object.freeze(['sampled' as const, 'attachment' as const]),
+    bufferCount: 2 as const
+});
+const CLEAR_ZERO = Object.freeze({ r: 0, g: 0, b: 0, a: 0 });
+
+const JITTER_SEQUENCE: readonly Readonly<{ x: number; y: number }>[] = Object.freeze([
+    Object.freeze({ x: 0, y: -1 / 6 }),
+    Object.freeze({ x: -1 / 4, y: 1 / 6 }),
+    Object.freeze({ x: 1 / 4, y: -7 / 18 }),
+    Object.freeze({ x: -3 / 8, y: -1 / 18 }),
+    Object.freeze({ x: 1 / 8, y: 5 / 18 }),
+    Object.freeze({ x: -1 / 8, y: -5 / 18 }),
+    Object.freeze({ x: 3 / 8, y: 1 / 18 }),
+    Object.freeze({ x: -7 / 16, y: 7 / 18 })
+]);
+
+interface CameraTemporalState {
+    readonly camera: Camera;
+    readonly colorHistoryKey: object;
+    readonly depthHistoryKey: object;
+    committedTransformRevision: number;
+    committedJitterIndex: number;
+    pendingTransformRevision: number;
+    pendingJitterIndex: number;
+    pendingFrame: number;
+}
+
+interface MutableVelocityColorAttachment extends RenderPipelineColorAttachment {
+    texture: RenderGraphTextureHandle;
+}
+
+interface MutableVelocityDepthAttachment extends RenderPipelineDepthStencilAttachment {
+    texture: RenderGraphTextureHandle;
+    stencilReadOnly?: boolean;
+}
+
+class VelocityPassParameters implements SceneRenderPassParameters {
+    rendererList = 0 as SceneRenderPassParameters['rendererList'];
+    readonly colorAttachments: MutableVelocityColorAttachment[] = [
+        {
+            texture: 0 as RenderGraphTextureHandle,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: CLEAR_ZERO
+        }
+    ];
+    readonly depthStencilAttachment: MutableVelocityDepthAttachment = {
+        texture: 0 as RenderGraphTextureHandle,
+        depthReadOnly: true
+    };
+
+    configure(
+        rendererList: SceneRenderPassParameters['rendererList'],
+        velocity: RenderGraphTextureHandle,
+        depth: RenderGraphTextureHandle,
+        stencilReadOnly: boolean
+    ): void {
+        this.rendererList = rendererList;
+        const color = this.colorAttachments[0];
+        if (color === undefined) throw new Error('TemporalAA velocity attachment is unavailable');
+        color.texture = velocity;
+        this.depthStencilAttachment.texture = depth;
+        if (stencilReadOnly) this.depthStencilAttachment.stencilReadOnly = true;
+        else delete this.depthStencilAttachment.stencilReadOnly;
+    }
+}
+
+interface MutableTemporalColorAttachment extends RenderPipelineColorAttachment {
+    texture: RenderGraphTextureHandle;
+}
+
+class TemporalResolveParameters implements FullscreenRenderPassParameters {
+    readonly inputTextures: RenderGraphTextureAccessHandle[] = [];
+    readonly colorAttachments: MutableTemporalColorAttachment[] = [
+        {
+            texture: 0 as RenderGraphTextureHandle,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: CLEAR_ZERO
+        },
+        {
+            texture: 0 as RenderGraphTextureHandle,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: CLEAR_ZERO
+        },
+        {
+            texture: 0 as RenderGraphTextureHandle,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: CLEAR_ZERO
+        }
+    ];
+
+    configure(
+        inputs: readonly RenderGraphTextureAccessHandle[],
+        colorHistory: RenderGraphTextureHandle,
+        resolved: RenderGraphTextureHandle,
+        depthHistory: RenderGraphTextureHandle
+    ): void {
+        this.inputTextures.length = inputs.length;
+        for (let index = 0; index < inputs.length; index += 1) {
+            const input = inputs[index];
+            if (input === undefined)
+                throw new TypeError('TemporalAA input array must not be sparse');
+            this.inputTextures[index] = input;
+        }
+        const colorAttachment = this.colorAttachments[0];
+        const resolvedAttachment = this.colorAttachments[1];
+        const depthAttachment = this.colorAttachments[2];
+        if (
+            colorAttachment === undefined ||
+            resolvedAttachment === undefined ||
+            depthAttachment === undefined
+        ) {
+            throw new Error('TemporalAA resolve attachments are incomplete');
+        }
+        colorAttachment.texture = colorHistory;
+        resolvedAttachment.texture = resolved;
+        depthAttachment.texture = depthHistory;
+    }
+
+    reset(): void {
+        this.inputTextures.length = 0;
+    }
+}
+
+/** Native-resolution temporal resolve controls. */
+export interface TemporalAAOptions {
+    /** Accepted history contribution after rejection and clamping. Defaults to 0.9. */
+    readonly historyWeight?: number;
+    /** Raw depth difference that rejects reprojected history. Defaults to 0.002. */
+    readonly depthThreshold?: number;
+}
+
+interface TemporalAASettings {
+    readonly historyWeight: number;
+    readonly depthThreshold: number;
+}
+
+function finiteRange(value: number, minimum: number, maximum: number, label: string): number {
+    if (!Number.isFinite(value) || value < minimum || value > maximum) {
+        throw new RangeError(
+            `${label} must be finite and between ${String(minimum)} and ${String(maximum)}`
+        );
+    }
+    return value;
+}
+
+function snapshotOptions(options: Readonly<TemporalAAOptions>): TemporalAASettings {
+    return Object.freeze({
+        historyWeight: finiteRange(options.historyWeight ?? 0.9, 0, 1, 'TemporalAA historyWeight'),
+        depthThreshold: finiteRange(
+            options.depthThreshold ?? 0.002,
+            0,
+            1,
+            'TemporalAA depthThreshold'
+        )
+    });
+}
+
+class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
+    readonly #block: UniformBuffer<typeof temporalAALayout.schema>;
+    readonly #velocityPass = new SceneRenderPass('TemporalAA motion vectors');
+    readonly #initializePass: FullscreenRenderPass;
+    readonly #resolvePass: FullscreenRenderPass;
+    readonly #velocityParameters = new RenderPassParameterPool(() => new VelocityPassParameters());
+    readonly #resolveParameters = new RenderPassParameterPool(
+        () => new TemporalResolveParameters(),
+        parameters => {
+            parameters.reset();
+        }
+    );
+    readonly #rendererListDescriptor: {
+        cullingResults: CullingResultsHandle;
+        readonly queue: 'opaque';
+        readonly sorting: 'material-front-to-back';
+        readonly materialPass: 'motion-vector';
+    } = {
+        cullingResults: 0 as CullingResultsHandle,
+        queue: 'opaque',
+        sorting: 'material-front-to-back',
+        materialPass: 'motion-vector'
+    };
+    readonly #states = new WeakMap<Camera, CameraTemporalState>();
+    readonly #ownedStates = new Set<CameraTemporalState>();
+    readonly #stagedStates: CameraTemporalState[] = [];
+    #destroyed = false;
+
+    constructor(settings: TemporalAASettings) {
+        this.#block = UniformBuffer.fromSchema(temporalAALayout, {
+            u_historyWeight: settings.historyWeight,
+            u_depthThreshold: settings.depthThreshold,
+            u_temporalPadding: [0, 0]
+        });
+        const pass = (name: string, fs: string, uniformBuffers: readonly UniformBuffer[]) =>
+            new FullscreenRenderPass({
+                name,
+                shader: new Shader({ vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE, fs }),
+                pipelineState: {
+                    ...DEFAULT_MATERIAL_PIPELINE_STATE,
+                    depthTest: false,
+                    depthWrite: false,
+                    cullMode: 'none'
+                },
+                uniformBuffers
+            });
+        this.#initializePass = pass('TemporalAA initialize history', INITIALIZE_FRAGMENT, []);
+        this.#resolvePass = pass('TemporalAA resolve', RESOLVE_FRAGMENT, [this.#block]);
+    }
+
+    record(context: ForwardRenderFeatureContext): void {
+        if (this.#destroyed) throw new Error('TemporalAA runtime is destroyed');
+        const pipeline = context.pipeline;
+        const scene = context.resources.color;
+        const depth = context.resources.depth;
+        if (scene === null || depth === null) {
+            throw new Error('TemporalAA requires opaque scene color and sampled depth');
+        }
+        const [x, y, width, height] = pipeline.viewport;
+        if (
+            x !== 0 ||
+            y !== 0 ||
+            width !== pipeline.output.width ||
+            height !== pipeline.output.height
+        ) {
+            throw new Error('TemporalAA currently requires a full-output viewport');
+        }
+        const state = this.stageCamera(pipeline.camera, pipeline.frameIndex, width, height);
+        const transformRevision = getTransformHistoryRevision(pipeline.camera);
+        if (
+            state.committedTransformRevision >= 0 &&
+            state.committedTransformRevision !== transformRevision
+        ) {
+            pipeline.graph.invalidateHistoryTexture(state.colorHistoryKey);
+            pipeline.graph.invalidateHistoryTexture(state.depthHistoryKey);
+        }
+
+        const colorHistory = pipeline.graph.acquireHistoryTexture(
+            state.colorHistoryKey,
+            COLOR_HISTORY_DESCRIPTOR
+        );
+        const depthHistory = pipeline.graph.acquireHistoryTexture(
+            state.depthHistoryKey,
+            DEPTH_HISTORY_DESCRIPTOR
+        );
+        const historyValid = colorHistory.valid && depthHistory.valid;
+        this.validateHistoryPair(colorHistory, depthHistory);
+
+        const velocity = pipeline.graph.createTexture(
+            'TemporalAA rg16float velocity',
+            VELOCITY_DESCRIPTOR
+        );
+        this.#rendererListDescriptor.cullingResults = context.cullingResults;
+        const velocityList = pipeline.createRendererList(this.#rendererListDescriptor);
+        const velocityParameters = pipeline.acquirePassParameters(this.#velocityParameters);
+        velocityParameters.configure(
+            velocityList,
+            velocity,
+            depth,
+            pipeline.output.depthStencilFormat !== null &&
+                renderTargetFormatHasStencil(pipeline.output.depthStencilFormat)
+        );
+        pipeline.graph.addPass(this.#velocityPass, velocityParameters);
+
+        const resolved = pipeline.graph.createTexture(
+            'TemporalAA resolved color',
+            RESOLVED_DESCRIPTOR
+        );
+        const parameters = pipeline.acquirePassParameters(this.#resolveParameters);
+        parameters.configure(
+            historyValid
+                ? [scene, colorHistory.history(), velocity, depth, depthHistory.history()]
+                : [scene, depth],
+            colorHistory.current,
+            resolved,
+            depthHistory.current
+        );
+        pipeline.graph.addPass(historyValid ? this.#resolvePass : this.#initializePass, parameters);
+        context.resources.replaceColor(resolved, 'linear');
+    }
+
+    frameSubmitted(frameIndex: number): void {
+        for (const state of this.#stagedStates) {
+            if (state.pendingFrame !== frameIndex) continue;
+            state.committedTransformRevision = state.pendingTransformRevision;
+            state.committedJitterIndex = (state.pendingJitterIndex + 1) % JITTER_SEQUENCE.length;
+            state.pendingFrame = -1;
+        }
+        this.#stagedStates.length = 0;
+    }
+
+    frameDiscarded(frameIndex: number): void {
+        for (const state of this.#stagedStates) {
+            if (state.pendingFrame !== frameIndex) continue;
+            state.pendingFrame = -1;
+            state.camera.clearProjectionJitter();
+        }
+        this.#stagedStates.length = 0;
+    }
+
+    destroy(): void {
+        if (this.#destroyed) return;
+        for (const state of this.#ownedStates) state.camera.clearProjectionJitter();
+        this.#ownedStates.clear();
+        this.#stagedStates.length = 0;
+        this.#destroyed = true;
+    }
+
+    private stageCamera(
+        camera: Camera,
+        frameIndex: number,
+        width: number,
+        height: number
+    ): CameraTemporalState {
+        let state = this.#states.get(camera);
+        if (state === undefined) {
+            state = {
+                camera,
+                colorHistoryKey: Object.freeze({}),
+                depthHistoryKey: Object.freeze({}),
+                committedTransformRevision: -1,
+                committedJitterIndex: 0,
+                pendingTransformRevision: -1,
+                pendingJitterIndex: 0,
+                pendingFrame: -1
+            };
+            this.#states.set(camera, state);
+            this.#ownedStates.add(state);
+        }
+        if (state.pendingFrame === frameIndex) {
+            throw new Error(
+                'TemporalAA supports one invocation per camera in an application frame'
+            );
+        }
+        state.pendingFrame = frameIndex;
+        state.pendingTransformRevision = getTransformHistoryRevision(camera);
+        state.pendingJitterIndex = state.committedJitterIndex;
+        this.#stagedStates.push(state);
+        const jitter = JITTER_SEQUENCE[state.pendingJitterIndex];
+        if (jitter === undefined) throw new Error('TemporalAA jitter sequence is incomplete');
+        camera.setProjectionJitter((jitter.x * 2) / width, (jitter.y * 2) / height);
+        return state;
+    }
+
+    private validateHistoryPair(
+        color: RenderPipelineHistoryTextureResources,
+        depth: RenderPipelineHistoryTextureResources
+    ): void {
+        if (color.valid !== depth.valid || color.generation !== depth.generation) {
+            throw new Error('TemporalAA color and depth history generations diverged');
+        }
+    }
+}
+
+/**
+ * Native-resolution temporal anti-aliasing feature.
+ *
+ * The feature records built-in opaque/masked motion vectors after opaque shading, resolves only
+ * opaque scene color, then lets transparent rendering and Bloom compose afterward. History uses
+ * submission-aware double buffers and is reset by camera cuts, resize, or device recovery.
+ */
+export class TemporalAA implements ForwardRenderPipelineFeature {
+    readonly name = 'temporal-aa';
+    readonly injectionPoint = 'after-opaque' as const;
+    readonly requirements = Object.freeze({
+        sampledSceneColor: true,
+        sampledDepth: true,
+        requiredLimits: Object.freeze({ maxColorAttachments: 3 }),
+        requiredTextureFormats: Object.freeze([
+            Object.freeze({ format: 'rgba16float' as const, use: 'color-attachment' as const }),
+            Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const }),
+            Object.freeze({ format: 'rg16float' as const, use: 'color-attachment' as const }),
+            Object.freeze({ format: 'rg16float' as const, use: 'filterable-sampled' as const }),
+            Object.freeze({ format: 'r16float' as const, use: 'color-attachment' as const }),
+            Object.freeze({ format: 'r16float' as const, use: 'filterable-sampled' as const })
+        ])
+    });
+    readonly #settings: TemporalAASettings;
+
+    constructor(options: Readonly<TemporalAAOptions> = {}) {
+        this.#settings = snapshotOptions(options);
+    }
+
+    create(): ForwardRenderPipelineFeatureRuntime {
+        return new TemporalAARuntime(this.#settings);
+    }
+}

--- a/src/render/postprocessing/index.ts
+++ b/src/render/postprocessing/index.ts
@@ -1,5 +1,6 @@
 export { Bloom, type BloomOptions } from './Bloom';
 export { ColorUber, type ColorUberOptions, type ToneMappingMode } from './ColorUber';
+export { TemporalAA, type TemporalAAOptions } from './TemporalAA';
 export {
     PostProcessRenderPipelineFactory,
     type PostProcessRenderPipelineOptions

--- a/src/render/renderer/FullscreenDrawProcessor.ts
+++ b/src/render/renderer/FullscreenDrawProcessor.ts
@@ -54,6 +54,7 @@ export class FullscreenDrawProcessor {
     readonly resourceUses: FrameResourceUseTracker;
     readonly submissions: SubmissionResourceTracker;
     readonly defaultSampler: ResourceRegistryHandle<RHISampler>;
+    readonly nonFilteringSampler: ResourceRegistryHandle<RHISampler>;
 
     readonly #draws: PreparedDrawCache<object>;
     #records = new WeakMap<object, FullscreenOwnerRecord>();
@@ -97,6 +98,19 @@ export class FullscreenDrawProcessor {
             addressModeW: 'clamp-to-edge',
             magFilter: 'linear',
             minFilter: 'linear',
+            mipmapFilter: 'nearest',
+            lodMinClamp: 0,
+            lodMaxClamp: 0,
+            maxAnisotropy: 1
+        });
+        this.nonFilteringSampler = registry.registerSampler({
+            label: 'Shared fullscreen non-filtering sampler',
+            lifetime: 'persistent',
+            addressModeU: 'clamp-to-edge',
+            addressModeV: 'clamp-to-edge',
+            addressModeW: 'clamp-to-edge',
+            magFilter: 'nearest',
+            minFilter: 'nearest',
             mipmapFilter: 'nearest',
             lodMinClamp: 0,
             lodMaxClamp: 0,
@@ -181,13 +195,16 @@ export class FullscreenDrawProcessor {
     prepareGraphPipeline(
         shader: Shader,
         pipelineState: Readonly<MaterialPipelineState>,
-        target: RHIMeshDrawTargetDescriptor
+        target: RHIMeshDrawTargetDescriptor,
+        numericDepthSamplerMask = 0
     ): Readonly<PipelineResourceRecord> {
         this.assertAlive();
         if (!this.active) {
             throw new Error('Fullscreen draw processor requires beginFrame before preparation');
         }
-        const compiled = this.compiler.compile(shader, this.registry.deviceBackend);
+        const compiled = this.compiler.compile(shader, this.registry.deviceBackend, {
+            numericDepthSamplerMask
+        });
         if (compiled.metadata.vertexInputs.length !== 0) {
             throw new TypeError('Fullscreen shaders must not declare vertex inputs');
         }
@@ -196,7 +213,11 @@ export class FullscreenDrawProcessor {
             shader,
             EMPTY_VERTEX_LAYOUTS,
             pipelineState,
-            target
+            target,
+            'color',
+            undefined,
+            undefined,
+            numericDepthSamplerMask
         );
         this.resourceUses.use(pipeline.pipeline);
         return pipeline;
@@ -240,6 +261,7 @@ export class FullscreenDrawProcessor {
         this.resourceUses.destroy();
         this.submissions.destroy();
         this.registry.release(this.defaultSampler);
+        this.registry.release(this.nonFilteringSampler);
         this.#pendingOwner = null;
         this.#pendingPipeline = null;
         this.#destroyed = true;

--- a/src/render/renderer/InstanceBatchCompiler.ts
+++ b/src/render/renderer/InstanceBatchCompiler.ts
@@ -31,13 +31,12 @@ export interface InstanceBatchCompilerCapabilities {
 
 /** Internal bridge to the submission-transactional current/previous transform store. */
 export interface InstanceTransformHistory {
-    readonly renderOrigin: Readonly<Float32Array>;
     writeInstanceModelMatrices(
         mesh: Mesh,
         current: Float32Array,
         previous: Float32Array,
         offset: number
-    ): void;
+    ): boolean;
 }
 
 /** One interleaved, high-water CPU stream appended after the per-vertex streams. */
@@ -104,7 +103,7 @@ interface MutablePerVertexInput {
 
 interface MutableInstanceInput {
     input: InstanceBatchVertexInputReflection;
-    binding: MaterialBindingInfo;
+    binding: MaterialBindingInfo | undefined;
     name: string;
     type: string;
     location: number;
@@ -114,7 +113,7 @@ interface MutableInstanceInput {
     rows: number;
     format: RHIVertexFormat;
     componentOffset: number;
-    builtIn: 0 | 1 | 2;
+    builtIn: 0 | 1 | 2 | 3 | 4;
 }
 
 interface InputSnapshot {
@@ -129,7 +128,7 @@ interface InputSnapshot {
     columns: number;
     rows: number;
     componentOffset: number;
-    builtIn: 0 | 1 | 2;
+    builtIn: 0 | 1 | 2 | 3 | 4;
 }
 
 interface OwnerRecords {
@@ -140,6 +139,8 @@ interface OwnerRecords {
 const EMPTY_PROGRAM_INFO: ProgramBindingInfo = Object.freeze({});
 const MODEL_MATRIX_INPUT = 'u_modelMatrix';
 const NORMAL_MATRIX_INPUT = 'u_normalWorldMatrix';
+const PREVIOUS_MODEL_MATRIX_INPUT = 'u_previousModelMatrix';
+const MODEL_HISTORY_VALID_INPUT = 'u_modelHistoryValid';
 const FLOAT_BYTES = Float32Array.BYTES_PER_ELEMENT;
 
 const FLOAT_SHAPE: InstanceShape = Object.freeze({
@@ -567,7 +568,7 @@ function emptyPerVertexInput(): MutablePerVertexInput {
 function emptyInstanceInput(): MutableInstanceInput {
     return {
         input: { name: '', type: '', location: 0 },
-        binding: null as unknown as MaterialBindingInfo,
+        binding: undefined,
         name: '',
         type: '',
         location: 0,
@@ -623,8 +624,11 @@ class BatchRecord {
     private modelScratch: Float32Array | null = null;
     private previousModelScratch: Float32Array | null = null;
     private normalScratch: Float32Array | null = null;
+    private historyScratch: Float32Array | null = null;
     private readonly normalMatrix3 = new Matrix3();
     private readonly normalMatrix4 = new Matrix4();
+    private readonly webGLCurrentModel = new Float32Array(16);
+    private readonly webGLPreviousModel = new Float32Array(16);
 
     constructor(backend: RHIBackend, diagnostics: MutableDiagnostics) {
         this.backend = backend;
@@ -822,7 +826,7 @@ class BatchRecord {
                 meshes,
                 material,
                 programInfo,
-                transformHistory?.renderOrigin
+                transformHistory
             );
         }
 
@@ -839,19 +843,25 @@ class BatchRecord {
                 this.normalScratch,
                 'normal-matrix staging storage'
             );
+            const historyScratch = requirePresent(
+                this.historyScratch,
+                'instance-history staging storage'
+            );
             modelScratch.fill(0);
             previousModelScratch.fill(0);
             normalScratch.fill(0);
+            historyScratch.fill(0);
             for (let meshIndex = 0; meshIndex < meshes.length; meshIndex += 1) {
                 const mesh = requirePresent(meshes[meshIndex], 'instance mesh');
                 const matrixOffset = meshIndex * 16;
                 if (transformHistory !== undefined) {
-                    transformHistory.writeInstanceModelMatrices(
+                    const historyValid = transformHistory.writeInstanceModelMatrices(
                         mesh,
                         modelScratch,
                         previousModelScratch,
                         matrixOffset
                     );
+                    historyScratch[meshIndex * 4] = historyValid ? 1 : 0;
                 } else {
                     const world = validateWorldMatrix(mesh);
                     for (let component = 0; component < 16; component += 1) {
@@ -883,6 +893,8 @@ class BatchRecord {
                     instanceBlockLayout.fields.u_instanceNormalMatrices.offset / FLOAT_BYTES;
                 const previousModelOffset =
                     instanceBlockLayout.fields.u_previousInstanceModelMatrices.offset / FLOAT_BYTES;
+                const historyOffset =
+                    instanceBlockLayout.fields.u_instanceHistoryParams.offset / FLOAT_BYTES;
                 modelChanged =
                     !arraysEqual(
                         modelScratch,
@@ -895,6 +907,12 @@ class BatchRecord {
                         this.uniformBufferFloats,
                         previousModelScratch.length,
                         previousModelOffset
+                    ) ||
+                    !arraysEqual(
+                        historyScratch,
+                        this.uniformBufferFloats,
+                        historyScratch.length,
+                        historyOffset
                     );
                 normalChanged = !arraysEqual(
                     normalScratch,
@@ -986,6 +1004,10 @@ class BatchRecord {
                         'previous model-matrix staging storage'
                     )
                 );
+                this.uniformBuffer.set(
+                    'u_instanceHistoryParams',
+                    requirePresent(this.historyScratch, 'instance-history staging storage')
+                );
             }
             if (normalChanged) {
                 this.uniformBuffer.set(
@@ -1042,6 +1064,7 @@ class BatchRecord {
         this.modelScratch = null;
         this.previousModelScratch = null;
         this.normalScratch = null;
+        this.historyScratch = null;
     }
 
     private classify(
@@ -1081,16 +1104,23 @@ class BatchRecord {
                 this.perVertexScratch.push(candidate);
                 continue;
             }
+            const builtIn =
+                name === MODEL_MATRIX_INPUT
+                    ? 1
+                    : name === NORMAL_MATRIX_INPUT
+                      ? 2
+                      : name === PREVIOUS_MODEL_MATRIX_INPUT
+                        ? 3
+                        : name === MODEL_HISTORY_VALID_INPUT
+                          ? 4
+                          : 0;
             const binding = findInstancedBinding(instancedBindings, name);
-            if (binding === undefined) {
+            if (binding === undefined && builtIn === 0) {
                 throw new TypeError(
                     `Vertex input ${name} has neither a per-vertex attribute nor a mesh-dependent instanced binding`
                 );
             }
-            if (
-                this.backend === 'webgpu' &&
-                (name === MODEL_MATRIX_INPUT || name === NORMAL_MATRIX_INPUT)
-            ) {
+            if (this.backend === 'webgpu' && builtIn !== 0) {
                 throw new TypeError(
                     `WebGPU built-in input ${name} must be supplied by InstanceBlock, not reflected as a vertex input`
                 );
@@ -1112,6 +1142,16 @@ class BatchRecord {
                     'u_normalWorldMatrix must be reflected as mat3 for WebGL2 instancing'
                 );
             }
+            if (name === PREVIOUS_MODEL_MATRIX_INPUT && (shape.columns !== 4 || shape.rows !== 4)) {
+                throw new TypeError(
+                    'u_previousModelMatrix must be reflected as mat4 for WebGL2 instancing'
+                );
+            }
+            if (name === MODEL_HISTORY_VALID_INPUT && (shape.columns !== 1 || shape.rows !== 1)) {
+                throw new TypeError(
+                    'u_modelHistoryValid must be reflected as float for WebGL2 instancing'
+                );
+            }
             const candidate = this.requireInstanceScratch(instanceIndex++);
             candidate.input = input;
             candidate.binding = binding;
@@ -1124,8 +1164,7 @@ class BatchRecord {
             candidate.rows = shape.rows;
             candidate.format = shape.format;
             candidate.componentOffset = 0;
-            candidate.builtIn =
-                name === MODEL_MATRIX_INPUT ? 1 : name === NORMAL_MATRIX_INPUT ? 2 : 0;
+            candidate.builtIn = builtIn;
             this.instanceScratch.push(candidate);
         }
         this.instanceScratch.sort(compareInstanceInputs);
@@ -1213,28 +1252,39 @@ class BatchRecord {
         meshes: readonly Mesh[],
         material: Material,
         programInfo: ProgramBindingInfo,
-        renderOrigin?: Readonly<Float32Array>
+        transformHistory?: InstanceTransformHistory
     ): void {
         let componentsPerInstance = 0;
         const last = this.instanceScratch.at(-1);
         if (last !== undefined) componentsPerInstance = last.componentOffset + last.components;
+        const needsModelHistory = this.instanceScratch.some(
+            input => input.builtIn === 1 || input.builtIn === 3 || input.builtIn === 4
+        );
         for (let meshIndex = 0; meshIndex < meshes.length; meshIndex += 1) {
             const mesh = requirePresent(meshes[meshIndex], 'instance mesh');
             const instanceOffset = meshIndex * componentsPerInstance;
+            let historyValid = false;
+            if (needsModelHistory) {
+                if (transformHistory === undefined) {
+                    const world = validateWorldMatrix(mesh);
+                    this.webGLCurrentModel.set(world);
+                    this.webGLPreviousModel.set(world);
+                } else {
+                    historyValid = transformHistory.writeInstanceModelMatrices(
+                        mesh,
+                        this.webGLCurrentModel,
+                        this.webGLPreviousModel,
+                        0
+                    );
+                }
+            }
             for (const input of this.instanceScratch) {
                 const targetOffset = instanceOffset + input.componentOffset;
                 if (input.builtIn === 1) {
-                    const world = validateWorldMatrix(mesh);
-                    if (renderOrigin !== undefined) {
-                        this.normalMatrix4.fromArray(world);
-                        this.normalMatrix4.elements[12] -= renderOrigin[0] ?? 0;
-                        this.normalMatrix4.elements[13] -= renderOrigin[1] ?? 0;
-                        this.normalMatrix4.elements[14] -= renderOrigin[2] ?? 0;
-                    }
                     copyResolvedValue(
                         target,
                         targetOffset,
-                        renderOrigin === undefined ? world : this.normalMatrix4.elements,
+                        this.webGLCurrentModel,
                         16,
                         input.name,
                         mesh
@@ -1251,8 +1301,29 @@ class BatchRecord {
                         input.name,
                         mesh
                     );
+                } else if (input.builtIn === 3) {
+                    copyResolvedValue(
+                        target,
+                        targetOffset,
+                        this.webGLPreviousModel,
+                        16,
+                        input.name,
+                        mesh
+                    );
+                } else if (input.builtIn === 4) {
+                    copyResolvedValue(
+                        target,
+                        targetOffset,
+                        historyValid ? 1 : 0,
+                        1,
+                        input.name,
+                        mesh
+                    );
                 } else {
-                    const value = input.binding.get(mesh, material, programInfo);
+                    const value = requirePresent(
+                        input.binding,
+                        `instanced binding ${input.name}`
+                    ).get(mesh, material, programInfo);
                     copyResolvedValue(
                         target,
                         targetOffset,
@@ -1270,14 +1341,16 @@ class BatchRecord {
         if (
             this.modelScratch !== null &&
             this.previousModelScratch !== null &&
-            this.normalScratch !== null
+            this.normalScratch !== null &&
+            this.historyScratch !== null
         )
             return;
         const componentCount = MAX_INSTANCES_PER_DRAW * 16;
         this.modelScratch = new Float32Array(componentCount);
         this.previousModelScratch = new Float32Array(componentCount);
         this.normalScratch = new Float32Array(componentCount);
-        this.diagnostics.storageAllocationCount += 3;
+        this.historyScratch = new Float32Array(MAX_INSTANCES_PER_DRAW * 4);
+        this.diagnostics.storageAllocationCount += 4;
     }
 
     private buildStreamLayout(stride: number): Readonly<RHIVertexBufferLayout> {

--- a/src/render/renderer/MeshDrawProcessor.ts
+++ b/src/render/renderer/MeshDrawProcessor.ts
@@ -170,6 +170,22 @@ function requireMaterialPassState(
     return state;
 }
 
+function validateMaterialPassTarget(
+    role: MaterialPassRole,
+    target: RHIMeshDrawTargetDescriptor
+): void {
+    if (role !== 'motion-vector') return;
+    if (
+        target.colorFormats.length !== 1 ||
+        target.colorFormats[0] !== 'rg16float' ||
+        target.sampleCount !== 1
+    ) {
+        throw new TypeError(
+            'Motion-vector mesh draws require one single-sample rg16float color target'
+        );
+    }
+}
+
 const SHADER_GEOMETRY_OPTION_FIELDS = Object.freeze([
     'positionDecodeMat',
     'normalDecodeMat',
@@ -655,6 +671,7 @@ export class MeshDrawProcessor {
         const fragmentOutputMode = this.fragmentOutputModeFor(target);
         const role =
             materialPass ?? (fragmentOutputMode === 'depth-only' ? 'depth-only' : 'forward');
+        validateMaterialPassTarget(role, target);
         const materialState = requireMaterialPassState(material, role);
         this.validateLighting(mesh, material, context);
         this.validateDeformation(mesh, geometry);
@@ -1195,6 +1212,7 @@ export class MeshDrawProcessor {
         const fragmentOutputMode = this.fragmentOutputModeFor(target);
         const role =
             materialPass ?? (fragmentOutputMode === 'depth-only' ? 'depth-only' : 'forward');
+        validateMaterialPassTarget(role, target);
         const materialState = requireMaterialPassState(material, role);
         this.validateLighting(representative, material, context);
         geometry.normalizePrimitiveTopology();

--- a/src/render/renderer/ShaderBindingLayoutCompiler.ts
+++ b/src/render/renderer/ShaderBindingLayoutCompiler.ts
@@ -46,6 +46,8 @@ export interface ShaderSampledBindingPlan {
     readonly textureBinding: number;
     readonly samplerBinding: number;
     readonly samplerKind: 'sampler' | 'comparison-sampler';
+    readonly sampleType: RHITextureSampleType;
+    readonly samplerType: 'filtering' | 'non-filtering' | 'comparison';
     readonly visibility: RHIShaderStageFlags;
 }
 
@@ -477,6 +479,8 @@ function sampledBindingPlan(binding: MutableSampledBinding): Readonly<ShaderSamp
         textureBinding: binding.textureBinding,
         samplerBinding: binding.samplerBinding,
         samplerKind: binding.samplerKind,
+        sampleType: binding.sampleType,
+        samplerType: binding.samplerType,
         visibility: binding.visibility
     });
 }

--- a/src/render/ubo/BuiltInUniformBlocks.ts
+++ b/src/render/ubo/BuiltInUniformBlocks.ts
@@ -36,7 +36,9 @@ export const cameraBlockLayout = createStd140Layout({
     u_renderOrigin: 'vec4',
     u_previousRenderOrigin: 'vec4',
     u_historyParams: 'vec4',
-    u_viewport: 'vec4'
+    u_viewport: 'vec4',
+    u_nonJitteredProjectionMatrix: 'mat4',
+    u_nonJitteredViewProjectionMatrix: 'mat4'
 });
 
 export const sceneBlockLayout = createStd140Layout({
@@ -132,7 +134,8 @@ export const modelBlockLayout = createStd140Layout({
     u_modelMatrix: 'mat4',
     u_previousModelMatrix: 'mat4',
     u_normalWorldMatrix: 'mat3',
-    u_objectIdColor: 'vec4'
+    u_objectIdColor: 'vec4',
+    u_modelHistoryParams: 'vec4'
 });
 
 export const geometryBlockLayout = createStd140Layout({
@@ -144,20 +147,23 @@ export const geometryBlockLayout = createStd140Layout({
 
 export const skinningBlockLayout = createStd140Layout({
     u_jointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS },
-    u_previousJointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS }
+    u_previousJointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS },
+    u_skinHistoryParams: 'vec4'
 });
 
 export const morphBlockLayout = createStd140Layout({
     u_morphWeights0: 'vec4',
     u_morphWeights1: 'vec4',
     u_previousMorphWeights0: 'vec4',
-    u_previousMorphWeights1: 'vec4'
+    u_previousMorphWeights1: 'vec4',
+    u_morphHistoryParams: 'vec4'
 });
 
 export const instanceBlockLayout = createStd140Layout({
     u_instanceModelMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW },
     u_previousInstanceModelMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW },
-    u_instanceNormalMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW }
+    u_instanceNormalMatrices: { type: 'mat4', arrayLength: MAX_INSTANCES_PER_DRAW },
+    u_instanceHistoryParams: { type: 'vec4', arrayLength: MAX_INSTANCES_PER_DRAW }
 });
 
 export const BUILT_IN_UNIFORM_BLOCK_LAYOUTS: Readonly<Record<string, Std140Layout>> = Object.freeze(

--- a/src/shader/Shader.ts
+++ b/src/shader/Shader.ts
@@ -481,6 +481,7 @@ class Shader {
         header += `#define HILO_MATERIAL_ROLE_${role.replaceAll('-', '_').replaceAll(':', '_').toUpperCase()} 1\n`;
         if (role === 'depth-only') header += '#define HILO_DEPTH_ONLY_PASS 1\n';
         else if (role === 'shadow-caster') header += '#define HILO_SHADOW_CASTER_PASS 1\n';
+        else if (role === 'motion-vector') header += '#define HILO_MOTION_VECTOR_PASS 1\n';
         else if (role === 'picking') header += '#define HILO_PICKING_PASS 1\n';
         if (linearOutput) header += '#define HILO_LINEAR_OUTPUT 1\n';
         const pass = resolveMaterialPassDefinition(material, role);

--- a/src/shader/basic.frag
+++ b/src/shader/basic.frag
@@ -13,6 +13,7 @@
 #include "./chunk/transparency.frag"
 #include "./chunk/fog.frag"
 #include "./chunk/logDepth.frag"
+#include "./chunk/motionVector.frag"
 #ifdef HILO_PICKING_PASS
 in vec4 v_objectIdColor;
 #endif
@@ -20,17 +21,25 @@ in vec4 v_objectIdColor;
 void main(void) {
     #ifdef HILO_PICKING_PASS
         hilo_FragColor = v_objectIdColor;
-        return;
+    #elif defined(HILO_MOTION_VECTOR_PASS)
+        {
+            vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
+            vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
+            #include "./chunk/diffuse_main.frag"
+            #include "./chunk/transparency_main.frag"
+            hilo_FragColor = vec4(hiloMotionVector(), 0.0, 1.0);
+            #include "./chunk/logDepth_main.frag"
+        }
+    #else
+        vec4 diffuse = vec4(0., 0., 0., 1.);
+        vec4 color = vec4(0., 0., 0., 1.);
+
+        #include "./chunk/normal_main.frag"
+        #include "./chunk/lightFog_main.frag"
+        #include "./chunk/diffuse_main.frag"
+        #include "./chunk/phong_main.frag"
+        #include "./chunk/transparency_main.frag"
+        #include "./chunk/frag_color.frag"
+        #include "./chunk/logDepth_main.frag"
     #endif
-
-    vec4 diffuse = vec4(0., 0., 0., 1.);
-    vec4 color = vec4(0., 0., 0., 1.);
-
-    #include "./chunk/normal_main.frag"
-    #include "./chunk/lightFog_main.frag"
-    #include "./chunk/diffuse_main.frag"
-    #include "./chunk/phong_main.frag"
-    #include "./chunk/transparency_main.frag"
-    #include "./chunk/frag_color.frag"
-    #include "./chunk/logDepth_main.frag"
 }

--- a/src/shader/basic.vert
+++ b/src/shader/basic.vert
@@ -16,6 +16,11 @@ in vec3 a_position;
 #ifdef HILO_PICKING_PASS
 out vec4 v_objectIdColor;
 #endif
+#ifdef HILO_MOTION_VECTOR_PASS
+out vec4 v_currentClipPosition;
+out vec4 v_previousClipPosition;
+flat out float v_motionHistoryValid;
+#endif
 void main(void) {
     vec4 pos = vec4(a_position, 1.0);
     #ifdef HILO_HAS_TEXCOORD0
@@ -34,13 +39,36 @@ void main(void) {
 
     #include "./chunk/color_main.vert"
     #include "./chunk/unQuantize_main.vert"
+    #ifdef HILO_MOTION_VECTOR_PASS
+        vec4 previousPos = pos;
+    #endif
     #include "./chunk/morph_main.vert"
     #include "./chunk/joint_main.vert"
     #include "./chunk/uv_main.vert"
     #include "./chunk/normal_main.vert"
     #include "./chunk/lightFog_main.vert"
 
-    gl_Position = u_viewProjectionMatrix * u_modelMatrix * pos;
+    vec4 currentClipPosition = u_viewProjectionMatrix * u_modelMatrix * pos;
+    gl_Position = currentClipPosition;
+
+    #ifdef HILO_MOTION_VECTOR_PASS
+        #if defined(HILO_MORPH_TARGET_COUNT) && defined(HILO_MORPH_HAS_POSITION)
+            previousPos.xyz += hiloPreviousMorphPositionOffset();
+        #endif
+        #ifdef HILO_JOINT_COUNT
+            previousPos = getPreviousJointMat(a_skinWeights, a_skinIndices) * previousPos;
+        #endif
+        v_currentClipPosition = currentClipPosition;
+        v_previousClipPosition =
+            u_previousViewProjectionMatrix * u_previousModelMatrix * previousPos;
+        v_motionHistoryValid = min(u_cameraHistoryValid, u_modelHistoryValid);
+        #ifdef HILO_JOINT_COUNT
+            v_motionHistoryValid = min(v_motionHistoryValid, u_skinHistoryValid);
+        #endif
+        #if defined(HILO_MORPH_TARGET_COUNT) && defined(HILO_MORPH_HAS_POSITION)
+            v_motionHistoryValid = min(v_motionHistoryValid, u_morphHistoryValid);
+        #endif
+    #endif
 
     #ifdef HILO_PICKING_PASS
         v_objectIdColor = u_objectIdColor;

--- a/src/shader/chunk/cameraBlock.glsl
+++ b/src/shader/chunk/cameraBlock.glsl
@@ -15,6 +15,8 @@ layout(std140) uniform CameraBlock {
     vec4 u_previousRenderOrigin;
     vec4 u_historyParams;
     vec4 u_viewport;
+    mat4 u_nonJitteredProjectionMatrix;
+    mat4 u_nonJitteredViewProjectionMatrix;
 };
 
 #define u_cameraPosition u_cameraPositionNear.xyz

--- a/src/shader/chunk/joint.vert
+++ b/src/shader/chunk/joint.vert
@@ -9,6 +9,13 @@
             mat += weights.w * u_jointMat[int(indices.w)];
             return mat;
         }
+        mat4 getPreviousJointMat(vec4 weights, uvec4 indices) {
+            mat4 mat = weights.x * u_previousJointMat[int(indices.x)];
+            mat += weights.y * u_previousJointMat[int(indices.y)];
+            mat += weights.z * u_previousJointMat[int(indices.z)];
+            mat += weights.w * u_previousJointMat[int(indices.w)];
+            return mat;
+        }
     #else
         in vec4 a_skinIndices;
         mat4 getJointMat(vec4 weights, vec4 indices) {
@@ -16,6 +23,13 @@
             mat += weights.y * u_jointMat[int(indices.y)];
             mat += weights.z * u_jointMat[int(indices.z)];
             mat += weights.w * u_jointMat[int(indices.w)];
+            return mat;
+        }
+        mat4 getPreviousJointMat(vec4 weights, vec4 indices) {
+            mat4 mat = weights.x * u_previousJointMat[int(indices.x)];
+            mat += weights.y * u_previousJointMat[int(indices.y)];
+            mat += weights.z * u_previousJointMat[int(indices.z)];
+            mat += weights.w * u_previousJointMat[int(indices.w)];
             return mat;
         }
     #endif

--- a/src/shader/chunk/morph.vert
+++ b/src/shader/chunk/morph.vert
@@ -94,4 +94,35 @@
             in vec3 a_morphTangent7;
         #endif
     #endif
+
+    #ifdef HILO_MORPH_HAS_POSITION
+        vec3 hiloPreviousMorphPositionOffset() {
+            vec3 offset = vec3(0.0);
+            #if HILO_MORPH_TARGET_COUNT > 0
+                offset += a_morphPosition0 * hiloPreviousMorphWeight(0);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 1
+                offset += a_morphPosition1 * hiloPreviousMorphWeight(1);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 2
+                offset += a_morphPosition2 * hiloPreviousMorphWeight(2);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 3
+                offset += a_morphPosition3 * hiloPreviousMorphWeight(3);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 4
+                offset += a_morphPosition4 * hiloPreviousMorphWeight(4);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 5
+                offset += a_morphPosition5 * hiloPreviousMorphWeight(5);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 6
+                offset += a_morphPosition6 * hiloPreviousMorphWeight(6);
+            #endif
+            #if HILO_MORPH_TARGET_COUNT > 7
+                offset += a_morphPosition7 * hiloPreviousMorphWeight(7);
+            #endif
+            return offset;
+        }
+    #endif
 #endif

--- a/src/shader/chunk/motionVector.frag
+++ b/src/shader/chunk/motionVector.frag
@@ -1,0 +1,24 @@
+#ifdef HILO_MOTION_VECTOR_PASS
+    #include "../method/portableCoordinates.glsl"
+
+    in vec4 v_currentClipPosition;
+    in vec4 v_previousClipPosition;
+    flat in float v_motionHistoryValid;
+
+    vec2 hiloMotionVector() {
+        if (
+            v_motionHistoryValid < 0.5 ||
+            abs(v_currentClipPosition.w) < 1e-6 ||
+            abs(v_previousClipPosition.w) < 1e-6
+        ) {
+            return vec2(0.0);
+        }
+        vec2 currentUV = hiloRenderTargetUV(
+            v_currentClipPosition.xy / v_currentClipPosition.w * 0.5 + 0.5
+        );
+        vec2 previousUV = hiloRenderTargetUV(
+            v_previousClipPosition.xy / v_previousClipPosition.w * 0.5 + 0.5
+        );
+        return currentUV - previousUV;
+    }
+#endif

--- a/src/shader/chunk/uniformBlocks.glsl
+++ b/src/shader/chunk/uniformBlocks.glsl
@@ -109,14 +109,22 @@ layout(std140) uniform MaterialTextureBlock {
             mat4 u_instanceModelMatrices[HILO_MAX_INSTANCES_PER_DRAW];
             mat4 u_previousInstanceModelMatrices[HILO_MAX_INSTANCES_PER_DRAW];
             mat4 u_instanceNormalMatrices[HILO_MAX_INSTANCES_PER_DRAW];
+            vec4 u_instanceHistoryParams[HILO_MAX_INSTANCES_PER_DRAW];
         };
         #define u_modelMatrix u_instanceModelMatrices[gl_InstanceIndex]
         #define u_previousModelMatrix u_previousInstanceModelMatrices[gl_InstanceIndex]
         #define u_normalWorldMatrix mat3(u_instanceNormalMatrices[gl_InstanceIndex])
+        #define u_modelHistoryValid u_instanceHistoryParams[gl_InstanceIndex].x
     #else
         in mat4 u_modelMatrix;
         in mat3 u_normalWorldMatrix;
-        #define u_previousModelMatrix u_modelMatrix
+        #ifdef HILO_MOTION_VECTOR_PASS
+            in mat4 u_previousModelMatrix;
+            in float u_modelHistoryValid;
+        #else
+            #define u_previousModelMatrix u_modelMatrix
+            #define u_modelHistoryValid 0.0
+        #endif
     #endif
 #else
     layout(std140) uniform ModelBlock {
@@ -124,7 +132,9 @@ layout(std140) uniform MaterialTextureBlock {
         mat4 u_previousModelMatrix;
         mat3 u_normalWorldMatrix;
         vec4 u_objectIdColor;
+        vec4 u_modelHistoryParams;
     };
+    #define u_modelHistoryValid u_modelHistoryParams.x
 #endif
 
 layout(std140) uniform GeometryBlock {
@@ -138,7 +148,9 @@ layout(std140) uniform GeometryBlock {
     layout(std140) uniform SkinningBlock {
         mat4 u_jointMat[HILO_MAX_SKIN_JOINTS];
         mat4 u_previousJointMat[HILO_MAX_SKIN_JOINTS];
+        vec4 u_skinHistoryParams;
     };
+    #define u_skinHistoryValid u_skinHistoryParams.x
 #endif
 
 #ifdef HILO_MORPH_TARGET_COUNT
@@ -147,10 +159,18 @@ layout(std140) uniform GeometryBlock {
         vec4 u_morphWeights1;
         vec4 u_previousMorphWeights0;
         vec4 u_previousMorphWeights1;
+        vec4 u_morphHistoryParams;
     };
+    #define u_morphHistoryValid u_morphHistoryParams.x
 
     float hiloMorphWeight(int index) {
         return index < 4 ? u_morphWeights0[index] : u_morphWeights1[index - 4];
+    }
+
+    float hiloPreviousMorphWeight(int index) {
+        return index < 4
+            ? u_previousMorphWeights0[index]
+            : u_previousMorphWeights1[index - 4];
     }
 #endif
 #endif

--- a/src/shader/geometry.frag
+++ b/src/shader/geometry.frag
@@ -25,25 +25,31 @@ vec4 transformDataToColor(vec3 data){
 }
 
 #include "./chunk/logDepth.frag"
+#include "./chunk/motionVector.frag"
 
 void main(void) {
-    #if defined(HILO_VERTEX_TYPE_POSITION)
-        hilo_FragColor = transformDataToColor(v_fragPos);
-    #elif defined(HILO_VERTEX_TYPE_NORMAL)
-        hilo_FragColor = transformDataToColor(v_normal);
-    #elif defined(HILO_VERTEX_TYPE_DEPTH)
-        #ifdef HILO_WRITE_ORIGIN_DATA
-            hilo_FragColor = vec4(gl_FragCoord.z, gl_FragCoord.z, gl_FragCoord.z, 1.0);
-        #else
-            hilo_FragColor = packFloat(gl_FragCoord.z);
+    #ifdef HILO_MOTION_VECTOR_PASS
+        hilo_FragColor = vec4(hiloMotionVector(), 0.0, 1.0);
+        #include "./chunk/logDepth_main.frag"
+    #else
+        #if defined(HILO_VERTEX_TYPE_POSITION)
+            hilo_FragColor = transformDataToColor(v_fragPos);
+        #elif defined(HILO_VERTEX_TYPE_NORMAL)
+            hilo_FragColor = transformDataToColor(v_normal);
+        #elif defined(HILO_VERTEX_TYPE_DEPTH)
+            #ifdef HILO_WRITE_ORIGIN_DATA
+                hilo_FragColor = vec4(gl_FragCoord.z, gl_FragCoord.z, gl_FragCoord.z, 1.0);
+            #else
+                hilo_FragColor = packFloat(gl_FragCoord.z);
+            #endif
+        #elif defined(HILO_VERTEX_TYPE_DISTANCE)
+            float distance = length(v_fragPos);
+            #ifdef HILO_WRITE_ORIGIN_DATA
+                hilo_FragColor = vec4(distance, distance, distance, 1.0);
+            #else
+                hilo_FragColor = packFloat((distance - u_cameraNear)/(u_cameraFar - u_cameraNear));
+            #endif
         #endif
-    #elif defined(HILO_VERTEX_TYPE_DISTANCE)
-        float distance = length(v_fragPos);
-        #ifdef HILO_WRITE_ORIGIN_DATA
-            hilo_FragColor = vec4(distance, distance, distance, 1.0);
-        #else
-            hilo_FragColor = packFloat((distance - u_cameraNear)/(u_cameraFar - u_cameraNear));
-        #endif
+        #include "./chunk/logDepth_main.frag"
     #endif
-    #include "./chunk/logDepth_main.frag"
 }

--- a/src/shader/pbr.frag
+++ b/src/shader/pbr.frag
@@ -12,13 +12,30 @@
 #include "./chunk/transparency.frag"
 #include "./chunk/fog.frag"
 #include "./chunk/logDepth.frag"
+#include "./chunk/motionVector.frag"
 
 void main(void) {
-    vec4 color = vec4(0., 0., 0., 1.);
+    #ifdef HILO_MOTION_VECTOR_PASS
+        {
+            vec4 baseColorSample = vec4(1.0);
+            #ifdef HILO_BASE_COLOR_MAP
+                baseColorSample = HILO_TEXTURE_2D(u_baseColorMap, HILO_BASE_COLOR_MAP);
+            #endif
+            vec4 color = hiloEvaluatePBRBaseColor(u_baseColor, baseColorSample);
+            #ifdef HILO_HAS_COLOR
+                color *= v_color;
+            #endif
+            #include "./chunk/transparency_main.frag"
+            hilo_FragColor = vec4(hiloMotionVector(), 0.0, 1.0);
+            #include "./chunk/logDepth_main.frag"
+        }
+    #else
+        vec4 color = vec4(0., 0., 0., 1.);
 
-    #include "./chunk/normal_main.frag"
-    #include "./chunk/lightFog_main.frag"
-    #include "./chunk/pbr_main.frag"
-    #include "./chunk/frag_color.frag"
-    #include "./chunk/logDepth_main.frag"
+        #include "./chunk/normal_main.frag"
+        #include "./chunk/lightFog_main.frag"
+        #include "./chunk/pbr_main.frag"
+        #include "./chunk/frag_color.frag"
+        #include "./chunk/logDepth_main.frag"
+    #endif
 }

--- a/test/spec/camera/PerspectiveCamera.test.ts
+++ b/test/spec/camera/PerspectiveCamera.test.ts
@@ -45,4 +45,30 @@ describe('PerspectiveCamera', () => {
         expect(() => new PerspectiveCamera({ near: 0 })).toThrow(/near/);
         expect(() => new PerspectiveCamera({ near: 2, far: 1 })).toThrow(/far/);
     });
+
+    it('separates raster jitter from the stable CPU projection', () => {
+        const camera = new PerspectiveCamera({ aspect: 16 / 9 });
+        camera.updateViewProjectionMatrix();
+        const stableProjection = Array.from(camera.projectionMatrix.elements);
+        const stableViewProjection = Array.from(camera.viewProjectionMatrix.elements);
+
+        camera.setProjectionJitter(0.01, -0.02);
+
+        expect(Array.from(camera.projectionMatrix.elements)).toEqual(stableProjection);
+        expect(Array.from(camera.viewProjectionMatrix.elements)).toEqual(stableViewProjection);
+        expect(camera.jitteredProjectionMatrix.elements).not.toEqual(
+            camera.projectionMatrix.elements
+        );
+        expect(camera.jitteredViewProjectionMatrix.elements).not.toEqual(
+            camera.viewProjectionMatrix.elements
+        );
+        expect(camera.projectionJitterX).toBe(0.01);
+        expect(camera.projectionJitterY).toBe(-0.02);
+
+        camera.clearProjectionJitter();
+        expect(camera.jitteredProjectionMatrix.elements).toEqual(camera.projectionMatrix.elements);
+        expect(camera.jitteredViewProjectionMatrix.elements).toEqual(
+            camera.viewProjectionMatrix.elements
+        );
+    });
 });

--- a/test/spec/material/Material.test.ts
+++ b/test/spec/material/Material.test.ts
@@ -95,14 +95,20 @@ describe('modern material model', () => {
         expect(Object.isFrozen(Hilo3d.MaterialTextureSlot)).toBe(true);
     });
 
-    it('only declares semantic passes that built-in shaders implement today', () => {
+    it('declares the implemented built-in semantic passes', () => {
         const material = new Hilo3d.BasicMaterial();
 
         expect(material.definition.getPass('forward')).not.toBeNull();
         expect(material.definition.getPass('depth-only')).not.toBeNull();
         expect(material.definition.getPass('shadow-caster')).not.toBeNull();
         expect(material.definition.getPass('picking')).not.toBeNull();
-        expect(material.definition.getPass('motion-vector')).toBeNull();
+        expect(material.definition.getPass('motion-vector')).toMatchObject({
+            fragmentOutput: 'motion-vector',
+            state: {
+                depthCompare: 'equal',
+                depthWrite: false
+            }
+        });
         expect(material.definition.getPass('material-attributes')).toBeNull();
     });
 });

--- a/test/spec/renderer/BuiltInUniformBlockManager.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlockManager.test.ts
@@ -638,11 +638,13 @@ describe('BuiltInUniformBlockManager', () => {
 
         let block = render(2);
         expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(2);
+        expect(readFloatField(block, 'u_modelHistoryParams', 1)[0]).toBe(0);
         manager.commit({} as never);
 
         block = render(3);
         expect(readFloatField(block, 'u_modelMatrix', 16)[12]).toBe(3);
         expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(2);
+        expect(readFloatField(block, 'u_modelHistoryParams', 1)[0]).toBe(1);
         manager.rollback();
 
         block = render(4);
@@ -652,6 +654,30 @@ describe('BuiltInUniformBlockManager', () => {
         mesh.invalidateTransformHistory();
         block = render(20);
         expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(20);
+        expect(readFloatField(block, 'u_modelHistoryParams', 1)[0]).toBe(0);
+    });
+
+    it('packs jittered raster matrices beside stable CPU camera matrices', () => {
+        const manager = new BuiltInUniformBlockManager({ width: 320, height: 180 });
+        const camera = new PerspectiveCamera({ aspect: 16 / 9 });
+        camera.setProjectionJitter(0.01, -0.02).updateViewProjectionMatrix();
+        manager.beginFrame(camera);
+        const block = manager.resolveUniformBlock(
+            'CameraBlock',
+            testEnv.mesh,
+            testEnv.material,
+            camera
+        );
+
+        expect(readFloatField(block, 'u_projectionMatrix', 16)).toEqualishValues(
+            ...camera.jitteredProjectionMatrix.elements
+        );
+        expect(readFloatField(block, 'u_nonJitteredProjectionMatrix', 16)).toEqualishValues(
+            ...camera.projectionMatrix.elements
+        );
+        expect(readFloatField(block, 'u_viewProjectionMatrix', 16)).not.toEqualishValues(
+            ...readFloatField(block, 'u_nonJitteredViewProjectionMatrix', 16)
+        );
     });
 
     it('packs ambient and directional lighting into LightBlock for every render pass', () => {

--- a/test/spec/renderer/BuiltInUniformBlocks.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlocks.test.ts
@@ -30,16 +30,16 @@ describe('built-in std140 ABI', () => {
             InstanceBlock: instanceBlockLayout.byteLength
         }).toEqual({
             FrameBlock: 16,
-            CameraBlock: 720,
+            CameraBlock: 848,
             SceneBlock: 32,
             LightBlock: 16288,
             MaterialBlock: 432,
             MaterialTextureBlock: 1920,
-            ModelBlock: 192,
+            ModelBlock: 208,
             GeometryBlock: 224,
-            SkinningBlock: 16384,
-            MorphBlock: 64,
-            InstanceBlock: 24576
+            SkinningBlock: 16400,
+            MorphBlock: 80,
+            InstanceBlock: 26624
         });
     });
 
@@ -61,6 +61,8 @@ describe('built-in std140 ABI', () => {
         expect(cameraBlockLayout.fields.u_previousRenderOrigin.offset).toBe(672);
         expect(cameraBlockLayout.fields.u_historyParams.offset).toBe(688);
         expect(cameraBlockLayout.fields.u_viewport.offset).toBe(704);
+        expect(cameraBlockLayout.fields.u_nonJitteredProjectionMatrix.offset).toBe(720);
+        expect(cameraBlockLayout.fields.u_nonJitteredViewProjectionMatrix.offset).toBe(784);
 
         expect(materialBlockLayout.fields.u_diffuseEnvSphereHarmonics3.offset).toBe(96);
         expect(materialBlockLayout.fields.u_diffuseEnvSphereHarmonics3.arrayStride).toBe(16);
@@ -82,6 +84,7 @@ describe('built-in std140 ABI', () => {
         expect(modelBlockLayout.fields.u_previousModelMatrix.offset).toBe(64);
         expect(modelBlockLayout.fields.u_normalWorldMatrix.offset).toBe(128);
         expect(modelBlockLayout.fields.u_objectIdColor.offset).toBe(176);
+        expect(modelBlockLayout.fields.u_modelHistoryParams.offset).toBe(192);
         expect(geometryBlockLayout.fields.u_positionDecodeMat.offset).toBe(0);
         expect(geometryBlockLayout.fields.u_uvDecodeMat.offset).toBe(128);
         expect(geometryBlockLayout.fields.u_uv1DecodeMat.offset).toBe(176);
@@ -104,11 +107,14 @@ describe('built-in std140 ABI', () => {
 
         expect(skinningBlockLayout.fields.u_jointMat.arrayStride).toBe(64);
         expect(skinningBlockLayout.fields.u_previousJointMat.offset).toBe(8192);
+        expect(skinningBlockLayout.fields.u_skinHistoryParams.offset).toBe(16384);
         expect(morphBlockLayout.fields.u_morphWeights1.offset).toBe(16);
         expect(morphBlockLayout.fields.u_previousMorphWeights0.offset).toBe(32);
         expect(morphBlockLayout.fields.u_previousMorphWeights1.offset).toBe(48);
+        expect(morphBlockLayout.fields.u_morphHistoryParams.offset).toBe(64);
         expect(instanceBlockLayout.fields.u_previousInstanceModelMatrices.offset).toBe(8192);
         expect(instanceBlockLayout.fields.u_instanceNormalMatrices.offset).toBe(16384);
+        expect(instanceBlockLayout.fields.u_instanceHistoryParams.offset).toBe(24576);
     });
 
     it('pads dynamic semantic arrays to the fixed ABI capacity and rejects overflow', () => {

--- a/test/spec/renderer/GlslToWgsl.test.ts
+++ b/test/spec/renderer/GlslToWgsl.test.ts
@@ -1110,6 +1110,23 @@ const builtInShaderCases: readonly BuiltInShaderCase[] = [
         expectedUniformBlocks: ['SkinningBlock', 'MorphBlock']
     },
     {
+        name: 'masked skinned and morphed motion vectors',
+        fragment: basicFragmentSource,
+        defines: {
+            HILO_LIGHT_TYPE_NONE: 1,
+            HILO_SIDE: 1028,
+            HILO_MOTION_VECTOR_PASS: 1,
+            HILO_HAS_TEXCOORD0: 1,
+            HILO_DIFFUSE_MAP: MaterialTextureSlot.DIFFUSE,
+            HILO_ALPHA_CUTOFF: 1,
+            HILO_JOINT_COUNT: 32,
+            HILO_MORPH_TARGET_COUNT: 8,
+            HILO_MORPH_HAS_POSITION: 1
+        },
+        expectedVertexInputs: ['a_skinIndices', 'a_skinWeights', 'a_morphPosition7'],
+        expectedUniformBlocks: ['CameraBlock', 'ModelBlock', 'SkinningBlock', 'MorphBlock']
+    },
+    {
         name: 'instanced model and normal matrices',
         fragment: basicFragmentSource,
         defines: {
@@ -1122,6 +1139,17 @@ const builtInShaderCases: readonly BuiltInShaderCase[] = [
             HILO_DIRECTIONAL_LIGHTS: 1
         },
         expectedUniformBlocks: ['InstanceBlock']
+    },
+    {
+        name: 'instanced motion vectors',
+        fragment: basicFragmentSource,
+        defines: {
+            HILO_LIGHT_TYPE_NONE: 1,
+            HILO_SIDE: 1028,
+            HILO_INSTANCED: 1,
+            HILO_MOTION_VECTOR_PASS: 1
+        },
+        expectedUniformBlocks: ['CameraBlock', 'InstanceBlock', 'GeometryBlock']
     },
     {
         name: 'quantized position, normal and both UV sets',

--- a/test/spec/renderer/PostProcessing.test.ts
+++ b/test/spec/renderer/PostProcessing.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
 import Mesh from '../../../src/core/Mesh';
 import Node from '../../../src/core/Node';
@@ -6,16 +6,110 @@ import BoxGeometry from '../../../src/geometry/BoxGeometry';
 import BasicMaterial from '../../../src/material/BasicMaterial';
 import PBRMaterial from '../../../src/material/PBRMaterial';
 import Color from '../../../src/math/Color';
+import Vector3 from '../../../src/math/Vector3';
 import Renderer from '../../../src/render/Renderer';
+import type {
+    ForwardRenderFeatureContext,
+    ForwardRenderPipelineFeature,
+    ForwardRenderPipelineFeatureRuntime
+} from '../../../src/render/pipeline/ForwardRenderPipeline';
 import { PORTABLE_FULLSCREEN_VERTEX_SOURCE } from '../../../src/render/pipeline/passes/internal/PortableFullscreenShader';
+import type {
+    RenderPipelineColorAttachment,
+    ScriptableRenderPass,
+    ScriptableRenderPassBuilder
+} from '../../../src/render/pipeline/ScriptableRenderGraph';
 import {
     Bloom,
     ColorUber,
-    PostProcessRenderPipelineFactory
+    PostProcessRenderPipelineFactory,
+    TemporalAA
 } from '../../../src/render/postprocessing';
 import Shader from '../../../src/shader/Shader';
+import type { RHIDevice } from '../../../src/render/rhi/core';
+
+declare const __HILO3D_GITHUB_ACTIONS_COVERAGE__: boolean;
 
 const activeRenderers: Renderer[] = [];
+
+interface TemporalFailureParameters {
+    readonly attachment: RenderPipelineColorAttachment;
+}
+
+class TemporalAcceptanceRuntime implements ForwardRenderPipelineFeatureRuntime {
+    fail = false;
+    readonly jitterSamples: { readonly x: number; readonly y: number }[] = [];
+    readonly pass: ScriptableRenderPass<TemporalFailureParameters> = {
+        name: 'TemporalAA acceptance failure boundary',
+        setup(builder: ScriptableRenderPassBuilder, parameters: TemporalFailureParameters): void {
+            builder.useColorAttachment(parameters.attachment);
+        },
+        execute: (): void => {
+            if (this.fail) throw new Error('forced TemporalAA submission failure');
+        }
+    };
+
+    record(context: ForwardRenderFeatureContext): void {
+        const color = context.resources.color;
+        if (color === null) throw new Error('TemporalAA acceptance color is unavailable');
+        this.jitterSamples.push({
+            x: context.pipeline.camera.projectionJitterX,
+            y: context.pipeline.camera.projectionJitterY
+        });
+        context.pipeline.graph.addPass(this.pass, {
+            attachment: {
+                texture: color,
+                loadOp: 'load',
+                storeOp: 'store'
+            }
+        });
+    }
+
+    destroy(): void {
+        // No renderer-local GPU objects.
+    }
+}
+
+class TemporalAcceptanceFeature implements ForwardRenderPipelineFeature {
+    readonly name = 'temporal-aa-acceptance-boundary';
+    readonly injectionPoint = 'after-opaque' as const;
+    readonly requirements = Object.freeze({ sampledSceneColor: false, sampledDepth: false });
+    readonly runtime = new TemporalAcceptanceRuntime();
+
+    create(): ForwardRenderPipelineFeatureRuntime {
+        return this.runtime;
+    }
+}
+
+function observePassLabels(device: RHIDevice): {
+    readonly labels: string[];
+    restore(): void;
+} {
+    const labels: string[] = [];
+    const queue = device.graphicsQueue;
+    const beginFrame = queue.beginFrame.bind(queue);
+    const spy = vi.spyOn(queue, 'beginFrame').mockImplementation(descriptor => {
+        const commands = beginFrame(descriptor);
+        const beginRenderPass = commands.beginRenderPass.bind(commands);
+        vi.spyOn(commands, 'beginRenderPass').mockImplementation(pass => {
+            labels.push(pass.label ?? '');
+            return beginRenderPass(pass);
+        });
+        return commands;
+    });
+    return {
+        labels,
+        restore: () => {
+            spy.mockRestore();
+        }
+    };
+}
+
+function rhiDevice(renderer: Renderer): RHIDevice {
+    const extension = renderer.getExtension('rhi') as { readonly device: RHIDevice } | null;
+    if (extension === null) throw new Error('Expected the public RHI extension');
+    return extension.device;
+}
 
 afterEach(() => {
     for (const renderer of activeRenderers.splice(0)) renderer.destroy();
@@ -67,14 +161,18 @@ describe('built-in post-processing', () => {
     it('declares the linear HDR feature requirements before renderer creation', () => {
         const bloom = new Bloom();
         const colorUber = new ColorUber();
-        const factory = new PostProcessRenderPipelineFactory();
+        const temporalAA = new TemporalAA();
+        const factory = new PostProcessRenderPipelineFactory({ temporalAA: {} });
 
+        expect(temporalAA.injectionPoint).toBe('after-opaque');
         expect(bloom.injectionPoint).toBe('after-transparent');
         expect(colorUber.injectionPoint).toBe('after-post-process');
         expect(factory.requirements.requiredTextureFormats).toEqual(
             expect.arrayContaining([
                 { format: 'rgba16float', use: 'color-attachment' },
                 { format: 'rgba16float', use: 'filterable-sampled' },
+                { format: 'rg16float', use: 'color-attachment' },
+                { format: 'r16float', use: 'color-attachment' },
                 { format: 'rgba8unorm', use: 'color-attachment' }
             ])
         );
@@ -83,6 +181,8 @@ describe('built-in post-processing', () => {
     it('validates bloom and grading ranges at construction time', () => {
         expect(() => new Bloom({ maxLevels: 0 })).toThrow(/maxLevels/u);
         expect(() => new Bloom({ knee: 0 })).toThrow(/knee/u);
+        expect(() => new TemporalAA({ historyWeight: 2 })).toThrow(/historyWeight/u);
+        expect(() => new TemporalAA({ depthThreshold: -1 })).toThrow(/depthThreshold/u);
         expect(() => new ColorUber({ temperature: 2 }).create()).toThrow(/temperature/u);
     });
 
@@ -96,6 +196,7 @@ describe('built-in post-processing', () => {
                 height: 24,
                 antialias: false,
                 renderPipeline: new PostProcessRenderPipelineFactory({
+                    temporalAA: {},
                     bloom: {
                         threshold: 0.7,
                         intensity: 0.8,
@@ -119,6 +220,44 @@ describe('built-in post-processing', () => {
                         diffuse: new Color(2.5, 0.3, 0.08)
                     }),
                     z: -1,
+                    frustumTest: false
+                })
+            );
+            const instancedGeometry = new BoxGeometry({
+                width: 0.25,
+                height: 0.25,
+                depth: 0.25
+            });
+            const instancedMaterial = new BasicMaterial({ lightType: 'NONE' });
+            scene.addChild(
+                new Mesh({
+                    geometry: instancedGeometry,
+                    material: instancedMaterial,
+                    x: -1,
+                    y: 0.7,
+                    useInstanced: true,
+                    frustumTest: false
+                })
+            );
+            scene.addChild(
+                new Mesh({
+                    geometry: instancedGeometry,
+                    material: instancedMaterial,
+                    x: -0.65,
+                    y: 0.7,
+                    useInstanced: true,
+                    frustumTest: false
+                })
+            );
+            scene.addChild(
+                new Mesh({
+                    geometry: new BoxGeometry({ width: 0.35, height: 0.35, depth: 0.35 }),
+                    material: new BasicMaterial({
+                        lightType: 'NONE',
+                        coverage: { mode: 'mask', cutoff: 0.5 },
+                        opacity: 0.75
+                    }),
+                    x: 1.1,
                     frustumTest: false
                 })
             );
@@ -147,6 +286,125 @@ describe('built-in post-processing', () => {
                 renderer.render(scene, camera);
             }).not.toThrow();
             expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
+        }
+    );
+
+    it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
+        'covers the native-resolution TemporalAA acceptance lifecycle on WebGPU',
+        async () => {
+            const boundary = new TemporalAcceptanceFeature();
+            const renderer = await Renderer.create({
+                backend: 'webgpu',
+                domElement: document.createElement('canvas'),
+                width: 24,
+                height: 16,
+                antialias: false,
+                renderPipeline: new PostProcessRenderPipelineFactory({
+                    temporalAA: {},
+                    bloom: false,
+                    features: [boundary]
+                })
+            });
+            activeRenderers.push(renderer);
+            const scene = new Node();
+            const material = new BasicMaterial({ lightType: 'NONE' });
+            const moving = new Mesh({
+                geometry: new BoxGeometry(),
+                material,
+                frustumTest: false
+            });
+            scene.addChild(moving);
+            const camera = new PerspectiveCamera({ aspect: 3 / 2, z: 4 });
+            let observed = observePassLabels(rhiDevice(renderer));
+
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA initialize history');
+
+            observed.labels.length = 0;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA resolve');
+
+            moving.x = 0.4;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+
+            camera.setPosition(0.25, 0, 4).lookAt(new Vector3(0, 0, 0));
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+
+            scene.addChild(
+                new Mesh({
+                    geometry: new BoxGeometry({ width: 0.5, height: 0.5, depth: 0.5 }),
+                    material,
+                    x: -0.75,
+                    frustumTest: false
+                })
+            );
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+
+            observed.labels.length = 0;
+            camera.invalidateTransformHistory();
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA initialize history');
+
+            observed.labels.length = 0;
+            renderer.resize(30, 18, true);
+            camera.aspect = 30 / 18;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA initialize history');
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+
+            boundary.runtime.fail = true;
+            expect(() => {
+                renderer.render(scene, camera);
+            }).toThrow(/forced TemporalAA submission failure/u);
+            const failedSample = boundary.runtime.jitterSamples.at(-1);
+            expect(camera.projectionJitterX).toBe(0);
+            expect(camera.projectionJitterY).toBe(0);
+
+            boundary.runtime.fail = false;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(boundary.runtime.jitterSamples.at(-1)).toEqual(failedSample);
+
+            observed.restore();
+            const deviceLost = new Promise<void>(resolve => {
+                renderer.on(
+                    'webgpuDeviceLost',
+                    () => {
+                        resolve();
+                    },
+                    true
+                );
+            });
+            const deviceRestored = new Promise<void>(resolve => {
+                renderer.on(
+                    'webgpuDeviceRestored',
+                    () => {
+                        resolve();
+                    },
+                    true
+                );
+            });
+            rhiDevice(renderer).destroy();
+            await deviceLost;
+            await Promise.all([renderer.waitForIdle(), deviceRestored]);
+
+            observed = observePassLabels(rhiDevice(renderer));
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA initialize history');
+            observed.labels.length = 0;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA resolve');
+            observed.restore();
         }
     );
 });

--- a/test/spec/renderer/ScriptableRenderPipeline.test.ts
+++ b/test/spec/renderer/ScriptableRenderPipeline.test.ts
@@ -2774,7 +2774,7 @@ describe('Scriptable render pipeline', () => {
         }
     );
 
-    it('rejects sampled depth requirements until the public binding path supports them', () => {
+    it('accepts portable sampled-depth requirements', () => {
         const runtime = new CountingForwardFeatureRuntime();
         const feature: ForwardRenderPipelineFeature = {
             name: 'sampled-depth-feature',
@@ -2787,9 +2787,7 @@ describe('Scriptable render pipeline', () => {
                 return runtime;
             }
         };
-        expect(() => {
-            new ForwardRenderPipelineFactory({ features: [feature] });
-        }).toThrow(/sampledDepth is not implemented end to end/u);
+        expect(() => new ForwardRenderPipelineFactory({ features: [feature] })).not.toThrow();
     });
 
     it('rejects scene-color sampling before opaque rendering initializes it', () => {

--- a/test/spec/renderer/ShaderBindingLayoutCompiler.test.ts
+++ b/test/spec/renderer/ShaderBindingLayoutCompiler.test.ts
@@ -129,6 +129,8 @@ describe('ShaderBindingLayoutCompiler', () => {
                 textureBinding: 0,
                 samplerBinding: 1,
                 samplerKind: 'sampler',
+                sampleType: 'depth',
+                samplerType: 'non-filtering',
                 visibility: RHIShaderStage.FRAGMENT
             }
         ]);
@@ -283,6 +285,8 @@ describe('ShaderBindingLayoutCompiler', () => {
                 textureBinding: 3,
                 samplerBinding: 4,
                 samplerKind: 'sampler',
+                sampleType: 'float',
+                samplerType: 'filtering',
                 visibility: RHIShaderStage.VERTEX | RHIShaderStage.FRAGMENT
             },
             {
@@ -292,6 +296,8 @@ describe('ShaderBindingLayoutCompiler', () => {
                 textureBinding: 5,
                 samplerBinding: 6,
                 samplerKind: 'sampler',
+                sampleType: 'float',
+                samplerType: 'filtering',
                 visibility: RHIShaderStage.VERTEX
             },
             {
@@ -301,6 +307,8 @@ describe('ShaderBindingLayoutCompiler', () => {
                 textureBinding: 1,
                 samplerBinding: 2,
                 samplerKind: 'comparison-sampler',
+                sampleType: 'depth',
+                samplerType: 'comparison',
                 visibility: RHIShaderStage.FRAGMENT
             }
         ]);
@@ -501,6 +509,8 @@ describe('ShaderBindingLayoutCompiler', () => {
                 textureBinding: 0,
                 samplerBinding: 1,
                 samplerKind: 'sampler',
+                sampleType: 'float',
+                samplerType: 'filtering',
                 visibility: RHIShaderStage.VERTEX
             },
             {
@@ -510,6 +520,8 @@ describe('ShaderBindingLayoutCompiler', () => {
                 textureBinding: 2,
                 samplerBinding: 3,
                 samplerKind: 'sampler',
+                sampleType: 'float',
+                samplerType: 'filtering',
                 visibility: RHIShaderStage.VERTEX
             }
         ]);


### PR DESCRIPTION
## Summary

- add a built-in opaque/masked `motion-vector` semantic pass with `rg16float` output
- reuse submission-aware camera, model, instance, skin, and morph history ABIs, emitting zero velocity for first appearance and invalidated history
- split jittered raster projection from stable non-jittered CPU culling/picking projection
- enable portable non-filtering depth sampling across WebGL2 and WebGPU
- add native-resolution TemporalAA after opaque and before transparent/Bloom, with double-buffered `rgba16float` color history, velocity/depth rejection, reprojection, disocclusion handling, and neighborhood clamp
- make TAA history/jitter submission-transactional and invalidate it on camera cuts, resize, and device recovery
- update the public API report, changelog, and rendering documentation

## Impact

Built-in opaque and masked materials can now participate in a portable temporal resolve without backend-specific rendering paths. Transparent rendering remains outside the opaque TAA history and is composited afterward.

Custom shader materials must provide their own `motion-vector` semantic pass. TAAU, dynamic resolution, and reactive masks remain follow-up work.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run api:update`
- `npm run api:check`
- `npm run test:types`
- `npm run test:package`
- `npm run docs:check`
- affected Vitest suites, including static convergence, moving objects, camera pan, first appearance, camera cut, resize, failed-frame rollback, and device recovery
- `npm run test:render:architecture`
- `npm run test:rhi`
- `npm run test:webgpu`
- `npm run test:ui:webgl2`
- `npm run test:ui:webgpu`

Not run: full `npm run validate`, visual-baseline lanes, or the physical-GPU performance gate.