### PR TITLE
fix(render): productionize Forward+, Hi-Z, batching, and TAA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,18 @@
 ### Changes
 
 - Add the native-resolution `TemporalAA` Forward feature. Built-in opaque/masked materials now
-  expose a strict single-sample `rg16float` motion-vector pass using submission-aware
-  current/previous camera, model, instance, skin, and morph state. TAA runs after opaque and before
-  transparent/Bloom, with `rgba16float` double-buffer color history, depth history, reprojection,
-  disocclusion, neighborhood clamp, camera-cut/resize/device-loss invalidation, and failed-frame
-  rollback. Add stable CPU projection matrices beside raster jitter and portable non-filtering depth
-  sampling for fullscreen passes. TAAU, dynamic resolution, reactive masks, and transparent history
-  remain deferred.
+  expose a strict single-sample `rgba16float` motion pass containing current-to-previous UV
+  velocity, expected previous logarithmic view depth, and current logarithmic view depth. Camera,
+  model, instance, skin, morph, visibility, and failed-frame history are submission-aware. TAA runs
+  after opaque and before transparent/Bloom with `rgba16float` color history, `r32float`
+  logarithmic-depth history, conservative depth rejection, YCoCg variance clipping,
+  motion/luminance-reactive history weight, resolve-only sharpening,
+  projection-cut/resize/device-loss invalidation, and deterministic jitter rollback. Clustered
+  Forward+ can opt into the same resolve; GPU Scene fuses motion output into its existing depth
+  prepass, double-buffers visibility, and composes ordinary Forward fallback opaque before TAA and
+  fallback transparent afterward. Add the WebGPU Temporal Observatory example and real-pixel
+  convergence/camera-cut/GPU-validation coverage. TAAU, dynamic resolution, authored reactive masks,
+  and transparent history remain deferred.
 
 - Add canonical built-in material definitions, stable material IDs and revisions, explicit
   forward/depth-only/shadow-caster/picking roles, role-aware shader variants, per-slot texture/UV
@@ -46,12 +51,13 @@
   renderer-owned CPU shadow. Migrate Clustered Forward+ from its private per-bucket PBR table so GPU
   Scene objects keep independent geometry-bucket and shared-material indices.
 - Complete the Forward+/Clustered/Hi-Z/batching remediation audit. Preserve one global direct/batch
-  draw order, pack per-slot PBR texture metadata, use a single compact visible table with indirect
-  `firstInstance`, make overflow membership deterministic, keep directional lights global, route
-  AreaLight and shadow-enabled lights through exact Forward fallback, restrict previous-frame Hi-Z
-  to stable conservative LOD bounds, compose fallback in linear HDR before separable Bloom/display,
-  elide Bloom resources and passes at zero strength, cache static batch normal matrices, and
-  separate CPU record timing from GPU completion in the 110k-object scale fixture.
+  draw order, pack per-slot PBR texture metadata, use a single compact visible table with aligned
+  per-bucket storage offsets and zero indirect `firstInstance`, make overflow membership
+  deterministic, keep directional lights global, route AreaLight and shadow-enabled lights through
+  exact Forward fallback, restrict previous-frame Hi-Z to stable conservative LOD bounds, compose
+  fallback in linear HDR before separable Bloom/display, elide Bloom resources and passes at zero
+  strength, cache static batch normal matrices, and separate CPU record timing from GPU completion
+  in the 110k-object scale fixture.
 - Add a repository-bundled Khronos Sponza Clustered Forward+ lighting lab with 202 animated local
   lights, including 10 slow chromatic runners that curve through a wall-height central volume, GPU
   Scene diagnostics, HDR bloom, a multi-region OrbitControls camera tour, responsive controls, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@
   only after valid submission, retry discarded frames, and retain recovery through the
   renderer-owned CPU shadow. Migrate Clustered Forward+ from its private per-bucket PBR table so GPU
   Scene objects keep independent geometry-bucket and shared-material indices.
+- Complete the Forward+/Clustered/Hi-Z/batching remediation audit. Preserve one global direct/batch
+  draw order, pack per-slot PBR texture metadata, use a single compact visible table with indirect
+  `firstInstance`, make overflow membership deterministic, keep directional lights global, route
+  AreaLight and shadow-enabled lights through exact Forward fallback, restrict previous-frame Hi-Z
+  to stable conservative LOD bounds, compose fallback in linear HDR before separable Bloom/display,
+  elide Bloom resources and passes at zero strength, cache static batch normal matrices, and
+  separate CPU record timing from GPU completion in the 110k-object scale fixture.
 - Add a repository-bundled Khronos Sponza Clustered Forward+ lighting lab with 202 animated local
   lights, including 10 slow chromatic runners that curve through a wall-height central volume, GPU
   Scene diagnostics, HDR bloom, a multi-region OrbitControls camera tour, responsive controls, and
@@ -58,8 +65,9 @@
 - Make previous-frame Hi-Z occlusion conservative for moving and stationary cameras. Disable it for
   the first frame after a view-projection or depth change, project bounds from the sphere's nearest
   depth and all eight corners of its view-space bounding cube, select a mip covering the full
-  projected extent, and skip objects larger than the coarsest pyramid footprint. The current pyramid
-  is still retained so culling resumes immediately on the next stable frame without temporal
+  projected extent, and cover the full configured viewport with a specialized pyramid of up to
+  thirteen levels. Only transform- and bounds-stable objects consume previous history. The current
+  pyramid is still retained so culling resumes immediately on the next stable frame without temporal
   disocclusion holes, off-axis under-bounds, or large-geometry false positives. GPU Scene frustum
   culling now tests the exact view-space side-plane radius instead of underestimating large spheres
   near a screen edge, and honors each mesh's `frustumTest` opt-out.
@@ -91,7 +99,7 @@
   plus submission-transactional current/previous camera, mesh, instance, skinning, and morph state.
   `Node.invalidateTransformHistory()` resets discontinuous motion deterministically.
 - Add the WebGPU-only `ClusteredForwardPlusPipelineFactory` high-end opaque-scene slice. Registered
-  ordinary Mesh buckets now use stable dirty GPU Scene records, six-level previous-frame Hi-Z
+  ordinary Mesh buckets now use stable dirty GPU Scene records, full-viewport previous-frame Hi-Z
   occlusion, projected-size LOD compaction, fixed indexed-indirect draws, depth-driven logarithmic
   3D clusters, a bounded count/prefix/write light allocator, storage GGX PBR, HDR Bloom, ACES
   display, and on-demand visibility/overflow diagnostics. Add real WebGPU renderer coverage for the

--- a/documentation/FORWARD_PLUS_REMEDIATION.md
+++ b/documentation/FORWARD_PLUS_REMEDIATION.md
@@ -2,7 +2,9 @@
 
 本文记录 2026-08 对 WebGPU high-end
 profile、普通 Forward 实例批处理和相关验证证据的代码审查结论，并定义一次性整改后的生产合同。它是当前实现的验收清单；长期功能扩展仍以
-[`MODERN_WEBGPU_RENDERING_ROADMAP.md`](./MODERN_WEBGPU_RENDERING_ROADMAP.md) 为准。
+[`MODERN_WEBGPU_RENDERING_ROADMAP.md`](./MODERN_WEBGPU_RENDERING_ROADMAP.md) 为准。后续 Motion
+Vector/TAA 与 Clustered 时域集成的专项审查、修复和性能合同见
+[`TEMPORAL_RENDERING_REMEDIATION.md`](./TEMPORAL_RENDERING_REMEDIATION.md)。
 
 ## 目标与边界
 
@@ -20,29 +22,30 @@ profile、普通 Forward 实例批处理和相关验证证据的代码审查结�
 
 ## 问题、整改方案与验收
 
-| 编号   | 问题                                                                                      | 整改方案                                                                                                                                                                 | 验收证据                                                      |
-| ------ | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| FPC-01 | GPU PBR record 只保存 base-color/normal UV，其他 slot 丢失 transform、encoding 和 channel | storage record 保存全部内置 PBR slot 的 UV matrix、UV set、encoding 与 channel；clustered shader 使用与 ordinary Forward 等价的采样函数                                  | 逐 slot transform/encoding/channel 单元测试与 shader 源码契约 |
-| FPC-02 | direct 与 instanced draw 分组提交，透明和显式 `renderOrder` 跨组失序                      | planner 输出统一的 ordered draw item；Forward、Offscreen、Scriptable 全部消费同一顺序                                                                                    | 混合 direct/batch 的 opaque、transparent 执行顺序测试         |
-| FPC-03 | 无覆盖 depth tile 被当作完整 Z 范围，浪费全局 light-index 预算                            | 无覆盖 tile 写入 invalid range，count/write 统一跳过                                                                                                                     | 空 tile + 极小预算测试                                        |
-| FPC-04 | light-centric atomic write 在截断时保留不确定的 light identity                            | bounded allocation 先以 sentinel 初始化，再用确定性的 `atomicMin` 插入链只保留最低稳定 light id；overflow 统计保持显式                                                   | 重复帧 membership 一致性测试                                  |
-| FPC-05 | 近面/相机后方中心的局部光投影可能漏 tile                                                  | 完全位于相机后的球先剔除；与 near plane 相交的 sphere/cone 使用全屏保守 bounds                                                                                           | near-plane crossing light 测试                                |
-| FPC-06 | directional light 被复制到每个 cluster；AreaLight 被按点光计算；shadow light 静默丢阴影   | directional light 使用独立全局列表；尚无 native LTC/shadow-atlas 采样时，AreaLight 或启用 shadow 的 light 明确触发整相机 ordinary Forward fallback                       | directional index、AreaLight 与 shadow-light 兼容路径测试     |
-| FPC-07 | temporal Hi-Z 允许小幅移动对象只测试 previous bounds                                      | 只有 bounds 与 transform 均未变化的对象使用 previous-frame Hi-Z；动态对象至少跳过一帧                                                                                    | 小幅横移 disocclusion 测试                                    |
-| FPC-08 | object sphere 不观察 position revision，且只覆盖 base LOD                                 | logical bucket 预计算所有 LOD 的保守 union sphere；position revision 变化时刷新 bounds 和 object record                                                                  | 动态 geometry 与 oversized LOD 测试                           |
-| FPC-09 | high-end path 每帧执行两到三次完整 CPU scene plan/traversal                               | scriptable context 提供只更新 scene/camera transforms 的内部入口；GPU Scene 单次遍历同时收集 GPU records、fallback 和 lights；有 fallback 时只额外构建一次 renderer list | planner/traversal 计数架构测试                                |
-| FPC-10 | 固定六张 Hi-Z texture 覆盖到 64 px，资源和剔除收益受限                                    | pyramid level 数按最大 viewport 规划；历史使用单 texture mip chain/subresource view 能力成熟前，至少完整覆盖 viewport 并按实际 level 绑定                                | 大于 64 px occluder/object 覆盖测试与资源上限测试             |
-| FPC-11 | fallback 在 tone map/display 后绘制                                                       | compatible 与 fallback opaque/transparent 都写 linear HDR scene color/depth，再统一执行 Bloom/Color display                                                              | fallback 与 GPU Scene 同曝光/色调映射像素测试                 |
-| FPC-12 | Bloom blur 把水平和垂直核混为不对称单 pass，强度为零仍分配和执行                          | 使用独立 horizontal/vertical pass；`bloomStrength: 0` 专门化 display shader 并省略 Bloom texture/pass                                                                    | 旋转对称与零强度 graph/shader 契约测试                        |
-| FPC-13 | visible table 按 object × physical bucket 分配                                            | 使用单一 compact index table，bucket 通过 prefix offset 写入自己的连续区间；容量与 `maxObjects` 同阶                                                                     | buffer requirement 与多 bucket 规模测试                       |
-| FPC-14 | ordinary WebGPU batch 每帧清空并求逆全部 normal matrix                                    | batch compiler 按 mesh identity 与 world-matrix revision 缓存 inverse-transpose normal matrix；model/previous 仍按提交事务逐帧打包                                       | 静止 batch 无 normal-matrix 重算诊断测试                      |
-| FPC-15 | 规模测试逐帧 idle 且无阈值，不构成性能证据                                                | warm-up 后连续提交采样 CPU frame record；GPU completion 单独测量；性能工作流使用已登记 baseline 和 percentile                                                            | fixture 字段、无逐帧 idle、benchmark protocol 检查            |
+| 编号   | 问题                                                                                           | 整改方案                                                                                                                                                                 | 验收证据                                                      |
+| ------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| FPC-01 | GPU PBR record 只保存 base-color/normal UV，其他 slot 丢失 transform、encoding 和 channel      | storage record 保存全部内置 PBR slot 的 UV matrix、UV set、encoding 与 channel；clustered shader 使用与 ordinary Forward 等价的采样函数                                  | 逐 slot transform/encoding/channel 单元测试与 shader 源码契约 |
+| FPC-02 | direct 与 instanced draw 分组提交，透明和显式 `renderOrder` 跨组失序                           | planner 输出统一的 ordered draw item；Forward、Offscreen、Scriptable 全部消费同一顺序                                                                                    | 混合 direct/batch 的 opaque、transparent 执行顺序测试         |
+| FPC-03 | 无覆盖 depth tile 被当作完整 Z 范围，浪费全局 light-index 预算                                 | 无覆盖 tile 写入 invalid range，count/write 统一跳过                                                                                                                     | 空 tile + 极小预算测试                                        |
+| FPC-04 | light-centric atomic write 在截断时保留不确定的 light identity                                 | bounded allocation 先以 sentinel 初始化，再用确定性的 `atomicMin` 插入链只保留最低稳定 light id；overflow 统计保持显式                                                   | 重复帧 membership 一致性测试                                  |
+| FPC-05 | 近面/相机后方中心的局部光投影可能漏 tile                                                       | 完全位于相机后的球先剔除；与 near plane 相交的 sphere/cone 使用全屏保守 bounds                                                                                           | near-plane crossing light 测试                                |
+| FPC-06 | directional light 被复制到每个 cluster；AreaLight 被按点光计算；shadow light 静默丢阴影        | directional light 使用独立全局列表；尚无 native LTC/shadow-atlas 采样时，AreaLight 或启用 shadow 的 light 明确触发整相机 ordinary Forward fallback                       | directional index、AreaLight 与 shadow-light 兼容路径测试     |
+| FPC-07 | temporal Hi-Z 允许小幅移动对象只测试 previous bounds                                           | 只有 bounds 与 transform 均未变化的对象使用 previous-frame Hi-Z；动态对象至少跳过一帧                                                                                    | 小幅横移 disocclusion 测试                                    |
+| FPC-08 | object sphere 不观察 position revision，且只覆盖 base LOD                                      | logical bucket 预计算所有 LOD 的保守 union sphere；position revision 变化时刷新 bounds 和 object record                                                                  | 动态 geometry 与 oversized LOD 测试                           |
+| FPC-09 | high-end path 每帧执行两到三次完整 CPU scene plan/traversal                                    | scriptable context 提供只更新 scene/camera transforms 的内部入口；GPU Scene 单次遍历同时收集 GPU records、fallback 和 lights；有 fallback 时只额外构建一次 renderer list | planner/traversal 计数架构测试                                |
+| FPC-10 | 固定六张 Hi-Z texture 覆盖到 64 px，资源和剔除收益受限                                         | pyramid level 数按最大 viewport 规划；历史使用单 texture mip chain/subresource view 能力成熟前，至少完整覆盖 viewport 并按实际 level 绑定                                | 大于 64 px occluder/object 覆盖测试与资源上限测试             |
+| FPC-11 | fallback 在 tone map/display 后绘制                                                            | compatible 与 fallback opaque/transparent 都写 linear HDR scene color/depth，再统一执行 Bloom/Color display                                                              | fallback 与 GPU Scene 同曝光/色调映射像素测试                 |
+| FPC-12 | Bloom blur 把水平和垂直核混为不对称单 pass，强度为零仍分配和执行                               | 使用独立 horizontal/vertical pass；`bloomStrength: 0` 专门化 display shader 并省略 Bloom texture/pass                                                                    | 旋转对称与零强度 graph/shader 契约测试                        |
+| FPC-13 | visible table 按 object × physical bucket 分配                                                 | 使用单一 compact index table，bucket 通过 prefix offset 写入自己的连续区间；容量与 `maxObjects` 同阶                                                                     | buffer requirement 与多 bucket 规模测试                       |
+| FPC-14 | ordinary WebGPU batch 每帧清空并求逆全部 normal matrix                                         | batch compiler 按 mesh identity 与 world-matrix revision 缓存 inverse-transpose normal matrix；model/previous 仍按提交事务逐帧打包                                       | 静止 batch 无 normal-matrix 重算诊断测试                      |
+| FPC-15 | 规模测试逐帧 idle 且无阈值，不构成性能证据                                                     | warm-up 后连续提交采样 CPU frame record；GPU completion 单独测量；性能工作流使用已登记 baseline 和 percentile                                                            | fixture 字段、无逐帧 idle、benchmark protocol 检查            |
+| FPC-16 | compact bucket offset 被写入 indirect `firstInstance`，未启用可选 feature 的设备只画首个 range | indirect `firstInstance` 永远为零；prefix offset 写入 256-byte 对齐 storage record，每个 batched draw 绑定自己的 4-byte range 并在 shader 内加本地 instance index        | 三种同 geometry 材质的真实 WebGPU readback 必须同时出现       |
 
 ## 实现顺序
 
 1. 先完成 FPC-01～FPC-08，封闭所有已知错误画面和非保守剔除。
 2. 再完成 FPC-09～FPC-14，减少重复 CPU/GPU 工作和无界内存放大。
-3. 最后完成 FPC-15 与浏览器像素覆盖，形成可复现证据。
+3. 最后完成 FPC-15～FPC-16 与浏览器像素覆盖，形成可复现证据。
 
 任何阶段不得通过放宽测试、覆盖不可达代码、吞掉 validation error 或降低现有 portable Forward/WebGL
 2 行为来取得通过结果。

--- a/documentation/FORWARD_PLUS_REMEDIATION.md
+++ b/documentation/FORWARD_PLUS_REMEDIATION.md
@@ -1,0 +1,56 @@
+# Forward+、Clustered、Hi-Z 与批处理整改规范
+
+本文记录 2026-08 对 WebGPU high-end
+profile、普通 Forward 实例批处理和相关验证证据的代码审查结论，并定义一次性整改后的生产合同。它是当前实现的验收清单；长期功能扩展仍以
+[`MODERN_WEBGPU_RENDERING_ROADMAP.md`](./MODERN_WEBGPU_RENDERING_ROADMAP.md) 为准。
+
+## 目标与边界
+
+整改后的 high-end profile 必须继续遵守以下架构边界：
+
+- 场景、深度、Hi-Z、cluster、HDR、兼容绘制和最终显示都通过同一个 Render Graph 与 RHI；
+- WebGPU-only 能力继续在创建阶段 fail closed，不添加 WebGL 2 模拟路径；
+- GPU Scene 可见性与 cluster light membership 不通过 CPU readback 决定；
+- ordinary Forward 和 clustered storage PBR 对同一个材质必须拥有相同的逐贴图 slot 语义；
+- 透明绘制严格保持全局 back-to-front 顺序，实例化不能改变混合结果；
+- frustum、LOD 和 Hi-Z 使用的 bounds 必须保守，不能产生 false-negative visibility；
+- 预算溢出必须保留确定性的 light membership，不能依赖 GPU invocation 调度顺序；
+- fallback mesh 必须在共同的 linear HDR composition 中完成，不能在 display transform 后混入；
+- 性能验收同时报告 CPU record/submit 与 GPU completion，不用逐帧 `waitForIdle()` 结果冒充吞吐。
+
+## 问题、整改方案与验收
+
+| 编号   | 问题                                                                                      | 整改方案                                                                                                                                                                 | 验收证据                                                      |
+| ------ | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| FPC-01 | GPU PBR record 只保存 base-color/normal UV，其他 slot 丢失 transform、encoding 和 channel | storage record 保存全部内置 PBR slot 的 UV matrix、UV set、encoding 与 channel；clustered shader 使用与 ordinary Forward 等价的采样函数                                  | 逐 slot transform/encoding/channel 单元测试与 shader 源码契约 |
+| FPC-02 | direct 与 instanced draw 分组提交，透明和显式 `renderOrder` 跨组失序                      | planner 输出统一的 ordered draw item；Forward、Offscreen、Scriptable 全部消费同一顺序                                                                                    | 混合 direct/batch 的 opaque、transparent 执行顺序测试         |
+| FPC-03 | 无覆盖 depth tile 被当作完整 Z 范围，浪费全局 light-index 预算                            | 无覆盖 tile 写入 invalid range，count/write 统一跳过                                                                                                                     | 空 tile + 极小预算测试                                        |
+| FPC-04 | light-centric atomic write 在截断时保留不确定的 light identity                            | bounded allocation 先以 sentinel 初始化，再用确定性的 `atomicMin` 插入链只保留最低稳定 light id；overflow 统计保持显式                                                   | 重复帧 membership 一致性测试                                  |
+| FPC-05 | 近面/相机后方中心的局部光投影可能漏 tile                                                  | 完全位于相机后的球先剔除；与 near plane 相交的 sphere/cone 使用全屏保守 bounds                                                                                           | near-plane crossing light 测试                                |
+| FPC-06 | directional light 被复制到每个 cluster；AreaLight 被按点光计算；shadow light 静默丢阴影   | directional light 使用独立全局列表；尚无 native LTC/shadow-atlas 采样时，AreaLight 或启用 shadow 的 light 明确触发整相机 ordinary Forward fallback                       | directional index、AreaLight 与 shadow-light 兼容路径测试     |
+| FPC-07 | temporal Hi-Z 允许小幅移动对象只测试 previous bounds                                      | 只有 bounds 与 transform 均未变化的对象使用 previous-frame Hi-Z；动态对象至少跳过一帧                                                                                    | 小幅横移 disocclusion 测试                                    |
+| FPC-08 | object sphere 不观察 position revision，且只覆盖 base LOD                                 | logical bucket 预计算所有 LOD 的保守 union sphere；position revision 变化时刷新 bounds 和 object record                                                                  | 动态 geometry 与 oversized LOD 测试                           |
+| FPC-09 | high-end path 每帧执行两到三次完整 CPU scene plan/traversal                               | scriptable context 提供只更新 scene/camera transforms 的内部入口；GPU Scene 单次遍历同时收集 GPU records、fallback 和 lights；有 fallback 时只额外构建一次 renderer list | planner/traversal 计数架构测试                                |
+| FPC-10 | 固定六张 Hi-Z texture 覆盖到 64 px，资源和剔除收益受限                                    | pyramid level 数按最大 viewport 规划；历史使用单 texture mip chain/subresource view 能力成熟前，至少完整覆盖 viewport 并按实际 level 绑定                                | 大于 64 px occluder/object 覆盖测试与资源上限测试             |
+| FPC-11 | fallback 在 tone map/display 后绘制                                                       | compatible 与 fallback opaque/transparent 都写 linear HDR scene color/depth，再统一执行 Bloom/Color display                                                              | fallback 与 GPU Scene 同曝光/色调映射像素测试                 |
+| FPC-12 | Bloom blur 把水平和垂直核混为不对称单 pass，强度为零仍分配和执行                          | 使用独立 horizontal/vertical pass；`bloomStrength: 0` 专门化 display shader 并省略 Bloom texture/pass                                                                    | 旋转对称与零强度 graph/shader 契约测试                        |
+| FPC-13 | visible table 按 object × physical bucket 分配                                            | 使用单一 compact index table，bucket 通过 prefix offset 写入自己的连续区间；容量与 `maxObjects` 同阶                                                                     | buffer requirement 与多 bucket 规模测试                       |
+| FPC-14 | ordinary WebGPU batch 每帧清空并求逆全部 normal matrix                                    | batch compiler 按 mesh identity 与 world-matrix revision 缓存 inverse-transpose normal matrix；model/previous 仍按提交事务逐帧打包                                       | 静止 batch 无 normal-matrix 重算诊断测试                      |
+| FPC-15 | 规模测试逐帧 idle 且无阈值，不构成性能证据                                                | warm-up 后连续提交采样 CPU frame record；GPU completion 单独测量；性能工作流使用已登记 baseline 和 percentile                                                            | fixture 字段、无逐帧 idle、benchmark protocol 检查            |
+
+## 实现顺序
+
+1. 先完成 FPC-01～FPC-08，封闭所有已知错误画面和非保守剔除。
+2. 再完成 FPC-09～FPC-14，减少重复 CPU/GPU 工作和无界内存放大。
+3. 最后完成 FPC-15 与浏览器像素覆盖，形成可复现证据。
+
+任何阶段不得通过放宽测试、覆盖不可达代码、吞掉 validation error 或降低现有 portable Forward/WebGL
+2 行为来取得通过结果。
+
+## 完成定义
+
+- `npm run typecheck`、`npm run lint`、targeted Vitest 全部通过；
+- renderer/Render Graph/RHI 改动通过 `npm run test:render:architecture` 与 `npm run test:rhi`；
+- storage shader 与 WebGPU pipeline 通过 `npm run test:webgpu`；
+- affected WebGPU UI/visual fixtures 通过；
+- 本文全部编号有实现和自动化证据，未完成项不得描述为已修复。

--- a/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
+++ b/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
@@ -121,15 +121,15 @@ const material = new Hilo3d.ShaderMaterial({
 
 Pipeline 通过 role 请求材质，而不是读取 `material.passes[]` 并让材质控制执行顺序。
 
-| Role                  | 当前内置支持 | 合同                                                                      |
-| --------------------- | ------------ | ------------------------------------------------------------------------- |
-| `forward`             | 是           | 普通 surface/unlit color 输出                                             |
-| `depth-only`          | 是           | 复用 deformation 与 coverage，无 color attachment                         |
-| `shadow-caster`       | 是           | 复用 deformation、coverage、cull 和 alpha cutoff                          |
-| `picking`             | 是           | 复用 geometry/coverage，输出稳定对象 ID                                   |
-| `motion-vector`       | 是           | opaque/masked 输出 single-sample `rg16float` current-to-previous velocity |
-| `material-attributes` | 保留类型     | 后续 GTAO/SSR/SSGI 工作包定义输出 ABI                                     |
-| `user:*`              | 自定义       | 只有自定义 Pipeline 显式请求才运行                                        |
+| Role                  | 当前内置支持 | 合同                                                                                          |
+| --------------------- | ------------ | --------------------------------------------------------------------------------------------- |
+| `forward`             | 是           | 普通 surface/unlit color 输出                                                                 |
+| `depth-only`          | 是           | 复用 deformation 与 coverage，无 color attachment                                             |
+| `shadow-caster`       | 是           | 复用 deformation、coverage、cull 和 alpha cutoff                                              |
+| `picking`             | 是           | 复用 geometry/coverage，输出稳定对象 ID                                                       |
+| `motion-vector`       | 是           | opaque/masked 输出 single-sample `rgba16float` UV velocity 与 previous/current log-view-depth |
+| `material-attributes` | 保留类型     | 后续 GTAO/SSR/SSGI 工作包定义输出 ABI                                                         |
+| `user:*`              | 自定义       | 只有自定义 Pipeline 显式请求才运行                                                            |
 
 [`MaterialCompiler.ts`](../src/material/MaterialCompiler.ts) 负责 role 解析、target
 contract 验证和稳定 variant key。fallback 只有三种：

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -348,7 +348,9 @@ slot/geometry/material
 range，GPU 执行 frustum、按声明 viewport 专门化（最多 13 级）的 previous-frame
 Hi-Z、projected-radius LOD、bucket prefix/compact，并写固定 indexed-indirect
 arguments。全部 bucket 共享一份与 `maxObjects` 同阶的 compact visible table，indirect
-`firstInstance` 指向各自连续 range；生产帧不读取 visible count。对象只有在 transform 与所有 LOD
+`firstInstance` 固定为零；prefix offset 写入 256-byte 对齐的 bucket storage record，raster
+draw 通过静态对齐 binding range 取得 base 后再索引 compact table。这样不要求可选
+`indirect-first-instance` feature，生产帧也不读取 visible count。对象只有在 transform 与所有 LOD
 bounds revision 都稳定时才使用 previous-frame occlusion。camera
 cut、失败帧和提交后的时域推进分别通过 history invalidation、`frameDiscarded()` 与 `frameSubmitted()`
 处理。previous-frame culling 使用同一已提交帧的 VP、view、projection 与 depth
@@ -449,11 +451,14 @@ light、transmission 和 device recovery 有真实 WebGPU 像素证据；overflo
 | 低分辨率当前帧、velocity、depth、history | reprojection、disocclusion、clamp、reactive mask、upscale | 稳定高分辨率画面与分辨率控制器 | camera cut 无旧帧闪回，运动物体不持续拖影 |
 
 当前已交付 T0 的原生分辨率首切片：内置 opaque/masked Basic/PBR/Geometry 输出 single-sample
-`rg16float` velocity；Camera 同时保留 jittered raster 与 non-jittered CPU projection； `TemporalAA`
-在 opaque 后、transparent/Bloom 前使用 `rgba16float` color history、`r16float` depth
-history、reprojection、depth disocclusion 和 3×3 neighborhood clamp。首次出现、camera
-cut、resize、失败帧和 device recovery 均进入提交事务与 history
-invalidation 验收。transparent、TAAU、动态分辨率和 reactive mask 保留到后续切片。
+`rgba16float` velocity/previous-current log-view-depth；Camera 同时保留 jittered
+raster 与 non-jittered CPU projection；`TemporalAA` 在 opaque 后、transparent/Bloom 前使用
+`rgba16float` color history、`r32float` log-view-depth history、relative-depth rejection、YCoCg
+variance clipping、motion/luminance-reactive weighting 和 resolve-only
+sharpen。普通 Forward 使用独立 motion semantic pass，Clustered Forward+ 则把 GPU Scene
+motion 融入 depth prepass并记录前一已提交帧 visibility。首次出现、显隐间断、camera/projection
+cut、resize、失败帧和 device recovery 均进入提交事务与 history invalidation 验收。transparent
+history、TAAU、动态分辨率和 authored reactive mask 保留到后续切片。
 
 - opaque/alpha-tested geometry 输出 motion vector；skinning/morph 必须有 previous pose；
 - camera jitter 不污染 CPU picking/frustum；提供 jittered 与 non-jittered matrix；

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -1,6 +1,6 @@
 # Hilo3D 现代 WebGPU 渲染缺口与落地路线
 
-> 审计基线：`902b9a7`（2026-08-01）；实施状态更新：2026-08-09，F0、F1、D0、G0/L0 的 WebGPU
+> 审计基线：`902b9a7`（2026-08-01）；实施状态更新：2026-08-10，F0、F1、D0、G0/L0 的 WebGPU
 > high-end 不透明场景切片，以及 MAT0 的 Definition/Instance、语义 Pass 基础与共享 PBR GPU Material
 > Database 已落地。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
 > 2 功能对等作为路线目标。
@@ -106,7 +106,7 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 | Forward+                             | high-end 切片 | 3D cluster count/prefix/write、有界预算和 storage GGX PBR 已闭环；阴影/完整 layered PBR/透明待补                                  |
 | Temporal rendering                   | 原生 TAA 切片 | jitter/non-jitter matrix、opaque/masked velocity、depth rejection、双缓冲 history 与 invalidation 已完成；TAAU/reactive mask 待补 |
 | Exposure / display transform         | 部分可用      | 有手动 EV、固定 tone mapper 与 Color Uber；无亮度统计、eye adaptation、exposure history 或 filmic 曲线控制                        |
-| Screen-space lighting                | 缺失          | 无 depth pyramid、normal/roughness attribute buffer、GTAO、SSR、SSGI                                                              |
+| Screen-space lighting                | 部分基础      | GPU Scene 已有 previous/current Hi-Z；仍无 normal/roughness attribute buffer、GTAO、SSR、SSGI                                     |
 | Volumetrics / atmosphere             | 缺失          | 无 froxel volume、temporal reprojection、physical sky 或 volumetric cloud                                                         |
 | Geometry / texture streaming         | 缺失          | 无 GPU LOD/meshlet/cluster streaming；KTX loader 仅支持 KTX 1.1 2D 容器                                                           |
 | GPU profiling / graph debugging      | 生产基线      | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 时不创建 query                           |
@@ -344,13 +344,15 @@ handle，扩展更多 surface family，并增加 variant manifest/warmup。完�
 已落地的 `ClusteredForwardPlusPipelineFactory` 以注册的 geometry/material
 identity 建立稳定对象槽和 LOD bucket；对象 current/previous transform、world bounds、layer 与 active
 flag 以及 inverse-transpose normal basis 使用 208-byte storage record。CPU 只合并 dirty
-slot/geometry/material range，GPU 执行 frustum、六级 previous-frame Hi-Z、projected-radius
-LOD、按 bucket compact，并写固定 indexed-indirect
-arguments。每个 bucket 的可见表使用满足 storage-offset 对齐的独立 range，不依赖
-`firstInstance`；生产帧不读取 visible count。camera cut、失败帧和提交后的时域推进分别通过 history
-invalidation、`frameDiscarded()` 与 `frameSubmitted()` 处理。previous-frame
-culling 使用同一已提交帧的 VP、view、projection 与 depth convention；Hi-Z 对 standard/reversed
-depth 分别保留区块 `max`/`min`
+slot/geometry/material
+range，GPU 执行 frustum、按声明 viewport 专门化（最多 13 级）的 previous-frame
+Hi-Z、projected-radius LOD、bucket prefix/compact，并写固定 indexed-indirect
+arguments。全部 bucket 共享一份与 `maxObjects` 同阶的 compact visible table，indirect
+`firstInstance` 指向各自连续 range；生产帧不读取 visible count。对象只有在 transform 与所有 LOD
+bounds revision 都稳定时才使用 previous-frame occlusion。camera
+cut、失败帧和提交后的时域推进分别通过 history invalidation、`frameDiscarded()` 与 `frameSubmitted()`
+处理。previous-frame culling 使用同一已提交帧的 VP、view、projection 与 depth
+convention；Hi-Z 对 standard/reversed depth 分别保留区块 `max`/`min`
 最远值。当前公开切片限定为单相机、single-sample、opaque、unskinned、indexed triangle PBR bucket GPU
 fast path；未注册 mesh、容量 overflow、skinning/morph、alpha/transparent/layered
 material 以及运行时 material/geometry replacement 会进入共享 Forward compatibility path，并通过 mesh
@@ -398,11 +400,14 @@ draw/instance 数显著下降；构建过程无逐 mip CPU 资源创建。
 | depth/Hi-Z、GPU light database | 3D cluster、count/prefix/write、有界 overflow、PBR light loop | cluster light list、Forward+ HDR | 数百局部光无越界、无 light-count variant 爆炸 |
 
 已落地切片把当前 depth 汇总为 tile depth bounds，再按 logarithmic Z slice 建立 3D
-cluster。光源分配使用 count → 256-entry workgroup scan → block prefix → bounded finalize → index
-write；全局 index budget 与 per-cluster ceiling 都有 deterministic truncation 和 overflow
-counter。点光、聚光、方向光与 area-light 近似共享固定 64-byte light record，fragment
-shader 只按 cluster grid/list 迭代，不产生 light-count variant。普通 Forward 与 clustered
-variant 现在共用 `pbr_surface.glsl`/`pbr_brdf.glsl`；Forward+ 只替换 light-list provider 与 light
+cluster。光源分配使用 count → 256-entry workgroup scan → block prefix → bounded finalize →
+sentinel/`atomicMin` stable index write；全局 index budget 与 per-cluster ceiling 都有 deterministic
+truncation 和 overflow counter。点光与聚光进入 cluster；方向光使用独立全局列表，空 depth
+tile 不分配 index，near-plane crossing local light 使用保守 tile bounds。精确 LTC
+AreaLight 当前明确让整帧 mesh 进入 ordinary Forward fallback，不做点光近似。fragment
+shader 只按 global directional + cluster grid/list 迭代，不产生 light-count
+variant。普通 Forward 与 clustered variant 现在共用
+`pbr_surface.glsl`/`pbr_brdf.glsl`；Forward+ 只替换 light-list provider 与 light
 iteration，不再维护第二套材质模型。结果进入 `rgba16float` HDR、Bloom 和 ACES display
 transform；`readDiagnostics()` 仅用于显式、按需的验收读回，不参与生产帧调度。当前 storage
 PBR 原生覆盖 base color、metallic、roughness、combined
@@ -412,9 +417,9 @@ scale 通过每对象 inverse-transpose normal
 basis 正确着色。贴图身份或同能力 variant 的运行时变化保留 GPU path；custom compile、layered
 PBR、alpha-test、transparent、transmission、parallax/environment 和变形输入由共享 Forward
 fallback 保持功能正确；fallback 的 opaque/transparent split、shadow 录制和 transmission opaque scene
-copy 已有真实 WebGPU 覆盖。它们尚未获得 clustered-native light
-list 或同一 HDR/Bloom/ACES 链；shadow/cookie/IES、LTC area light、完整 layered
-PBR 与透明的 clustered-native 像素/性能证据仍是 L0 最终画质门禁。
+copy 已有真实 WebGPU 覆盖，并与 GPU Scene 一起写 linear HDR 后统一经过 separable
+Bloom/ACES。它们尚未获得 clustered-native light list；shadow/cookie/IES、LTC area
+light、完整 layered PBR 与透明的 clustered-native 像素/性能证据仍是 L0 最终画质门禁。
 
 第一版不应继续扩充固定 LightBlock，而应：
 

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -101,16 +101,27 @@ ray；volume 根据折射方向修正光程，再用 Beer-Lambert attenuation �
 ## 内置 TemporalAA
 
 `TemporalAA` 是可选的 `after-opaque` feature。它先用内置材质的 `motion-vector` semantic
-pass 把 opaque/masked velocity 写入 single-sample `rg16float`，再用当前 sampled depth、上一帧
-`rgba16float` color history 与 `r16float` depth history 做原生分辨率 reprojection、depth
-disocclusion 和 3×3 neighborhood clamp。history 双缓冲只在有效 submission 后轮换；camera
-cut、resize、显式 transform invalidation 和 device
+pass 把 opaque/masked 的 current-to-previous UV velocity、expected previous
+log-view-depth 与 current log-view-depth 写入 single-sample `rgba16float`。resolve 使用上一帧
+`rgba16float` color history 与 `r32float` log-view-depth history 做原生分辨率 reprojection、保守 2×2
+relative-depth disocclusion、YCoCg 3×3 variance clipping、motion/luminance-reactive history
+weight 和只作用于输出的轻量 sharpen；未经 sharpen 的 resolved
+color 才回写 history，避免逐帧反馈过锐。history 双缓冲只在有效 submission 后轮换；camera
+cut、显著 projection 变化、resize、显隐间断、显式 transform invalidation 和 device
 recovery 会让下一帧重新初始化，失败帧保留上一份已提交 history 和 jitter index。
 
 Camera 同时维护 jittered raster projection 与 non-jittered CPU
 projection；frustum、picking、project/unproject 不读取 jitter。TAA
 resolve 只处理 opaque 结果，transparent/transmission 在它之后合成，Bloom 再消费完整线性 HDR 颜色。TAAU、动态分辨率和 reactive
-mask 不属于当前首版。
+mask 不属于当前首版；当前 luminance reactive
+response 是 resolve 内部启发式，不等同于材质提供的 authored reactive mask。
+
+`ClusteredForwardPlusPipelineFactory` 通过 `temporalAA` 显式 opt-in 同一 resolve。GPU
+Scene 把 motion/depth 输出融合到已有 depth prepass，并用双缓冲 object
+visibility 防止 Hi-Z/frustum 剔除后重现的物体读取陈旧 velocity；ordinary Forward fallback
+opaque 在 resolve 前参与 color、depth 和 motion，transparent
+fallback 在 resolve 后合成。未启用时不分配 visibility-history
+buffer，也不执行对应 clear/write，保持默认 Clustered 路径无 TAA 带宽成本。
 
 ## 内置 Bloom
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -13,6 +13,7 @@ committed.
 | [Material system modernization](./MATERIAL_SYSTEM_MODERNIZATION.md)        | Current Definition/Instance architecture, semantic passes, typed bindings, texture-slot ABI, breaking changes, and roadmap |
 | [Modern WebGPU rendering roadmap](./MODERN_WEBGPU_RENDERING_ROADMAP.md)    | Current rendering gaps and an actionable GPU Scene, temporal, lighting, virtualization, and high-end WebGPU roadmap        |
 | [Forward+ remediation](./FORWARD_PLUS_REMEDIATION.md)                      | Audited Forward+/Clustered/Hi-Z/batching correctness, performance fixes, and executable acceptance matrix                  |
+| [Temporal rendering remediation](./TEMPORAL_RENDERING_REMEDIATION.md)      | Production Motion Vector/TAA ABI, history validity, Clustered integration, performance contract, and release evidence      |
 | [2D rendering and multi-camera composition](./2D_RENDERING.md)             | Sprite batching, frame animation, Canvas text, pointer input, camera priority, clear policy, and layer masks               |
 | [Compute/storage implementation](./COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md) | Implemented Direct WGSL compute, storage resources, GPU-driven raster contract, first-release boundaries, and evidence     |
 | [Scriptable Render Pipeline design](./SCRIPTABLE_RENDER_PIPELINE_PLAN.md)  | SRP API, implemented architecture, migration record, release performance gates, and compute/storage integration            |

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,6 +12,7 @@ committed.
 | [PBR, HDR, and post-processing](./PBR_AND_POST_PROCESSING.md)              | Layered glTF materials, modern PBR lighting, opaque scene texture, Bloom, Color Uber, and linear color contracts           |
 | [Material system modernization](./MATERIAL_SYSTEM_MODERNIZATION.md)        | Current Definition/Instance architecture, semantic passes, typed bindings, texture-slot ABI, breaking changes, and roadmap |
 | [Modern WebGPU rendering roadmap](./MODERN_WEBGPU_RENDERING_ROADMAP.md)    | Current rendering gaps and an actionable GPU Scene, temporal, lighting, virtualization, and high-end WebGPU roadmap        |
+| [Forward+ remediation](./FORWARD_PLUS_REMEDIATION.md)                      | Audited Forward+/Clustered/Hi-Z/batching correctness, performance fixes, and executable acceptance matrix                  |
 | [2D rendering and multi-camera composition](./2D_RENDERING.md)             | Sprite batching, frame animation, Canvas text, pointer input, camera priority, clear policy, and layer masks               |
 | [Compute/storage implementation](./COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md) | Implemented Direct WGSL compute, storage resources, GPU-driven raster contract, first-release boundaries, and evidence     |
 | [Scriptable Render Pipeline design](./SCRIPTABLE_RENDER_PIPELINE_PLAN.md)  | SRP API, implemented architecture, migration record, release performance gates, and compute/storage integration            |

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -82,7 +82,9 @@ Sprite 仍是 Mesh：共享单位 quad、按 atlas Texture 共享 SpriteMaterial
 `sortingLayer / zIndex / stable scene traversal` 确定显示顺序，再仅对相邻兼容项合批，并把 UV
 rect、size/anchor、tint 与 transform 编译成 portable instance batch。WebGL 2 使用 instance vertex
 stream，WebGPU 使用固定 InstanceBlock 加 Sprite instance
-stream；没有 2D 专用 backend 或第二套 shader 树。
+stream；没有 2D 专用 backend 或第二套 shader 树。普通 Forward 与离屏路径也消费同一份 direct/instance-batch
+ordered item list；透明 batch 只能合并深度排序后相邻的兼容项，不能跨 direct draw、`renderOrder`
+或 blending 顺序移动。
 
 普通前向渲染至少包含 Main Pass；存在透明物体时增加 Transparent
 Pass；存在投影灯光时在它们之前加入 Shadow
@@ -119,8 +121,9 @@ identity 去重，保留公共 `materialId` 并分配按 family/layout 分类的
 handle；`MaterialInstance.revision` 驱动 record 重打包，相邻 dirty record 合并上传。staged
 revision 和 texture-slot dirtiness 只在成功 submission 后提交，失败帧重试；renderer-owned
 `cpu-shadow` buffer 在 device recovery 后重建而不替换材质或 handle identity。首个
-`builtin-pbr-storage-v1` record 由 GPU Scene 与 clustered indirect draw 共享，logical geometry
-bucket 与 material handle 在对象 record 中保持为两个独立字段。
+`builtin-pbr-storage-v2` record 由 GPU Scene 与 clustered indirect draw 共享；除 surface
+scalar 外，它为每个内置 PBR texture slot 保存独立 UV matrix、UV set、encoding、presence 与 channel
+mapping。logical geometry bucket 与 material handle 在对象 record 中保持为两个独立字段。
 
 ### 1.3 RenderPipelineHost：统一的可脚本化编排
 
@@ -131,6 +134,8 @@ runtime。创建时未传 `renderPipeline` 时也由进程级 `ForwardRenderPipe
 
 - `cull()` 与 `createRendererList()` 复用 shared renderer 的场景收集、排序、instancing 和 mesh
   processor；
+- `prepareScene()` 只更新 scene world matrix 与 active camera，不构造 CPU render list；GPU-driven
+  pipeline 可先完成一次自有 scene collection，仅在确有 compatibility mesh 时再调用一次 `cull()`；
 - `recordShadows()` 复用同一 Shadow Atlas、LightBlock、resource owner 和恢复链路；
 - `ScriptableRenderGraph` 可创建 transient texture/buffer，导入 output、RenderTarget、renderer-owned
   `StorageBuffer` 和 sampled engine `Texture`，获取 recovery-aware persistent target、按 stable
@@ -209,18 +214,22 @@ allocator、storage-aware GGX PBR、HDR Bloom 与 ACES
 display。WebGPU 不支持 multi-draw-indirect-count，因此 runtime 对每个固定 LOD bucket 发一个 indirect
 draw，GPU 为不可见 bucket 写零 instance count；这些 bucket draw 在共享层分别合并到一个 depth render
 pass 和一个 color render pass，仍可逐 draw 切换 pipeline、bind group、vertex/index
-buffer，但不再为每个 bucket 重开 attachment。Hi-Z 对 standard depth 取区块最远值 `max`、对 reversed
+buffer，但不再为每个 bucket 重开 attachment。可见对象先写 selected-bucket table，再通过 bucket
+prefix 产生 indirect `firstInstance`，最终压缩到一份与 `maxObjects` 同阶的连续 visible
+table，不再按 object × physical-bucket 放大。Hi-Z 对 standard depth 取区块最远值 `max`、对 reversed
 depth 取区块最远值 `min`；previous-frame occlusion 同时读取已提交的 previous
 view/projection/depth 参数，不把上一帧 VP 与当前帧投影约定混用。颜色阶段 load 深度预通过结果，物体 record 携带 model
 basis 的 inverse-transpose normal matrix，因此 non-uniform scale 不改变法线方向。depth
 prepass 与 color pass 通过同一段 byte-identical clip-space transform 计算
 `gl_Position`，避免相机移动时跨 shader 浮点舍入差异被 reversed-depth
 test 放大成缺面。相机的 view-projection 或 depth 参数相对已提交帧发生变化时，runtime 会暂时关闭一帧 previous-frame
-Hi-Z 遮挡判定以避免视角移动造成 disocclusion 误剔除，同时仍生成当帧 pyramid，使静止后的下一帧即可恢复遮挡剔除。静止帧从包围球最近深度和 view-space 包围立方体的八个角计算保守的屏幕投影，避免偏离画面中心时低估范围，并向上选择覆盖完整投影的 mip；投影大于最粗 pyramid
-footprint 的物体不参与 Hi-Z 遮挡剔除，避免稀疏采样把大块局部几何误判为完全遮挡。GPU
-Scene 的 frustum 阶段使用 view-space side plane 的完整法线长度计算球体半径，不以 projection
-scale 近似斜平面距离；`Mesh.frustumTest = false` 与普通 renderer
-list 一样关闭该 mesh 的视锥剔除。普通 Forward PBR 与 clustered storage variant 共用
+Hi-Z 遮挡判定以避免视角移动造成 disocclusion 误剔除，同时仍生成当帧 pyramid，使静止后的下一帧即可恢复遮挡剔除。对象只有在 transform 和 bounds
+revision 都相对提交帧稳定时才允许使用 previous-frame Hi-Z；动态对象至少跳过一帧。logical
+bucket 的 bounds 是 base geometry 与全部 LOD geometry 的保守 union，并在 position
+revision 变化时刷新。静止帧从包围球最近深度和 view-space 包围立方体的八个角计算保守的屏幕投影，避免偏离画面中心时低估范围；半分辨率 history 按工厂声明的最大 viewport 专门化，最多 13 级覆盖允许的 8192-pixel
+viewport。GPU Scene 的 frustum 阶段使用 view-space side
+plane 的完整法线长度计算球体半径，不以 projection scale 近似斜平面距离；`Mesh.frustumTest = false`
+与普通 renderer list 一样关闭该 mesh 的视锥剔除。普通 Forward PBR 与 clustered storage variant 共用
 `pbr_surface.glsl` 和 `pbr_brdf.glsl`；后者只把 light provider 换成 cluster
 grid/list，不复制材质模型。GPU Scene geometry database 可携带 UV0/UV1 与对应 tangent stream，sampled
 engine `Texture` 通过 graph import 复用 renderer 的上传、恢复与 submission 生命周期。
@@ -234,13 +243,18 @@ map，支持每纹理槽独立的 UV0/UV1、UV transform、encoding、channel �
 mutation，仍要求默认 depth/alpha 状态。未注册 mesh、对象容量 overflow、skinning/morph，以及注册 bucket 在运行时发生的不兼容 material/geometry/raster-state
 replacement 会在同一帧迁移到共享 Forward compatibility path；恢复兼容后可重新进入 GPU
 Scene。fallback 使用显式 mesh identity
-exclusion 避免重复绘制，按 opaque/transparent 分开排序，复用共享 shadow 录制，并为 transmission 提供已经完成 display 与 fallback
-opaque 的 scene-color copy。由于 fallback 发生在 Clustered HDR/Bloom/ACES
-display 之后，它保留普通 Forward 材质正确性但不获得 clustered light
-list 或同一 HDR 后处理；这是可通过 `fallbackObjectCount`
-观测的性能/画质边界，而不是静默丢失。初始 bucket 声明不合法、非 perspective/multisample
-output 或不支持的 WebGPU 设备仍 fail-closed；shadow/cookie/IES 和精确 LTC area
-light 的 clustered-native 实现继续走后续 high-end 扩展，不会静默退化到 WebGL 2。factory 的 required
+exclusion 避免重复绘制，按 opaque/transparent 分开排序并复用共享 shadow 录制。compatibility
+opaque/transparent 与 GPU Scene color 都写同一 linear `rgba16float` scene
+color/depth；transmission 读取 HDR opaque copy，最后统一经过 separable horizontal/vertical
+Bloom 与一次 ACES display；`bloomStrength: 0` 不创建 Bloom transient
+texture，也不记录其 pass。方向光走独立全局列表，不复制到每个 cluster；局部光与 near
+plane 相交时使用保守 full-screen tile bounds，空 depth tile 使用 invalid slice range；index
+budget 通过 sentinel + `atomicMin` 插入链确定性保留最低 light id。当前 clustered
+BRDF 没有精确 LTC 或 shadow-atlas 采样，因此检测到 AreaLight 或启用 shadow 的 light 时，整相机明确转入 ordinary
+Forward fallback，而不是近似 area
+light 或静默丢阴影。初始 bucket 声明不合法、非 perspective/multisample
+output 或不支持的 WebGPU 设备仍 fail-closed；native clustered
+LTC、shadow、cookie/IES 继续走后续 high-end 扩展，不会静默退化到 WebGL 2。factory 的 required
 limits 覆盖 object/geometry/visible/cluster/light-index 全部 buffer 与最坏 dispatch
 dimension，在 runtime 分配前完成设备准入。
 
@@ -631,7 +645,9 @@ commit/rollback 和 device-loss 恢复边界不变，也避免多 pass
 pipeline 为每个 bucket 重复遍历场景并打包全部灯光。Clustered
 Forward+ 进一步把同 attachment 的 fixed-bucket indirect draws 汇入高水位复用的内部 batch
 pass：Render Graph 仍声明全部 storage/vertex/index/indirect 依赖并准备独立 draw
-packet，但 depth/color 各只打开一次原生 render pass。
+packet，但 depth/color 各只打开一次原生 render pass。普通 WebGPU instance batch 按 Mesh identity 与
+`worldMatrixVersion` 缓存 inverse-transpose normal matrix；静止 batch 不再每帧清空并重算全部 normal
+matrix，diagnostics 可观测累计重算数。
 
 ### 5.2 提交感知的生命周期
 
@@ -738,7 +754,9 @@ Renderer 的组合式 Pass，使未来加入新的图优化、调试可视化或
   database、previous-frame Hi-Z cull/LOD/compact、fixed bucket indirect depth/color、depth-driven 3D
   cluster count/prefix/write、HDR/Bloom/ACES 和按需 diagnostics；readback 不参与 draw 或 light
   allocation。独立 scale fixture 覆盖 100k static + 10k dynamic、256 lights 和 device
-  recovery 的规模正确性；可比较的物理 GPU 性能回归阈值仍使用单独的受控基线协议。
+  recovery 的规模正确性；fixture 将连续提交的 CPU frame-record 时间与 batch GPU
+  completion 分开报告，不在每个采样帧内
+  `waitForIdle()`。可比较的物理 GPU 性能回归阈值仍使用单独的受控基线协议。
 - 旧的 WebGPU-only effect 页面同时是可展示 example 与真实浏览器验收：depth prepass → sampled-depth
   tile cull → Scene group-3 storage、Gaussian cull/reorder/indirect draw，以及 1024 粒子 Hilo3D
   wordmark 的 fractal value/curl noise、呼吸、涡旋、回归、compact、GPU indirect additive

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -104,9 +104,11 @@ layout，需要改变 topology 时构造另一个材质实例。
 Render Pipeline 请求 `forward`、`depth-only`、`shadow-caster`、`motion-vector` 或 `picking`
 role，材质不拥有 graph pass 顺序。Shadow Atlas 直接编译 `shadow-caster`，不创建 proxy
 material；role 缺失或 target output 不匹配会在 RHI frame 前失败。内置 Basic/PBR/Geometry 的
-`motion-vector` pass 只接受 single-sample `rg16float` target，复用 current/previous
-camera、model、instance、skin、morph 与 coverage ABI；首次出现或任一 transform
-history 失效时写零。`material-attributes` 仍保留给后续属性缓冲路线。
+`motion-vector` pass 只接受 single-sample `rgba16float` target：XY 是 current-to-previous UV
+velocity，Z 是 expected previous `log2(1 + viewDepth)`，W 是 current
+`log2(1 + viewDepth)`。它复用 current/previous camera、model、instance、skin、morph 与 coverage
+ABI；首次出现、显隐/提交间断或任一 transform history 失效时写 invalid history
+marker，不能消费陈旧 pose。`material-attributes` 仍保留给后续属性缓冲路线。
 
 portable material UBO 分为 432-byte `MaterialBlock` 与 1,920-byte
 `MaterialTextureBlock`，二者按最终 std140 bytes 独立更新。WebGPU material group 的 binding
@@ -181,13 +183,16 @@ transfer。
 内置 HDR 组合由 `PostProcessRenderPipelineFactory` 提供：attachment-zero scene color 使用
 `rgba16float`，opaque queue 完成后由 graph `TextureCopyPass` 捕获 opaque scene
 texture，再把该 texture 作为 pass-global binding 交给 transparent PBR transmission/volume draw。可选
-`TemporalAA` 在 opaque 后记录 `rg16float` velocity，并用 sampled depth、`rgba16float` 双缓冲 color
-history 和 `r16float` 双缓冲 depth history 完成原生分辨率 reprojection、disocclusion 与 neighborhood
-clamp。resolved opaque color 随后才接受 transparent composition，因此透明不写入 TAA history。之后
-`Bloom` 在 tone mapping 前记录 soft-knee/Karis prefilter、13-tap downsample pyramid、tent
-upsample 与线性 composite；`ColorUber` 最后统一完成 grading、tone
-mapping、linear-to-sRGB 与 dithering，并把输出编码标记为 `srgb`，避免 surface output
-pass 重复转换。float scene target 会选择 linear-output material
+`TemporalAA` 在 opaque 后记录 `rgba16float` motion/log-depth，并用 `rgba16float` 双缓冲 color
+history 和 `r32float` 双缓冲 log-view-depth history 完成原生分辨率 reprojection、relative-depth
+disocclusion、YCoCg variance clipping 与 reactive resolve。resolved opaque
+color 随后才接受 transparent composition，因此透明不写入 TAA history。Clustered Forward+ opt-in
+TAA 时把 GPU Scene motion 融入 depth prepass，以前一已提交帧的 visibility
+buffer 拒绝重现物体的陈旧 history；fallback opaque/masked 在 resolve 前补写同一 motion
+target，fallback transparent 在 resolve 后合成。之后 `Bloom` 在 tone mapping 前记录 soft-knee/Karis
+prefilter、13-tap downsample pyramid、tent upsample 与线性 composite；`ColorUber`
+最后统一完成 grading、tone mapping、linear-to-sRGB 与 dithering，并把输出编码标记为
+`srgb`，避免 surface output pass 重复转换。float scene target 会选择 linear-output material
 variant，禁止材质 shader 提前执行 gamma encode 或旧的局部 tone mapping。完整颜色与材质合同见
 [`PBR_AND_POST_PROCESSING.md`](./PBR_AND_POST_PROCESSING.md)。
 
@@ -215,9 +220,12 @@ display。WebGPU 不支持 multi-draw-indirect-count，因此 runtime 对每个�
 draw，GPU 为不可见 bucket 写零 instance count；这些 bucket draw 在共享层分别合并到一个 depth render
 pass 和一个 color render pass，仍可逐 draw 切换 pipeline、bind group、vertex/index
 buffer，但不再为每个 bucket 重开 attachment。可见对象先写 selected-bucket table，再通过 bucket
-prefix 产生 indirect `firstInstance`，最终压缩到一份与 `maxObjects` 同阶的连续 visible
-table，不再按 object × physical-bucket 放大。Hi-Z 对 standard depth 取区块最远值 `max`、对 reversed
-depth 取区块最远值 `min`；previous-frame occlusion 同时读取已提交的 previous
+prefix 产生连续 range offset，最终压缩到一份与 `maxObjects` 同阶的 visible table，不再按 object ×
+physical-bucket 放大。所有 indexed-indirect command 的 `firstInstance` 保持为零；每个 bucket
+draw 通过 256-byte 对齐的只读 storage range 取得自己的 compact base，再与本地 `gl_InstanceIndex`
+相加，因此 baseline 不依赖 WebGPU 可选的 `indirect-first-instance` feature。Hi-Z 对 standard
+depth 取区块最远值 `max`、对 reversed depth 取区块最远值 `min`；previous-frame
+occlusion 同时读取已提交的 previous
 view/projection/depth 参数，不把上一帧 VP 与当前帧投影约定混用。颜色阶段 load 深度预通过结果，物体 record 携带 model
 basis 的 inverse-transpose normal matrix，因此 non-uniform scale 不改变法线方向。depth
 prepass 与 color pass 通过同一段 byte-identical clip-space transform 计算

--- a/documentation/TEMPORAL_RENDERING_REMEDIATION.md
+++ b/documentation/TEMPORAL_RENDERING_REMEDIATION.md
@@ -1,0 +1,126 @@
+# Motion Vector 与 TemporalAA 上线整改规范
+
+本文记录 2026-08 在最新 `origin/dev` 基线上对 Motion Vector、TemporalAA、Clustered
+Forward+ 时域集成、Hi-Z 显隐连续性和兼容 Forward
+fallback 的专项审查。目标不是增加一个仅在 demo 中可用的滤镜，而是形成可回滚、可恢复、可验证且默认无性能回归的生产合同。
+
+## 上线合同
+
+- Motion Vector 是材质语义 pass，不允许 backend 私有旁路或平行 shader 树。
+- previous state 只来自最近一次成功 submission；失败帧、不可见帧和 device
+  generation 不能推进 camera、model、instance、skin、morph、GPU Scene object 或 visibility history。
+- Camera 的 raster jitter 不改变 CPU
+  frustum、picking、project/unproject；成功和失败路径都必须在 frame 边界清零 jitter。
+- TAA
+  history 只包含 opaque/masked 线性 HDR 结果。transparent/transmission 在 resolve 后合成，Bloom/display 再消费完整场景。
+- Clustered GPU Scene 复用已有 depth prepass 输出 motion，不为 GPU-managed
+  object 增加第二次几何 replay；ordinary Forward 与 Clustered fallback 继续使用材质 `motion-vector`
+  pass。
+- `temporalAA` 未启用时不分配或清空 GPU Scene visibility history，不增加默认 Clustered 的 GPU
+  buffer 带宽。
+- camera cut、显著 projection 变化、resize、显隐间断、显式 transform invalidation、history
+  generation 变化和 device recovery 都必须 fail closed 到当前帧。
+
+## Motion 数据 ABI
+
+内置 Basic/PBR/Geometry 和 Clustered storage raster 使用同一 single-sample `rgba16float` 合同：
+
+| 通道 | 含义                                              | 单位与方向                                                      | 无效值           |
+| ---- | ------------------------------------------------- | --------------------------------------------------------------- | ---------------- |
+| X/Y  | current-to-previous motion                        | render-target UV；resolve 使用 `historyUV = currentUV - motion` | `0, 0`           |
+| Z    | 当前 surface 在 previous view 中的 expected depth | `log2(1 + abs(previousViewZ))`                                  | `-1`             |
+| W    | 当前 surface 的 depth                             | `log2(1 + abs(currentViewZ))`                                   | 仍写当前有效深度 |
+
+Z/W 不保存 device depth。这样同一判定不依赖 standard/reversed
+depth、near/far 的非线性分布或 log-depth framebuffer 写法。previous clip `w <= 0`、history
+revision 不连续或上一提交未参与 motion pass 时，Z 必须写 `-1`，resolve 不得猜测可用 history。
+
+## 审查问题与整改
+
+| 编号  | 审查发现                                                                                  | 生产风险                                                            | 整改结果                                                                                                          |
+| ----- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| TR-01 | velocity 只有 `rg16float`，resolve 用当前 raw device depth 对比上一帧同 UV depth          | 运动 surface 比较的是错误位置；reversed/log depth 下阈值无物理意义  | ABI 扩为 `rgba16float`，携带 previous/current log-view-depth，并用 relative linear-depth error 判定               |
+| TR-02 | mesh transform history 只看 revision，不知道上一帧是否真正输出过 motion                   | 物体离屏、隐藏或被裁剪后重现会读取陈旧 pose，形成长拖影             | direct/instanced motion draw 显式登记 participation；只接受最近成功 submission 的参与记录                         |
+| TR-03 | camera/model history 没有成功提交序号                                                     | 中间失败或相机跳帧后仍可能把非连续帧当成上一帧                      | Camera 与所有 motion domain 加入 submission continuity；rollback 不推进序号                                       |
+| TR-04 | RGB min/max clamp 与固定 history weight 对高反差运动过于宽松                              | emissive 边缘、薄几何和遮挡变化持续 ghost                           | 使用 YCoCg 3×3 variance clipping、motion response 与 luminance reactive response                                  |
+| TR-05 | sharpened 输出直接反馈 history                                                            | 逐帧过锐和 ringing 累积                                             | history 保存未 sharpen 的 resolved color；sharpness 只作用最终输出                                                |
+| TR-06 | WebGPU 在非 uniform control flow 中使用隐式导数 texture sample                            | Naga/WGSL validation 失败，真实设备或 SwiftShader 不能上线          | history 使用显式 LOD 采样；GPU validation 纳入浏览器验收                                                          |
+| TR-07 | jitter/cut 生命周期分散，projection jump 不能可靠失效                                     | FOV jump、失败帧或多 camera 生命周期可出现旧帧闪回                  | Forward/Clustered 共用 submission-aware controller；检测 projection discontinuity，并在 submit/discard 清 jitter  |
+| TR-08 | Clustered Forward+ 没有接入 TAA；若直接追加独立 motion pass 会重放全部 GPU Scene geometry | high-end profile 功能缺失或付出明显额外顶点成本                     | GPU Scene depth prepass 在启用时增加 motion MRT，复用同一 indirect bucket batch                                   |
+| TR-09 | Hi-Z/frustum 剔除后的 GPU object 没有上一帧可见性证据                                     | 重新出现时可能使用很久以前的 object velocity                        | 启用 TAA 时双缓冲 per-object visibility；只有 previous visibility 非零才允许 motion history                       |
+| TR-10 | GPU object dirty state 没有区分“本帧移动”和“移动后已稳定”                                 | stale previous matrix 可能重复输出非零 velocity，或静止物体每帧上传 | motion-changed flag 在稳定后的首帧清除；之后不再上传稳定 object record                                            |
+| TR-11 | fallback opaque/transparent 与 resolve 顺序未定义                                         | fallback 物体缺 motion，或透明被错误写入 history                    | opaque fallback 先写 HDR/depth/motion，TAA resolve，transparent fallback 后合成，再 Bloom/display                 |
+| TR-12 | camera history 长期持有且 TAA 关闭也可能产生新 buffer 工作                                | 多 camera 长会话增长；默认路径性能倒退                              | inactive camera history 由 graph 释放；Clustered visibility buffer、clear 和 compact write 全部按 TAA opt-in 创建 |
+
+## 帧序
+
+启用 Clustered TAA 后，一个 camera frame 的关键顺序是：
+
+1. 更新 stable camera/scene transform，并暂存 jitter；
+2. GPU frustum/Hi-Z cull、bucket prefix 与 visible compact，同时写 current visibility；
+3. GPU Scene depth batch，一次 raster 同时写 depth 与 motion；
+4. Cluster allocation 与 Clustered PBR opaque；
+5. ordinary Forward fallback opaque 写入同一 HDR/depth，随后用材质 motion role 补写同一 motion
+   target；
+6. TAA initialize 或 resolve，写 current color/depth history 与未进入 history 的 sharpened output；
+7. ordinary Forward fallback transparent/transmission 合成；
+8. Bloom、display transform、present；
+9. 只有 queue 接受 submission 后才轮换 color/depth/visibility history 并提交 previous transforms。
+
+任何 setup、prepare、execute 或提交失败都会走 discard：jitter 被清除，history index、visibility
+index 和 previous transform 都保持最后成功状态。
+
+## 画质策略
+
+- history UV 必须留在 half-texel 内；越界直接拒绝。
+- depth rejection 在 reprojected UV 周围取保守 2×2 history depth 最小误差，降低边缘 sampling
+  mismatch，同时不允许跨越相对深度阈值。
+- clamp 在 YCoCg 中使用 3×3 mean/variance 与真实 neighborhood extent 的交集，避免单纯 RGB
+  box 对亮度和色度同时过宽。
+- 大 motion 最多只保留 60%
+  history；当前/上一亮度差进一步降低 weight。该 response 是安全默认，不是 authored reactive
+  mask 的替代品。
+- transparent、particle、UI 不写当前 history。它们保持清晰的当前帧 composition，后续 TAAU 工作包再定义单独的 reactive/composition
+  policy。
+
+## 性能与内存
+
+TAA 是明确 opt-in。以不含 backend row-pitch/alignment 的格式字节估算：
+
+| 资源/工作          | ordinary Forward                                        | Clustered Forward+                                                                    |
+| ------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Motion target      | `8 B/pixel` transient；额外 opaque/masked motion replay | `8 B/pixel` transient；GPU object 融入已有 depth prepass，只有 fallback opaque replay |
+| Color history      | 双缓冲 `rgba16float`，合计 `16 B/pixel` persistent      | 相同                                                                                  |
+| Depth history      | 双缓冲 `r32float`，合计 `8 B/pixel` persistent          | 相同                                                                                  |
+| Resolved target    | `8 B/pixel` transient                                   | 相同                                                                                  |
+| Visibility history | 无                                                      | 双缓冲 `uint`，合计 `8 B/object`；只在启用时存在                                      |
+
+1080p 下，上述 history 加 motion/resolved 的理论额外峰值约 83 MB；其中约 50 MB 是跨帧 persistent
+history。resolve 每像素读取 3×3 current neighborhood、一个 color history、一个 motion
+sample 和最多四个 depth history texel，并输出三张 attachment。它适合 high-end/native-resolution
+profile，不应在内存受限设备上默认开启。TAAU、动态分辨率、history packing 或 half-resolution
+variant 必须作为独立质量档设计，不能偷偷改变当前 ABI。
+
+## 自动化验收
+
+| 范围           | 自动化入口                                            | 必须证明                                                                                                              |
+| -------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| ABI/target     | Material、shader、PostProcessing Vitest               | 只有 `rgba16float`/single-sample 合法，previous/current view depth 均存在                                             |
+| 提交事务       | BuiltIn UBO 与 PostProcessing Vitest                  | 成功帧推进；失败、显隐间断、显式 invalidation 不消费旧 history；jitter 恢复为零                                       |
+| Clustered 集成 | Clustered Forward+ real-WebGPU Vitest                 | fused depth/motion pipeline、全部 compact material bucket、fallback、Hi-Z、resize、camera cut、device recovery 均有效 |
+| 真实画面       | `test/ui/temporal-aa.spec.ts`                         | 静态 history 收敛、camera cut 首帧不闪回、后续稳定、浏览器 GPU validation 为零                                        |
+| 架构/RHI       | `test:render:architecture`、`test:rhi`、`test:webgpu` | 不绕过 Render Graph/RHI，portable shader 与真实 WebGPU pipeline 可创建                                                |
+
+用于人工审阅和自动化像素验收的页面是
+[`examples/temporal_aa_observatory.html`](../examples/temporal_aa_observatory.html)。它同时覆盖 100 个 GPU
+Scene object、ordinary Forward opaque/transmission fallback、动态局部光、Hi-Z、Bloom、camera
+cut 和 motion pause，测试模式固定内部 640×360 以保持软件 WebGPU 的确定性。
+
+## 明确保留到后续版本
+
+- transparent/particle history 与 per-material authored reactive mask；
+- TAAU、动态分辨率、exposure-compensated history 和 resolution-scale controller；
+- normal/material ID rejection、velocity dilation 和专用 thin-feature reconstruction；
+- memory-constrained quality tier 与 history format packing。
+
+这些是功能路线，不是当前实现的隐藏缺陷；在各自 ABI、质量和性能证据完成前不得以无测试开关并入当前生产路径。

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -6172,6 +6172,7 @@ export interface RenderPipelineContext {
     readonly frameIndex: number;
     readonly graph: ScriptableRenderGraph;
     readonly output: RenderPipelineOutput;
+    prepareScene(): void;
     recordShadows(cullingResults: CullingResultsHandle): void;
     readonly scene: RendererScene;
     readonly viewport: RendererViewport;

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -740,6 +740,7 @@ export interface ClusteredForwardPlusPipelineOptions {
     readonly maxObjects?: number;
     readonly maxViewportHeight?: number;
     readonly maxViewportWidth?: number;
+    readonly temporalAA?: Readonly<TemporalAAOptions> | false;
     readonly tileSize?: number;
     readonly zSlices?: number;
 }
@@ -8129,8 +8130,6 @@ export class TemporalAA implements ForwardRenderPipelineFeature {
     readonly name = "temporal-aa";
     // (undocumented)
     readonly requirements: Readonly<{
-        sampledSceneColor: true;
-        sampledDepth: true;
         requiredLimits: Readonly<{
             maxColorAttachments: 3;
         }>;
@@ -8141,18 +8140,14 @@ export class TemporalAA implements ForwardRenderPipelineFeature {
             format: "rgba16float";
             use: "filterable-sampled";
         }> | Readonly<{
-            format: "rg16float";
+            format: "r32float";
             use: "color-attachment";
         }> | Readonly<{
-            format: "rg16float";
-            use: "filterable-sampled";
-        }> | Readonly<{
-            format: "r16float";
-            use: "color-attachment";
-        }> | Readonly<{
-            format: "r16float";
-            use: "filterable-sampled";
+            format: "r32float";
+            use: "sampled";
         }>)[];
+        sampledSceneColor: true;
+        sampledDepth: true;
     }>;
 }
 
@@ -8160,6 +8155,8 @@ export class TemporalAA implements ForwardRenderPipelineFeature {
 export interface TemporalAAOptions {
     readonly depthThreshold?: number;
     readonly historyWeight?: number;
+    readonly sharpness?: number;
+    readonly varianceGamma?: number;
 }
 
 // @public

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -100,6 +100,7 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'webgl_support.html': 'Graphics Backend Support',
     'compute_gpu_driven.html': 'WebGPU Compute & GPU-Driven Rendering',
     'clustered_forward_plus_sponza.html': 'Sponza Clustered Forward+ Lighting Lab',
+    'temporal_aa_observatory.html': 'Temporal Observatory — Signals in Deep Time',
     'compute_eclipse_shrine.html': 'Eclipse Shrine — WebGPU Compute Installation',
     'compute_particles.html': 'Hilo3D Compute Particle Field',
     'compute_raytracing.html': 'Hilo3D Crystal Compute Path Tracer',
@@ -124,6 +125,8 @@ const DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
         'See Forward+, Gaussian splats, and a curl-noise Hilo3D GPU particle wordmark stay on the public Render Graph.',
     'clustered_forward_plus_sponza.html':
         'Explore Khronos Sponza under 192 animated local lights, GPU Scene culling, clustered shading, HDR bloom, and a cinematic camera tour.',
+    'temporal_aa_observatory.html':
+        'Stress fused motion vectors, visibility-aware history, logarithmic depth rejection, and native-resolution TAA in a kinetic WebGPU constellation.',
     'compute_eclipse_shrine.html':
         'Orbit a cinematic eclipse built from 65,536 compute-simulated bodies, three indirect spectral layers, PBR relics, HDR bloom, and interactive gravity.',
     'compute_particles.html':
@@ -195,6 +198,7 @@ const FEATURED_PATHS = new Set([
     'video.html',
     'compute_gpu_driven.html',
     'clustered_forward_plus_sponza.html',
+    'temporal_aa_observatory.html',
     'compute_eclipse_shrine.html',
     'compute_particles.html',
     'compute_raytracing.html'
@@ -225,7 +229,7 @@ function categoryForPath(path: string): ExampleCategoryId {
         return 'textures';
     }
     if (
-        /(?:post_process|bloom|rendertarget|drawbuffers|depthtexture|stencil|multisampled|scriptable_pipeline|clustered_forward_plus|compute_gpu_driven|compute_eclipse_shrine|compute_particles)/u.test(
+        /(?:post_process|bloom|temporal_aa|rendertarget|drawbuffers|depthtexture|stencil|multisampled|scriptable_pipeline|clustered_forward_plus|compute_gpu_driven|compute_eclipse_shrine|compute_particles)/u.test(
             normalized
         )
     ) {
@@ -310,6 +314,7 @@ function createEntry(path: string): ExampleCatalogEntry {
             ? WEBGL2_ONLY
             : path === 'bloom.html' ||
                 path === 'clustered_forward_plus_sponza.html' ||
+                path === 'temporal_aa_observatory.html' ||
                 path === 'compute_gpu_driven.html' ||
                 path === 'compute_eclipse_shrine.html' ||
                 path === 'compute_particles.html' ||

--- a/examples/temporal_aa_observatory.css
+++ b/examples/temporal_aa_observatory.css
@@ -1,0 +1,204 @@
+:root {
+    color-scheme: dark;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
+}
+
+body {
+    overflow: hidden;
+    background: #03050a;
+}
+
+#container,
+#container canvas {
+    width: 100%;
+    height: 100%;
+}
+
+.temporalPanel {
+    position: fixed;
+    z-index: 4;
+    top: clamp(22px, 5vw, 70px);
+    left: clamp(20px, 5vw, 76px);
+    width: min(390px, calc(100vw - 40px));
+    padding: 28px 30px 24px;
+    border: 1px solid rgb(182 218 255 / 18%);
+    border-radius: 2px;
+    background: linear-gradient(145deg, rgb(4 8 17 / 83%), rgb(4 7 13 / 58%));
+    box-shadow:
+        0 28px 90px rgb(0 0 0 / 44%),
+        inset 0 1px rgb(255 255 255 / 5%);
+    backdrop-filter: blur(20px) saturate(120%);
+}
+
+.temporalPanel::before {
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    width: 82px;
+    height: 1px;
+    content: '';
+    background: #7ce8ff;
+    box-shadow: 0 0 20px #38cfff;
+}
+
+.temporalEyebrow,
+.temporalCaption span {
+    margin: 0;
+    color: #7ce8ff;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.19em;
+    text-transform: uppercase;
+}
+
+.temporalPanel h1 {
+    margin: 15px 0 13px;
+    color: #f5f7ff;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: clamp(44px, 5.2vw, 72px);
+    font-weight: 400;
+    letter-spacing: -0.055em;
+    line-height: 0.86;
+}
+
+.temporalIntro {
+    max-width: 340px;
+    margin: 22px 0 26px;
+    color: rgb(220 231 255 / 68%);
+    font-size: 12px;
+    line-height: 1.75;
+}
+
+.temporalMetrics {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1px;
+    margin: 0 0 22px;
+    background: rgb(157 199 255 / 12%);
+}
+
+.temporalMetrics div {
+    padding: 12px 10px;
+    background: rgb(4 8 16 / 88%);
+}
+
+.temporalMetrics dt {
+    color: rgb(186 205 235 / 44%);
+    font-size: 8px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.temporalMetrics dd {
+    margin: 5px 0 0;
+    color: #eef4ff;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+}
+
+.temporalActions {
+    display: flex;
+    gap: 9px;
+}
+
+.temporalActions button {
+    flex: 1;
+    padding: 10px 12px;
+    border: 1px solid rgb(151 205 255 / 20%);
+    border-radius: 999px;
+    color: rgb(231 240 255 / 82%);
+    background: rgb(28 55 86 / 23%);
+    font: inherit;
+    font-size: 10px;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+        border-color 160ms ease,
+        background 160ms ease,
+        color 160ms ease;
+}
+
+.temporalActions button:hover,
+.temporalActions button:focus-visible {
+    border-color: rgb(124 232 255 / 70%);
+    color: white;
+    background: rgb(29 108 144 / 28%);
+    outline: none;
+}
+
+.temporalActions button[aria-pressed='false'] {
+    color: #ffca82;
+}
+
+.temporalStatus {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin-top: 18px;
+    color: rgb(210 226 250 / 47%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.temporalPulse {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #7ce8ff;
+    box-shadow: 0 0 11px #34d9ff;
+}
+
+.temporalCaption {
+    position: fixed;
+    z-index: 4;
+    right: clamp(20px, 4vw, 62px);
+    bottom: clamp(20px, 4vw, 48px);
+    text-align: right;
+}
+
+.temporalCaption p {
+    margin: 8px 0 0;
+    color: rgb(220 230 250 / 48%);
+    font-size: 10px;
+    letter-spacing: 0.04em;
+}
+
+.temporalGrain {
+    position: fixed;
+    z-index: 3;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.05;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 120 120' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.8'/%3E%3C/svg%3E");
+    mix-blend-mode: soft-light;
+}
+
+@media (max-width: 720px) {
+    .temporalPanel {
+        top: 16px;
+        left: 16px;
+        width: min(330px, calc(100vw - 32px));
+        padding: 20px;
+    }
+
+    .temporalPanel h1 {
+        font-size: 43px;
+    }
+    .temporalIntro {
+        margin: 16px 0 18px;
+    }
+    .temporalCaption {
+        display: none;
+    }
+}

--- a/examples/temporal_aa_observatory.html
+++ b/examples/temporal_aa_observatory.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0"
+        />
+        <title>Hilo3D Temporal Observatory</title>
+        <link rel="stylesheet" href="./example.css" />
+        <link rel="stylesheet" href="./temporal_aa_observatory.css" />
+    </head>
+    <body>
+        <div id="container"></div>
+
+        <main class="temporalPanel" aria-label="Temporal anti-aliasing showcase">
+            <p class="temporalEyebrow">Hilo3D · temporal study 01</p>
+            <h1>Signals in<br />Deep Time</h1>
+            <p class="temporalIntro">
+                Fine geometry crosses a moving, GPU-driven constellation. Fused motion vectors,
+                logarithmic view-depth rejection and YCoCg history clipping keep every signal
+                legible without sacrificing the present frame.
+            </p>
+
+            <dl class="temporalMetrics">
+                <div>
+                    <dt>resolve</dt>
+                    <dd>native</dd>
+                </div>
+                <div>
+                    <dt>history</dt>
+                    <dd>92%</dd>
+                </div>
+                <div>
+                    <dt>depth</dt>
+                    <dd>relative</dd>
+                </div>
+            </dl>
+
+            <div class="temporalActions">
+                <button id="motionToggle" type="button" aria-pressed="true">pause orbit</button>
+                <button id="cutButton" type="button">camera cut</button>
+            </div>
+
+            <div class="temporalStatus">
+                <span class="temporalPulse" aria-hidden="true"></span>
+                <span id="statusLabel">building temporal history</span>
+            </div>
+        </main>
+
+        <aside class="temporalCaption">
+            <span>WEBGPU / CLUSTERED FORWARD+</span>
+            <p>Drag to orbit · wheel to inspect · press Space to pause</p>
+        </aside>
+        <div class="temporalGrain" aria-hidden="true"></div>
+
+        <script type="module" src="./temporal_aa_observatory.ts"></script>
+    </body>
+</html>

--- a/examples/temporal_aa_observatory.ts
+++ b/examples/temporal_aa_observatory.ts
@@ -1,0 +1,382 @@
+import * as Hilo3d from '../src/Hilo3d';
+
+interface OrbitalBody {
+    readonly mesh: Hilo3d.Mesh;
+    readonly radius: number;
+    readonly height: number;
+    readonly phase: number;
+    readonly speed: number;
+}
+
+interface TemporalObservatoryEvidence {
+    readonly backend: 'webgpu';
+    readonly objectCount: number;
+    readonly fallbackObjectCount: number;
+    readonly visibleObjectCount: number;
+    readonly hiZValid: boolean;
+    readonly temporalAA: true;
+}
+
+const search = new URLSearchParams(location.search);
+const testMode = search.get('test') === '1';
+const prefersReducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+function requireElement(selector: string): HTMLElement {
+    const element = document.querySelector<HTMLElement>(selector);
+    if (element === null) throw new Error(`Temporal Observatory is missing ${selector}`);
+    return element;
+}
+const container = requireElement('#container');
+const motionToggle = requireElement('#motionToggle');
+const cutButton = requireElement('#cutButton');
+const statusLabel = requireElement('#statusLabel');
+
+const orbGeometry = new Hilo3d.SphereGeometry({
+    radius: 0.22,
+    widthSegments: 20,
+    heightSegments: 12
+});
+const orbLOD = new Hilo3d.SphereGeometry({
+    radius: 0.22,
+    widthSegments: 10,
+    heightSegments: 6
+});
+const signalGeometry = new Hilo3d.BoxGeometry({ width: 0.055, height: 1.45, depth: 0.055 });
+const cyan = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.06, 0.5, 0.88),
+    metallic: 0.45,
+    roughness: 0.19,
+    emission: new Hilo3d.Color(0.01, 0.12, 0.28),
+    emissionFactor: new Hilo3d.Color(0.04, 0.3, 1)
+});
+const violet = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.38, 0.09, 0.72),
+    metallic: 0.35,
+    roughness: 0.22,
+    emission: new Hilo3d.Color(0.14, 0.015, 0.26),
+    emissionFactor: new Hilo3d.Color(0.65, 0.04, 0.9)
+});
+const gold = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.82, 0.39, 0.07),
+    metallic: 0.65,
+    roughness: 0.2,
+    emission: new Hilo3d.Color(0.25, 0.07, 0.005),
+    emissionFactor: new Hilo3d.Color(1.2, 0.28, 0.015)
+});
+const signalMaterial = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.48, 0.7, 0.92),
+    metallic: 0.88,
+    roughness: 0.14,
+    emission: new Hilo3d.Color(0.01, 0.08, 0.13),
+    emissionFactor: new Hilo3d.Color(0.05, 0.35, 0.75)
+});
+const orbMaterials = [cyan, violet, gold] as const;
+const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
+    buckets: [
+        ...orbMaterials.map(material => ({
+            geometry: orbGeometry,
+            material,
+            lods: [{ geometry: orbLOD, maximumProjectedRadius: 12 }]
+        })),
+        { geometry: signalGeometry, material: signalMaterial }
+    ],
+    maxObjects: testMode ? 128 : 160,
+    maxLights: testMode ? 16 : 24,
+    maxLightIndices: testMode ? 8_192 : 262_144,
+    maxLightsPerCluster: 48,
+    tileSize: 24,
+    zSlices: 24,
+    maxViewportWidth: testMode ? 640 : 2560,
+    maxViewportHeight: testMode ? 360 : 1440,
+    hiZ: true,
+    bloomStrength: 0.45,
+    exposure: 1,
+    temporalAA: {
+        historyWeight: 0.92,
+        depthThreshold: 0.02,
+        varianceGamma: 1.25,
+        sharpness: 0.08
+    }
+});
+
+const initialWidth = testMode ? 640 : innerWidth;
+const initialHeight = testMode ? 360 : innerHeight;
+const camera = new Hilo3d.PerspectiveCamera({
+    aspect: initialWidth / Math.max(initialHeight, 1),
+    fov: 42,
+    near: 0.05,
+    far: 80,
+    depthMode: 'reversed'
+});
+document.body.dataset['temporalPhase'] = 'creating-stage';
+const stage = await Hilo3d.Stage.create<'webgpu'>({
+    backend: 'webgpu',
+    container,
+    camera,
+    width: initialWidth,
+    height: initialHeight,
+    pixelRatio: testMode ? 1 : Math.min(devicePixelRatio, 1.5),
+    antialias: false,
+    alpha: false,
+    clearColor: new Hilo3d.Color(0.0015, 0.003, 0.009),
+    renderingProfile: 'high-end',
+    renderPipeline: factory
+});
+document.body.dataset['temporalPhase'] = 'building-scene';
+
+new Hilo3d.AmbientLight({
+    amount: 0.36,
+    color: new Hilo3d.Color(0.38, 0.3, 0.46)
+}).addTo(stage);
+new Hilo3d.DirectionalLight({
+    amount: 1.8,
+    color: new Hilo3d.Color(0.95, 0.8, 0.65),
+    direction: new Hilo3d.Vector3(-0.55, -0.82, -0.28)
+}).addTo(stage);
+
+const lightColors = [
+    new Hilo3d.Color(0.12, 0.62, 1),
+    new Hilo3d.Color(0.78, 0.16, 1),
+    new Hilo3d.Color(1, 0.36, 0.08)
+] as const;
+const movingLights: Hilo3d.PointLight[] = [];
+for (let index = 0; index < 12; index += 1) {
+    const angle = (index / 12) * Math.PI * 2;
+    const color = lightColors[index % lightColors.length];
+    if (color === undefined) throw new Error('Temporal light palette is incomplete');
+    movingLights.push(
+        new Hilo3d.PointLight({
+            amount: 3.6,
+            range: 7,
+            color,
+            x: Math.cos(angle) * 3.2,
+            y: Math.sin(angle * 2) * 0.9,
+            z: Math.sin(angle) * 3.2
+        }).addTo(stage)
+    );
+}
+
+const orbitals: OrbitalBody[] = [];
+for (let index = 0; index < 72; index += 1) {
+    const band = index % 4;
+    const phase = (index / 72) * Math.PI * 2 + band * 0.43;
+    const material = orbMaterials[index % orbMaterials.length];
+    if (material === undefined) throw new Error('Temporal material palette is incomplete');
+    const mesh = new Hilo3d.Mesh({
+        geometry: orbGeometry,
+        material,
+        frustumTest: true,
+        pointerEnabled: false
+    }).addTo(stage);
+    mesh.setScale(0.62 + (index % 7) * 0.065);
+    orbitals.push({
+        mesh,
+        radius: 1.45 + band * 0.78,
+        height: (band - 1.5) * 0.72,
+        phase,
+        speed: 0.12 + band * 0.025 + (index % 5) * 0.004
+    });
+}
+
+const signals: Hilo3d.Mesh[] = [];
+for (let index = 0; index < 28; index += 1) {
+    const angle = (index / 28) * Math.PI * 2;
+    const signal = new Hilo3d.Mesh({
+        geometry: signalGeometry,
+        material: signalMaterial,
+        x: Math.cos(angle) * 2.85,
+        y: Math.sin(angle * 3) * 0.7,
+        z: Math.sin(angle) * 2.85,
+        rotationX: 18 + (index % 5) * 13,
+        rotationZ: 90 + (index / 28) * 180,
+        pointerEnabled: false
+    }).addTo(stage);
+    signals.push(signal);
+}
+
+const floor = new Hilo3d.Mesh({
+    geometry: new Hilo3d.PlaneGeometry({ width: 18, height: 18 }),
+    material: new Hilo3d.PBRMaterial({
+        baseColor: new Hilo3d.Color(0.008, 0.015, 0.035),
+        metallic: 0.78,
+        roughness: 0.24
+    }),
+    y: -2.15,
+    rotationX: -90,
+    pointerEnabled: false
+}).addTo(stage);
+floor.receiveShadows = false;
+
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.SphereGeometry({ radius: 0.72, widthSegments: 36, heightSegments: 22 }),
+    material: new Hilo3d.PBRMaterial({
+        baseColor: new Hilo3d.Color(0.22, 0.35, 0.62, 0.64),
+        metallic: 0.04,
+        roughness: 0.08,
+        transmissionFactor: 0.78,
+        thicknessFactor: 1.4,
+        attenuationDistance: 3.5,
+        attenuationColor: new Hilo3d.Color(0.14, 0.5, 0.9),
+        ior: 1.42
+    }),
+    y: 0.05,
+    pointerEnabled: false,
+    frustumTest: false
+}).addTo(stage);
+
+const controls = new Hilo3d.OrbitControls(stage, {
+    camera,
+    target: new Hilo3d.Vector3(0, -0.05, 0),
+    enablePan: false,
+    minDistance: 5.2,
+    maxDistance: 12,
+    minPolarAngle: Math.PI * 0.25,
+    maxPolarAngle: Math.PI * 0.72,
+    rotateSpeed: 0.62,
+    zoomSpeed: 0.8
+});
+const heroView = new Hilo3d.Vector3(6.8, 3.2, 8.4);
+const cutView = new Hilo3d.Vector3(-7.4, 2.15, 6.1);
+const viewTarget = new Hilo3d.Vector3(0, -0.05, 0);
+controls.setView(heroView, viewTarget);
+
+let time = 0;
+let motionEnabled = search.get('motion') !== 'false' && !prefersReducedMotion;
+let alternateView = false;
+
+function updateScene(deltaMilliseconds: number): void {
+    if (motionEnabled) time += Math.min(deltaMilliseconds, 50) * 0.001;
+    for (const orbital of orbitals) {
+        const angle = orbital.phase + time * orbital.speed * Math.PI * 2;
+        orbital.mesh.setPosition(
+            Math.cos(angle) * orbital.radius,
+            orbital.height + Math.sin(angle * 2.7) * 0.42,
+            Math.sin(angle) * orbital.radius
+        );
+        orbital.mesh.rotationY = (angle * 180) / Math.PI;
+    }
+    for (let index = 0; index < signals.length; index += 1) {
+        const signal = signals[index];
+        if (signal === undefined) continue;
+        signal.rotationY = time * 34 + index * 12;
+        signal.rotationZ = 90 + Math.sin(time * 0.9 + index) * 34;
+    }
+    for (let index = 0; index < movingLights.length; index += 1) {
+        const light = movingLights[index];
+        if (light === undefined) continue;
+        const angle = (index / movingLights.length) * Math.PI * 2 - time * 0.16;
+        light.setPosition(
+            Math.cos(angle) * 3.15,
+            Math.sin(angle * 2.2) * 0.85,
+            Math.sin(angle) * 3.15
+        );
+    }
+}
+
+const ticker = new Hilo3d.Ticker(60);
+const simulation: Hilo3d.Tickable = { tick: updateScene };
+ticker.addTick(simulation);
+ticker.addTick(stage);
+
+function setMotion(value: boolean): void {
+    motionEnabled = value;
+    motionToggle.setAttribute('aria-pressed', String(value));
+    motionToggle.textContent = value ? 'pause orbit' : 'resume orbit';
+    document.body.dataset['motion'] = String(value);
+}
+
+function applyCameraCut(): void {
+    alternateView = !alternateView;
+    controls.setView(alternateView ? cutView : heroView, viewTarget);
+    camera.invalidateTransformHistory();
+    statusLabel.textContent = 'history reset · camera cut';
+}
+
+async function stepFrames(frameCount: number, advanceMotion = false): Promise<void> {
+    ticker.stop();
+    const previousMotion = motionEnabled;
+    if (!advanceMotion) motionEnabled = false;
+    try {
+        for (let frame = 0; frame < frameCount; frame += 1) {
+            updateScene(1000 / 60);
+            stage.tick(1000 / 60);
+            await stage.renderer.waitForIdle();
+        }
+    } finally {
+        motionEnabled = previousMotion;
+    }
+}
+
+motionToggle.addEventListener('click', () => {
+    setMotion(!motionEnabled);
+});
+cutButton.addEventListener('click', applyCameraCut);
+window.addEventListener('keydown', event => {
+    if (event.code === 'Space') {
+        event.preventDefault();
+        setMotion(!motionEnabled);
+    }
+});
+
+const resize = (): void => {
+    if (testMode) return;
+    camera.aspect = innerWidth / Math.max(innerHeight, 1);
+    stage.resize(innerWidth, innerHeight, Math.min(devicePixelRatio, 1.5));
+};
+window.addEventListener('resize', resize);
+
+setMotion(motionEnabled);
+updateScene(0);
+document.body.dataset['temporalPhase'] = 'warming-history';
+await stepFrames(3, false);
+const diagnostics = await factory.readDiagnostics();
+window.__HILO3D_TEMPORAL_OBSERVATORY_RESULT__ = {
+    backend: 'webgpu',
+    objectCount: diagnostics.objectCount,
+    fallbackObjectCount: diagnostics.fallbackObjectCount,
+    visibleObjectCount: diagnostics.visibleObjectCount,
+    hiZValid: diagnostics.hiZValid,
+    temporalAA: true
+};
+window.__HILO3D_TEMPORAL_OBSERVATORY_TEST_API__ = {
+    async settle(frames = 8): Promise<void> {
+        await stepFrames(frames, false);
+    },
+    async cutAndSettle(frames = 1): Promise<void> {
+        applyCameraCut();
+        await stepFrames(frames, false);
+    },
+    async teleportAndSettle(frames = 1): Promise<void> {
+        const signal = signals[0];
+        if (signal === undefined) throw new Error('Temporal test signal is unavailable');
+        signal.x *= -1;
+        signal.z *= -1;
+        signal.invalidateTransformHistory();
+        await stepFrames(frames, false);
+    }
+};
+statusLabel.textContent = `${String(diagnostics.visibleObjectCount)} signals · history stable`;
+document.body.dataset['temporalReady'] = 'true';
+document.body.dataset['temporalPhase'] = 'ready';
+if (!testMode) ticker.start();
+
+window.addEventListener(
+    'pagehide',
+    () => {
+        window.removeEventListener('resize', resize);
+        ticker.stop();
+        controls.dispose();
+        stage.destroy();
+    },
+    { once: true }
+);
+
+declare global {
+    interface Window {
+        __HILO3D_TEMPORAL_OBSERVATORY_RESULT__?: TemporalObservatoryEvidence;
+        __HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?: {
+            settle(frames?: number): Promise<void>;
+            cutAndSettle(frames?: number): Promise<void>;
+            teleportAndSettle(frames?: number): Promise<void>;
+        };
+    }
+}

--- a/src/material/MaterialCompiler.ts
+++ b/src/material/MaterialCompiler.ts
@@ -190,11 +190,11 @@ export class MaterialCompiler {
         if (
             pass.fragmentOutput === 'motion-vector' &&
             (request.target.colorFormats.length !== 1 ||
-                request.target.colorFormats[0] !== 'rg16float' ||
+                request.target.colorFormats[0] !== 'rgba16float' ||
                 request.target.sampleCount !== 1)
         ) {
             throw new TypeError(
-                'Material motion-vector role requires one single-sample rg16float color target'
+                'Material motion-vector role requires one single-sample rgba16float color target'
             );
         }
         const state = role === 'forward' ? resolveForwardState(instance, pass) : pass.state;

--- a/src/render/BuiltInUniformBlockManager.ts
+++ b/src/render/BuiltInUniformBlockManager.ts
@@ -94,6 +94,7 @@ interface CameraHistoryRecord {
     committedDepthMode: Camera['depthMode'];
     pendingDepthMode: Camera['depthMode'];
     committedGeneration: number;
+    committedSubmission: number;
     pendingFrame: number;
 }
 
@@ -103,6 +104,11 @@ interface TransformHistoryRecord {
     committedRevision: number;
     pendingRevision: number;
     committedGeneration: number;
+    pendingFrame: number;
+}
+
+interface MotionParticipationRecord {
+    committedSubmission: number;
     pendingFrame: number;
 }
 
@@ -447,10 +453,12 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
     private readonly modelHistory = new WeakMap<Mesh, TransformHistoryRecord>();
     private readonly skinningHistory = new WeakMap<Mesh, TransformHistoryRecord>();
     private readonly morphHistory = new WeakMap<Mesh, TransformHistoryRecord>();
+    private readonly motionParticipation = new WeakMap<Mesh, MotionParticipationRecord>();
     private readonly stagedCameras: CameraHistoryRecord[] = [];
     private readonly stagedModels: TransformHistoryRecord[] = [];
     private readonly stagedSkinning: TransformHistoryRecord[] = [];
     private readonly stagedMorphs: TransformHistoryRecord[] = [];
+    private readonly stagedMotionParticipation: MotionParticipationRecord[] = [];
     private readonly bufferOwners = new WeakMap<UniformBuffer, OwnedBufferRegistration>();
     private camera: Camera | null = null;
     private semanticFrame: SemanticFrameState | null = null;
@@ -459,6 +467,7 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
     private sceneRevision = -1;
     private lightRevision = -1;
     private historyGeneration = 1;
+    private submissionIndex = 0;
 
     constructor(renderer: RendererSize) {
         this.renderer = renderer;
@@ -517,6 +526,7 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
     }
 
     commit(_submission: RHISubmission): void {
+        const committedSubmission = this.submissionIndex + 1;
         for (const record of this.stagedCameras) {
             record.committedView.set(record.pendingView);
             record.committedProjection.set(record.pendingProjection);
@@ -526,11 +536,17 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             record.committedRevision = record.pendingRevision;
             record.committedDepthMode = record.pendingDepthMode;
             record.committedGeneration = this.historyGeneration;
+            record.committedSubmission = committedSubmission;
             record.pendingFrame = -1;
         }
         this.commitTransformRecords(this.stagedModels);
         this.commitTransformRecords(this.stagedSkinning);
         this.commitTransformRecords(this.stagedMorphs);
+        for (const record of this.stagedMotionParticipation) {
+            record.committedSubmission = committedSubmission;
+            record.pendingFrame = -1;
+        }
+        this.submissionIndex = committedSubmission;
         this.clearStagedHistory();
     }
 
@@ -539,12 +555,25 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         for (const record of this.stagedModels) record.pendingFrame = -1;
         for (const record of this.stagedSkinning) record.pendingFrame = -1;
         for (const record of this.stagedMorphs) record.pendingFrame = -1;
+        for (const record of this.stagedMotionParticipation) record.pendingFrame = -1;
         this.clearStagedHistory();
     }
 
     /** Invalidate every previous transform at a device-generation boundary. */
     synchronizeAfterRecovery(): void {
         this.historyGeneration += 1;
+    }
+
+    /** @internal Record that a visible mesh emitted motion data in this submitted frame. */
+    markMotionVectorParticipation(mesh: Mesh): void {
+        let record = this.motionParticipation.get(mesh);
+        if (record === undefined) {
+            record = { committedSubmission: -1, pendingFrame: -1 };
+            this.motionParticipation.set(mesh, record);
+        }
+        if (record.pendingFrame === this.frameIndex) return;
+        record.pendingFrame = this.frameIndex;
+        this.stagedMotionParticipation.push(record);
     }
 
     /** @internal Stage and write one current/previous camera-relative instance transform. */
@@ -568,7 +597,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         current.set(history.pending, offset);
         const valid =
             history.committedGeneration === this.historyGeneration &&
-            history.committedRevision === getTransformHistoryRevision(mesh);
+            history.committedRevision === getTransformHistoryRevision(mesh) &&
+            this.hasConsecutiveMotionParticipation(mesh);
         previous.set(valid ? history.committed : history.pending, offset);
         return valid;
     }
@@ -672,7 +702,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         const historyValid =
             history.committedGeneration === this.historyGeneration &&
             history.committedRevision === getTransformHistoryRevision(camera) &&
-            history.committedDepthMode === camera.depthMode;
+            history.committedDepthMode === camera.depthMode &&
+            history.committedSubmission === this.submissionIndex;
         const previousView = historyValid ? history.committedView : history.pendingView;
         const previousProjection = historyValid
             ? history.committedProjection
@@ -984,7 +1015,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             }
             const historyValid =
                 history.committedGeneration === this.historyGeneration &&
-                history.committedRevision === getTransformHistoryRevision(mesh);
+                history.committedRevision === getTransformHistoryRevision(mesh) &&
+                this.hasConsecutiveMotionParticipation(mesh);
             updateModelTransformBlock(
                 cached.buffer,
                 mesh,
@@ -1070,7 +1102,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             this.stagedSkinning.push(history);
             const historyValid =
                 history.committedGeneration === this.historyGeneration &&
-                history.committedRevision === history.pendingRevision;
+                history.committedRevision === history.pendingRevision &&
+                this.hasConsecutiveMotionParticipation(mesh);
             cached.buffer
                 .set('u_jointMat', history.pending)
                 .set('u_previousJointMat', historyValid ? history.committed : history.pending)
@@ -1132,7 +1165,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         this.stagedMorphs.push(history);
         const historyValid =
             history.committedGeneration === this.historyGeneration &&
-            history.committedRevision === history.pendingRevision;
+            history.committedRevision === history.pendingRevision &&
+            this.hasConsecutiveMotionParticipation(mesh);
         const previous = historyValid ? history.committed : history.pending;
         cached.buffer
             .set('u_morphWeights0', cached.weights0)
@@ -1220,6 +1254,7 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             committedDepthMode: 'standard',
             pendingDepthMode: 'standard',
             committedGeneration: 0,
+            committedSubmission: -1,
             pendingFrame: -1
         };
         this.cameraHistory.set(camera, record);
@@ -1254,11 +1289,16 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
         }
     }
 
+    private hasConsecutiveMotionParticipation(mesh: Mesh): boolean {
+        return this.motionParticipation.get(mesh)?.committedSubmission === this.submissionIndex;
+    }
+
     private clearStagedHistory(): void {
         this.stagedCameras.length = 0;
         this.stagedModels.length = 0;
         this.stagedSkinning.length = 0;
         this.stagedMorphs.length = 0;
+        this.stagedMotionParticipation.length = 0;
     }
 
     private createBuffer(layout: Std140Layout): UniformBuffer {

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -117,7 +117,11 @@ import type {
     ScriptableRenderPassContext,
     ScriptableRenderPrepareContext
 } from '../pipeline/ScriptableRenderGraph';
-import { MeshDrawListPlanner, type MeshDrawListPlan } from '../renderer/MeshDrawListPlanner';
+import {
+    isMeshDrawInstanceBatch,
+    MeshDrawListPlanner,
+    type MeshDrawListPlan
+} from '../renderer/MeshDrawListPlanner';
 import type { FullscreenDrawProcessor } from '../renderer/FullscreenDrawProcessor';
 import type {
     MeshDrawProcessor,
@@ -3860,6 +3864,11 @@ class RenderPipelineContextLease implements RenderPipelineContext, ScriptableRen
         return this;
     }
 
+    prepareScene(): void {
+        this.#owner.assertLeaseActive(this.#lease);
+        this.#owner.prepareScene();
+    }
+
     cull(options?: Readonly<CullingOptions>): CullingResultsHandle {
         this.#owner.assertLeaseActive(this.#lease);
         return this.#owner.cull(options);
@@ -4347,6 +4356,11 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         );
         this.#cullingByHandle.set(handle, slot);
         return handle;
+    }
+
+    prepareScene(): void {
+        this.assertActive();
+        this.services.prepareScriptableCullingScene(this.scene, this.camera);
     }
 
     createRendererList(descriptor: Readonly<RendererListDescriptor>): RendererListHandle {
@@ -5109,33 +5123,33 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 `Storage scene draws do not support material pass ${list.materialPass}`
             );
         }
-        for (const mesh of plan.opaqueMeshes) {
-            drawPass.addDrawSnapshot(
-                storageVariant === null
-                    ? processor.prepare(
-                          mesh,
-                          target,
-                          list.overrideMaterial,
-                          sceneTexturePreparation,
-                          list.materialPass
-                      )
-                    : processor.prepareStorageScene(
-                          mesh,
-                          target,
-                          storageVariant.shader,
-                          storagePipelines,
-                          storagePreparation,
-                          list.overrideMaterial
-                      )
-            );
-        }
-        for (const batch of plan.instancedBatches) {
-            if (batch.transparent) continue;
+        for (const item of plan.opaqueItems) {
+            if (item instanceof Mesh) {
+                drawPass.addDrawSnapshot(
+                    storageVariant === null
+                        ? processor.prepare(
+                              item,
+                              target,
+                              list.overrideMaterial,
+                              sceneTexturePreparation,
+                              list.materialPass
+                          )
+                        : processor.prepareStorageScene(
+                              item,
+                              target,
+                              storageVariant.shader,
+                              storagePipelines,
+                              storagePreparation,
+                              list.overrideMaterial
+                          )
+                );
+                continue;
+            }
             if (storageVariant === null) {
                 drawPass.addDrawSnapshot(
                     processor.prepareInstancedBatch(
-                        batch,
-                        batch.meshes,
+                        item,
+                        item.meshes,
                         target,
                         list.overrideMaterial,
                         sceneTexturePreparation,
@@ -5144,7 +5158,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 );
                 continue;
             }
-            for (const mesh of batch.meshes) {
+            for (const mesh of item.meshes) {
                 drawPass.addDrawSnapshot(
                     processor.prepareStorageScene(
                         mesh,
@@ -5158,33 +5172,33 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 );
             }
         }
-        for (const mesh of plan.transparentMeshes) {
-            drawPass.addDrawSnapshot(
-                storageVariant === null
-                    ? processor.prepare(
-                          mesh,
-                          target,
-                          list.overrideMaterial,
-                          sceneTexturePreparation,
-                          list.materialPass
-                      )
-                    : processor.prepareStorageScene(
-                          mesh,
-                          target,
-                          storageVariant.shader,
-                          storagePipelines,
-                          storagePreparation,
-                          list.overrideMaterial
-                      )
-            );
-        }
-        for (const batch of plan.instancedBatches) {
-            if (!batch.transparent) continue;
+        for (const item of plan.transparentItems) {
+            if (!isMeshDrawInstanceBatch(item)) {
+                drawPass.addDrawSnapshot(
+                    storageVariant === null
+                        ? processor.prepare(
+                              item,
+                              target,
+                              list.overrideMaterial,
+                              sceneTexturePreparation,
+                              list.materialPass
+                          )
+                        : processor.prepareStorageScene(
+                              item,
+                              target,
+                              storageVariant.shader,
+                              storagePipelines,
+                              storagePreparation,
+                              list.overrideMaterial
+                          )
+                );
+                continue;
+            }
             if (storageVariant === null) {
                 drawPass.addDrawSnapshot(
                     processor.prepareInstancedBatch(
-                        batch,
-                        batch.meshes,
+                        item,
+                        item.meshes,
                         target,
                         list.overrideMaterial,
                         sceneTexturePreparation,
@@ -5193,7 +5207,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 );
                 continue;
             }
-            for (const mesh of batch.meshes) {
+            for (const mesh of item.meshes) {
                 drawPass.addDrawSnapshot(
                     processor.prepareStorageScene(
                         mesh,

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -59,7 +59,8 @@ import SharedMaterialRecordDatabase from '../renderer/SharedMaterialRecordDataba
 import {
     packPBRGPUMaterialRecord,
     PBR_GPU_MATERIAL_RECORD_BYTES,
-    PBR_GPU_MATERIAL_RECORD_LAYOUT
+    PBR_GPU_MATERIAL_RECORD_LAYOUT,
+    type PBR_GPU_MATERIAL_TEXTURE_SLOTS
 } from '../renderer/PBRGPUMaterialRecord';
 import type { StorageBuffer } from '../StorageBuffer';
 import type {
@@ -79,7 +80,6 @@ import {
     ComputeRenderPass,
     FullscreenRenderPass,
     GPUDrivenRenderPass,
-    PresentRenderPass,
     SceneRenderPass,
     TextureCopyPass,
     type ComputeRenderPassParameters,
@@ -105,13 +105,16 @@ import type {
 const OBJECT_RECORD_BYTES = 208;
 const LIGHT_RECORD_BYTES = 64;
 const BUCKET_RECORD_BYTES = 48;
-const FRAME_RECORD_BYTES = 496;
+const FRAME_RECORD_BYTES = 512;
 const INDIRECT_ARGUMENT_BYTES = 20;
 const STATS_BYTES = 16;
-const HIZ_LEVEL_COUNT = 6;
-const MAX_HIZ_OCCLUSION_DIAMETER = 1 << HIZ_LEVEL_COUNT;
+// WebGPU guarantees at least an 8192-wide 2D texture. Factories specialize the shader and graph
+// to the exact configured viewport pyramid while this remains the portable upper bound.
+const MAX_HIZ_LEVEL_COUNT = 13;
+const MAX_HIZ_OCCLUSION_DIAMETER = 1 << MAX_HIZ_LEVEL_COUNT;
 const OBJECT_ACTIVE_FLAG = 1;
 const OBJECT_FRUSTUM_CULLING_FLAG = 2;
+const OBJECT_HIZ_STABLE_FLAG = 4;
 const CULL_WORKGROUP_SIZE = 64;
 const PREFIX_WORKGROUP_SIZE = 256;
 const DEFAULT_MAX_OBJECTS = 16_384;
@@ -229,6 +232,7 @@ interface NormalizedOptions {
     readonly maxViewportWidth: number;
     readonly maxViewportHeight: number;
     readonly hiZ: boolean;
+    readonly hiZLevelCount: number;
     readonly bloomStrength: number;
     readonly exposure: number;
 }
@@ -294,6 +298,7 @@ interface PBRTextureBinding {
     readonly shaderName: string;
     readonly texture: Texture<unknown>;
     readonly uv: 0 | 1;
+    readonly slotIndex: number;
 }
 
 interface PBRMaterialVariant {
@@ -302,7 +307,6 @@ interface PBRMaterialVariant {
     readonly usesUV0: boolean;
     readonly usesUV1: boolean;
     readonly normalUV: 0 | 1 | null;
-    readonly gammaCorrection: boolean;
     readonly occlusionInMetallicRoughness: boolean;
 }
 
@@ -315,8 +319,19 @@ interface GPUSceneObjectRecord {
     committedWorldVersion: number;
     pendingFrustumTest: boolean;
     committedFrustumTest: boolean;
+    pendingBoundsRevision: number;
+    committedBoundsRevision: number;
+    pendingOcclusionStable: boolean;
+    committedOcclusionStable: boolean;
     readonly committedMatrix: Float32Array;
     readonly pendingMatrix: Float32Array;
+}
+
+interface LogicalBucketBounds {
+    readonly center: Vector3;
+    radius: number;
+    revision: number;
+    readonly positionRevisions: number[];
 }
 
 function positiveInteger(value: unknown, name: string): number {
@@ -446,32 +461,57 @@ function requireBucketPassState(
 const PBR_TEXTURE_ROLES: readonly Readonly<{
     role: PBRTextureRole;
     shaderName: string;
+    slotName: (typeof PBR_GPU_MATERIAL_TEXTURE_SLOTS)[number];
+    slotIndex: number;
 }>[] = Object.freeze([
-    Object.freeze({ role: 'baseColorMap', shaderName: 'u_baseColorMap' }),
-    Object.freeze({ role: 'metallicMap', shaderName: 'u_metallicMap' }),
-    Object.freeze({ role: 'roughnessMap', shaderName: 'u_roughnessMap' }),
-    Object.freeze({ role: 'metallicRoughnessMap', shaderName: 'u_metallicRoughnessMap' }),
-    Object.freeze({ role: 'occlusionMap', shaderName: 'u_occlusionMap' }),
-    Object.freeze({ role: 'emission', shaderName: 'u_emission' }),
-    Object.freeze({ role: 'normalMap', shaderName: 'u_normalMap' })
+    Object.freeze({
+        role: 'baseColorMap',
+        shaderName: 'u_baseColorMap',
+        slotName: 'baseColor',
+        slotIndex: 0
+    }),
+    Object.freeze({
+        role: 'metallicMap',
+        shaderName: 'u_metallicMap',
+        slotName: 'metallic',
+        slotIndex: 1
+    }),
+    Object.freeze({
+        role: 'roughnessMap',
+        shaderName: 'u_roughnessMap',
+        slotName: 'roughness',
+        slotIndex: 2
+    }),
+    Object.freeze({
+        role: 'metallicRoughnessMap',
+        shaderName: 'u_metallicRoughnessMap',
+        slotName: 'metallicRoughness',
+        slotIndex: 3
+    }),
+    Object.freeze({
+        role: 'occlusionMap',
+        shaderName: 'u_occlusionMap',
+        slotName: 'occlusion',
+        slotIndex: 4
+    }),
+    Object.freeze({
+        role: 'emission',
+        shaderName: 'u_emission',
+        slotName: 'emission',
+        slotIndex: 5
+    }),
+    Object.freeze({
+        role: 'normalMap',
+        shaderName: 'u_normalMap',
+        slotName: 'normal',
+        slotIndex: 6
+    })
 ]);
 
 function materialTexture(material: PBRMaterial, role: PBRTextureRole): Texture<unknown> | null {
-    const slotName =
-        role === 'baseColorMap'
-            ? 'baseColor'
-            : role === 'metallicMap'
-              ? 'metallic'
-              : role === 'roughnessMap'
-                ? 'roughness'
-                : role === 'metallicRoughnessMap'
-                  ? 'metallicRoughness'
-                  : role === 'occlusionMap'
-                    ? 'occlusion'
-                    : role === 'normalMap'
-                      ? 'normal'
-                      : 'emission';
-    return material.getTextureSlot(slotName)?.texture ?? null;
+    const definition = PBR_TEXTURE_ROLES.find(candidate => candidate.role === role);
+    if (definition === undefined) throw new Error(`Unknown clustered PBR texture role ${role}`);
+    return material.getTextureSlot(definition.slotName)?.texture ?? null;
 }
 
 function pbrMaterialVariant(material: PBRMaterial): Readonly<PBRMaterialVariant> {
@@ -482,21 +522,7 @@ function pbrMaterialVariant(material: PBRMaterial): Readonly<PBRMaterialVariant>
     for (const definition of PBR_TEXTURE_ROLES) {
         const texture = materialTexture(material, definition.role);
         if (texture === null) continue;
-        const slotName =
-            definition.role === 'baseColorMap'
-                ? 'baseColor'
-                : definition.role === 'metallicMap'
-                  ? 'metallic'
-                  : definition.role === 'roughnessMap'
-                    ? 'roughness'
-                    : definition.role === 'metallicRoughnessMap'
-                      ? 'metallicRoughness'
-                      : definition.role === 'occlusionMap'
-                        ? 'occlusion'
-                        : definition.role === 'normalMap'
-                          ? 'normal'
-                          : 'emission';
-        const uv = material.getTextureSlot(slotName)?.uvSet ?? 0;
+        const uv = material.getTextureSlot(definition.slotName)?.uvSet ?? 0;
         usesUV0 ||= uv === 0;
         usesUV1 ||= uv === 1;
         if (definition.role === 'normalMap') normalUV = uv;
@@ -505,15 +531,14 @@ function pbrMaterialVariant(material: PBRMaterial): Readonly<PBRMaterialVariant>
                 role: definition.role,
                 shaderName: definition.shaderName,
                 texture,
-                uv
+                uv,
+                slotIndex: definition.slotIndex
             })
         );
     }
-    const gammaCorrection = material.getTextureSlot('baseColor')?.encoding === 'srgb';
     const occlusionInMetallicRoughness = material.isOcclusionInMetallicRoughnessMap;
     return Object.freeze({
         key: [
-            gammaCorrection ? 'gamma' : 'linear',
             occlusionInMetallicRoughness ? 'mrao' : 'separate-ao',
             ...textures.map(binding => `${binding.role}:${String(binding.uv)}`)
         ].join('|'),
@@ -521,7 +546,6 @@ function pbrMaterialVariant(material: PBRMaterial): Readonly<PBRMaterialVariant>
         usesUV0,
         usesUV1,
         normalUV,
-        gammaCorrection,
         occlusionInMetallicRoughness
     });
 }
@@ -638,14 +662,14 @@ function bufferRequirementPlan(
         safeProduct(
             'GPU Scene visible database size',
             visibleBucketCapacity(options.maxObjects),
-            physicalCount,
             4
         ),
+        safeProduct('GPU Scene selected-bucket database size', options.maxObjects, 4),
+        safeProduct('GPU Scene bucket-cursor database size', physicalCount, 4),
         safeProduct('GPU Scene indirect database size', physicalCount, INDIRECT_ARGUMENT_BYTES),
         safeProduct('Clustered Forward+ tile-depth database size', capacity.maxTiles, 8),
         safeProduct('Clustered Forward+ cluster-count database size', capacity.maxClusters, 4),
         safeProduct('Clustered Forward+ cluster-grid database size', capacity.maxClusters, 8),
-        safeProduct('Clustered Forward+ cluster-cursor database size', capacity.maxClusters, 4),
         safeProduct('Clustered Forward+ cluster-block database size', capacity.maxClusterBlocks, 4),
         safeProduct('Clustered Forward+ light-index database size', options.maxLightIndices, 4),
         STATS_BYTES
@@ -788,6 +812,19 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         input.maxViewportHeight ?? DEFAULT_MAX_VIEWPORT_HEIGHT,
         'Clustered Forward+ maxViewportHeight'
     );
+    if (input.hiZ !== undefined && typeof input.hiZ !== 'boolean') {
+        throw new TypeError('Clustered Forward+ hiZ must be a boolean');
+    }
+    const hiZ = input.hiZ ?? true;
+    if (
+        hiZ &&
+        (maxViewportWidth > MAX_HIZ_OCCLUSION_DIAMETER ||
+            maxViewportHeight > MAX_HIZ_OCCLUSION_DIAMETER)
+    ) {
+        throw new RangeError(
+            `Clustered Forward+ maximum viewport cannot exceed ${String(MAX_HIZ_OCCLUSION_DIAMETER)} pixels`
+        );
+    }
     const tileSize = positiveInteger(
         input.tileSize ?? DEFAULT_TILE_SIZE,
         'Clustered Forward+ tileSize'
@@ -800,9 +837,6 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         'Clustered Forward+ zSlices'
     );
     if (zSlices > 64) throw new RangeError('Clustered Forward+ zSlices cannot exceed 64');
-    if (input.hiZ !== undefined && typeof input.hiZ !== 'boolean') {
-        throw new TypeError('Clustered Forward+ hiZ must be a boolean');
-    }
     return Object.freeze({
         buckets: Object.freeze(buckets),
         maxObjects: positiveInteger(
@@ -825,7 +859,10 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         zSlices,
         maxViewportWidth,
         maxViewportHeight,
-        hiZ: input.hiZ ?? true,
+        hiZ,
+        hiZLevelCount: hiZ
+            ? Math.max(1, Math.ceil(Math.log2(Math.max(maxViewportWidth, maxViewportHeight))))
+            : 0,
         bloomStrength: finiteNonNegative(
             input.bloomStrength ?? 0.7,
             'Clustered Forward+ bloomStrength'
@@ -852,6 +889,7 @@ struct FrameData {
     cluster: vec4<u32>,
     counts: vec4<u32>,
     budgets: vec4<u32>,
+    directional: vec4<u32>,
     ambient: vec4<f32>,
 };
 struct ObjectRecord {
@@ -891,34 +929,39 @@ fn selectPhysicalBucket(bucket: BucketRecord, radiusPixels: f32) -> u32 {
 }
 `;
 
-function gpuSceneCullShader(withHiZ: boolean): ComputeShader {
+function gpuSceneCullShader(hiZLevelCount: number): ComputeShader {
+    const withHiZ = hiZLevelCount > 0;
+    const maxHiZOcclusionDiameter = 2 ** hiZLevelCount;
     const textureDeclarations = withHiZ
         ? Array.from(
-              { length: HIZ_LEVEL_COUNT },
+              { length: hiZLevelCount },
               (_unused, index) =>
                   `@group(0) @binding(${String(6 + index)}) var previousHiZ${String(index)}: texture_2d<f32>;`
           ).join('\n')
         : '';
+    const dimensionCases = Array.from(
+        { length: Math.max(0, hiZLevelCount - 1) },
+        (_unused, index) =>
+            `        case ${String(index)}u: { return textureDimensions(previousHiZ${String(index)}); }`
+    ).join('\n');
+    const loadCases = Array.from(
+        { length: Math.max(0, hiZLevelCount - 1) },
+        (_unused, index) =>
+            `        case ${String(index)}u: { return textureLoad(previousHiZ${String(index)}, pixel, 0).x; }`
+    ).join('\n');
+    const lastHiZLevel = Math.max(0, hiZLevelCount - 1);
     const textureSample = withHiZ
         ? `
 fn hiZDimensions(level: u32) -> vec2<u32> {
     switch level {
-        case 0u: { return textureDimensions(previousHiZ0); }
-        case 1u: { return textureDimensions(previousHiZ1); }
-        case 2u: { return textureDimensions(previousHiZ2); }
-        case 3u: { return textureDimensions(previousHiZ3); }
-        case 4u: { return textureDimensions(previousHiZ4); }
-        default: { return textureDimensions(previousHiZ5); }
+${dimensionCases}
+        default: { return textureDimensions(previousHiZ${String(lastHiZLevel)}); }
     }
 }
 fn hiZLoad(level: u32, pixel: vec2<i32>) -> f32 {
     switch level {
-        case 0u: { return textureLoad(previousHiZ0, pixel, 0).x; }
-        case 1u: { return textureLoad(previousHiZ1, pixel, 0).x; }
-        case 2u: { return textureLoad(previousHiZ2, pixel, 0).x; }
-        case 3u: { return textureLoad(previousHiZ3, pixel, 0).x; }
-        case 4u: { return textureLoad(previousHiZ4, pixel, 0).x; }
-        default: { return textureLoad(previousHiZ5, pixel, 0).x; }
+${loadCases}
+        default: { return textureLoad(previousHiZ${String(lastHiZLevel)}, pixel, 0).x; }
     }
 }
 fn depthFromDistance(depthParameters: vec4<f32>, distance: f32) -> f32 {
@@ -931,10 +974,9 @@ fn depthFromDistance(depthParameters: vec4<f32>, distance: f32) -> f32 {
 fn occludedByPreviousHiZ(
     frame: FrameData,
     previousCenter: vec3<f32>,
-    radius: f32,
-    motion: f32
+    radius: f32
 ) -> bool {
-    if (frame.budgets.z == 0u || motion > radius * 0.25 || radius <= 0.0) { return false; }
+    if (frame.budgets.z == 0u || radius <= 0.0) { return false; }
     let viewCenter = frame.previousView * vec4<f32>(previousCenter, 1.0);
     let viewDepth = max(-viewCenter.z, frame.previousDepth.x);
     let nearestViewDepth = max(viewDepth - radius, frame.previousDepth.x);
@@ -958,8 +1000,8 @@ fn occludedByPreviousHiZ(
     maximumUv = clamp(maximumUv, vec2<f32>(0.0), vec2<f32>(0.999999));
     let extentPixels = max((maximumUv - minimumUv) * frame.viewport.zw, vec2<f32>(1.0));
     let diameter = max(extentPixels.x, extentPixels.y);
-    if (diameter > ${String(MAX_HIZ_OCCLUSION_DIAMETER)}.0) { return false; }
-    let level = u32(clamp(ceil(log2(diameter)) - 1.0, 0.0, ${String(HIZ_LEVEL_COUNT - 1)}.0));
+    if (diameter > ${String(maxHiZOcclusionDiameter)}.0) { return false; }
+    let level = u32(clamp(ceil(log2(diameter)) - 1.0, 0.0, ${String(lastHiZLevel)}.0));
     let dimensions = hiZDimensions(level);
     let nearestDepth = depthFromDistance(frame.previousDepth, nearestViewDepth);
     var hidden = true;
@@ -983,8 +1025,7 @@ fn occludedByPreviousHiZ(
 fn occludedByPreviousHiZ(
     frame: FrameData,
     previousCenter: vec3<f32>,
-    radius: f32,
-    motion: f32
+    radius: f32
 ) -> bool {
     return false;
 }`;
@@ -996,7 +1037,7 @@ fn occludedByPreviousHiZ(
 @group(0) @binding(0) var<storage, read> frameData: FrameData;
 @group(0) @binding(1) var<storage, read> objects: array<ObjectRecord>;
 @group(0) @binding(2) var<storage, read> buckets: array<BucketRecord>;
-@group(0) @binding(3) var<storage, read_write> visibleIndices: array<u32>;
+@group(0) @binding(3) var<storage, read_write> selectedPhysicalBuckets: array<u32>;
 @group(0) @binding(4) var<storage, read_write> indirectArguments: array<atomic<u32>>;
 @group(0) @binding(5) var<storage, read_write> cullStats: array<atomic<u32>>;
 ${textureDeclarations}
@@ -1004,6 +1045,7 @@ ${textureSample}
 @compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     if (id.x >= frameData.counts.x || id.x >= frameData.budgets.x) { return; }
+    selectedPhysicalBuckets[id.x] = 0xffffffffu;
     let object = objects[id.x];
     let objectFlags = object.metadata.z;
     if ((objectFlags & ${String(OBJECT_ACTIVE_FLAG)}u) == 0u || (object.metadata.y & frameData.budgets.w) == 0u) { return; }
@@ -1025,8 +1067,10 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
         if (any(sidePlaneDistance > sidePlaneRadius)) { return; }
         if (viewDepth + radius < frameData.depth.x || viewDepth - radius > frameData.depth.y) { return; }
     }
-    let motion = distance(center, previousCenter) + abs(radius - previousRadius);
-    if (occludedByPreviousHiZ(frameData, previousCenter, previousRadius, motion)) {
+    if (
+        (objectFlags & ${String(OBJECT_HIZ_STABLE_FLAG)}u) != 0u &&
+        occludedByPreviousHiZ(frameData, previousCenter, previousRadius)
+    ) {
         _ = atomicAdd(&cullStats[1], 1u);
         return;
     }
@@ -1039,26 +1083,22 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     if (physicalBucket != buckets[object.metadata.x].indices0.x) {
         _ = atomicAdd(&cullStats[2], 1u);
     }
-    let localIndex = atomicAdd(&indirectArguments[physicalBucket * 5u + 1u], 1u);
-    if (localIndex >= frameData.budgets.x) {
-        _ = atomicAdd(&cullStats[3], 1u);
-        return;
-    }
-    visibleIndices[physicalBucket * frameData.budgets.x + localIndex] = id.x;
+    _ = atomicAdd(&indirectArguments[physicalBucket * 5u + 1u], 1u);
+    selectedPhysicalBuckets[id.x] = physicalBucket;
     _ = atomicAdd(&cullStats[0], 1u);
 }`,
         workgroupSize: [CULL_WORKGROUP_SIZE],
-        bindings: gpuSceneCullBindings(withHiZ)
+        bindings: gpuSceneCullBindings(hiZLevelCount)
     });
 }
 
-function gpuSceneCullBindings(withHiZ: boolean): readonly ComputeShaderBinding[] {
+function gpuSceneCullBindings(hiZLevelCount: number): readonly ComputeShaderBinding[] {
     const bindings: ComputeShaderBinding[] = [
         { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
         { name: 'objects', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
         { name: 'buckets', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
         {
-            name: 'visibleIndices',
+            name: 'selectedPhysicalBuckets',
             group: 0,
             binding: 3,
             kind: 'storage-buffer',
@@ -1079,8 +1119,8 @@ function gpuSceneCullBindings(withHiZ: boolean): readonly ComputeShaderBinding[]
             access: 'read-write'
         }
     ];
-    if (withHiZ) {
-        for (let index = 0; index < HIZ_LEVEL_COUNT; index += 1) {
+    if (hiZLevelCount > 0) {
+        for (let index = 0; index < hiZLevelCount; index += 1) {
             bindings.push({
                 name: `previousHiZ${String(index)}`,
                 group: 0,
@@ -1093,9 +1133,99 @@ function gpuSceneCullBindings(withHiZ: boolean): readonly ComputeShaderBinding[]
     return Object.freeze(bindings);
 }
 
-const GPU_SCENE_CULL_PASS = computePass(gpuSceneCullShader(false));
+const GPU_SCENE_CULL_PASS = computePass(gpuSceneCullShader(0));
 
-const GPU_SCENE_HIZ_CULL_PASS = computePass(gpuSceneCullShader(true));
+const GPU_SCENE_BUCKET_PREFIX_PASS = computePass(
+    new ComputeShader({
+        label: 'GPU Scene visible bucket prefix',
+        source: `
+${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read_write> indirectArguments: array<atomic<u32>>;
+@group(0) @binding(2) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@compute @workgroup_size(1)
+fn main() {
+    var offset = 0u;
+    for (var bucket = 0u; bucket < frameData.counts.y; bucket += 1u) {
+        let count = atomicLoad(&indirectArguments[bucket * 5u + 1u]);
+        atomicStore(&indirectArguments[bucket * 5u + 4u], offset);
+        atomicStore(&bucketCursors[bucket], 0u);
+        offset += count;
+    }
+}`,
+        workgroupSize: [1],
+        bindings: [
+            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            {
+                name: 'indirectArguments',
+                group: 0,
+                binding: 1,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'bucketCursors',
+                group: 0,
+                binding: 2,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            }
+        ]
+    })
+);
+
+const GPU_SCENE_VISIBLE_COMPACT_PASS = computePass(
+    new ComputeShader({
+        label: 'GPU Scene visible compact write',
+        source: `
+${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read> selectedPhysicalBuckets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> indirectArguments: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> visibleIndices: array<u32>;
+@compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= frameData.counts.x || id.x >= frameData.budgets.x) { return; }
+    let bucket = selectedPhysicalBuckets[id.x];
+    if (bucket == 0xffffffffu) { return; }
+    let localIndex = atomicAdd(&bucketCursors[bucket], 1u);
+    let offset = atomicLoad(&indirectArguments[bucket * 5u + 4u]);
+    visibleIndices[offset + localIndex] = id.x;
+}`,
+        workgroupSize: [CULL_WORKGROUP_SIZE],
+        bindings: [
+            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            {
+                name: 'selectedPhysicalBuckets',
+                group: 0,
+                binding: 1,
+                kind: 'read-only-storage-buffer'
+            },
+            {
+                name: 'indirectArguments',
+                group: 0,
+                binding: 2,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'bucketCursors',
+                group: 0,
+                binding: 3,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'visibleIndices',
+                group: 0,
+                binding: 4,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            }
+        ]
+    })
+);
 
 const HIZ_DEPTH_REDUCE_PASS = computePass(
     new ComputeShader({
@@ -1243,7 +1373,7 @@ fn main(
         let minimumDistance = bitcast<f32>(atomicLoad(&minimumDepthBits));
         let maximumDistance = bitcast<f32>(atomicLoad(&maximumDepthBits));
         tileDepthBounds[tileIndex] = select(
-            vec2<u32>(0u, frameData.cluster.z - 1u),
+            vec2<u32>(frameData.cluster.z, 0u),
             vec2<u32>(depthSlice(frameData, minimumDistance), depthSlice(frameData, maximumDistance)),
             covered
         );
@@ -1287,9 +1417,17 @@ fn lightTileBounds(frame: FrameData, light: LightRecord) -> vec4<u32> {
     if (lightType == 2u) {
         return vec4<u32>(0u, 0u, frame.cluster.x - 1u, frame.cluster.y - 1u);
     }
-    let depth = max(-light.positionRange.z, frame.depth.x);
+    let viewDepth = -light.positionRange.z;
+    let radius = light.positionRange.w;
+    if (viewDepth + radius <= frame.depth.x) {
+        return vec4<u32>(frame.cluster.x, frame.cluster.y, 0u, 0u);
+    }
+    if (viewDepth - radius <= frame.depth.x) {
+        return vec4<u32>(0u, 0u, frame.cluster.x - 1u, frame.cluster.y - 1u);
+    }
+    let depth = viewDepth;
     let clip = frame.projection * vec4<f32>(light.positionRange.xyz, 1.0);
-    let center = clip.xy / max(clip.w, 0.0001);
+    let center = clip.xy / clip.w;
     let radiusNdc = vec2<f32>(
         abs(frame.projection[0][0]), abs(frame.projection[1][1])
     ) * light.positionRange.w / depth;
@@ -1332,9 +1470,10 @@ ${LIGHT_CLUSTER_COMMON}
 @group(0) @binding(3) var<storage, read_write> clusterCounts: array<atomic<u32>>;
 @compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
-    if (id.x >= frameData.counts.w) { return; }
-    let light = lights[id.x];
+    if (id.x >= frameData.directional.y) { return; }
+    let light = lights[frameData.directional.x + id.x];
     let tiles = lightTileBounds(frameData, light);
+    if (tiles.x > tiles.z || tiles.y > tiles.w) { return; }
     let slices = lightSliceBounds(frameData, light);
     let tileCount = frameData.cluster.x * frameData.cluster.y;
     for (var y = tiles.y; y <= tiles.w; y += 1u) {
@@ -1485,8 +1624,7 @@ ${FRAME_WGSL}
 @group(0) @binding(1) var<storage, read> clusterCounts: array<u32>;
 @group(0) @binding(2) var<storage, read_write> clusterGrid: array<vec2<u32>>;
 @group(0) @binding(3) var<storage, read> blockOffsets: array<u32>;
-@group(0) @binding(4) var<storage, read_write> clusterCursors: array<atomic<u32>>;
-@group(0) @binding(5) var<storage, read_write> clusterStats: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> clusterStats: array<atomic<u32>>;
 @compute @workgroup_size(${String(PREFIX_WORKGROUP_SIZE)})
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let clusterCount = frameData.cluster.x * frameData.cluster.y * frameData.cluster.z;
@@ -1497,7 +1635,6 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let offset = min(rawOffset, frameData.counts.z);
     let available = min(localAllocation.y, frameData.counts.z - offset);
     clusterGrid[id.x] = vec2<u32>(offset, available);
-    atomicStore(&clusterCursors[id.x], 0u);
     _ = atomicAdd(&clusterStats[1], available);
     _ = atomicAdd(&clusterStats[2], clusterCounts[id.x] - available);
 }`,
@@ -1514,18 +1651,37 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
             },
             { name: 'blockOffsets', group: 0, binding: 3, kind: 'read-only-storage-buffer' },
             {
-                name: 'clusterCursors',
+                name: 'clusterStats',
                 group: 0,
                 binding: 4,
                 kind: 'storage-buffer',
-                access: 'write-discard'
-            },
-            {
-                name: 'clusterStats',
-                group: 0,
-                binding: 5,
-                kind: 'storage-buffer',
                 access: 'read-write'
+            }
+        ]
+    })
+);
+
+const CLUSTER_INDEX_RESET_PASS = computePass(
+    new ComputeShader({
+        label: 'Clustered Forward+ deterministic light-index reset',
+        source: `
+${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read_write> clusterLightIndices: array<atomic<u32>>;
+@compute @workgroup_size(${String(PREFIX_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= frameData.counts.z) { return; }
+    atomicStore(&clusterLightIndices[id.x], 0xffffffffu);
+}`,
+        workgroupSize: [PREFIX_WORKGROUP_SIZE],
+        bindings: [
+            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            {
+                name: 'clusterLightIndices',
+                group: 0,
+                binding: 1,
+                kind: 'storage-buffer',
+                access: 'write-discard'
             }
         ]
     })
@@ -1540,13 +1696,14 @@ ${LIGHT_CLUSTER_COMMON}
 @group(0) @binding(1) var<storage, read> lights: array<LightRecord>;
 @group(0) @binding(2) var<storage, read> tileDepthBounds: array<vec2<u32>>;
 @group(0) @binding(3) var<storage, read> clusterGrid: array<vec2<u32>>;
-@group(0) @binding(4) var<storage, read_write> clusterCursors: array<atomic<u32>>;
-@group(0) @binding(5) var<storage, read_write> clusterLightIndices: array<u32>;
+@group(0) @binding(4) var<storage, read_write> clusterLightIndices: array<atomic<u32>>;
 @compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
-    if (id.x >= frameData.counts.w) { return; }
-    let light = lights[id.x];
+    if (id.x >= frameData.directional.y) { return; }
+    let lightIndex = frameData.directional.x + id.x;
+    let light = lights[lightIndex];
     let tiles = lightTileBounds(frameData, light);
+    if (tiles.x > tiles.z || tiles.y > tiles.w) { return; }
     let slices = lightSliceBounds(frameData, light);
     let tileCount = frameData.cluster.x * frameData.cluster.y;
     for (var y = tiles.y; y <= tiles.w; y += 1u) {
@@ -1558,10 +1715,14 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
             if (firstSlice <= lastSlice) {
                 for (var z = firstSlice; z <= lastSlice; z += 1u) {
                     let cluster = z * tileCount + tile;
-                    let cursor = atomicAdd(&clusterCursors[cluster], 1u);
                     let allocation = clusterGrid[cluster];
-                    if (cursor < allocation.y) {
-                        clusterLightIndices[allocation.x + cursor] = id.x;
+                    var candidate = lightIndex;
+                    for (var slot = 0u; slot < allocation.y; slot += 1u) {
+                        let previous = atomicMin(
+                            &clusterLightIndices[allocation.x + slot], candidate
+                        );
+                        candidate = max(candidate, previous);
+                        if (candidate == 0xffffffffu) { break; }
                     }
                 }
             }
@@ -1575,18 +1736,11 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
             { name: 'tileDepthBounds', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
             { name: 'clusterGrid', group: 0, binding: 3, kind: 'read-only-storage-buffer' },
             {
-                name: 'clusterCursors',
+                name: 'clusterLightIndices',
                 group: 0,
                 binding: 4,
                 kind: 'storage-buffer',
                 access: 'read-write'
-            },
-            {
-                name: 'clusterLightIndices',
-                group: 0,
-                binding: 5,
-                kind: 'storage-buffer',
-                access: 'write-discard'
             }
         ]
     })
@@ -1667,12 +1821,8 @@ function gpuScenePBRShader(variant: Readonly<PBRMaterialVariant>): StorageGraphi
         .filter(Boolean)
         .join('\n');
     const vertexUVWrites = [
-        variant.usesUV0
-            ? 'v_uv0 = (readMaterialMatrix(materialBase + 3u) * vec3(a_uv0, 1.0)).xy;'
-            : '',
-        variant.usesUV1
-            ? 'v_uv1 = (readMaterialMatrix(materialBase + 6u) * vec3(a_uv1, 1.0)).xy;'
-            : '',
+        variant.usesUV0 ? 'v_uv0 = a_uv0;' : '',
+        variant.usesUV1 ? 'v_uv1 = a_uv1;' : '',
         variant.normalUV === null
             ? ''
             : `vec3 tangent = normalize(viewNormalMatrix * a_tangent.xyz);
@@ -1689,8 +1839,8 @@ function gpuScenePBRShader(variant: Readonly<PBRMaterialVariant>): StorageGraphi
     const occlusionMap = variantTexture(variant, 'occlusionMap');
     const emissionMap = variantTexture(variant, 'emission');
     const normalMap = variantTexture(variant, 'normalMap');
-    const decode = (sample: string): string =>
-        variant.gammaCorrection ? `sRGBToLinear(${sample})` : sample;
+    const materialSample = (binding: Readonly<PBRTextureBinding>): string =>
+        `hiloMaterialSample(${binding.shaderName}, materialBase, ${String(binding.slotIndex)}u, ${variantSampleUV(binding)})`;
     const bindings: ShaderReadBinding[] = [
         { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
         { name: 'objects', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
@@ -1740,9 +1890,6 @@ ${GPU_SCENE_POSITION_TRANSFORM_SOURCE}
 mat3 readObjectNormalMatrix(uint base) {
     return mat3(objects.values[base + 8u].xyz, objects.values[base + 9u].xyz, objects.values[base + 10u].xyz);
 }
-mat3 readMaterialMatrix(uint base) {
-    return mat3(materials.values[base].xyz, materials.values[base + 1u].xyz, materials.values[base + 2u].xyz);
-}
 void main() {
     uint objectIndex = visibleIndices.values[uint(gl_InstanceIndex)];
     uint objectBase = objectIndex * 13u;
@@ -1754,7 +1901,6 @@ void main() {
     v_viewPosition = (view * worldPosition).xyz;
     v_viewNormal = viewNormal;
     v_materialIndex = floatBitsToUint(objects.values[objectBase + 12u].w);
-    uint materialBase = v_materialIndex * 9u;
     ${vertexUVWrites}
     gl_Position = gpuSceneClipPosition(objectBase, a_position);
 }`,
@@ -1777,51 +1923,109 @@ ${fragmentUVDeclarations}
 flat in uint v_materialIndex;
 layout(location=0) out vec4 color;
 ${encodingSource}
+float hiloMaterialChannel(vec4 value, int channel) {
+    if (channel == 0) return value.r;
+    if (channel == 1) return value.g;
+    if (channel == 2) return value.b;
+    if (channel == 3) return value.a;
+    return channel == 5 ? 1.0 : 0.0;
+}
+vec4 hiloMaterialSample(sampler2D source, uint materialBase, uint slotIndex, vec2 uv) {
+    uint slotBase = materialBase + 3u + slotIndex * 5u;
+    mat3 transform = mat3(
+        materials.values[slotBase].xyz,
+        materials.values[slotBase + 1u].xyz,
+        materials.values[slotBase + 2u].xyz
+    );
+    vec4 info = materials.values[slotBase + 3u];
+    vec4 sampled = texture(source, (transform * vec3(uv, 1.0)).xy);
+    if (int(info.y) == 1) sampled = sRGBToLinear(sampled);
+    ivec4 channels = ivec4(materials.values[slotBase + 4u]);
+    return vec4(
+        hiloMaterialChannel(sampled, channels.x),
+        hiloMaterialChannel(sampled, channels.y),
+        hiloMaterialChannel(sampled, channels.z),
+        hiloMaterialChannel(sampled, channels.w)
+    );
+}
 ${pbrSurfaceSource}
 ${pbrBrdfSource}
+vec3 hiloEvaluateClusteredLight(
+    uint lightIndex,
+    vec3 viewPosition,
+    vec3 normal,
+    vec3 viewDirection,
+    HiloMetallicRoughnessSurface surface
+) {
+    uint lightBase = lightIndex * 4u;
+    vec4 positionRange = lights.values[lightBase];
+    vec4 colorType = lights.values[lightBase + 1u];
+    vec4 directionOuter = lights.values[lightBase + 2u];
+    vec4 attenuationInner = lights.values[lightBase + 3u];
+    uint lightType = uint(colorType.w + 0.5);
+    vec3 lightDirection;
+    vec3 radiance = colorType.rgb;
+    if (lightType == 2u) {
+        lightDirection = normalize(-directionOuter.xyz);
+    } else {
+        vec3 delta = positionRange.xyz - viewPosition;
+        float distanceToLight = max(length(delta), 0.0001);
+        lightDirection = delta / distanceToLight;
+        float attenuation = 1.0 / max(
+            attenuationInner.x + attenuationInner.y * distanceToLight +
+                attenuationInner.z * distanceToLight * distanceToLight,
+            0.0001
+        );
+        float rangeFade = clamp(
+            1.0 - pow(distanceToLight / max(positionRange.w, 0.0001), 4.0),
+            0.0,
+            1.0
+        );
+        radiance *= attenuation * rangeFade * rangeFade;
+        if (lightType == 1u) {
+            float theta = dot(lightDirection, normalize(-directionOuter.xyz));
+            radiance *= smoothstep(directionOuter.w, attenuationInner.w, theta);
+        }
+    }
+    vec3 lightDiffuse;
+    vec3 lightSpecular;
+    hiloEvaluateBaseBRDF(
+        normal,
+        viewDirection,
+        lightDirection,
+        normal,
+        normal,
+        surface.specularColor,
+        surface.diffuseColor,
+        surface.roughness,
+        0.0,
+        0.0,
+        1.3,
+        0.0,
+        lightDiffuse,
+        lightSpecular
+    );
+    return radiance * (lightDiffuse + lightSpecular);
+}
 void main() {
-    uint materialBase = v_materialIndex * 9u;
+    uint materialBase = v_materialIndex * ${String(PBR_GPU_MATERIAL_RECORD_BYTES / 16)}u;
     vec4 baseMetallic = materials.values[materialBase];
     vec4 emissionRoughness = materials.values[materialBase + 1u];
     vec4 materialParameters = materials.values[materialBase + 2u];
     vec4 baseColorSample = vec4(1.0);
-    ${
-        baseColorMap === null
-            ? ''
-            : `baseColorSample = ${decode(
-                  `texture(${baseColorMap.shaderName}, ${variantSampleUV(baseColorMap)})`
-              )};`
-    }
+    ${baseColorMap === null ? '' : `baseColorSample = ${materialSample(baseColorMap)};`}
     vec3 emissionSample = vec3(1.0);
-    ${
-        emissionMap === null
-            ? ''
-            : `emissionSample = ${decode(
-                  `texture(${emissionMap.shaderName}, ${variantSampleUV(emissionMap)})`
-              )}.rgb;`
-    }
+    ${emissionMap === null ? '' : `emissionSample = ${materialSample(emissionMap)}.rgb;`}
     float metallic = baseMetallic.a;
-    ${
-        metallicMap === null
-            ? ''
-            : `metallic *= texture(${metallicMap.shaderName}, ${variantSampleUV(metallicMap)}).r;`
-    }
+    ${metallicMap === null ? '' : `metallic *= ${materialSample(metallicMap)}.r;`}
     float roughness = emissionRoughness.a;
-    ${
-        roughnessMap === null
-            ? ''
-            : `roughness *= texture(${roughnessMap.shaderName}, ${variantSampleUV(roughnessMap)}).r;`
-    }
+    ${roughnessMap === null ? '' : `roughness *= ${materialSample(roughnessMap)}.r;`}
     float occlusion = 1.0;
-    ${
-        occlusionMap === null
-            ? ''
-            : `occlusion = texture(${occlusionMap.shaderName}, ${variantSampleUV(occlusionMap)}).r;`
-    }
+    ${occlusionMap === null ? '' : `occlusion = ${materialSample(occlusionMap)}.r;`}
     ${
         metallicRoughnessMap === null
             ? ''
-            : `vec4 metallicRoughnessSample = texture(${metallicRoughnessMap.shaderName}, ${variantSampleUV(metallicRoughnessMap)});
+            : `vec4 metallicRoughnessSample = ${materialSample(metallicRoughnessMap)};
     roughness *= metallicRoughnessSample.g;
     metallic *= metallicRoughnessSample.b;
     ${variant.occlusionInMetallicRoughness ? 'occlusion = metallicRoughnessSample.r;' : ''}`
@@ -1839,7 +2043,7 @@ void main() {
     ${
         normalMap === null
             ? ''
-            : `vec3 tangentNormal = texture(${normalMap.shaderName}, ${variantSampleUV(normalMap)}).rgb * 2.0 - 1.0;
+            : `vec3 tangentNormal = ${materialSample(normalMap)}.rgb * 2.0 - 1.0;
     tangentNormal.xy *= materialParameters.z;
     normal = normalize(v_TBN * tangentNormal);`
     }
@@ -1852,55 +2056,19 @@ void main() {
     uint slice = min(uint(clamp(log(depth / frameData.values[25u].x) / logScale, 0.0, 0.999999) * float(cluster.z)), cluster.z - 1u);
     uint clusterIndex = slice * cluster.x * cluster.y + tileY * cluster.x + tileX;
     uvec2 allocation = clusterGrid.values[clusterIndex];
-    vec3 lighting = frameData.values[30u].rgb * surface.iblDiffuseColor *
+    uvec4 directional = floatBitsToUint(frameData.values[30u]);
+    vec3 lighting = frameData.values[31u].rgb * surface.iblDiffuseColor *
         surface.occlusion * HILO_INVERSE_PI;
+    for (uint lightIndex = 0u; lightIndex < directional.x; lightIndex += 1u) {
+        lighting += hiloEvaluateClusteredLight(
+            lightIndex, v_viewPosition, normal, viewDirection, surface
+        );
+    }
     for (uint localIndex = 0u; localIndex < allocation.y; localIndex += 1u) {
         uint lightIndex = clusterIndices.values[allocation.x + localIndex];
-        uint lightBase = lightIndex * 4u;
-        vec4 positionRange = lights.values[lightBase];
-        vec4 colorType = lights.values[lightBase + 1u];
-        vec4 directionOuter = lights.values[lightBase + 2u];
-        vec4 attenuationInner = lights.values[lightBase + 3u];
-        uint lightType = uint(colorType.w + 0.5);
-        vec3 lightDirection;
-        vec3 radiance = colorType.rgb;
-        if (lightType == 2u) {
-            lightDirection = normalize(-directionOuter.xyz);
-        } else {
-            vec3 delta = positionRange.xyz - v_viewPosition;
-            float distanceToLight = max(length(delta), 0.0001);
-            lightDirection = delta / distanceToLight;
-            float attenuation = 1.0 / max(
-                attenuationInner.x + attenuationInner.y * distanceToLight +
-                    attenuationInner.z * distanceToLight * distanceToLight,
-                0.0001
-            );
-            float rangeFade = clamp(1.0 - pow(distanceToLight / max(positionRange.w, 0.0001), 4.0), 0.0, 1.0);
-            radiance *= attenuation * rangeFade * rangeFade;
-            if (lightType == 1u) {
-                float theta = dot(lightDirection, normalize(-directionOuter.xyz));
-                radiance *= smoothstep(directionOuter.w, attenuationInner.w, theta);
-            }
-        }
-        vec3 lightDiffuse;
-        vec3 lightSpecular;
-        hiloEvaluateBaseBRDF(
-            normal,
-            viewDirection,
-            lightDirection,
-            normal,
-            normal,
-            surface.specularColor,
-            surface.diffuseColor,
-            surface.roughness,
-            0.0,
-            0.0,
-            1.3,
-            0.0,
-            lightDiffuse,
-            lightSpecular
+        lighting += hiloEvaluateClusteredLight(
+            lightIndex, v_viewPosition, normal, viewDirection, surface
         );
-        lighting += radiance * (lightDiffuse + lightSpecular);
     }
     color = vec4(lighting + surface.emissionColor, 1.0);
 }`,
@@ -1940,34 +2108,42 @@ void main() {
     }
 });
 
-const BLOOM_BLUR_PASS = new FullscreenRenderPass({
-    name: 'Clustered Forward+ bloom blur',
-    shader: new Shader({
-        vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE,
-        fs: `#version 300 es
+function bloomBlurPass(name: string, axis: 'x' | 'y'): FullscreenRenderPass {
+    const offset = axis === 'x' ? 'vec2(texel.x, 0.0)' : 'vec2(0.0, texel.y)';
+    return new FullscreenRenderPass({
+        name,
+        shader: new Shader({
+            vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE,
+            fs: `#version 300 es
 precision highp float;
 in vec2 v_uv;
 uniform sampler2D u_source;
 layout(location=0) out vec4 color;
 void main() {
     vec2 texel = 1.0 / vec2(textureSize(u_source, 0));
+    vec2 axisOffset = ${offset};
     vec3 value = texture(u_source, v_uv).rgb * 0.227027;
-    value += texture(u_source, v_uv + vec2(texel.x * 1.384615, 0.0)).rgb * 0.316216;
-    value += texture(u_source, v_uv - vec2(texel.x * 1.384615, 0.0)).rgb * 0.316216;
-    value += texture(u_source, v_uv + vec2(0.0, texel.y * 3.230769)).rgb * 0.070270;
-    value += texture(u_source, v_uv - vec2(0.0, texel.y * 3.230769)).rgb * 0.070270;
+    value += texture(u_source, v_uv + axisOffset * 1.384615).rgb * 0.316216;
+    value += texture(u_source, v_uv - axisOffset * 1.384615).rgb * 0.316216;
+    value += texture(u_source, v_uv + axisOffset * 3.230769).rgb * 0.070270;
+    value += texture(u_source, v_uv - axisOffset * 3.230769).rgb * 0.070270;
     color = vec4(value, 1.0);
 }`
-    }),
-    pipelineState: {
-        ...DEFAULT_MATERIAL_PIPELINE_STATE,
-        depthTest: false,
-        depthWrite: false,
-        cullMode: 'none'
-    }
-});
+        }),
+        pipelineState: {
+            ...DEFAULT_MATERIAL_PIPELINE_STATE,
+            depthTest: false,
+            depthWrite: false,
+            cullMode: 'none'
+        }
+    });
+}
+
+const BLOOM_HORIZONTAL_PASS = bloomBlurPass('Clustered Forward+ bloom horizontal blur', 'x');
+const BLOOM_VERTICAL_PASS = bloomBlurPass('Clustered Forward+ bloom vertical blur', 'y');
 
 function displayPass(exposure: number, bloomStrength: number): FullscreenRenderPass {
+    const withBloom = bloomStrength > 0;
     return new FullscreenRenderPass({
         name: 'Clustered Forward+ ACES display transform',
         shader: new Shader({
@@ -1976,7 +2152,7 @@ function displayPass(exposure: number, bloomStrength: number): FullscreenRenderP
 precision highp float;
 in vec2 v_uv;
 uniform sampler2D u_scene;
-uniform sampler2D u_bloom;
+${withBloom ? 'uniform sampler2D u_bloom;' : ''}
 layout(location=0) out vec4 color;
 vec3 aces(vec3 value) {
     const float a = 2.51;
@@ -1987,8 +2163,7 @@ vec3 aces(vec3 value) {
     return clamp((value * (a * value + b)) / (value * (c * value + d) + e), 0.0, 1.0);
 }
 void main() {
-    vec3 hdr = texture(u_scene, v_uv).rgb * ${String(exposure)} +
-        texture(u_bloom, v_uv).rgb * ${String(bloomStrength)};
+    vec3 hdr = texture(u_scene, v_uv).rgb * ${String(exposure)}${withBloom ? ` + texture(u_bloom, v_uv).rgb * ${String(bloomStrength)}` : ''};
     float vignette = smoothstep(0.9, 0.22, length(v_uv - vec2(0.5)));
     vec3 mapped = aces(hdr) * mix(0.78, 1.0, vignette);
     color = vec4(pow(mapped, vec3(1.0 / 2.2)), 1.0);
@@ -2389,7 +2564,7 @@ function matrixElements(source: Matrix4, target: Float32Array, offset: number): 
     }
 }
 
-function arraysDiffer(first: Float32Array, second: Float32Array): boolean {
+function arraysDiffer(first: ArrayLike<number>, second: ArrayLike<number>): boolean {
     for (let index = 0; index < first.length; index += 1) {
         if (first[index] !== second[index]) return true;
     }
@@ -2421,18 +2596,20 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #materialDatabase: SharedMaterialRecordDatabase<PBRMaterial>;
     readonly #lights: StorageBuffer;
     readonly #visibleIndices: StorageBuffer;
+    readonly #selectedPhysicalBuckets: StorageBuffer;
+    readonly #visibleBucketCursors: StorageBuffer;
     readonly #indirectArguments: StorageBuffer;
     readonly #cullStats: StorageBuffer;
     readonly #tileDepthBounds: StorageBuffer;
     readonly #clusterCounts: StorageBuffer;
     readonly #clusterGrid: StorageBuffer;
-    readonly #clusterCursors: StorageBuffer;
     readonly #clusterBlockSums: StorageBuffer;
     readonly #clusterBlockOffsets: StorageBuffer;
     readonly #clusterLightIndices: StorageBuffer;
     readonly #clusterStats: StorageBuffer;
     readonly #visibleBucketCapacity: number;
     readonly #physicalBuckets: readonly PhysicalBucket[];
+    readonly #logicalBounds: readonly LogicalBucketBounds[];
     readonly #logicalBucketByGeometry = new Map<Geometry, Map<PBRMaterial, number>>();
     readonly #logicalGPUCompatible: Uint8Array;
     readonly #gpuManagedMeshes: Mesh[] = [];
@@ -2445,6 +2622,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #frameFloats = new Float32Array(this.#frameBytes);
     readonly #frameUInts = new Uint32Array(this.#frameBytes);
     readonly #lightFloats: Float32Array;
+    readonly #localLightFloats: Float32Array;
+    readonly #directionalLightFloats: Float32Array;
     readonly #samplerByTexture = new WeakMap<
         Texture<unknown>,
         Readonly<{ key: string; sampler: ComputeSampler }>
@@ -2457,8 +2636,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #committedProjectionMatrix = new Float32Array(16);
     readonly #stagedDepth = new Float32Array(4);
     readonly #committedDepth = new Float32Array(4);
-    readonly #hizKeys = Array.from({ length: HIZ_LEVEL_COUNT }, () => Object.freeze({}));
+    readonly #hizKeys: readonly object[];
     readonly #hizDescriptors: readonly Readonly<RenderPipelineHistoryTextureDescriptor>[];
+    readonly #hizCullPass: ComputeRenderPass | null;
     readonly #clearPass = new ClearBuffersPass();
     readonly #clearPool = new RenderPassParameterPool(
         () => new ClearBuffersParameters(),
@@ -2467,8 +2647,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
     );
     readonly #cullPool = new RenderPassParameterPool(() => new MutableComputeParameters(6, 0));
-    readonly #hizCullPool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(6, HIZ_LEVEL_COUNT)
+    readonly #hizCullPool: RenderPassParameterPool<MutableComputeParameters>;
+    readonly #bucketPrefixPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(3, 0)
+    );
+    readonly #visibleCompactPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(5, 0)
     );
     readonly #hizPool = new RenderPassParameterPool(() => new MutableComputeParameters(1, 2));
     readonly #clusterDepthPool = new RenderPassParameterPool(
@@ -2484,10 +2668,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         () => new MutableComputeParameters(4, 0)
     );
     readonly #clusterPrefixFinalizePool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(6, 0)
+        () => new MutableComputeParameters(5, 0)
+    );
+    readonly #clusterIndexResetPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(2, 0)
     );
     readonly #clusterWritePool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(6, 0)
+        () => new MutableComputeParameters(5, 0)
     );
     readonly #depthDrawPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenParameters(3, 1)
@@ -2527,9 +2714,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #fallbackCopyPass = new TextureCopyPass(
         'Clustered Forward+ compatibility opaque copy'
     );
-    readonly #fallbackPresentPass = new PresentRenderPass(
-        'Clustered Forward+ compatibility output'
-    );
     readonly #fallbackOpaqueListDescriptor: MutableFallbackRendererListDescriptor = {
         cullingResults: INVALID_CULLING_RESULTS,
         queue: 'opaque',
@@ -2553,7 +2737,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     #fallbackHasOpaque = false;
     #fallbackHasTransparent = false;
     #lightCount = 0;
+    #localLightCount = 0;
+    #directionalLightCount = 0;
     #droppedLightCount = 0;
+    #forceFullFallback = false;
     #lastRecordedFrame = -1;
     #pendingCamera: Camera | null = null;
     #committedCamera: Camera | null = null;
@@ -2569,12 +2756,30 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     ) {
         this.#options = options;
         this.#onDestroy = onDestroy;
+        this.#hizKeys = Object.freeze(
+            Array.from({ length: options.hiZLevelCount }, () => Object.freeze({}))
+        );
+        this.#hizCullPass = options.hiZ
+            ? computePass(gpuSceneCullShader(options.hiZLevelCount))
+            : null;
+        this.#hizCullPool = new RenderPassParameterPool(
+            () => new MutableComputeParameters(6, options.hiZLevelCount)
+        );
         const physicalCount = options.buckets.reduce(
             (count, bucket) => count + 1 + bucket.lods.length,
             0
         );
         this.#visibleBucketCapacity = visibleBucketCapacity(options.maxObjects);
         this.#logicalGPUCompatible = new Uint8Array(options.buckets.length);
+        this.#logicalBounds = Object.freeze(
+            options.buckets.map(() => ({
+                center: new Vector3(),
+                radius: 0,
+                revision: 0,
+                positionRevisions: []
+            }))
+        );
+        this.refreshLogicalBounds();
         const capacity = clusterCapacityPlan(options);
         const create = (
             descriptor: Parameters<RenderPipelineCreateContext['createStorageBuffer']>[0]
@@ -2611,6 +2816,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             packRecord: packPBRGPUMaterialRecord
         });
         this.#lightFloats = new Float32Array(options.maxLights * 16);
+        this.#localLightFloats = new Float32Array(options.maxLights * 16);
+        this.#directionalLightFloats = new Float32Array(options.maxLights * 16);
         this.#lights = create({
             label: 'Clustered Forward+ light database',
             byteLength: this.#lightFloats.byteLength,
@@ -2619,7 +2826,19 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         });
         this.#visibleIndices = create({
             label: 'GPU Scene visible compact table',
-            byteLength: this.#visibleBucketCapacity * physicalCount * 4,
+            byteLength: this.#visibleBucketCapacity * 4,
+            usage: ['storage'],
+            recovery: 'reinitialize'
+        });
+        this.#selectedPhysicalBuckets = create({
+            label: 'GPU Scene selected physical bucket table',
+            byteLength: options.maxObjects * 4,
+            usage: ['storage'],
+            recovery: 'reinitialize'
+        });
+        this.#visibleBucketCursors = create({
+            label: 'GPU Scene visible bucket compact cursors',
+            byteLength: physicalCount * 4,
             usage: ['storage'],
             recovery: 'reinitialize'
         });
@@ -2657,12 +2876,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             usage: ['storage'],
             recovery: 'reinitialize'
         });
-        this.#clusterCursors = create({
-            label: 'Clustered Forward+ cluster write cursors',
-            byteLength: capacity.maxClusters * 4,
-            usage: ['storage'],
-            recovery: 'reinitialize'
-        });
         this.#clusterBlockSums = create({
             label: 'Clustered Forward+ cluster block sums',
             byteLength: capacity.maxClusterBlocks * 4,
@@ -2688,7 +2901,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             recovery: 'reinitialize'
         });
         this.#hizDescriptors = Object.freeze(
-            Array.from({ length: HIZ_LEVEL_COUNT }, (_unused, index) =>
+            Array.from({ length: options.hiZLevelCount }, (_unused, index) =>
                 Object.freeze({
                     label: `GPU Scene Hi-Z level ${String(index)}`,
                     format: 'r32float' as const,
@@ -2748,9 +2961,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             throw new RangeError('Clustered Forward+ currently requires a single-sample output');
         }
 
-        // This performs canonical scene/camera matrix updates while GPU Scene retains visibility
-        // ownership for compatible registered buckets.
-        context.cull({ frustumCulling: false });
+        // Update canonical transforms without constructing a CPU render list. GPU Scene retains
+        // visibility ownership; a CPU cull is built only when fallback meshes actually exist.
+        context.prepareScene();
         this.refreshGPUCompatibility();
         this.collectScene(context);
         let fallbackCulling: CullingResultsHandle | null = null;
@@ -2765,13 +2978,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
 
         const output = context.graph.importOutput();
         const outputColor = output.color(0);
-        const displayColor = this.#fallbackHasTransparent
-            ? context.graph.createTexture('Clustered Forward+ compatibility display', {
-                  format: context.output.colorFormat(0),
-                  extent: { relativeTo: 'output', scale: 1 },
-                  sampleCount: 1
-              })
-            : outputColor;
         const sceneColor = context.graph.createTexture('Clustered Forward+ HDR scene', {
             format: 'rgba16float',
             extent: { relativeTo: 'output', scale: 1 },
@@ -2782,16 +2988,23 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             extent: { relativeTo: 'output', scale: 1 },
             sampleCount: 1
         });
-        const bloomA = context.graph.createTexture('Clustered Forward+ bloom half A', {
-            format: 'rgba16float',
-            extent: { relativeTo: 'output', scale: 0.5, minWidth: 1, minHeight: 1 },
-            sampleCount: 1
-        });
-        const bloomB = context.graph.createTexture('Clustered Forward+ bloom half B', {
-            format: 'rgba16float',
-            extent: { relativeTo: 'output', scale: 0.5, minWidth: 1, minHeight: 1 },
-            sampleCount: 1
-        });
+        const bloomEnabled = this.#options.bloomStrength > 0;
+        const createBloomTexture = (label: string): RenderGraphTextureHandle | null =>
+            bloomEnabled
+                ? context.graph.createTexture(label, {
+                      format: 'rgba16float',
+                      extent: {
+                          relativeTo: 'output',
+                          scale: 0.5,
+                          minWidth: 1,
+                          minHeight: 1
+                      },
+                      sampleCount: 1
+                  })
+                : null;
+        const bloomA = createBloomTexture('Clustered Forward+ bloom half A');
+        const bloomB = createBloomTexture('Clustered Forward+ bloom half B');
+        const bloomC = createBloomTexture('Clustered Forward+ bloom half C');
 
         const frameBuffer = context.graph.importStorageBuffer(this.#frameData);
         const objects = context.graph.importStorageBuffer(this.#objects);
@@ -2799,12 +3012,15 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const materials = context.graph.importStorageBuffer(this.#materialDatabase.buffer);
         const lights = context.graph.importStorageBuffer(this.#lights);
         const visible = context.graph.importStorageBuffer(this.#visibleIndices);
+        const selectedPhysicalBuckets = context.graph.importStorageBuffer(
+            this.#selectedPhysicalBuckets
+        );
+        const visibleBucketCursors = context.graph.importStorageBuffer(this.#visibleBucketCursors);
         const indirect = context.graph.importStorageBuffer(this.#indirectArguments);
         const cullStats = context.graph.importStorageBuffer(this.#cullStats);
         const tileDepthBounds = context.graph.importStorageBuffer(this.#tileDepthBounds);
         const clusterCounts = context.graph.importStorageBuffer(this.#clusterCounts);
         const clusterGrid = context.graph.importStorageBuffer(this.#clusterGrid);
-        const clusterCursors = context.graph.importStorageBuffer(this.#clusterCursors);
         const clusterBlockSums = context.graph.importStorageBuffer(this.#clusterBlockSums);
         const clusterBlockOffsets = context.graph.importStorageBuffer(this.#clusterBlockOffsets);
         const clusterIndices = context.graph.importStorageBuffer(this.#clusterLightIndices);
@@ -2828,21 +3044,38 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         cull.setBuffer(0, frameBuffer);
         cull.setBuffer(1, objects);
         cull.setBuffer(2, bucketData);
-        cull.setBuffer(3, visible);
+        cull.setBuffer(3, selectedPhysicalBuckets);
         cull.setBuffer(4, indirect);
         cull.setBuffer(5, cullStats);
         if (histories.valid) {
-            for (let index = 0; index < HIZ_LEVEL_COUNT; index += 1) {
+            for (let index = 0; index < this.#options.hiZLevelCount; index += 1) {
                 const texture = histories.previous[index];
                 if (texture === undefined) throw new Error('GPU Scene Hi-Z history is incomplete');
                 cull.setTexture(index, texture);
             }
         }
         cull.setDispatch(Math.max(1, Math.ceil(this.#activeObjectHighWater / CULL_WORKGROUP_SIZE)));
-        context.graph.addPass(
-            histories.valid ? GPU_SCENE_HIZ_CULL_PASS : GPU_SCENE_CULL_PASS,
-            cull
+        const cullPass = histories.valid ? this.#hizCullPass : GPU_SCENE_CULL_PASS;
+        if (cullPass === null) throw new Error('GPU Scene Hi-Z cull pass is unavailable');
+        context.graph.addPass(cullPass, cull);
+
+        const bucketPrefix = context.acquirePassParameters(this.#bucketPrefixPool);
+        bucketPrefix.setBuffer(0, frameBuffer);
+        bucketPrefix.setBuffer(1, indirect);
+        bucketPrefix.setBuffer(2, visibleBucketCursors);
+        bucketPrefix.setDispatch(1);
+        context.graph.addPass(GPU_SCENE_BUCKET_PREFIX_PASS, bucketPrefix);
+
+        const compact = context.acquirePassParameters(this.#visibleCompactPool);
+        compact.setBuffer(0, frameBuffer);
+        compact.setBuffer(1, selectedPhysicalBuckets);
+        compact.setBuffer(2, indirect);
+        compact.setBuffer(3, visibleBucketCursors);
+        compact.setBuffer(4, visible);
+        compact.setDispatch(
+            Math.max(1, Math.ceil(this.#activeObjectHighWater / CULL_WORKGROUP_SIZE))
         );
+        context.graph.addPass(GPU_SCENE_VISIBLE_COMPACT_PASS, compact);
 
         this.recordDepthPrepass(context, {
             frameBuffer,
@@ -2860,7 +3093,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             tileDepthBounds,
             clusterCounts,
             clusterGrid,
-            clusterCursors,
             clusterBlockSums,
             clusterBlockOffsets,
             clusterIndices,
@@ -2878,13 +3110,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             sceneColor,
             sceneDepth
         });
-        this.recordDisplay(context, sceneColor, bloomA, bloomB, displayColor);
         if (fallbackCulling !== null) {
-            this.recordFallback(context, fallbackCulling, displayColor, sceneDepth);
+            this.recordFallback(context, fallbackCulling, sceneColor, sceneDepth);
         }
-        if (displayColor !== outputColor) {
-            this.recordFallbackPresent(context, displayColor, outputColor);
-        }
+        this.recordDisplay(context, sceneColor, bloomA, bloomB, bloomC, outputColor);
     }
 
     frameSubmitted(frameIndex: number): void {
@@ -2892,13 +3121,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#materialDatabase.frameSubmitted(frameIndex);
         for (const record of this.#objectByMesh.values()) {
             if (record.pendingWorldVersion < 0) continue;
-            const moved = arraysDiffer(record.committedMatrix, record.pendingMatrix);
             record.committedMatrix.set(record.pendingMatrix);
             record.committedWorldVersion = record.pendingWorldVersion;
             record.committedFrustumTest = record.pendingFrustumTest;
+            record.committedBoundsRevision = record.pendingBoundsRevision;
+            record.committedOcclusionStable = record.pendingOcclusionStable;
             record.pendingWorldVersion = -1;
-            // One following upload makes previous == current after motion stops.
-            if (moved) record.committedWorldVersion = -1;
         }
         this.#committedCameraMatrix.set(this.#stagedCameraMatrix);
         this.#committedViewMatrix.set(this.#stagedViewMatrix);
@@ -2912,7 +3140,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     frameDiscarded(frameIndex: number): void {
         if (frameIndex !== this.#lastRecordedFrame) return;
         this.#materialDatabase.frameDiscarded(frameIndex);
-        for (const record of this.#objectByMesh.values()) record.pendingWorldVersion = -1;
+        for (const record of this.#objectByMesh.values()) {
+            record.pendingWorldVersion = -1;
+            record.pendingBoundsRevision = -1;
+            record.pendingOcclusionStable = false;
+        }
         this.#pendingCamera = null;
     }
 
@@ -2953,12 +3185,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             this.#bucketData,
             this.#lights,
             this.#visibleIndices,
+            this.#selectedPhysicalBuckets,
+            this.#visibleBucketCursors,
             this.#indirectArguments,
             this.#cullStats,
             this.#tileDepthBounds,
             this.#clusterCounts,
             this.#clusterGrid,
-            this.#clusterCursors,
             this.#clusterBlockSums,
             this.#clusterBlockOffsets,
             this.#clusterLightIndices,
@@ -3214,6 +3447,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
 
     private collectScene(context: RenderPipelineContext): void {
         this.#frameSerial++;
+        this.refreshLogicalBounds();
         let dirtyStart = this.#options.maxObjects;
         let dirtyEnd = 0;
         let activeCount = 0;
@@ -3224,11 +3458,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#fallbackObjectCount = 0;
         this.#fallbackHasOpaque = false;
         this.#fallbackHasTransparent = false;
-        ambient[120] = 0;
-        ambient[121] = 0;
-        ambient[122] = 0;
+        ambient[124] = 0;
+        ambient[125] = 0;
+        ambient[126] = 0;
         this.#lightCount = 0;
+        this.#localLightCount = 0;
+        this.#directionalLightCount = 0;
         this.#droppedLightCount = 0;
+        this.#forceFullFallback = false;
 
         context.scene.traverse(node => {
             if (!node.visible) return Node.TRAVERSE_STOP_CHILDREN;
@@ -3255,6 +3492,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                                 committedWorldVersion: -1,
                                 pendingFrustumTest: node.frustumTest,
                                 committedFrustumTest: node.frustumTest,
+                                pendingBoundsRevision: -1,
+                                committedBoundsRevision: -1,
+                                pendingOcclusionStable: false,
+                                committedOcclusionStable: false,
                                 committedMatrix: initial.slice(),
                                 pendingMatrix: initial
                             };
@@ -3268,13 +3509,24 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                     } else {
                         this.#gpuManagedMeshes.push(node);
                         record.seenFrame = this.#frameSerial;
+                        const bounds = this.#logicalBounds[logicalIndex];
+                        if (bounds === undefined) {
+                            throw new Error('GPU Scene logical bounds are unavailable');
+                        }
+                        const transformStable =
+                            record.committedWorldVersion === node.worldMatrixVersion &&
+                            !arraysDiffer(record.committedMatrix, node.worldMatrix.elements);
+                        const boundsStable = record.committedBoundsRevision === bounds.revision;
+                        const occlusionStable = transformStable && boundsStable;
                         const dirty =
                             record.logicalBucket !== logicalIndex ||
                             record.committedWorldVersion !== node.worldMatrixVersion ||
-                            record.committedFrustumTest !== node.frustumTest;
+                            record.committedFrustumTest !== node.frustumTest ||
+                            !boundsStable ||
+                            record.committedOcclusionStable !== occlusionStable;
                         record.logicalBucket = logicalIndex;
                         if (dirty) {
-                            this.packObject(record, node, logicalIndex);
+                            this.packObject(record, node, logicalIndex, occlusionStable);
                             dirtyStart = Math.min(dirtyStart, record.slot);
                             dirtyEnd = Math.max(dirtyEnd, record.slot + 1);
                         }
@@ -3291,9 +3543,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             } else if ((cameraVisibility & (node.layer >>> 0)) !== 0) {
                 if (node instanceof AmbientLight && node.enabled) {
                     const color = node.getRealColor();
-                    ambient[120] = (ambient[120] ?? 0) + color.r;
-                    ambient[121] = (ambient[121] ?? 0) + color.g;
-                    ambient[122] = (ambient[122] ?? 0) + color.b;
+                    ambient[124] = (ambient[124] ?? 0) + color.r;
+                    ambient[125] = (ambient[125] ?? 0) + color.g;
+                    ambient[126] = (ambient[126] ?? 0) + color.b;
                 } else if (
                     node instanceof PointLight ||
                     node instanceof SpotLight ||
@@ -3305,6 +3557,24 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             }
             return Node.TRAVERSE_STOP_NONE;
         });
+
+        const forceFullFallback = this.readForceFullFallback();
+        if (forceFullFallback) {
+            for (const mesh of this.#gpuManagedMeshes) {
+                this.trackFallbackMesh(mesh);
+                const record = this.#objectByMesh.get(mesh);
+                if (record === undefined) continue;
+                const metaOffset = record.slot * (OBJECT_RECORD_BYTES / 4) + 48;
+                this.#objectUInts[metaOffset + 2] = 0;
+                record.committedWorldVersion = -1;
+                record.pendingWorldVersion = -1;
+                dirtyStart = Math.min(dirtyStart, record.slot);
+                dirtyEnd = Math.max(dirtyEnd, record.slot + 1);
+            }
+            this.#gpuManagedMeshes.length = 0;
+            activeCount = 0;
+            highWater = 0;
+        }
 
         for (const [mesh, record] of this.#objectByMesh) {
             if (record.seenFrame === this.#frameSerial) continue;
@@ -3320,7 +3590,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             highWater = Math.max(highWater, record.slot + 1);
         }
         this.#objectCount = activeCount;
-        this.#activeObjectHighWater = highWater;
+        this.#activeObjectHighWater = forceFullFallback ? 0 : highWater;
         if (dirtyEnd > dirtyStart) {
             const byteOffset = dirtyStart * OBJECT_RECORD_BYTES;
             const byteLength = (dirtyEnd - dirtyStart) * OBJECT_RECORD_BYTES;
@@ -3330,12 +3600,24 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 new Uint8Array(this.#objectData, byteOffset, byteLength)
             );
         }
+        this.#lightFloats.set(
+            this.#directionalLightFloats.subarray(0, this.#directionalLightCount * 16),
+            0
+        );
+        this.#lightFloats.set(
+            this.#localLightFloats.subarray(0, this.#localLightCount * 16),
+            this.#directionalLightCount * 16
+        );
         const lightBytes = Math.max(1, this.#lightCount) * LIGHT_RECORD_BYTES;
         context.writeStorageBuffer(
             this.#lights,
             0,
             new Uint8Array(this.#lightFloats.buffer, 0, lightBytes)
         );
+    }
+
+    private readForceFullFallback(): boolean {
+        return this.#forceFullFallback;
     }
 
     private trackFallbackMesh(mesh: Mesh): void {
@@ -3353,10 +3635,90 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         return this.#logicalBucketByGeometry.get(geometry)?.get(material) ?? null;
     }
 
-    private packObject(record: GPUSceneObjectRecord, mesh: Mesh, logicalIndex: number): void {
+    private refreshLogicalBounds(): void {
+        for (let logicalIndex = 0; logicalIndex < this.#options.buckets.length; logicalIndex += 1) {
+            const bucket = this.#options.buckets[logicalIndex];
+            const bounds = this.#logicalBounds[logicalIndex];
+            if (bucket === undefined || bounds === undefined) {
+                throw new Error('GPU Scene logical bounds configuration is incomplete');
+            }
+            const geometryCount = 1 + bucket.lods.length;
+            let changed = bounds.positionRevisions.length !== geometryCount;
+            for (let geometryIndex = 0; geometryIndex < geometryCount; geometryIndex += 1) {
+                const geometry =
+                    geometryIndex === 0
+                        ? bucket.geometry
+                        : bucket.lods[geometryIndex - 1]?.geometry;
+                const revision = geometry?.vertices?.revision ?? -1;
+                changed ||= bounds.positionRevisions[geometryIndex] !== revision;
+            }
+            if (!changed) continue;
+
+            let centerX = 0;
+            let centerY = 0;
+            let centerZ = 0;
+            let radius = 0;
+            let initialized = false;
+            bounds.positionRevisions.length = geometryCount;
+            for (let geometryIndex = 0; geometryIndex < geometryCount; geometryIndex += 1) {
+                const geometry =
+                    geometryIndex === 0
+                        ? bucket.geometry
+                        : bucket.lods[geometryIndex - 1]?.geometry;
+                if (geometry === undefined) {
+                    throw new Error('GPU Scene LOD geometry configuration is incomplete');
+                }
+                const vertices = geometry.vertices;
+                if (vertices === null) {
+                    throw new Error('GPU Scene bounds require position data');
+                }
+                bounds.positionRevisions[geometryIndex] = vertices.revision;
+                const sphere = geometry.getLocalSphereBounds(true);
+                if (!initialized) {
+                    centerX = sphere.center.x;
+                    centerY = sphere.center.y;
+                    centerZ = sphere.center.z;
+                    radius = sphere.radius;
+                    initialized = true;
+                    continue;
+                }
+                const deltaX = sphere.center.x - centerX;
+                const deltaY = sphere.center.y - centerY;
+                const deltaZ = sphere.center.z - centerZ;
+                const distance = Math.hypot(deltaX, deltaY, deltaZ);
+                if (distance + sphere.radius <= radius) continue;
+                if (distance + radius <= sphere.radius) {
+                    centerX = sphere.center.x;
+                    centerY = sphere.center.y;
+                    centerZ = sphere.center.z;
+                    radius = sphere.radius;
+                    continue;
+                }
+                const nextRadius = (radius + distance + sphere.radius) * 0.5;
+                if (distance > 0) {
+                    const shift = (nextRadius - radius) / distance;
+                    centerX += deltaX * shift;
+                    centerY += deltaY * shift;
+                    centerZ += deltaZ * shift;
+                }
+                radius = nextRadius;
+            }
+            bounds.center.set(centerX, centerY, centerZ);
+            bounds.radius = radius;
+            bounds.revision++;
+        }
+    }
+
+    private packObject(
+        record: GPUSceneObjectRecord,
+        mesh: Mesh,
+        logicalIndex: number,
+        occlusionStable: boolean
+    ): void {
         const bucket = this.#options.buckets[logicalIndex];
         if (bucket === undefined) throw new Error('GPU Scene logical bucket is unavailable');
-        const sphere = bucket.geometry.getSphereBounds();
+        const sphere = this.#logicalBounds[logicalIndex];
+        if (sphere === undefined) throw new Error('GPU Scene logical bounds are unavailable');
         const floatOffset = record.slot * (OBJECT_RECORD_BYTES / 4);
         matrixElements(mesh.worldMatrix, this.#objectFloats, floatOffset);
         const hasCommitted = record.committedWorldVersion >= 0;
@@ -3391,33 +3753,47 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#objectUInts[floatOffset + 48] = logicalIndex;
         this.#objectUInts[floatOffset + 49] = mesh.layer >>> 0;
         this.#objectUInts[floatOffset + 50] =
-            OBJECT_ACTIVE_FLAG | (mesh.frustumTest ? OBJECT_FRUSTUM_CULLING_FLAG : 0);
+            OBJECT_ACTIVE_FLAG |
+            (mesh.frustumTest ? OBJECT_FRUSTUM_CULLING_FLAG : 0) |
+            (occlusionStable ? OBJECT_HIZ_STABLE_FLAG : 0);
         this.#objectUInts[floatOffset + 51] = this.#materialDatabase.getHandle(
             bucket.material
         ).recordIndex;
         matrixElements(mesh.worldMatrix, record.pendingMatrix, 0);
         record.pendingWorldVersion = mesh.worldMatrixVersion;
         record.pendingFrustumTest = mesh.frustumTest;
+        record.pendingBoundsRevision = sphere.revision;
+        record.pendingOcclusionStable = occlusionStable;
     }
 
     private packLight(
         light: PointLight | SpotLight | DirectionalLight | AreaLight,
         camera: Camera
     ): void {
+        if (light instanceof AreaLight || light.shadow !== null) {
+            // The clustered BRDF has neither LTC area-light evaluation nor shadow-atlas sampling.
+            // Preserve exact ordinary Forward semantics for the whole camera instead of silently
+            // approximating the light or dropping its shadow.
+            this.#forceFullFallback = true;
+            return;
+        }
         if (this.#lightCount >= this.#options.maxLights) {
             this.#droppedLightCount++;
             return;
         }
-        const base = this.#lightCount * 16;
+        const directional = light instanceof DirectionalLight;
+        const target = directional ? this.#directionalLightFloats : this.#localLightFloats;
+        const lightIndex = directional ? this.#directionalLightCount : this.#localLightCount;
+        const base = lightIndex * 16;
         let type = 0;
         let range = light.range;
         let inner = 1;
         let outer = -1;
         camera.getModelViewMatrix(light, this.#tempMatrix).getTranslation(this.#tempVector);
-        this.#lightFloats[base] = this.#tempVector.x;
-        this.#lightFloats[base + 1] = this.#tempVector.y;
-        this.#lightFloats[base + 2] = this.#tempVector.z;
-        if (light instanceof DirectionalLight) {
+        const positionX = this.#tempVector.x;
+        const positionY = this.#tempVector.y;
+        const positionZ = this.#tempVector.z;
+        if (directional) {
             type = 2;
             range = this.cameraFar(camera);
             this.#tempVector.copy(light.getViewDirection(camera));
@@ -3426,28 +3802,29 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             inner = light.cutoffCos;
             outer = light.outerCutoffCos;
             this.#tempVector.copy(light.getViewDirection(camera));
-        } else if (light instanceof AreaLight) {
-            type = 3;
-            range ||= Math.max(light.width, light.height) * 2;
-            this.#tempVector.set(0, 0, 1).transformDirection(this.#tempMatrix).normalize();
         } else {
             this.#tempVector.set(0, 0, 0);
         }
         range ||= this.cameraFar(camera);
-        this.#lightFloats[base + 3] = range;
+        target[base] = positionX;
+        target[base + 1] = positionY;
+        target[base + 2] = positionZ;
+        target[base + 3] = range;
         const color = light.getRealColor();
-        this.#lightFloats[base + 4] = color.r;
-        this.#lightFloats[base + 5] = color.g;
-        this.#lightFloats[base + 6] = color.b;
-        this.#lightFloats[base + 7] = type;
-        this.#lightFloats[base + 8] = this.#tempVector.x;
-        this.#lightFloats[base + 9] = this.#tempVector.y;
-        this.#lightFloats[base + 10] = this.#tempVector.z;
-        this.#lightFloats[base + 11] = outer;
-        this.#lightFloats[base + 12] = light.constantAttenuation;
-        this.#lightFloats[base + 13] = light.linearAttenuation;
-        this.#lightFloats[base + 14] = light.quadraticAttenuation;
-        this.#lightFloats[base + 15] = inner;
+        target[base + 4] = color.r;
+        target[base + 5] = color.g;
+        target[base + 6] = color.b;
+        target[base + 7] = type;
+        target[base + 8] = this.#tempVector.x;
+        target[base + 9] = this.#tempVector.y;
+        target[base + 10] = this.#tempVector.z;
+        target[base + 11] = outer;
+        target[base + 12] = light.constantAttenuation;
+        target[base + 13] = light.linearAttenuation;
+        target[base + 14] = light.quadraticAttenuation;
+        target[base + 15] = inner;
+        if (directional) this.#directionalLightCount++;
+        else this.#localLightCount++;
         this.#lightCount++;
     }
 
@@ -3587,17 +3964,21 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#frameUInts[110] = this.#options.zSlices;
         this.#frameUInts[111] = this.#options.tileSize;
         this.#frameUInts[112] = this.#activeObjectHighWater;
-        this.#frameUInts[113] = this.#options.buckets.length;
+        this.#frameUInts[113] = this.#physicalBuckets.length;
         this.#frameUInts[114] = this.#options.maxLightIndices;
         this.#frameUInts[115] = this.#lightCount;
         this.#frameUInts[116] = this.#visibleBucketCapacity;
         this.#frameUInts[117] = this.#options.maxLightsPerCluster;
         this.#frameUInts[118] = cameraOcclusionStable && this.#options.hiZ ? 1 : 0;
         this.#frameUInts[119] = camera.visibility >>> 0;
-        this.#frameFloats[120] = Math.min(this.#frameFloats[120] ?? 0, 4);
-        this.#frameFloats[121] = Math.min(this.#frameFloats[121] ?? 0, 4);
-        this.#frameFloats[122] = Math.min(this.#frameFloats[122] ?? 0, 4);
-        this.#frameFloats[123] = 0;
+        this.#frameUInts[120] = this.#directionalLightCount;
+        this.#frameUInts[121] = this.#localLightCount;
+        this.#frameUInts[122] = 0;
+        this.#frameUInts[123] = 0;
+        this.#frameFloats[124] = Math.min(this.#frameFloats[124] ?? 0, 4);
+        this.#frameFloats[125] = Math.min(this.#frameFloats[125] ?? 0, 4);
+        this.#frameFloats[126] = Math.min(this.#frameFloats[126] ?? 0, 4);
+        this.#frameFloats[127] = 0;
         matrixElements(camera.viewProjectionMatrix, this.#stagedCameraMatrix, 0);
         matrixElements(camera.viewMatrix, this.#stagedViewMatrix, 0);
         matrixElements(camera.projectionMatrix, this.#stagedProjectionMatrix, 0);
@@ -3632,7 +4013,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const previous: RenderGraphTextureHandle[] = [];
         const current: RenderGraphTextureHandle[] = [];
         let valid = true;
-        for (let index = 0; index < HIZ_LEVEL_COUNT; index += 1) {
+        for (let index = 0; index < this.#options.hiZLevelCount; index += 1) {
             const key = this.#hizKeys[index];
             const descriptor = this.#hizDescriptors[index];
             if (key === undefined || descriptor === undefined) {
@@ -3676,12 +4057,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             const parameters = context.acquirePassParameters(this.#depthDrawPool);
             parameters.setBuffer(0, resources.frameBuffer);
             parameters.setBuffer(1, resources.objects);
-            parameters.setBufferRange(
-                2,
-                resources.visible,
-                index * this.#visibleBucketCapacity * 4,
-                this.#visibleBucketCapacity * 4
-            );
+            parameters.setBuffer(2, resources.visible);
             parameters.setVertexBuffer(0, context.graph.importStorageBuffer(bucket.position));
             parameters.indexBuffer.buffer = context.graph.importStorageBuffer(bucket.index);
             parameters.draw.buffer = resources.indirect;
@@ -3701,7 +4077,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     ): void {
         if (!this.#options.hiZ) return;
         let source: RenderGraphTextureAccessHandle = sceneDepth;
-        for (let index = 0; index < HIZ_LEVEL_COUNT; index += 1) {
+        for (let index = 0; index < this.#options.hiZLevelCount; index += 1) {
             const destination = current[index];
             if (destination === undefined)
                 throw new Error('GPU Scene Hi-Z current slot is missing');
@@ -3731,7 +4107,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             tileDepthBounds: RenderGraphBufferHandle;
             clusterCounts: RenderGraphBufferHandle;
             clusterGrid: RenderGraphBufferHandle;
-            clusterCursors: RenderGraphBufferHandle;
             clusterBlockSums: RenderGraphBufferHandle;
             clusterBlockOffsets: RenderGraphBufferHandle;
             clusterIndices: RenderGraphBufferHandle;
@@ -3750,7 +4125,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         count.setBuffer(1, resources.lights);
         count.setBuffer(2, resources.tileDepthBounds);
         count.setBuffer(3, resources.clusterCounts);
-        count.setDispatch(Math.max(1, Math.ceil(this.#lightCount / CULL_WORKGROUP_SIZE)));
+        count.setDispatch(Math.max(1, Math.ceil(this.#localLightCount / CULL_WORKGROUP_SIZE)));
         context.graph.addPass(CLUSTER_LIGHT_COUNT_PASS, count);
 
         const blockCount = Math.ceil(resources.frame.clusterCount / PREFIX_WORKGROUP_SIZE);
@@ -3775,19 +4150,25 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         finalize.setBuffer(1, resources.clusterCounts);
         finalize.setBuffer(2, resources.clusterGrid);
         finalize.setBuffer(3, resources.clusterBlockOffsets);
-        finalize.setBuffer(4, resources.clusterCursors);
-        finalize.setBuffer(5, resources.clusterStats);
+        finalize.setBuffer(4, resources.clusterStats);
         finalize.setDispatch(blockCount);
         context.graph.addPass(CLUSTER_PREFIX_FINALIZE_PASS, finalize);
+
+        const reset = context.acquirePassParameters(this.#clusterIndexResetPool);
+        reset.setBuffer(0, resources.frameBuffer);
+        reset.setBuffer(1, resources.clusterIndices);
+        reset.setDispatch(
+            Math.max(1, Math.ceil(this.#options.maxLightIndices / PREFIX_WORKGROUP_SIZE))
+        );
+        context.graph.addPass(CLUSTER_INDEX_RESET_PASS, reset);
 
         const write = context.acquirePassParameters(this.#clusterWritePool);
         write.setBuffer(0, resources.frameBuffer);
         write.setBuffer(1, resources.lights);
         write.setBuffer(2, resources.tileDepthBounds);
         write.setBuffer(3, resources.clusterGrid);
-        write.setBuffer(4, resources.clusterCursors);
-        write.setBuffer(5, resources.clusterIndices);
-        write.setDispatch(Math.max(1, Math.ceil(this.#lightCount / CULL_WORKGROUP_SIZE)));
+        write.setBuffer(4, resources.clusterIndices);
+        write.setDispatch(Math.max(1, Math.ceil(this.#localLightCount / CULL_WORKGROUP_SIZE)));
         context.graph.addPass(CLUSTER_LIGHT_WRITE_PASS, write);
     }
 
@@ -3811,7 +4192,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             texture: resources.sceneColor,
             loadOp: 'clear',
             storeOp: 'store',
-            clearValue: { r: 0.004, g: 0.008, b: 0.022, a: 1 }
+            clearValue: context.clearColor
         };
         const depthAttachment: RenderPipelineDepthStencilAttachment = {
             texture: resources.sceneDepth,
@@ -3835,12 +4216,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.configure(bucket.colorPass.vertexLayouts.length, variant.textures.length);
             parameters.setBuffer(0, resources.frameBuffer);
             parameters.setBuffer(1, resources.objects);
-            parameters.setBufferRange(
-                2,
-                resources.visible,
-                index * this.#visibleBucketCapacity * 4,
-                this.#visibleBucketCapacity * 4
-            );
+            parameters.setBuffer(2, resources.visible);
             parameters.setBuffer(3, resources.materials);
             parameters.setBuffer(4, resources.lights);
             parameters.setBuffer(5, resources.clusterGrid);
@@ -3896,41 +4272,59 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     private recordDisplay(
         context: RenderPipelineContext,
         sceneColor: RenderGraphTextureHandle,
-        bloomA: RenderGraphTextureHandle,
-        bloomB: RenderGraphTextureHandle,
+        bloomA: RenderGraphTextureHandle | null,
+        bloomB: RenderGraphTextureHandle | null,
+        bloomC: RenderGraphTextureHandle | null,
         outputColor: RenderGraphTextureHandle
     ): void {
-        const prefilter = context.acquirePassParameters(this.#fullscreenPool);
-        prefilter.inputTextures.length = 1;
-        prefilter.inputTextures[0] = sceneColor;
-        prefilter.colorAttachments[0] = {
-            texture: bloomA,
-            loadOp: 'clear',
-            storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 0, a: 1 }
-        };
-        context.graph.addPass(BLOOM_PREFILTER_PASS, prefilter);
+        if (this.#options.bloomStrength > 0) {
+            if (bloomA === null || bloomB === null || bloomC === null) {
+                throw new Error('Clustered Forward+ Bloom textures are unavailable');
+            }
+            const prefilter = context.acquirePassParameters(this.#fullscreenPool);
+            prefilter.inputTextures.length = 1;
+            prefilter.inputTextures[0] = sceneColor;
+            prefilter.colorAttachments[0] = {
+                texture: bloomA,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: { r: 0, g: 0, b: 0, a: 1 }
+            };
+            context.graph.addPass(BLOOM_PREFILTER_PASS, prefilter);
 
-        const blur = context.acquirePassParameters(this.#fullscreenPool);
-        blur.inputTextures.length = 1;
-        blur.inputTextures[0] = bloomA;
-        blur.colorAttachments[0] = {
-            texture: bloomB,
-            loadOp: 'clear',
-            storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 0, a: 1 }
-        };
-        context.graph.addPass(BLOOM_BLUR_PASS, blur);
+            const horizontal = context.acquirePassParameters(this.#fullscreenPool);
+            horizontal.inputTextures.length = 1;
+            horizontal.inputTextures[0] = bloomA;
+            horizontal.colorAttachments[0] = {
+                texture: bloomB,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: { r: 0, g: 0, b: 0, a: 1 }
+            };
+            context.graph.addPass(BLOOM_HORIZONTAL_PASS, horizontal);
+
+            const vertical = context.acquirePassParameters(this.#fullscreenPool);
+            vertical.inputTextures.length = 1;
+            vertical.inputTextures[0] = bloomB;
+            vertical.colorAttachments[0] = {
+                texture: bloomC,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: { r: 0, g: 0, b: 0, a: 1 }
+            };
+            context.graph.addPass(BLOOM_VERTICAL_PASS, vertical);
+        }
 
         const display = context.acquirePassParameters(this.#fullscreenPool);
-        display.inputTextures.length = 2;
+        display.inputTextures.length = this.#options.bloomStrength > 0 ? 2 : 1;
         display.inputTextures[0] = sceneColor;
-        display.inputTextures[1] = bloomB;
+        if (bloomC !== null) display.inputTextures[1] = bloomC;
+        const outputPolicy = context.output.colorAttachment(0);
         display.colorAttachments[0] = {
             texture: outputColor,
-            loadOp: 'clear',
-            storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 0, a: 1 }
+            loadOp: outputPolicy.loadOp,
+            storeOp: outputPolicy.storeOp,
+            ...(outputPolicy.loadOp === 'clear' ? { clearValue: outputPolicy.clearValue } : {})
         };
         context.graph.addPass(this.#displayPass, display);
     }
@@ -3953,7 +4347,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         if (!this.#fallbackHasTransparent) return;
         const opaqueTexture = context.graph.createTexture('Forward fallback opaque scene color', {
-            format: context.output.colorFormat(0),
+            format: 'rgba16float',
             extent: { relativeTo: 'output', scale: 1 },
             sampleCount: 1
         });
@@ -3996,23 +4390,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         if (opaqueTexture !== null) parameters.opaqueTexture = opaqueTexture;
         context.graph.addPass(this.#fallbackPass, parameters);
     }
-
-    private recordFallbackPresent(
-        context: RenderPipelineContext,
-        source: RenderGraphTextureHandle,
-        output: RenderGraphTextureHandle
-    ): void {
-        const parameters = context.acquirePassParameters(this.#fullscreenPool);
-        parameters.inputTextures.length = 1;
-        parameters.inputTextures[0] = source;
-        parameters.colorAttachments[0] = {
-            texture: output,
-            loadOp: 'clear',
-            storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 0, a: 1 }
-        };
-        context.graph.addPass(this.#fallbackPresentPass, parameters);
-    }
 }
 
 /**
@@ -4041,10 +4418,11 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
             0
         );
         const requirements = bufferRequirementPlan(this.#options, physicalCount);
+        const hiZ = this.#options.hiZ;
         this.requirements = Object.freeze({
             requiredCapabilities: Object.freeze([
                 'storage-buffer' as const,
-                'storage-texture' as const,
+                ...(hiZ ? (['storage-texture' as const] as const) : []),
                 'compute-pass' as const,
                 'indirect-draw' as const
             ]),
@@ -4054,8 +4432,18 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     use: 'depth-stencil-attachment' as const
                 }),
                 Object.freeze({ format: 'depth32float' as const, use: 'sampled' as const }),
-                Object.freeze({ format: 'r32float' as const, use: 'sampled' as const }),
-                Object.freeze({ format: 'r32float' as const, use: 'storage' as const }),
+                ...(hiZ
+                    ? [
+                          Object.freeze({
+                              format: 'r32float' as const,
+                              use: 'sampled' as const
+                          }),
+                          Object.freeze({
+                              format: 'r32float' as const,
+                              use: 'storage' as const
+                          })
+                      ]
+                    : []),
                 Object.freeze({ format: 'rgba16float' as const, use: 'color-attachment' as const }),
                 Object.freeze({
                     format: 'rgba16float' as const,
@@ -4064,16 +4452,16 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
             ]),
             requiredLimits: Object.freeze({
                 maxBindingsPerBindGroup: Math.max(
-                    6 + HIZ_LEVEL_COUNT,
+                    hiZ ? 6 + this.#options.hiZLevelCount : 6,
                     PBR_TEXTURE_ROLES.length * 2
                 ),
                 maxStorageBuffersPerShaderStage: 7,
-                maxStorageTexturesPerShaderStage: 1,
                 maxSampledTexturesPerShaderStage: Math.max(
-                    HIZ_LEVEL_COUNT,
+                    hiZ ? this.#options.hiZLevelCount : 0,
                     PBR_TEXTURE_ROLES.length
                 ),
                 maxSamplersPerShaderStage: PBR_TEXTURE_ROLES.length,
+                ...(hiZ ? { maxStorageTexturesPerShaderStage: 1 } : {}),
                 maxStorageBufferBindingSize: requirements.maxStorageBufferBindingSize,
                 maxBufferSize: requirements.maxBufferSize,
                 maxComputeInvocationsPerWorkgroup: PREFIX_WORKGROUP_SIZE,

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -25,6 +25,7 @@ import Shader from '../../shader/Shader';
 import pbrBrdfSource from '../../shader/chunk/pbr_brdf.glsl';
 import pbrSurfaceSource from '../../shader/chunk/pbr_surface.glsl';
 import encodingSource from '../../shader/method/encoding.glsl';
+import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type Texture from '../../texture/Texture';
 import {
     CLAMP_TO_EDGE,
@@ -76,6 +77,7 @@ import type {
     RendererListHandle
 } from './RendererList';
 import { RenderPassParameterPool } from './RenderPassParameterPool';
+import { snapshotRenderPipelineRequirements } from './RenderPipelineFactory';
 import {
     ComputeRenderPass,
     FullscreenRenderPass,
@@ -101,12 +103,26 @@ import type {
     ScriptableRenderPassBuilder,
     ScriptableRenderPassContext
 } from './ScriptableRenderGraph';
+import {
+    TEMPORAL_AA_REQUIREMENTS,
+    TEMPORAL_MOTION_CLEAR,
+    TEMPORAL_MOTION_DESCRIPTOR,
+    TemporalResolveController,
+    snapshotTemporalAAOptions,
+    type TemporalAAOptions,
+    type TemporalAASettings
+} from '../postprocessing/TemporalAA';
 
 const OBJECT_RECORD_BYTES = 208;
 const LIGHT_RECORD_BYTES = 64;
 const BUCKET_RECORD_BYTES = 48;
 const FRAME_RECORD_BYTES = 512;
 const INDIRECT_ARGUMENT_BYTES = 20;
+// The draw-local visible-range base is exposed through a statically aligned storage binding.
+// WebGPU's default/minimum storage offset alignment is at most 256 bytes, so one record per
+// aligned stride is portable without requesting the optional indirect-first-instance feature.
+const BUCKET_OFFSET_STRIDE_BYTES = 256;
+const BUCKET_OFFSET_STRIDE_WORDS = BUCKET_OFFSET_STRIDE_BYTES / 4;
 const STATS_BYTES = 16;
 // WebGPU guarantees at least an 8192-wide 2D texture. Factories specialize the shader and graph
 // to the exact configured viewport pyramid while this remains the portable upper bound.
@@ -115,6 +131,8 @@ const MAX_HIZ_OCCLUSION_DIAMETER = 1 << MAX_HIZ_LEVEL_COUNT;
 const OBJECT_ACTIVE_FLAG = 1;
 const OBJECT_FRUSTUM_CULLING_FLAG = 2;
 const OBJECT_HIZ_STABLE_FLAG = 4;
+const OBJECT_MOTION_HISTORY_FLAG = 8;
+const OBJECT_MOTION_CHANGED_FLAG = 16;
 const CULL_WORKGROUP_SIZE = 64;
 const PREFIX_WORKGROUP_SIZE = 256;
 const DEFAULT_MAX_OBJECTS = 16_384;
@@ -182,6 +200,8 @@ export interface ClusteredForwardPlusPipelineOptions {
     readonly bloomStrength?: number;
     /** Exposure multiplier applied before the ACES display transform. Defaults to 1. */
     readonly exposure?: number;
+    /** Integrated native-resolution temporal AA. Disabled by default; `false` explicitly disables it. */
+    readonly temporalAA?: Readonly<TemporalAAOptions> | false;
 }
 
 /** On-demand GPU counters plus current CPU database occupancy. */
@@ -235,6 +255,7 @@ interface NormalizedOptions {
     readonly hiZLevelCount: number;
     readonly bloomStrength: number;
     readonly exposure: number;
+    readonly temporalAA: TemporalAASettings | null;
 }
 
 interface ClusterCapacityPlan {
@@ -323,6 +344,13 @@ interface GPUSceneObjectRecord {
     committedBoundsRevision: number;
     pendingOcclusionStable: boolean;
     committedOcclusionStable: boolean;
+    pendingMotionChanged: boolean;
+    committedMotionChanged: boolean;
+    pendingMotionHistoryValid: boolean;
+    committedMotionHistoryValid: boolean;
+    pendingHistoryRevision: number;
+    committedHistoryRevision: number;
+    committedSubmission: number;
     readonly committedMatrix: Float32Array;
     readonly pendingMatrix: Float32Array;
 }
@@ -666,6 +694,11 @@ function bufferRequirementPlan(
         ),
         safeProduct('GPU Scene selected-bucket database size', options.maxObjects, 4),
         safeProduct('GPU Scene bucket-cursor database size', physicalCount, 4),
+        safeProduct(
+            'GPU Scene bucket-offset database size',
+            physicalCount,
+            BUCKET_OFFSET_STRIDE_BYTES
+        ),
         safeProduct('GPU Scene indirect database size', physicalCount, INDIRECT_ARGUMENT_BYTES),
         safeProduct('Clustered Forward+ tile-depth database size', capacity.maxTiles, 8),
         safeProduct('Clustered Forward+ cluster-count database size', capacity.maxClusters, 4),
@@ -837,6 +870,10 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         'Clustered Forward+ zSlices'
     );
     if (zSlices > 64) throw new RangeError('Clustered Forward+ zSlices cannot exceed 64');
+    const temporalAA =
+        input.temporalAA === undefined || input.temporalAA === false
+            ? null
+            : snapshotTemporalAAOptions(input.temporalAA);
     return Object.freeze({
         buckets: Object.freeze(buckets),
         maxObjects: positiveInteger(
@@ -867,7 +904,8 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
             input.bloomStrength ?? 0.7,
             'Clustered Forward+ bloomStrength'
         ),
-        exposure: finitePositive(input.exposure ?? 1, 'Clustered Forward+ exposure')
+        exposure: finitePositive(input.exposure ?? 1, 'Clustered Forward+ exposure'),
+        temporalAA
     });
 }
 
@@ -1143,12 +1181,14 @@ ${FRAME_WGSL}
 @group(0) @binding(0) var<storage, read> frameData: FrameData;
 @group(0) @binding(1) var<storage, read_write> indirectArguments: array<atomic<u32>>;
 @group(0) @binding(2) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read_write> bucketOffsets: array<u32>;
 @compute @workgroup_size(1)
 fn main() {
     var offset = 0u;
     for (var bucket = 0u; bucket < frameData.counts.y; bucket += 1u) {
         let count = atomicLoad(&indirectArguments[bucket * 5u + 1u]);
-        atomicStore(&indirectArguments[bucket * 5u + 4u], offset);
+        bucketOffsets[bucket * ${String(BUCKET_OFFSET_STRIDE_WORDS)}u] = offset;
+        atomicStore(&indirectArguments[bucket * 5u + 4u], 0u);
         atomicStore(&bucketCursors[bucket], 0u);
         offset += count;
     }
@@ -1169,63 +1209,89 @@ fn main() {
                 binding: 2,
                 kind: 'storage-buffer',
                 access: 'write-discard'
+            },
+            {
+                name: 'bucketOffsets',
+                group: 0,
+                binding: 3,
+                kind: 'storage-buffer',
+                access: 'read-write'
             }
         ]
     })
 );
 
-const GPU_SCENE_VISIBLE_COMPACT_PASS = computePass(
-    new ComputeShader({
-        label: 'GPU Scene visible compact write',
-        source: `
+function gpuSceneVisibleCompactPass(trackVisibility: boolean): ComputeRenderPass {
+    return computePass(
+        new ComputeShader({
+            label: trackVisibility
+                ? 'GPU Scene visible compact and temporal visibility write'
+                : 'GPU Scene visible compact write',
+            source: `
 ${FRAME_WGSL}
 @group(0) @binding(0) var<storage, read> frameData: FrameData;
 @group(0) @binding(1) var<storage, read> selectedPhysicalBuckets: array<u32>;
-@group(0) @binding(2) var<storage, read_write> indirectArguments: array<atomic<u32>>;
-@group(0) @binding(3) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@group(0) @binding(2) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read> bucketOffsets: array<u32>;
 @group(0) @binding(4) var<storage, read_write> visibleIndices: array<u32>;
+${trackVisibility ? '@group(0) @binding(5) var<storage, read_write> currentVisibility: array<u32>;' : ''}
 @compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     if (id.x >= frameData.counts.x || id.x >= frameData.budgets.x) { return; }
     let bucket = selectedPhysicalBuckets[id.x];
     if (bucket == 0xffffffffu) { return; }
     let localIndex = atomicAdd(&bucketCursors[bucket], 1u);
-    let offset = atomicLoad(&indirectArguments[bucket * 5u + 4u]);
+    let offset = bucketOffsets[bucket * ${String(BUCKET_OFFSET_STRIDE_WORDS)}u];
     visibleIndices[offset + localIndex] = id.x;
+    ${trackVisibility ? 'currentVisibility[id.x] = 1u;' : ''}
 }`,
-        workgroupSize: [CULL_WORKGROUP_SIZE],
-        bindings: [
-            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
-            {
-                name: 'selectedPhysicalBuckets',
-                group: 0,
-                binding: 1,
-                kind: 'read-only-storage-buffer'
-            },
-            {
-                name: 'indirectArguments',
-                group: 0,
-                binding: 2,
-                kind: 'storage-buffer',
-                access: 'read-write'
-            },
-            {
-                name: 'bucketCursors',
-                group: 0,
-                binding: 3,
-                kind: 'storage-buffer',
-                access: 'read-write'
-            },
-            {
-                name: 'visibleIndices',
-                group: 0,
-                binding: 4,
-                kind: 'storage-buffer',
-                access: 'write-discard'
-            }
-        ]
-    })
-);
+            workgroupSize: [CULL_WORKGROUP_SIZE],
+            bindings: [
+                { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+                {
+                    name: 'selectedPhysicalBuckets',
+                    group: 0,
+                    binding: 1,
+                    kind: 'read-only-storage-buffer'
+                },
+                {
+                    name: 'bucketCursors',
+                    group: 0,
+                    binding: 2,
+                    kind: 'storage-buffer',
+                    access: 'read-write'
+                },
+                {
+                    name: 'bucketOffsets',
+                    group: 0,
+                    binding: 3,
+                    kind: 'read-only-storage-buffer'
+                },
+                {
+                    name: 'visibleIndices',
+                    group: 0,
+                    binding: 4,
+                    kind: 'storage-buffer',
+                    access: 'write-discard'
+                },
+                ...(trackVisibility
+                    ? ([
+                          {
+                              name: 'currentVisibility',
+                              group: 0,
+                              binding: 5,
+                              kind: 'storage-buffer',
+                              access: 'read-write'
+                          }
+                      ] as const)
+                    : [])
+            ]
+        })
+    );
+}
+
+const GPU_SCENE_VISIBLE_COMPACT_PASS = gpuSceneVisibleCompactPass(false);
+const GPU_SCENE_TEMPORAL_VISIBLE_COMPACT_PASS = gpuSceneVisibleCompactPass(true);
 
 const HIZ_DEPTH_REDUCE_PASS = computePass(
     new ComputeShader({
@@ -1761,6 +1827,11 @@ vec4 gpuSceneClipPosition(uint objectBase, vec3 position) {
     return readFrameMatrix(0u) * readObjectMatrix(objectBase) * vec4(position, 1.0);
 }`;
 
+const GPU_SCENE_VISIBLE_INDEX_SOURCE = `
+uint gpuSceneVisibleObjectIndex() {
+    return visibleIndices.values[visibleOffset.value + uint(gl_InstanceIndex)];
+}`;
+
 const GPU_SCENE_DEPTH_SHADER = new StorageGraphicsShader({
     label: 'GPU Scene indirect depth prepass',
     vertexSource: `#version 310 es
@@ -1770,10 +1841,12 @@ invariant gl_Position;
 layout(std430) readonly buffer FrameDataBlock { vec4 values[]; } frameData;
 layout(std430) readonly buffer ObjectBlock { vec4 values[]; } objects;
 layout(std430) readonly buffer VisibleBlock { uint values[]; } visibleIndices;
+layout(std430) readonly buffer VisibleOffsetBlock { uint value; } visibleOffset;
 layout(location=0) in vec3 a_position;
 ${GPU_SCENE_POSITION_TRANSFORM_SOURCE}
+${GPU_SCENE_VISIBLE_INDEX_SOURCE}
 void main() {
-    uint objectIndex = visibleIndices.values[uint(gl_InstanceIndex)];
+    uint objectIndex = gpuSceneVisibleObjectIndex();
     uint objectBase = objectIndex * 13u;
     gl_Position = gpuSceneClipPosition(objectBase, a_position);
 }`,
@@ -1783,7 +1856,101 @@ void main() {}`,
     bindings: [
         { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
         { name: 'objects', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
-        { name: 'visibleIndices', group: 0, binding: 2, kind: 'read-only-storage-buffer' }
+        { name: 'visibleIndices', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
+        {
+            name: 'visibleOffset',
+            group: 0,
+            binding: 3,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 4
+        }
+    ]
+});
+
+const GPU_SCENE_TEMPORAL_DEPTH_SHADER = new StorageGraphicsShader({
+    label: 'GPU Scene fused depth and temporal motion prepass',
+    vertexSource: `#version 310 es
+precision highp float;
+precision highp int;
+invariant gl_Position;
+layout(std430) readonly buffer FrameDataBlock { vec4 values[]; } frameData;
+layout(std430) readonly buffer ObjectBlock { vec4 values[]; } objects;
+layout(std430) readonly buffer VisibleBlock { uint values[]; } visibleIndices;
+layout(std430) readonly buffer VisibleOffsetBlock { uint value; } visibleOffset;
+layout(std430) readonly buffer PreviousVisibilityBlock { uint values[]; } previousVisibility;
+layout(location=0) in vec3 a_position;
+out vec4 v_currentClipPosition;
+out vec4 v_previousClipPosition;
+out float v_currentViewDepth;
+out float v_previousViewDepth;
+flat out float v_motionHistoryValid;
+${GPU_SCENE_POSITION_TRANSFORM_SOURCE}
+${GPU_SCENE_VISIBLE_INDEX_SOURCE}
+void main() {
+    uint objectIndex = gpuSceneVisibleObjectIndex();
+    uint objectBase = objectIndex * 13u;
+    uint flags = floatBitsToUint(objects.values[objectBase + 12u].z);
+    mat4 currentModel = readObjectMatrix(objectBase);
+    mat4 previousModel = (flags & ${String(OBJECT_MOTION_CHANGED_FLAG)}u) != 0u
+        ? readObjectMatrix(objectBase + 4u)
+        : currentModel;
+    vec4 localPosition = vec4(a_position, 1.0);
+    gl_Position = gpuSceneClipPosition(objectBase, a_position);
+    v_currentClipPosition = gl_Position;
+    v_previousClipPosition = readFrameMatrix(4u) * previousModel * localPosition;
+    v_currentViewDepth = abs((readFrameMatrix(8u) * currentModel * localPosition).z);
+    v_previousViewDepth = abs((readFrameMatrix(16u) * previousModel * localPosition).z);
+    bool cameraHistoryValid = floatBitsToUint(frameData.values[30u].z) != 0u;
+    v_motionHistoryValid =
+        cameraHistoryValid &&
+        (flags & ${String(OBJECT_MOTION_HISTORY_FLAG)}u) != 0u &&
+        previousVisibility.values[objectIndex] != 0u
+            ? 1.0
+            : 0.0;
+}`,
+    fragmentSource: `#version 310 es
+precision highp float;
+${portableCoordinatesSource}
+in vec4 v_currentClipPosition;
+in vec4 v_previousClipPosition;
+in float v_currentViewDepth;
+in float v_previousViewDepth;
+flat in float v_motionHistoryValid;
+layout(location=0) out vec4 motionData;
+void main() {
+    float currentLogDepth = log2(1.0 + max(v_currentViewDepth, 0.0));
+    if (
+        v_motionHistoryValid < 0.5 ||
+        v_currentClipPosition.w <= 1e-6 ||
+        v_previousClipPosition.w <= 1e-6
+    ) {
+        motionData = vec4(0.0, 0.0, -1.0, currentLogDepth);
+        return;
+    }
+    vec2 currentUV = hiloRenderTargetUV(
+        v_currentClipPosition.xy / v_currentClipPosition.w * 0.5 + 0.5
+    );
+    vec2 previousUV = hiloRenderTargetUV(
+        v_previousClipPosition.xy / v_previousClipPosition.w * 0.5 + 0.5
+    );
+    motionData = vec4(
+        currentUV - previousUV,
+        log2(1.0 + max(v_previousViewDepth, 0.0)),
+        currentLogDepth
+    );
+}`,
+    bindings: [
+        { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+        { name: 'objects', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+        { name: 'visibleIndices', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
+        {
+            name: 'visibleOffset',
+            group: 0,
+            binding: 3,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 4
+        },
+        { name: 'previousVisibility', group: 0, binding: 4, kind: 'read-only-storage-buffer' }
     ]
 });
 
@@ -1848,7 +2015,14 @@ function gpuScenePBRShader(variant: Readonly<PBRMaterialVariant>): StorageGraphi
         { name: 'materials', group: 0, binding: 3, kind: 'read-only-storage-buffer' },
         { name: 'lights', group: 0, binding: 4, kind: 'read-only-storage-buffer' },
         { name: 'clusterGrid', group: 0, binding: 5, kind: 'read-only-storage-buffer' },
-        { name: 'clusterIndices', group: 0, binding: 6, kind: 'read-only-storage-buffer' }
+        { name: 'clusterIndices', group: 0, binding: 6, kind: 'read-only-storage-buffer' },
+        {
+            name: 'visibleOffset',
+            group: 0,
+            binding: 7,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 4
+        }
     ];
     for (let index = 0; index < variant.textures.length; index += 1) {
         const texture = variant.textures[index];
@@ -1880,6 +2054,7 @@ layout(std430) readonly buffer MaterialDataBlock { vec4 values[]; } materials;
 layout(std430) readonly buffer LightDataBlock { vec4 values[]; } lights;
 layout(std430) readonly buffer ClusterGridBlock { uvec2 values[]; } clusterGrid;
 layout(std430) readonly buffer ClusterIndexBlock { uint values[]; } clusterIndices;
+layout(std430) readonly buffer VisibleOffsetBlock { uint value; } visibleOffset;
 layout(location=0) in vec3 a_position;
 layout(location=1) in vec3 a_normal;
 ${vertexUVDeclarations}
@@ -1887,11 +2062,12 @@ out vec3 v_viewPosition;
 out vec3 v_viewNormal;
 flat out uint v_materialIndex;
 ${GPU_SCENE_POSITION_TRANSFORM_SOURCE}
+${GPU_SCENE_VISIBLE_INDEX_SOURCE}
 mat3 readObjectNormalMatrix(uint base) {
     return mat3(objects.values[base + 8u].xyz, objects.values[base + 9u].xyz, objects.values[base + 10u].xyz);
 }
 void main() {
-    uint objectIndex = visibleIndices.values[uint(gl_InstanceIndex)];
+    uint objectIndex = gpuSceneVisibleObjectIndex();
     uint objectBase = objectIndex * 13u;
     mat4 model = readObjectMatrix(objectBase);
     mat4 view = readFrameMatrix(8u);
@@ -2299,6 +2475,13 @@ class MutableGPUDrivenParameters implements GPUDrivenRenderPassParameters {
         this.samplers.length = textureCount;
     }
 
+    configureStorageBufferCount(bufferCount: number): void {
+        while (this.buffers.length < bufferCount) {
+            this.buffers.push({ buffer: INVALID_BUFFER });
+        }
+        this.buffers.length = bufferCount;
+    }
+
     setBuffer(index: number, buffer: RenderGraphBufferHandle): void {
         const binding = this.buffers[index];
         if (binding === undefined) throw new RangeError('GPU-driven buffer slot is unavailable');
@@ -2597,7 +2780,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #lights: StorageBuffer;
     readonly #visibleIndices: StorageBuffer;
     readonly #selectedPhysicalBuckets: StorageBuffer;
+    readonly #visibilityHistory: readonly [StorageBuffer, StorageBuffer] | null;
     readonly #visibleBucketCursors: StorageBuffer;
+    readonly #visibleBucketOffsets: StorageBuffer;
     readonly #indirectArguments: StorageBuffer;
     readonly #cullStats: StorageBuffer;
     readonly #tileDepthBounds: StorageBuffer;
@@ -2613,6 +2798,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #logicalBucketByGeometry = new Map<Geometry, Map<PBRMaterial, number>>();
     readonly #logicalGPUCompatible: Uint8Array;
     readonly #gpuManagedMeshes: Mesh[] = [];
+    readonly #fallbackTemporalParticipation = new WeakMap<Mesh, number>();
+    readonly #pendingFallbackTemporalMeshes = new Set<Mesh>();
     readonly #objectByMesh = new Map<Mesh, GPUSceneObjectRecord>();
     readonly #freeObjectSlots: number[] = [];
     readonly #objectData: ArrayBuffer;
@@ -2630,6 +2817,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     >();
     readonly #stagedCameraMatrix = new Float32Array(16);
     readonly #committedCameraMatrix = new Float32Array(16);
+    readonly #stagedRasterCameraMatrix = new Float32Array(16);
+    readonly #committedRasterCameraMatrix = new Float32Array(16);
     readonly #stagedViewMatrix = new Float32Array(16);
     readonly #committedViewMatrix = new Float32Array(16);
     readonly #stagedProjectionMatrix = new Float32Array(16);
@@ -2639,6 +2828,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #hizKeys: readonly object[];
     readonly #hizDescriptors: readonly Readonly<RenderPipelineHistoryTextureDescriptor>[];
     readonly #hizCullPass: ComputeRenderPass | null;
+    readonly #temporal: TemporalResolveController | null;
     readonly #clearPass = new ClearBuffersPass();
     readonly #clearPool = new RenderPassParameterPool(
         () => new ClearBuffersParameters(),
@@ -2649,10 +2839,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #cullPool = new RenderPassParameterPool(() => new MutableComputeParameters(6, 0));
     readonly #hizCullPool: RenderPassParameterPool<MutableComputeParameters>;
     readonly #bucketPrefixPool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(3, 0)
+        () => new MutableComputeParameters(4, 0)
     );
     readonly #visibleCompactPool = new RenderPassParameterPool(
         () => new MutableComputeParameters(5, 0)
+    );
+    readonly #temporalVisibleCompactPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(6, 0)
     );
     readonly #hizPool = new RenderPassParameterPool(() => new MutableComputeParameters(1, 2));
     readonly #clusterDepthPool = new RenderPassParameterPool(
@@ -2677,7 +2870,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         () => new MutableComputeParameters(5, 0)
     );
     readonly #depthDrawPool = new RenderPassParameterPool(
-        () => new MutableGPUDrivenParameters(3, 1)
+        () => new MutableGPUDrivenParameters(4, 1)
     );
     readonly #depthBatchPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenBatchParameters(),
@@ -2686,7 +2879,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
     );
     readonly #colorDrawPool = new RenderPassParameterPool(
-        () => new MutableGPUDrivenParameters(7, 2)
+        () => new MutableGPUDrivenParameters(8, 2)
     );
     readonly #colorBatchPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenBatchParameters(),
@@ -2711,6 +2904,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #depthBatchPass = new GPUDrivenRenderBatchPass('GPU Scene depth buckets');
     readonly #colorBatchPass = new GPUDrivenRenderBatchPass('Clustered PBR buckets');
     readonly #fallbackPass = new SceneRenderPass('Clustered Forward+ compatibility fallback');
+    readonly #fallbackMotionPass = new SceneRenderPass(
+        'Clustered Forward+ fallback temporal motion'
+    );
     readonly #fallbackCopyPass = new TextureCopyPass(
         'Clustered Forward+ compatibility opaque copy'
     );
@@ -2724,6 +2920,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         cullingResults: INVALID_CULLING_RESULTS,
         queue: 'transparent',
         sorting: 'back-to-front',
+        excludeMeshes: this.#gpuManagedMeshes
+    };
+    readonly #fallbackMotionListDescriptor: MutableFallbackRendererListDescriptor = {
+        cullingResults: INVALID_CULLING_RESULTS,
+        queue: 'opaque',
+        sorting: 'material-front-to-back',
+        materialPass: 'motion-vector',
         excludeMeshes: this.#gpuManagedMeshes
     };
     readonly #normalMatrix = new Matrix3();
@@ -2746,6 +2949,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     #committedCamera: Camera | null = null;
     #pendingCameraRevision = -1;
     #committedCameraRevision = -1;
+    #committedCameraSubmission = -1;
+    #submissionIndex = 0;
+    #visibilityHistoryIndex: 0 | 1 = 0;
     #hiZValid = false;
     #destroyed = false;
 
@@ -2756,6 +2962,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     ) {
         this.#options = options;
         this.#onDestroy = onDestroy;
+        this.#temporal =
+            options.temporalAA === null ? null : new TemporalResolveController(options.temporalAA);
         this.#hizKeys = Object.freeze(
             Array.from({ length: options.hiZLevelCount }, () => Object.freeze({}))
         );
@@ -2836,11 +3044,39 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             usage: ['storage'],
             recovery: 'reinitialize'
         });
+        if (this.#temporal === null) {
+            this.#visibilityHistory = null;
+        } else {
+            const visibilityInitialData = new Uint32Array(options.maxObjects);
+            this.#visibilityHistory = Object.freeze([
+                create({
+                    label: 'GPU Scene visibility history A',
+                    byteLength: visibilityInitialData.byteLength,
+                    usage: ['storage', 'copy-destination'],
+                    initialData: visibilityInitialData,
+                    recovery: 'cpu-shadow'
+                }),
+                create({
+                    label: 'GPU Scene visibility history B',
+                    byteLength: visibilityInitialData.byteLength,
+                    usage: ['storage', 'copy-destination'],
+                    initialData: visibilityInitialData,
+                    recovery: 'cpu-shadow'
+                })
+            ]);
+        }
         this.#visibleBucketCursors = create({
             label: 'GPU Scene visible bucket compact cursors',
             byteLength: physicalCount * 4,
             usage: ['storage'],
             recovery: 'reinitialize'
+        });
+        this.#visibleBucketOffsets = create({
+            label: 'GPU Scene aligned visible bucket offsets',
+            byteLength: physicalCount * BUCKET_OFFSET_STRIDE_BYTES,
+            usage: ['storage'],
+            initialData: new Uint32Array(physicalCount * BUCKET_OFFSET_STRIDE_WORDS),
+            recovery: 'cpu-shadow'
         });
         const indirectData = new Uint32Array(physicalCount * 5);
         this.#physicalBuckets = Object.freeze(this.createPhysicalBuckets(context, indirectData));
@@ -2964,6 +3200,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         // Update canonical transforms without constructing a CPU render list. GPU Scene retains
         // visibility ownership; a CPU cull is built only when fallback meshes actually exist.
         context.prepareScene();
+        const temporalFrame = this.#temporal?.begin(context) ?? null;
         this.refreshGPUCompatibility();
         this.collectScene(context);
         let fallbackCulling: CullingResultsHandle | null = null;
@@ -2988,6 +3225,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             extent: { relativeTo: 'output', scale: 1 },
             sampleCount: 1
         });
+        const temporalMotion =
+            temporalFrame === null
+                ? null
+                : context.graph.createTexture(
+                      'Clustered Forward+ temporal motion and view depth',
+                      TEMPORAL_MOTION_DESCRIPTOR
+                  );
         const bloomEnabled = this.#options.bloomStrength > 0;
         const createBloomTexture = (label: string): RenderGraphTextureHandle | null =>
             bloomEnabled
@@ -3015,7 +3259,20 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const selectedPhysicalBuckets = context.graph.importStorageBuffer(
             this.#selectedPhysicalBuckets
         );
+        const visibilityHistory = this.#visibilityHistory;
+        const currentVisibilityBuffer = visibilityHistory?.[this.#visibilityHistoryIndex] ?? null;
+        const previousVisibilityBuffer =
+            visibilityHistory?.[this.#visibilityHistoryIndex === 0 ? 1 : 0] ?? null;
+        const currentVisibility =
+            currentVisibilityBuffer === null
+                ? null
+                : context.graph.importStorageBuffer(currentVisibilityBuffer);
+        const previousVisibility =
+            previousVisibilityBuffer === null
+                ? null
+                : context.graph.importStorageBuffer(previousVisibilityBuffer);
         const visibleBucketCursors = context.graph.importStorageBuffer(this.#visibleBucketCursors);
+        const visibleBucketOffsets = context.graph.importStorageBuffer(this.#visibleBucketOffsets);
         const indirect = context.graph.importStorageBuffer(this.#indirectArguments);
         const cullStats = context.graph.importStorageBuffer(this.#cullStats);
         const tileDepthBounds = context.graph.importStorageBuffer(this.#tileDepthBounds);
@@ -3033,6 +3290,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         // uses only a prefix of the configured maximum cluster capacity.
         clear.add(clusterCounts, 0, this.#clusterCounts.byteLength);
         clear.add(cullStats, 0, STATS_BYTES);
+        if (currentVisibility !== null && currentVisibilityBuffer !== null) {
+            clear.add(currentVisibility, 0, currentVisibilityBuffer.byteLength);
+        }
         for (let index = 0; index < this.#physicalBuckets.length; index += 1) {
             clear.add(indirect, index * INDIRECT_ARGUMENT_BYTES + 4, 4);
         }
@@ -3063,26 +3323,38 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         bucketPrefix.setBuffer(0, frameBuffer);
         bucketPrefix.setBuffer(1, indirect);
         bucketPrefix.setBuffer(2, visibleBucketCursors);
+        bucketPrefix.setBuffer(3, visibleBucketOffsets);
         bucketPrefix.setDispatch(1);
         context.graph.addPass(GPU_SCENE_BUCKET_PREFIX_PASS, bucketPrefix);
 
-        const compact = context.acquirePassParameters(this.#visibleCompactPool);
+        const compact = context.acquirePassParameters(
+            currentVisibility === null ? this.#visibleCompactPool : this.#temporalVisibleCompactPool
+        );
         compact.setBuffer(0, frameBuffer);
         compact.setBuffer(1, selectedPhysicalBuckets);
-        compact.setBuffer(2, indirect);
-        compact.setBuffer(3, visibleBucketCursors);
+        compact.setBuffer(2, visibleBucketCursors);
+        compact.setBuffer(3, visibleBucketOffsets);
         compact.setBuffer(4, visible);
+        if (currentVisibility !== null) compact.setBuffer(5, currentVisibility);
         compact.setDispatch(
             Math.max(1, Math.ceil(this.#activeObjectHighWater / CULL_WORKGROUP_SIZE))
         );
-        context.graph.addPass(GPU_SCENE_VISIBLE_COMPACT_PASS, compact);
+        context.graph.addPass(
+            currentVisibility === null
+                ? GPU_SCENE_VISIBLE_COMPACT_PASS
+                : GPU_SCENE_TEMPORAL_VISIBLE_COMPACT_PASS,
+            compact
+        );
 
         this.recordDepthPrepass(context, {
             frameBuffer,
             objects,
             visible,
+            visibleBucketOffsets,
             indirect,
-            sceneDepth
+            sceneDepth,
+            previousVisibility,
+            temporalMotion
         });
         this.recordCurrentHiZ(context, frameBuffer, sceneDepth, histories.current);
         this.recordClusterAllocation(context, {
@@ -3102,6 +3374,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             frameBuffer,
             objects,
             visible,
+            visibleBucketOffsets,
             materials,
             lights,
             clusterGrid,
@@ -3110,42 +3383,81 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             sceneColor,
             sceneDepth
         });
-        if (fallbackCulling !== null) {
-            this.recordFallback(context, fallbackCulling, sceneColor, sceneDepth);
+        if (fallbackCulling !== null && this.#fallbackHasOpaque) {
+            this.recordFallbackOpaque(context, fallbackCulling, sceneColor, sceneDepth);
         }
-        this.recordDisplay(context, sceneColor, bloomA, bloomB, bloomC, outputColor);
+        let resolvedSceneColor = sceneColor;
+        if (temporalFrame !== null && temporalMotion !== null) {
+            if (fallbackCulling !== null && this.#fallbackHasOpaque) {
+                this.recordFallbackMotion(context, fallbackCulling, temporalMotion, sceneDepth);
+            }
+            resolvedSceneColor =
+                this.#temporal?.resolve(context, temporalFrame, sceneColor, temporalMotion) ??
+                sceneColor;
+        }
+        if (fallbackCulling !== null && this.#fallbackHasTransparent) {
+            this.recordFallbackTransparent(
+                context,
+                fallbackCulling,
+                resolvedSceneColor,
+                sceneDepth
+            );
+        }
+        this.recordDisplay(context, resolvedSceneColor, bloomA, bloomB, bloomC, outputColor);
     }
 
     frameSubmitted(frameIndex: number): void {
         if (frameIndex !== this.#lastRecordedFrame) return;
+        const committedSubmission = this.#submissionIndex + 1;
         this.#materialDatabase.frameSubmitted(frameIndex);
+        for (const mesh of this.#pendingFallbackTemporalMeshes) {
+            this.#fallbackTemporalParticipation.set(mesh, committedSubmission);
+        }
+        this.#pendingFallbackTemporalMeshes.clear();
         for (const record of this.#objectByMesh.values()) {
-            if (record.pendingWorldVersion < 0) continue;
-            record.committedMatrix.set(record.pendingMatrix);
-            record.committedWorldVersion = record.pendingWorldVersion;
-            record.committedFrustumTest = record.pendingFrustumTest;
-            record.committedBoundsRevision = record.pendingBoundsRevision;
-            record.committedOcclusionStable = record.pendingOcclusionStable;
-            record.pendingWorldVersion = -1;
+            if (record.seenFrame !== this.#frameSerial || this.#forceFullFallback) continue;
+            if (record.pendingWorldVersion >= 0) {
+                record.committedMatrix.set(record.pendingMatrix);
+                record.committedWorldVersion = record.pendingWorldVersion;
+                record.committedFrustumTest = record.pendingFrustumTest;
+                record.committedBoundsRevision = record.pendingBoundsRevision;
+                record.committedOcclusionStable = record.pendingOcclusionStable;
+                record.committedMotionChanged = record.pendingMotionChanged;
+                record.committedMotionHistoryValid = record.pendingMotionHistoryValid;
+                record.pendingWorldVersion = -1;
+            }
+            record.committedHistoryRevision = record.pendingHistoryRevision;
+            record.committedSubmission = committedSubmission;
         }
         this.#committedCameraMatrix.set(this.#stagedCameraMatrix);
+        this.#committedRasterCameraMatrix.set(this.#stagedRasterCameraMatrix);
         this.#committedViewMatrix.set(this.#stagedViewMatrix);
         this.#committedProjectionMatrix.set(this.#stagedProjectionMatrix);
         this.#committedDepth.set(this.#stagedDepth);
         this.#committedCamera = this.#pendingCamera;
         this.#committedCameraRevision = this.#pendingCameraRevision;
+        this.#committedCameraSubmission = committedSubmission;
         this.#pendingCamera = null;
+        this.#submissionIndex = committedSubmission;
+        if (this.#visibilityHistory !== null) {
+            this.#visibilityHistoryIndex = this.#visibilityHistoryIndex === 0 ? 1 : 0;
+        }
+        this.#temporal?.frameSubmitted(frameIndex);
     }
 
     frameDiscarded(frameIndex: number): void {
         if (frameIndex !== this.#lastRecordedFrame) return;
         this.#materialDatabase.frameDiscarded(frameIndex);
+        this.#pendingFallbackTemporalMeshes.clear();
         for (const record of this.#objectByMesh.values()) {
             record.pendingWorldVersion = -1;
             record.pendingBoundsRevision = -1;
             record.pendingOcclusionStable = false;
+            record.pendingMotionChanged = false;
+            record.pendingMotionHistoryValid = false;
         }
         this.#pendingCamera = null;
+        this.#temporal?.frameDiscarded(frameIndex);
     }
 
     async readDiagnostics(): Promise<Readonly<ClusteredForwardPlusDiagnostics>> {
@@ -3186,7 +3498,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             this.#lights,
             this.#visibleIndices,
             this.#selectedPhysicalBuckets,
+            ...(this.#visibilityHistory ?? []),
             this.#visibleBucketCursors,
+            this.#visibleBucketOffsets,
             this.#indirectArguments,
             this.#cullStats,
             this.#tileDepthBounds,
@@ -3204,6 +3518,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             }
         }
         const failures: unknown[] = [];
+        try {
+            this.#temporal?.destroy();
+        } catch (error) {
+            failures.push(error);
+        }
         try {
             this.#materialDatabase.destroy();
         } catch (error) {
@@ -3346,7 +3665,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                     indexRevision: validated.index.revision,
                     depthPass: new GPUDrivenRenderPass({
                         name: `GPU Scene depth bucket ${String(physicalIndex)}`,
-                        shader: GPU_SCENE_DEPTH_SHADER,
+                        shader:
+                            this.#options.temporalAA === null
+                                ? GPU_SCENE_DEPTH_SHADER
+                                : GPU_SCENE_TEMPORAL_DEPTH_SHADER,
                         pipelineState: requireBucketPassState(logical.material, 'depth-only'),
                         vertexLayouts: GPU_SCENE_DEPTH_VERTEX_LAYOUTS,
                         indexFormat: validated.indexFormat
@@ -3466,6 +3788,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#directionalLightCount = 0;
         this.#droppedLightCount = 0;
         this.#forceFullFallback = false;
+        const temporalEnabled = this.#temporal !== null;
 
         context.scene.traverse(node => {
             if (!node.visible) return Node.TRAVERSE_STOP_CHILDREN;
@@ -3496,6 +3819,15 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                                 committedBoundsRevision: -1,
                                 pendingOcclusionStable: false,
                                 committedOcclusionStable: false,
+                                pendingMotionChanged: false,
+                                committedMotionChanged: false,
+                                pendingMotionHistoryValid: false,
+                                committedMotionHistoryValid: false,
+                                pendingHistoryRevision: temporalEnabled
+                                    ? getTransformHistoryRevision(node)
+                                    : -1,
+                                committedHistoryRevision: -1,
+                                committedSubmission: -1,
                                 committedMatrix: initial.slice(),
                                 pendingMatrix: initial
                             };
@@ -3516,6 +3848,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                         const transformStable =
                             record.committedWorldVersion === node.worldMatrixVersion &&
                             !arraysDiffer(record.committedMatrix, node.worldMatrix.elements);
+                        const motionChanged = temporalEnabled && !transformStable;
+                        const historyRevision = temporalEnabled
+                            ? getTransformHistoryRevision(node)
+                            : record.committedHistoryRevision;
+                        const motionHistoryValid =
+                            temporalEnabled &&
+                            record.committedSubmission === this.#submissionIndex &&
+                            record.committedHistoryRevision === historyRevision;
                         const boundsStable = record.committedBoundsRevision === bounds.revision;
                         const occlusionStable = transformStable && boundsStable;
                         const dirty =
@@ -3523,10 +3863,20 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                             record.committedWorldVersion !== node.worldMatrixVersion ||
                             record.committedFrustumTest !== node.frustumTest ||
                             !boundsStable ||
-                            record.committedOcclusionStable !== occlusionStable;
+                            record.committedOcclusionStable !== occlusionStable ||
+                            record.committedMotionChanged !== motionChanged ||
+                            record.committedMotionHistoryValid !== motionHistoryValid;
                         record.logicalBucket = logicalIndex;
+                        record.pendingHistoryRevision = historyRevision;
                         if (dirty) {
-                            this.packObject(record, node, logicalIndex, occlusionStable);
+                            this.packObject(
+                                record,
+                                node,
+                                logicalIndex,
+                                occlusionStable,
+                                motionHistoryValid,
+                                motionChanged
+                            );
                             dirtyStart = Math.min(dirtyStart, record.slot);
                             dirtyEnd = Math.max(dirtyEnd, record.slot + 1);
                         }
@@ -3623,6 +3973,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     private trackFallbackMesh(mesh: Mesh): void {
         const material = mesh.material;
         if (material === null) return;
+        if (this.#temporal !== null && !this.#pendingFallbackTemporalMeshes.has(mesh)) {
+            const previousSubmission = this.#fallbackTemporalParticipation.get(mesh);
+            if (previousSubmission !== undefined && previousSubmission !== this.#submissionIndex) {
+                mesh.invalidateTransformHistory();
+            }
+            this.#pendingFallbackTemporalMeshes.add(mesh);
+        }
         this.#fallbackObjectCount++;
         if (material.forwardQueue === 'transparent') this.#fallbackHasTransparent = true;
         else this.#fallbackHasOpaque = true;
@@ -3713,7 +4070,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         record: GPUSceneObjectRecord,
         mesh: Mesh,
         logicalIndex: number,
-        occlusionStable: boolean
+        occlusionStable: boolean,
+        motionHistoryValid: boolean,
+        motionChanged: boolean
     ): void {
         const bucket = this.#options.buckets[logicalIndex];
         if (bucket === undefined) throw new Error('GPU Scene logical bucket is unavailable');
@@ -3721,8 +4080,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         if (sphere === undefined) throw new Error('GPU Scene logical bounds are unavailable');
         const floatOffset = record.slot * (OBJECT_RECORD_BYTES / 4);
         matrixElements(mesh.worldMatrix, this.#objectFloats, floatOffset);
-        const hasCommitted = record.committedWorldVersion >= 0;
-        const previous = hasCommitted ? record.committedMatrix : mesh.worldMatrix.elements;
+        const previous = motionHistoryValid ? record.committedMatrix : mesh.worldMatrix.elements;
         for (let index = 0; index < 16; index += 1) {
             this.#objectFloats[floatOffset + 16 + index] = previous[index] ?? 0;
         }
@@ -3755,7 +4113,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#objectUInts[floatOffset + 50] =
             OBJECT_ACTIVE_FLAG |
             (mesh.frustumTest ? OBJECT_FRUSTUM_CULLING_FLAG : 0) |
-            (occlusionStable ? OBJECT_HIZ_STABLE_FLAG : 0);
+            (occlusionStable ? OBJECT_HIZ_STABLE_FLAG : 0) |
+            (motionHistoryValid ? OBJECT_MOTION_HISTORY_FLAG : 0) |
+            (motionChanged ? OBJECT_MOTION_CHANGED_FLAG : 0);
         this.#objectUInts[floatOffset + 51] = this.#materialDatabase.getHandle(
             bucket.material
         ).recordIndex;
@@ -3764,6 +4124,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         record.pendingFrustumTest = mesh.frustumTest;
         record.pendingBoundsRevision = sphere.revision;
         record.pendingOcclusionStable = occlusionStable;
+        record.pendingMotionHistoryValid = motionHistoryValid;
+        record.pendingMotionChanged = motionChanged;
     }
 
     private packLight(
@@ -3921,13 +4283,15 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const tilesX = Math.ceil(context.output.width / this.#options.tileSize);
         const tilesY = Math.ceil(context.output.height / this.#options.tileSize);
         const clusterCount = tilesX * tilesY * this.#options.zSlices;
-        matrixElements(camera.viewProjectionMatrix, this.#frameFloats, 0);
+        matrixElements(camera.jitteredViewProjectionMatrix, this.#frameFloats, 0);
         const cameraRevision = getTransformHistoryRevision(camera);
         const cameraHistoryValid =
-            this.#committedCamera === camera && this.#committedCameraRevision === cameraRevision;
+            this.#committedCamera === camera &&
+            this.#committedCameraRevision === cameraRevision &&
+            this.#committedCameraSubmission === this.#submissionIndex;
         const previousViewProjection = cameraHistoryValid
-            ? this.#committedCameraMatrix
-            : camera.viewProjectionMatrix.elements;
+            ? this.#committedRasterCameraMatrix
+            : camera.jitteredViewProjectionMatrix.elements;
         const previousView = cameraHistoryValid
             ? this.#committedViewMatrix
             : camera.viewMatrix.elements;
@@ -3951,7 +4315,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#frameFloats[103] = camera.depthMode === 'reversed' ? 1 : 0;
         const cameraOcclusionStable =
             cameraHistoryValid &&
-            !arrayRangeDiffers(this.#committedCameraMatrix, this.#frameFloats, 0) &&
+            !arraysDiffer(this.#committedViewMatrix, camera.viewMatrix.elements) &&
+            !arraysDiffer(this.#committedProjectionMatrix, camera.projectionMatrix.elements) &&
             !arrayRangeDiffers(this.#committedDepth, this.#frameFloats, 100);
         const previousDepth = cameraHistoryValid ? this.#committedDepth : this.#frameFloats;
         const previousDepthOffset = cameraHistoryValid ? 0 : 100;
@@ -3973,13 +4338,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#frameUInts[119] = camera.visibility >>> 0;
         this.#frameUInts[120] = this.#directionalLightCount;
         this.#frameUInts[121] = this.#localLightCount;
-        this.#frameUInts[122] = 0;
+        this.#frameUInts[122] = cameraHistoryValid ? 1 : 0;
         this.#frameUInts[123] = 0;
         this.#frameFloats[124] = Math.min(this.#frameFloats[124] ?? 0, 4);
         this.#frameFloats[125] = Math.min(this.#frameFloats[125] ?? 0, 4);
         this.#frameFloats[126] = Math.min(this.#frameFloats[126] ?? 0, 4);
         this.#frameFloats[127] = 0;
         matrixElements(camera.viewProjectionMatrix, this.#stagedCameraMatrix, 0);
+        matrixElements(camera.jitteredViewProjectionMatrix, this.#stagedRasterCameraMatrix, 0);
         matrixElements(camera.viewMatrix, this.#stagedViewMatrix, 0);
         matrixElements(camera.projectionMatrix, this.#stagedProjectionMatrix, 0);
         this.#pendingCamera = camera;
@@ -4039,8 +4405,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             frameBuffer: RenderGraphBufferHandle;
             objects: RenderGraphBufferHandle;
             visible: RenderGraphBufferHandle;
+            visibleBucketOffsets: RenderGraphBufferHandle;
             indirect: RenderGraphBufferHandle;
             sceneDepth: RenderGraphTextureHandle;
+            previousVisibility: RenderGraphBufferHandle | null;
+            temporalMotion: RenderGraphTextureHandle | null;
         }>
     ): void {
         const batch = context.acquirePassParameters(this.#depthBatchPool);
@@ -4051,18 +4420,42 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             depthClearValue: depthClearValue(context.camera.depthMode)
         };
         batch.depthStencilAttachment = depthAttachment;
+        const motionAttachment: RenderPipelineColorAttachment | null =
+            resources.temporalMotion === null
+                ? null
+                : {
+                      texture: resources.temporalMotion,
+                      loadOp: 'clear',
+                      storeOp: 'store',
+                      clearValue: TEMPORAL_MOTION_CLEAR
+                  };
+        if (motionAttachment !== null) batch.colorAttachments[0] = motionAttachment;
         for (let index = 0; index < this.#physicalBuckets.length; index += 1) {
             const bucket = this.#physicalBuckets[index];
             if (bucket === undefined) continue;
             const parameters = context.acquirePassParameters(this.#depthDrawPool);
+            parameters.configureStorageBufferCount(resources.temporalMotion === null ? 4 : 5);
             parameters.setBuffer(0, resources.frameBuffer);
             parameters.setBuffer(1, resources.objects);
             parameters.setBuffer(2, resources.visible);
+            parameters.setBufferRange(
+                3,
+                resources.visibleBucketOffsets,
+                index * BUCKET_OFFSET_STRIDE_BYTES,
+                4
+            );
+            if (resources.temporalMotion !== null) {
+                if (resources.previousVisibility === null) {
+                    throw new Error('GPU Scene temporal visibility history is unavailable');
+                }
+                parameters.setBuffer(4, resources.previousVisibility);
+            }
             parameters.setVertexBuffer(0, context.graph.importStorageBuffer(bucket.position));
             parameters.indexBuffer.buffer = context.graph.importStorageBuffer(bucket.index);
             parameters.draw.buffer = resources.indirect;
             parameters.draw.byteOffset = index * INDIRECT_ARGUMENT_BYTES;
-            parameters.colorAttachments.length = 0;
+            parameters.colorAttachments.length = motionAttachment === null ? 0 : 1;
+            if (motionAttachment !== null) parameters.colorAttachments[0] = motionAttachment;
             parameters.depthStencilAttachment = depthAttachment;
             batch.add(bucket.depthPass, parameters);
         }
@@ -4178,6 +4571,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             frameBuffer: RenderGraphBufferHandle;
             objects: RenderGraphBufferHandle;
             visible: RenderGraphBufferHandle;
+            visibleBucketOffsets: RenderGraphBufferHandle;
             materials: RenderGraphBufferHandle;
             lights: RenderGraphBufferHandle;
             clusterGrid: RenderGraphBufferHandle;
@@ -4221,6 +4615,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.setBuffer(4, resources.lights);
             parameters.setBuffer(5, resources.clusterGrid);
             parameters.setBuffer(6, resources.clusterIndices);
+            parameters.setBufferRange(
+                7,
+                resources.visibleBucketOffsets,
+                index * BUCKET_OFFSET_STRIDE_BYTES,
+                4
+            );
             parameters.setVertexBuffer(0, context.graph.importStorageBuffer(bucket.position));
             parameters.setVertexBuffer(1, context.graph.importStorageBuffer(bucket.normal));
             let vertexSlot = 2;
@@ -4329,23 +4729,28 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         context.graph.addPass(this.#displayPass, display);
     }
 
-    private recordFallback(
+    private recordFallbackOpaque(
         context: RenderPipelineContext,
         cullingResults: CullingResultsHandle,
         outputColor: RenderGraphTextureHandle,
         sceneDepth: RenderGraphTextureHandle
     ): void {
-        if (this.#fallbackHasOpaque) {
-            this.recordFallbackList(
-                context,
-                cullingResults,
-                this.#fallbackOpaqueListDescriptor,
-                outputColor,
-                sceneDepth,
-                null
-            );
-        }
-        if (!this.#fallbackHasTransparent) return;
+        this.recordFallbackList(
+            context,
+            cullingResults,
+            this.#fallbackOpaqueListDescriptor,
+            outputColor,
+            sceneDepth,
+            null
+        );
+    }
+
+    private recordFallbackTransparent(
+        context: RenderPipelineContext,
+        cullingResults: CullingResultsHandle,
+        outputColor: RenderGraphTextureHandle,
+        sceneDepth: RenderGraphTextureHandle
+    ): void {
         const opaqueTexture = context.graph.createTexture('Forward fallback opaque scene color', {
             format: 'rgba16float',
             extent: { relativeTo: 'output', scale: 1 },
@@ -4363,6 +4768,28 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             sceneDepth,
             opaqueTexture
         );
+    }
+
+    private recordFallbackMotion(
+        context: RenderPipelineContext,
+        cullingResults: CullingResultsHandle,
+        temporalMotion: RenderGraphTextureHandle,
+        sceneDepth: RenderGraphTextureHandle
+    ): void {
+        this.#fallbackMotionListDescriptor.cullingResults = cullingResults;
+        const rendererList = context.createRendererList(this.#fallbackMotionListDescriptor);
+        const parameters = context.acquirePassParameters(this.#fallbackPool);
+        parameters.rendererList = rendererList;
+        const color = parameters.colorAttachments[0];
+        if (color === undefined) {
+            throw new Error('Forward fallback motion attachment is unavailable');
+        }
+        color.texture = temporalMotion;
+        parameters.depthStencilAttachment = {
+            texture: sceneDepth,
+            depthReadOnly: true
+        };
+        context.graph.addPass(this.#fallbackMotionPass, parameters);
     }
 
     private recordFallbackList(
@@ -4419,7 +4846,7 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
         );
         const requirements = bufferRequirementPlan(this.#options, physicalCount);
         const hiZ = this.#options.hiZ;
-        this.requirements = Object.freeze({
+        this.requirements = snapshotRenderPipelineRequirements({
             requiredCapabilities: Object.freeze([
                 'storage-buffer' as const,
                 ...(hiZ ? (['storage-texture' as const] as const) : []),
@@ -4448,14 +4875,17 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                 Object.freeze({
                     format: 'rgba16float' as const,
                     use: 'filterable-sampled' as const
-                })
+                }),
+                ...(this.#options.temporalAA === null
+                    ? []
+                    : TEMPORAL_AA_REQUIREMENTS.requiredTextureFormats)
             ]),
             requiredLimits: Object.freeze({
                 maxBindingsPerBindGroup: Math.max(
                     hiZ ? 6 + this.#options.hiZLevelCount : 6,
                     PBR_TEXTURE_ROLES.length * 2
                 ),
-                maxStorageBuffersPerShaderStage: 7,
+                maxStorageBuffersPerShaderStage: 8,
                 maxSampledTexturesPerShaderStage: Math.max(
                     hiZ ? this.#options.hiZLevelCount : 0,
                     PBR_TEXTURE_ROLES.length
@@ -4465,7 +4895,8 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                 maxStorageBufferBindingSize: requirements.maxStorageBufferBindingSize,
                 maxBufferSize: requirements.maxBufferSize,
                 maxComputeInvocationsPerWorkgroup: PREFIX_WORKGROUP_SIZE,
-                maxComputeWorkgroupsPerDimension: requirements.maxComputeWorkgroupsPerDimension
+                maxComputeWorkgroupsPerDimension: requirements.maxComputeWorkgroupsPerDimension,
+                ...(this.#options.temporalAA === null ? {} : { maxColorAttachments: 3 })
             })
         });
     }

--- a/src/render/pipeline/RenderPipeline.ts
+++ b/src/render/pipeline/RenderPipeline.ts
@@ -202,6 +202,8 @@ export interface RenderPipelineContext {
     /** Backend-neutral graph facade for this invocation. */
     readonly graph: ScriptableRenderGraph;
 
+    /** Update scene world matrices and the active camera without building a CPU render list. */
+    prepareScene(): void;
     /** Collect camera-visible scene meshes and lights into a frame-scoped handle. */
     cull(options?: Readonly<CullingOptions>): CullingResultsHandle;
     /** Select and sort a reusable draw list from current-frame culling results. */

--- a/src/render/postprocessing/TemporalAA.ts
+++ b/src/render/postprocessing/TemporalAA.ts
@@ -9,6 +9,7 @@ import type {
     ForwardRenderPipelineFeature,
     ForwardRenderPipelineFeatureRuntime
 } from '../pipeline/ForwardRenderPipeline';
+import type { RenderPipelineContext, RenderPipelineRequirements } from '../pipeline/RenderPipeline';
 import { RenderPassParameterPool } from '../pipeline/RenderPassParameterPool';
 import type { CullingResultsHandle } from '../pipeline/RendererList';
 import {
@@ -31,22 +32,24 @@ import { registerUniformBlockBinding } from '../ubo/UniformBlockBindings';
 const TEMPORAL_AA_BLOCK = `layout(std140) uniform TemporalAABlock {
     float u_historyWeight;
     float u_depthThreshold;
-    vec2 u_temporalPadding;
+    float u_varianceGamma;
+    float u_sharpness;
 };`;
 
 const INITIALIZE_FRAGMENT = `#version 300 es
 precision highp float;
 in vec2 v_uv;
 uniform sampler2D u_scene;
-uniform sampler2D u_depth;
+uniform sampler2D u_velocity;
 layout(location = 0) out vec4 historyColor;
 layout(location = 1) out vec4 resolvedColor;
 layout(location = 2) out float historyDepth;
 void main() {
     vec4 current = texture(u_scene, v_uv);
+    vec4 motion = texture(u_velocity, v_uv);
     historyColor = current;
     resolvedColor = current;
-    historyDepth = texture(u_depth, v_uv).r;
+    historyDepth = motion.w;
 }`;
 
 const RESOLVE_FRAGMENT = `#version 300 es
@@ -55,42 +58,107 @@ in vec2 v_uv;
 uniform sampler2D u_scene;
 uniform sampler2D u_history;
 uniform sampler2D u_velocity;
-uniform sampler2D u_depth;
 uniform sampler2D u_historyDepth;
 ${TEMPORAL_AA_BLOCK}
 layout(location = 0) out vec4 historyColor;
 layout(location = 1) out vec4 resolvedColor;
 layout(location = 2) out float historyDepth;
 
-void main() {
-    vec4 current = texture(u_scene, v_uv);
-    float currentDepth = texture(u_depth, v_uv).r;
-    vec2 velocity = texture(u_velocity, v_uv).xy;
-    vec2 historyUV = v_uv - velocity;
-    bool inside = all(greaterThanEqual(historyUV, vec2(0.0))) &&
-        all(lessThanEqual(historyUV, vec2(1.0)));
+vec3 rgbToYCoCg(vec3 value) {
+    return vec3(
+        dot(value, vec3(0.25, 0.5, 0.25)),
+        dot(value, vec3(0.5, 0.0, -0.5)),
+        dot(value, vec3(-0.25, 0.5, -0.25))
+    );
+}
 
-    vec2 texel = 1.0 / vec2(textureSize(u_scene, 0));
-    vec3 neighborhoodMin = current.rgb;
-    vec3 neighborhoodMax = current.rgb;
+vec3 yCoCgToRgb(vec3 value) {
+    return vec3(value.x + value.y - value.z, value.x + value.z, value.x - value.y - value.z);
+}
+
+float relativeDepthError(float historyLogDepth, float expectedLogDepth) {
+    float historyLinear = exp2(max(historyLogDepth, 0.0)) - 1.0;
+    float expectedLinear = exp2(max(expectedLogDepth, 0.0)) - 1.0;
+    return abs(historyLinear - expectedLinear) / max(expectedLinear, 1e-3);
+}
+
+float minimumHistoryDepthError(vec2 historyUV, float expectedLogDepth) {
+    ivec2 dimensions = textureSize(u_historyDepth, 0);
+    vec2 samplePosition = historyUV * vec2(dimensions) - 0.5;
+    ivec2 base = ivec2(floor(samplePosition));
+    float error = 1e20;
+    for (int y = 0; y <= 1; y++) {
+        for (int x = 0; x <= 1; x++) {
+            ivec2 coordinate = clamp(base + ivec2(x, y), ivec2(0), dimensions - ivec2(1));
+            error = min(
+                error,
+                relativeDepthError(texelFetch(u_historyDepth, coordinate, 0).r, expectedLogDepth)
+            );
+        }
+    }
+    return error;
+}
+
+void main() {
+    ivec2 dimensions = textureSize(u_scene, 0);
+    ivec2 pixel = clamp(ivec2(v_uv * vec2(dimensions)), ivec2(0), dimensions - ivec2(1));
+    vec4 current = texelFetch(u_scene, pixel, 0);
+    vec4 motion = texelFetch(u_velocity, pixel, 0);
+    vec2 historyUV = v_uv - motion.xy;
+    vec2 halfTexel = 0.5 / vec2(dimensions);
+    bool inside = all(greaterThanEqual(historyUV, halfTexel)) &&
+        all(lessThanEqual(historyUV, vec2(1.0) - halfTexel));
+
+    vec3 currentWorking = rgbToYCoCg(current.rgb);
+    vec3 neighborhoodMin = currentWorking;
+    vec3 neighborhoodMax = currentWorking;
+    vec3 moment1 = currentWorking;
+    vec3 moment2 = currentWorking * currentWorking;
+    vec3 crossSum = vec3(0.0);
     for (int y = -1; y <= 1; y++) {
         for (int x = -1; x <= 1; x++) {
-            vec3 sampleColor = texture(u_scene, v_uv + vec2(float(x), float(y)) * texel).rgb;
-            neighborhoodMin = min(neighborhoodMin, sampleColor);
-            neighborhoodMax = max(neighborhoodMax, sampleColor);
+            if (x == 0 && y == 0) continue;
+            ivec2 coordinate = clamp(pixel + ivec2(x, y), ivec2(0), dimensions - ivec2(1));
+            vec3 sampleWorking = rgbToYCoCg(texelFetch(u_scene, coordinate, 0).rgb);
+            neighborhoodMin = min(neighborhoodMin, sampleWorking);
+            neighborhoodMax = max(neighborhoodMax, sampleWorking);
+            moment1 += sampleWorking;
+            moment2 += sampleWorking * sampleWorking;
+            if (abs(x) + abs(y) == 1) crossSum += sampleWorking;
         }
     }
 
-    vec4 previous = inside ? texture(u_history, historyUV) : current;
-    float previousDepth = inside ? texture(u_historyDepth, historyUV).r : currentDepth;
-    float depthLimit = u_depthThreshold * max(1.0, abs(currentDepth));
-    float accepted = inside && abs(previousDepth - currentDepth) <= depthLimit ? 1.0 : 0.0;
-    vec3 clampedHistory = clamp(previous.rgb, neighborhoodMin, neighborhoodMax);
-    vec3 resolved = mix(current.rgb, clampedHistory, u_historyWeight * accepted);
-    vec4 result = vec4(resolved, current.a);
-    historyColor = result;
-    resolvedColor = result;
-    historyDepth = currentDepth;
+    vec3 mean = moment1 / 9.0;
+    vec3 deviation = sqrt(max(moment2 / 9.0 - mean * mean, vec3(0.0)));
+    vec3 clipMin = max(neighborhoodMin, mean - deviation * u_varianceGamma);
+    vec3 clipMax = min(neighborhoodMax, mean + deviation * u_varianceGamma);
+    vec2 sampledHistoryUV = clamp(historyUV, halfTexel, vec2(1.0) - halfTexel);
+    vec4 sampledPrevious = textureLod(u_history, sampledHistoryUV, 0.0);
+    vec4 previous = inside ? sampledPrevious : current;
+    vec3 previousWorking = clamp(rgbToYCoCg(previous.rgb), clipMin, clipMax);
+
+    bool velocityValid = motion.z >= 0.0;
+    float depthError = velocityValid && inside
+        ? minimumHistoryDepthError(historyUV, motion.z)
+        : 1e20;
+    float accepted = velocityValid && inside && depthError <= u_depthThreshold ? 1.0 : 0.0;
+    float velocityPixels = length(motion.xy * vec2(dimensions));
+    float motionResponse = clamp(velocityPixels / 32.0, 0.0, 1.0);
+    float temporalWeight = mix(u_historyWeight, min(u_historyWeight, 0.6), motionResponse);
+    float luminanceDelta = abs(previousWorking.x - currentWorking.x) /
+        max(max(abs(previousWorking.x), abs(currentWorking.x)), 0.1);
+    float reactive = clamp(luminanceDelta * 1.5, 0.0, 1.0);
+    temporalWeight *= 1.0 - reactive * 0.8;
+
+    vec3 resolvedWorking = mix(currentWorking, previousWorking, temporalWeight * accepted);
+    vec3 resolved = max(yCoCgToRgb(resolvedWorking), vec3(0.0));
+    vec3 crossAverage = crossSum * 0.25;
+    vec3 sharpenedWorking = resolvedWorking +
+        (resolvedWorking - crossAverage) * u_sharpness;
+    vec3 sharpened = max(yCoCgToRgb(sharpenedWorking), vec3(0.0));
+    historyColor = vec4(resolved, current.a);
+    resolvedColor = vec4(sharpened, current.a);
+    historyDepth = motion.w;
 }`;
 
 registerUniformBlockBinding('TemporalAABlock');
@@ -98,12 +166,14 @@ registerUniformBlockBinding('TemporalAABlock');
 const temporalAALayout = createStd140Layout({
     u_historyWeight: 'float',
     u_depthThreshold: 'float',
-    u_temporalPadding: 'vec2'
+    u_varianceGamma: 'float',
+    u_sharpness: 'float'
 });
 
 const OUTPUT_EXTENT = Object.freeze({ relativeTo: 'output' as const, scale: 1 });
-const VELOCITY_DESCRIPTOR = Object.freeze({
-    format: 'rg16float' as const,
+/** @internal Motion XY, expected previous log2 view depth, and current log2 view depth. */
+export const TEMPORAL_MOTION_DESCRIPTOR = Object.freeze({
+    format: 'rgba16float' as const,
     extent: OUTPUT_EXTENT
 });
 const RESOLVED_DESCRIPTOR = Object.freeze({
@@ -118,13 +188,17 @@ const COLOR_HISTORY_DESCRIPTOR = Object.freeze({
     bufferCount: 2 as const
 });
 const DEPTH_HISTORY_DESCRIPTOR = Object.freeze({
-    label: 'TemporalAA depth history',
-    format: 'r16float' as const,
+    label: 'TemporalAA linear-depth history',
+    format: 'r32float' as const,
     extent: OUTPUT_EXTENT,
     usage: Object.freeze(['sampled' as const, 'attachment' as const]),
     bufferCount: 2 as const
 });
 const CLEAR_ZERO = Object.freeze({ r: 0, g: 0, b: 0, a: 0 });
+/** @internal Clear value that marks pixels without a valid previous surface. */
+export const TEMPORAL_MOTION_CLEAR = Object.freeze({ r: 0, g: 0, b: -1, a: 0 });
+const CAMERA_HISTORY_RETENTION_FRAMES = 2;
+const PROJECTION_CUT_THRESHOLD = 0.1;
 
 const JITTER_SEQUENCE: readonly Readonly<{ x: number; y: number }>[] = Object.freeze([
     Object.freeze({ x: 0, y: -1 / 6 }),
@@ -141,11 +215,23 @@ interface CameraTemporalState {
     readonly camera: Camera;
     readonly colorHistoryKey: object;
     readonly depthHistoryKey: object;
+    readonly committedProjection: Float32Array;
+    readonly pendingProjection: Float32Array;
     committedTransformRevision: number;
     committedJitterIndex: number;
+    committedSubmission: number;
     pendingTransformRevision: number;
     pendingJitterIndex: number;
     pendingFrame: number;
+    lastTouchedFrame: number;
+}
+
+/** @internal Resources staged for one temporal resolve invocation. */
+export interface TemporalResolveFrame {
+    readonly state: CameraTemporalState;
+    readonly historyValid: boolean;
+    readonly colorHistory: RenderPipelineHistoryTextureResources;
+    readonly depthHistory: RenderPipelineHistoryTextureResources;
 }
 
 interface MutableVelocityColorAttachment extends RenderPipelineColorAttachment {
@@ -164,7 +250,7 @@ class VelocityPassParameters implements SceneRenderPassParameters {
             texture: 0 as RenderGraphTextureHandle,
             loadOp: 'clear',
             storeOp: 'store',
-            clearValue: CLEAR_ZERO
+            clearValue: TEMPORAL_MOTION_CLEAR
         }
     ];
     readonly depthStencilAttachment: MutableVelocityDepthAttachment = {
@@ -250,15 +336,22 @@ class TemporalResolveParameters implements FullscreenRenderPassParameters {
 
 /** Native-resolution temporal resolve controls. */
 export interface TemporalAAOptions {
-    /** Accepted history contribution after rejection and clamping. Defaults to 0.9. */
+    /** Maximum accepted history contribution after rejection. Defaults to 0.92. */
     readonly historyWeight?: number;
-    /** Raw depth difference that rejects reprojected history. Defaults to 0.002. */
+    /** Maximum relative previous-view-depth error. Defaults to 0.02. */
     readonly depthThreshold?: number;
+    /** Standard-deviation extent used by YCoCg variance clipping. Defaults to 1.25. */
+    readonly varianceGamma?: number;
+    /** Resolve-only contrast restoration; history remains unsharpened. Defaults to 0.08. */
+    readonly sharpness?: number;
 }
 
-interface TemporalAASettings {
+/** @internal Immutable temporal settings shared by Forward and GPU Scene pipelines. */
+export interface TemporalAASettings {
     readonly historyWeight: number;
     readonly depthThreshold: number;
+    readonly varianceGamma: number;
+    readonly sharpness: number;
 }
 
 function finiteRange(value: number, minimum: number, maximum: number, label: string): number {
@@ -270,51 +363,80 @@ function finiteRange(value: number, minimum: number, maximum: number, label: str
     return value;
 }
 
-function snapshotOptions(options: Readonly<TemporalAAOptions>): TemporalAASettings {
+/** @internal Validate and freeze public temporal options. */
+export function snapshotTemporalAAOptions(
+    options: Readonly<TemporalAAOptions>
+): TemporalAASettings {
     return Object.freeze({
-        historyWeight: finiteRange(options.historyWeight ?? 0.9, 0, 1, 'TemporalAA historyWeight'),
+        historyWeight: finiteRange(options.historyWeight ?? 0.92, 0, 1, 'TemporalAA historyWeight'),
         depthThreshold: finiteRange(
-            options.depthThreshold ?? 0.002,
+            options.depthThreshold ?? 0.02,
             0,
             1,
             'TemporalAA depthThreshold'
-        )
+        ),
+        varianceGamma: finiteRange(
+            options.varianceGamma ?? 1.25,
+            0.25,
+            4,
+            'TemporalAA varianceGamma'
+        ),
+        sharpness: finiteRange(options.sharpness ?? 0.08, 0, 0.5, 'TemporalAA sharpness')
     });
 }
 
-class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
+/** Static requirements shared by every pipeline that uses the built-in temporal resolve. */
+export const TEMPORAL_AA_REQUIREMENTS = Object.freeze({
+    requiredLimits: Object.freeze({ maxColorAttachments: 3 }),
+    requiredTextureFormats: Object.freeze([
+        Object.freeze({ format: 'rgba16float' as const, use: 'color-attachment' as const }),
+        Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const }),
+        Object.freeze({ format: 'r32float' as const, use: 'color-attachment' as const }),
+        Object.freeze({ format: 'r32float' as const, use: 'sampled' as const })
+    ])
+}) satisfies Readonly<RenderPipelineRequirements>;
+
+function projectionCut(previous: ArrayLike<number>, current: ArrayLike<number>): boolean {
+    // Any depth mapping change invalidates linear-depth history. XY scale/offset changes are
+    // reprojectable until they cross a deliberate cut threshold.
+    for (const index of [10, 11, 14, 15]) {
+        if (Math.abs((previous[index] ?? 0) - (current[index] ?? 0)) > 1e-6) return true;
+    }
+    for (const index of [0, 4, 5, 8, 9, 12, 13]) {
+        const before = previous[index] ?? 0;
+        const after = current[index] ?? 0;
+        const scale = Math.max(Math.abs(before), Math.abs(after), 1e-6);
+        if (Math.abs(before - after) / scale > PROJECTION_CUT_THRESHOLD) return true;
+    }
+    return false;
+}
+
+/**
+ * @internal Submission-aware temporal history and resolve controller shared by rendering paths.
+ */
+export class TemporalResolveController {
     readonly #block: UniformBuffer<typeof temporalAALayout.schema>;
-    readonly #velocityPass = new SceneRenderPass('TemporalAA motion vectors');
     readonly #initializePass: FullscreenRenderPass;
     readonly #resolvePass: FullscreenRenderPass;
-    readonly #velocityParameters = new RenderPassParameterPool(() => new VelocityPassParameters());
     readonly #resolveParameters = new RenderPassParameterPool(
         () => new TemporalResolveParameters(),
         parameters => {
             parameters.reset();
         }
     );
-    readonly #rendererListDescriptor: {
-        cullingResults: CullingResultsHandle;
-        readonly queue: 'opaque';
-        readonly sorting: 'material-front-to-back';
-        readonly materialPass: 'motion-vector';
-    } = {
-        cullingResults: 0 as CullingResultsHandle,
-        queue: 'opaque',
-        sorting: 'material-front-to-back',
-        materialPass: 'motion-vector'
-    };
     readonly #states = new WeakMap<Camera, CameraTemporalState>();
     readonly #ownedStates = new Set<CameraTemporalState>();
     readonly #stagedStates: CameraTemporalState[] = [];
+    readonly #pendingEvictions: CameraTemporalState[] = [];
     #destroyed = false;
+    #submissionIndex = 0;
 
     constructor(settings: TemporalAASettings) {
         this.#block = UniformBuffer.fromSchema(temporalAALayout, {
             u_historyWeight: settings.historyWeight,
             u_depthThreshold: settings.depthThreshold,
-            u_temporalPadding: [0, 0]
+            u_varianceGamma: settings.varianceGamma,
+            u_sharpness: settings.sharpness
         });
         const pass = (name: string, fs: string, uniformBuffers: readonly UniformBuffer[]) =>
             new FullscreenRenderPass({
@@ -329,88 +451,97 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
                 uniformBuffers
             });
         this.#initializePass = pass('TemporalAA initialize history', INITIALIZE_FRAGMENT, []);
-        this.#resolvePass = pass('TemporalAA resolve', RESOLVE_FRAGMENT, [this.#block]);
+        this.#resolvePass = pass('TemporalAA production resolve', RESOLVE_FRAGMENT, [this.#block]);
     }
 
-    record(context: ForwardRenderFeatureContext): void {
-        if (this.#destroyed) throw new Error('TemporalAA runtime is destroyed');
-        const pipeline = context.pipeline;
-        const scene = context.resources.color;
-        const depth = context.resources.depth;
-        if (scene === null || depth === null) {
-            throw new Error('TemporalAA requires opaque scene color and sampled depth');
-        }
-        const [x, y, width, height] = pipeline.viewport;
+    begin(context: RenderPipelineContext): TemporalResolveFrame {
+        if (this.#destroyed) throw new Error('TemporalAA resolve controller is destroyed');
+        const [x, y, width, height] = context.viewport;
         if (
             x !== 0 ||
             y !== 0 ||
-            width !== pipeline.output.width ||
-            height !== pipeline.output.height
+            width !== context.output.width ||
+            height !== context.output.height
         ) {
             throw new Error('TemporalAA currently requires a full-output viewport');
         }
-        const state = this.stageCamera(pipeline.camera, pipeline.frameIndex, width, height);
-        const transformRevision = getTransformHistoryRevision(pipeline.camera);
-        if (
-            state.committedTransformRevision >= 0 &&
-            state.committedTransformRevision !== transformRevision
-        ) {
-            pipeline.graph.invalidateHistoryTexture(state.colorHistoryKey);
-            pipeline.graph.invalidateHistoryTexture(state.depthHistoryKey);
+        this.sweepInactiveStates(context, context.camera);
+        const state = this.stageCamera(context.camera, context.frameIndex, width, height);
+        const transformRevision = getTransformHistoryRevision(context.camera);
+        const discontinuous =
+            state.committedSubmission >= 0 &&
+            (state.committedSubmission !== this.#submissionIndex ||
+                state.committedTransformRevision !== transformRevision ||
+                projectionCut(state.committedProjection, context.camera.projectionMatrix.elements));
+        if (discontinuous) {
+            context.graph.invalidateHistoryTexture(state.colorHistoryKey);
+            context.graph.invalidateHistoryTexture(state.depthHistoryKey);
         }
-
-        const colorHistory = pipeline.graph.acquireHistoryTexture(
+        const colorHistory = context.graph.acquireHistoryTexture(
             state.colorHistoryKey,
             COLOR_HISTORY_DESCRIPTOR
         );
-        const depthHistory = pipeline.graph.acquireHistoryTexture(
+        const depthHistory = context.graph.acquireHistoryTexture(
             state.depthHistoryKey,
             DEPTH_HISTORY_DESCRIPTOR
         );
-        const historyValid = colorHistory.valid && depthHistory.valid;
         this.validateHistoryPair(colorHistory, depthHistory);
+        return Object.freeze({
+            state,
+            historyValid: !discontinuous && colorHistory.valid && depthHistory.valid,
+            colorHistory,
+            depthHistory
+        });
+    }
 
-        const velocity = pipeline.graph.createTexture(
-            'TemporalAA rg16float velocity',
-            VELOCITY_DESCRIPTOR
-        );
-        this.#rendererListDescriptor.cullingResults = context.cullingResults;
-        const velocityList = pipeline.createRendererList(this.#rendererListDescriptor);
-        const velocityParameters = pipeline.acquirePassParameters(this.#velocityParameters);
-        velocityParameters.configure(
-            velocityList,
-            velocity,
-            depth,
-            pipeline.output.depthStencilFormat !== null &&
-                renderTargetFormatHasStencil(pipeline.output.depthStencilFormat)
-        );
-        pipeline.graph.addPass(this.#velocityPass, velocityParameters);
-
-        const resolved = pipeline.graph.createTexture(
+    resolve(
+        context: RenderPipelineContext,
+        frame: TemporalResolveFrame,
+        scene: RenderGraphTextureHandle,
+        velocity: RenderGraphTextureHandle
+    ): RenderGraphTextureHandle {
+        if (frame.state.pendingFrame !== context.frameIndex) {
+            throw new Error('TemporalAA resolve frame belongs to another application frame');
+        }
+        const resolved = context.graph.createTexture(
             'TemporalAA resolved color',
             RESOLVED_DESCRIPTOR
         );
-        const parameters = pipeline.acquirePassParameters(this.#resolveParameters);
+        const parameters = context.acquirePassParameters(this.#resolveParameters);
         parameters.configure(
-            historyValid
-                ? [scene, colorHistory.history(), velocity, depth, depthHistory.history()]
-                : [scene, depth],
-            colorHistory.current,
+            frame.historyValid
+                ? [scene, frame.colorHistory.history(), velocity, frame.depthHistory.history()]
+                : [scene, velocity],
+            frame.colorHistory.current,
             resolved,
-            depthHistory.current
+            frame.depthHistory.current
         );
-        pipeline.graph.addPass(historyValid ? this.#resolvePass : this.#initializePass, parameters);
-        context.resources.replaceColor(resolved, 'linear');
+        context.graph.addPass(
+            frame.historyValid ? this.#resolvePass : this.#initializePass,
+            parameters
+        );
+        return resolved;
     }
 
     frameSubmitted(frameIndex: number): void {
+        const committedSubmission = this.#submissionIndex + 1;
         for (const state of this.#stagedStates) {
             if (state.pendingFrame !== frameIndex) continue;
             state.committedTransformRevision = state.pendingTransformRevision;
             state.committedJitterIndex = (state.pendingJitterIndex + 1) % JITTER_SEQUENCE.length;
+            state.committedProjection.set(state.pendingProjection);
+            state.committedSubmission = committedSubmission;
             state.pendingFrame = -1;
+            state.camera.clearProjectionJitter();
+        }
+        for (const state of this.#pendingEvictions) {
+            this.#states.delete(state.camera);
+            this.#ownedStates.delete(state);
+            state.camera.clearProjectionJitter();
         }
         this.#stagedStates.length = 0;
+        this.#pendingEvictions.length = 0;
+        this.#submissionIndex = committedSubmission;
     }
 
     frameDiscarded(frameIndex: number): void {
@@ -420,6 +551,7 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
             state.camera.clearProjectionJitter();
         }
         this.#stagedStates.length = 0;
+        this.#pendingEvictions.length = 0;
     }
 
     destroy(): void {
@@ -427,6 +559,7 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
         for (const state of this.#ownedStates) state.camera.clearProjectionJitter();
         this.#ownedStates.clear();
         this.#stagedStates.length = 0;
+        this.#pendingEvictions.length = 0;
         this.#destroyed = true;
     }
 
@@ -442,11 +575,15 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
                 camera,
                 colorHistoryKey: Object.freeze({}),
                 depthHistoryKey: Object.freeze({}),
+                committedProjection: new Float32Array(16),
+                pendingProjection: new Float32Array(16),
                 committedTransformRevision: -1,
                 committedJitterIndex: 0,
+                committedSubmission: -1,
                 pendingTransformRevision: -1,
                 pendingJitterIndex: 0,
-                pendingFrame: -1
+                pendingFrame: -1,
+                lastTouchedFrame: frameIndex
             };
             this.#states.set(camera, state);
             this.#ownedStates.add(state);
@@ -457,13 +594,31 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
             );
         }
         state.pendingFrame = frameIndex;
+        state.lastTouchedFrame = frameIndex;
         state.pendingTransformRevision = getTransformHistoryRevision(camera);
         state.pendingJitterIndex = state.committedJitterIndex;
+        state.pendingProjection.set(camera.projectionMatrix.elements);
         this.#stagedStates.push(state);
         const jitter = JITTER_SEQUENCE[state.pendingJitterIndex];
         if (jitter === undefined) throw new Error('TemporalAA jitter sequence is incomplete');
         camera.setProjectionJitter((jitter.x * 2) / width, (jitter.y * 2) / height);
         return state;
+    }
+
+    private sweepInactiveStates(context: RenderPipelineContext, activeCamera: Camera): void {
+        for (const state of this.#ownedStates) {
+            if (
+                state.camera === activeCamera ||
+                state.pendingFrame >= 0 ||
+                state.lastTouchedFrame >= context.frameIndex - CAMERA_HISTORY_RETENTION_FRAMES ||
+                this.#pendingEvictions.includes(state)
+            ) {
+                continue;
+            }
+            context.graph.releaseHistoryTexture(state.colorHistoryKey);
+            context.graph.releaseHistoryTexture(state.depthHistoryKey);
+            this.#pendingEvictions.push(state);
+        }
     }
 
     private validateHistoryPair(
@@ -476,12 +631,75 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
     }
 }
 
+class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
+    readonly #resolve: TemporalResolveController;
+    readonly #velocityPass = new SceneRenderPass('TemporalAA motion vectors');
+    readonly #velocityParameters = new RenderPassParameterPool(() => new VelocityPassParameters());
+    readonly #rendererListDescriptor: {
+        cullingResults: CullingResultsHandle;
+        readonly queue: 'opaque';
+        readonly sorting: 'material-front-to-back';
+        readonly materialPass: 'motion-vector';
+    } = {
+        cullingResults: 0 as CullingResultsHandle,
+        queue: 'opaque',
+        sorting: 'material-front-to-back',
+        materialPass: 'motion-vector'
+    };
+
+    constructor(settings: TemporalAASettings) {
+        this.#resolve = new TemporalResolveController(settings);
+    }
+
+    record(context: ForwardRenderFeatureContext): void {
+        const pipeline = context.pipeline;
+        const scene = context.resources.color;
+        const depth = context.resources.depth;
+        if (scene === null || depth === null) {
+            throw new Error('TemporalAA requires opaque scene color and sampled depth');
+        }
+        const frame = this.#resolve.begin(pipeline);
+        const velocity = pipeline.graph.createTexture(
+            'TemporalAA rgba16float motion and view depth',
+            TEMPORAL_MOTION_DESCRIPTOR
+        );
+        this.#rendererListDescriptor.cullingResults = context.cullingResults;
+        const velocityList = pipeline.createRendererList(this.#rendererListDescriptor);
+        const velocityParameters = pipeline.acquirePassParameters(this.#velocityParameters);
+        velocityParameters.configure(
+            velocityList,
+            velocity,
+            depth,
+            pipeline.output.depthStencilFormat !== null &&
+                renderTargetFormatHasStencil(pipeline.output.depthStencilFormat)
+        );
+        pipeline.graph.addPass(this.#velocityPass, velocityParameters);
+        context.resources.replaceColor(
+            this.#resolve.resolve(pipeline, frame, scene, velocity),
+            'linear'
+        );
+    }
+
+    frameSubmitted(frameIndex: number): void {
+        this.#resolve.frameSubmitted(frameIndex);
+    }
+
+    frameDiscarded(frameIndex: number): void {
+        this.#resolve.frameDiscarded(frameIndex);
+    }
+
+    destroy(): void {
+        this.#resolve.destroy();
+    }
+}
+
 /**
  * Native-resolution temporal anti-aliasing feature.
  *
- * The feature records built-in opaque/masked motion vectors after opaque shading, resolves only
- * opaque scene color, then lets transparent rendering and Bloom compose afterward. History uses
- * submission-aware double buffers and is reset by camera cuts, resize, or device recovery.
+ * The feature records built-in opaque/masked motion and logarithmic view-depth data after opaque
+ * shading, resolves only opaque scene color, then lets transparent rendering and Bloom compose
+ * afterward. History uses submission-aware double buffers and is reset by camera cuts, resize,
+ * projection discontinuities, visibility gaps, or device recovery.
  */
 export class TemporalAA implements ForwardRenderPipelineFeature {
     readonly name = 'temporal-aa';
@@ -489,20 +707,12 @@ export class TemporalAA implements ForwardRenderPipelineFeature {
     readonly requirements = Object.freeze({
         sampledSceneColor: true,
         sampledDepth: true,
-        requiredLimits: Object.freeze({ maxColorAttachments: 3 }),
-        requiredTextureFormats: Object.freeze([
-            Object.freeze({ format: 'rgba16float' as const, use: 'color-attachment' as const }),
-            Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const }),
-            Object.freeze({ format: 'rg16float' as const, use: 'color-attachment' as const }),
-            Object.freeze({ format: 'rg16float' as const, use: 'filterable-sampled' as const }),
-            Object.freeze({ format: 'r16float' as const, use: 'color-attachment' as const }),
-            Object.freeze({ format: 'r16float' as const, use: 'filterable-sampled' as const })
-        ])
+        ...TEMPORAL_AA_REQUIREMENTS
     });
     readonly #settings: TemporalAASettings;
 
     constructor(options: Readonly<TemporalAAOptions> = {}) {
-        this.#settings = snapshotOptions(options);
+        this.#settings = snapshotTemporalAAOptions(options);
     }
 
     create(): ForwardRenderPipelineFeatureRuntime {

--- a/src/render/renderer/ForwardRenderer.ts
+++ b/src/render/renderer/ForwardRenderer.ts
@@ -14,7 +14,11 @@ import {
     type RHITextureFormat
 } from '../rhi/core';
 import { assertRHIObjectOwnedBy } from '../rhi/core/RHIValidation';
-import { MeshDrawListPlanner, type MeshDrawInstanceBatch } from './MeshDrawListPlanner';
+import {
+    isMeshDrawInstanceBatch,
+    MeshDrawListPlanner,
+    type MeshDrawListItem
+} from './MeshDrawListPlanner';
 import type { MeshDrawProcessor } from './MeshDrawProcessor';
 import type { PreparedDraw } from './PreparedDraw';
 import type { RHIMeshDrawTargetDescriptor } from './RHIDescriptorMapping';
@@ -25,7 +29,7 @@ import { MainPassTemplate, SharedDrawPassParameters, TransparentPassTemplate } f
 const DEFAULT_CLEAR_COLOR: Readonly<RHIColor> = Object.freeze({ r: 0, g: 0, b: 0, a: 1 });
 const EMPTY_DRAWS: readonly PreparedDraw[] = Object.freeze([]);
 const EMPTY_MESHES: readonly Mesh[] = Object.freeze([]);
-const EMPTY_INSTANCE_BATCHES: readonly Readonly<MeshDrawInstanceBatch>[] = Object.freeze([]);
+const EMPTY_DRAW_ITEMS: readonly MeshDrawListItem[] = Object.freeze([]);
 
 function requireSampleCount(value: number | undefined): number {
     const sampleCount = value ?? 1;
@@ -272,7 +276,8 @@ export class ForwardRenderer {
         const meshDrawListPlanner = passes.meshDrawListPlanner;
         let opaqueMeshes = options.opaqueMeshes ?? options.meshes ?? EMPTY_MESHES;
         let transparentMeshes = options.transparentMeshes ?? EMPTY_MESHES;
-        let instancedBatches = EMPTY_INSTANCE_BATCHES;
+        let opaqueItems = EMPTY_DRAW_ITEMS;
+        let transparentItems = EMPTY_DRAW_ITEMS;
         if (options.classifiedMeshes !== undefined) {
             const plan = meshDrawListPlanner.build(
                 options.classifiedMeshes,
@@ -282,21 +287,18 @@ export class ForwardRenderer {
             );
             opaqueMeshes = plan.opaqueMeshes;
             transparentMeshes = plan.transparentMeshes;
-            instancedBatches = plan.instancedBatches;
+            opaqueItems = plan.opaqueItems;
+            transparentItems = plan.transparentItems;
         } else {
             meshDrawListPlanner.reset();
         }
         const meshProcessor = options.meshProcessor;
-        let hasTransparentInstanceBatch = false;
-        for (const batch of instancedBatches) {
-            if (!batch.transparent) continue;
-            hasTransparentInstanceBatch = true;
-            break;
-        }
         const hasTransparentPass =
             meshProcessor === undefined
                 ? transparentDraws.length > 0
-                : transparentMeshes.length > 0 || hasTransparentInstanceBatch;
+                : options.classifiedMeshes === undefined
+                  ? transparentMeshes.length > 0
+                  : transparentItems.length > 0;
         const depthStencilFormat = options.depthStencilFormat;
         requireDepthStencilFormat(depthStencilFormat);
         const meshTarget: RHIMeshDrawTargetDescriptor | null = meshProcessor
@@ -399,16 +401,20 @@ export class ForwardRenderer {
             });
         }
         if (meshProcessor && meshTarget) {
-            for (const mesh of opaqueMeshes) {
-                const draw = meshProcessor.prepare(mesh, meshTarget);
-                if (meshFrameStarted) mainPass.addDrawSnapshot(draw);
-                else mainPass.addDraw(draw);
-            }
-            for (const batch of instancedBatches) {
-                if (batch.transparent) continue;
-                const draw = meshProcessor.prepareInstancedBatch(batch, batch.meshes, meshTarget);
-                if (meshFrameStarted) mainPass.addDrawSnapshot(draw);
-                else mainPass.addDraw(draw);
+            if (options.classifiedMeshes === undefined) {
+                for (const mesh of opaqueMeshes) {
+                    const draw = meshProcessor.prepare(mesh, meshTarget);
+                    if (meshFrameStarted) mainPass.addDrawSnapshot(draw);
+                    else mainPass.addDraw(draw);
+                }
+            } else {
+                for (const item of opaqueItems) {
+                    const draw = isMeshDrawInstanceBatch(item)
+                        ? meshProcessor.prepareInstancedBatch(item, item.meshes, meshTarget)
+                        : meshProcessor.prepare(item, meshTarget);
+                    if (meshFrameStarted) mainPass.addDrawSnapshot(draw);
+                    else mainPass.addDraw(draw);
+                }
             }
         } else {
             for (const draw of opaqueDraws) mainPass.addDraw(draw);
@@ -457,20 +463,20 @@ export class ForwardRenderer {
             }
             if (meshProcessor && meshTarget) {
                 meshProcessor.beginPass(context.camera, context.viewport);
-                for (const mesh of transparentMeshes) {
-                    const draw = meshProcessor.prepare(mesh, meshTarget);
-                    if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
-                    else transparentPass.addDraw(draw);
-                }
-                for (const batch of instancedBatches) {
-                    if (!batch.transparent) continue;
-                    const draw = meshProcessor.prepareInstancedBatch(
-                        batch,
-                        batch.meshes,
-                        meshTarget
-                    );
-                    if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
-                    else transparentPass.addDraw(draw);
+                if (options.classifiedMeshes === undefined) {
+                    for (const mesh of transparentMeshes) {
+                        const draw = meshProcessor.prepare(mesh, meshTarget);
+                        if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
+                        else transparentPass.addDraw(draw);
+                    }
+                } else {
+                    for (const item of transparentItems) {
+                        const draw = isMeshDrawInstanceBatch(item)
+                            ? meshProcessor.prepareInstancedBatch(item, item.meshes, meshTarget)
+                            : meshProcessor.prepare(item, meshTarget);
+                        if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
+                        else transparentPass.addDraw(draw);
+                    }
                 }
             } else {
                 for (const draw of transparentDraws) transparentPass.addDraw(draw);

--- a/src/render/renderer/InstanceBatchCompiler.ts
+++ b/src/render/renderer/InstanceBatchCompiler.ts
@@ -73,6 +73,8 @@ export interface InstanceBatchCompilerDiagnostics {
     readonly resolvedInputCapacity: number;
     readonly maxInstanceCapacity: number;
     readonly storageAllocationCount: number;
+    /** Total inverse-transpose matrices recomputed since compiler creation. */
+    readonly normalMatrixRecomputeCount: number;
 }
 
 interface MutableDiagnostics {
@@ -82,6 +84,7 @@ interface MutableDiagnostics {
     resolvedInputCapacity: number;
     maxInstanceCapacity: number;
     storageAllocationCount: number;
+    normalMatrixRecomputeCount: number;
 }
 
 interface InstanceShape {
@@ -625,6 +628,8 @@ class BatchRecord {
     private previousModelScratch: Float32Array | null = null;
     private normalScratch: Float32Array | null = null;
     private historyScratch: Float32Array | null = null;
+    private readonly normalMatrixMeshes: Mesh[] = [];
+    private readonly normalMatrixVersions: number[] = [];
     private readonly normalMatrix3 = new Matrix3();
     private readonly normalMatrix4 = new Matrix4();
     private readonly webGLCurrentModel = new Float32Array(16);
@@ -849,7 +854,6 @@ class BatchRecord {
             );
             modelScratch.fill(0);
             previousModelScratch.fill(0);
-            normalScratch.fill(0);
             historyScratch.fill(0);
             for (let meshIndex = 0; meshIndex < meshes.length; meshIndex += 1) {
                 const mesh = requirePresent(meshes[meshIndex], 'instance mesh');
@@ -870,19 +874,29 @@ class BatchRecord {
                         previousModelScratch[matrixOffset + component] = value;
                     }
                 }
-                requireInvertibleWorldMatrix(mesh);
-                this.normalMatrix4.invert(mesh.worldMatrix).transpose();
-                const normal = this.normalMatrix4.elements;
-                for (let component = 0; component < 16; component += 1) {
-                    const value = requirePresent(normal[component], 'normal-matrix component');
-                    if (!Number.isFinite(value)) {
-                        throw new TypeError(
-                            `Mesh ${mesh.name || mesh.id} produced a non-finite normal matrix`
-                        );
+                if (
+                    this.normalMatrixMeshes[meshIndex] !== mesh ||
+                    this.normalMatrixVersions[meshIndex] !== mesh.worldMatrixVersion
+                ) {
+                    requireInvertibleWorldMatrix(mesh);
+                    this.normalMatrix4.invert(mesh.worldMatrix).transpose();
+                    const normal = this.normalMatrix4.elements;
+                    for (let component = 0; component < 16; component += 1) {
+                        const value = requirePresent(normal[component], 'normal-matrix component');
+                        if (!Number.isFinite(value)) {
+                            throw new TypeError(
+                                `Mesh ${mesh.name || mesh.id} produced a non-finite normal matrix`
+                            );
+                        }
+                        normalScratch[matrixOffset + component] = value;
                     }
-                    normalScratch[matrixOffset + component] = value;
+                    this.normalMatrixMeshes[meshIndex] = mesh;
+                    this.normalMatrixVersions[meshIndex] = mesh.worldMatrixVersion;
+                    this.diagnostics.normalMatrixRecomputeCount++;
                 }
             }
+            this.normalMatrixMeshes.length = meshes.length;
+            this.normalMatrixVersions.length = meshes.length;
             if (this.uniformBufferFloats === null) {
                 modelChanged = true;
                 normalChanged = true;
@@ -1065,6 +1079,8 @@ class BatchRecord {
         this.previousModelScratch = null;
         this.normalScratch = null;
         this.historyScratch = null;
+        this.normalMatrixMeshes.length = 0;
+        this.normalMatrixVersions.length = 0;
     }
 
     private classify(
@@ -1425,7 +1441,8 @@ export class InstanceBatchCompiler {
         planCapacity: 0,
         resolvedInputCapacity: 0,
         maxInstanceCapacity: 0,
-        storageAllocationCount: 0
+        storageAllocationCount: 0,
+        normalMatrixRecomputeCount: 0
     };
     readonly diagnostics: Readonly<InstanceBatchCompilerDiagnostics>;
 
@@ -1449,6 +1466,9 @@ export class InstanceBatchCompiler {
             },
             get storageAllocationCount() {
                 return state.storageAllocationCount;
+            },
+            get normalMatrixRecomputeCount() {
+                return state.normalMatrixRecomputeCount;
             }
         });
     }

--- a/src/render/renderer/MeshDrawListPlanner.ts
+++ b/src/render/renderer/MeshDrawListPlanner.ts
@@ -14,14 +14,28 @@ export interface MeshDrawInstanceBatch {
     readonly transparent: boolean;
 }
 
+/** One item in the final backend-neutral draw order produced by the shared planner. */
+export type MeshDrawListItem = Mesh | Readonly<MeshDrawInstanceBatch>;
+
+/** Narrow one ordered draw-list item without relying on private batch fields. */
+export function isMeshDrawInstanceBatch(
+    item: MeshDrawListItem
+): item is Readonly<MeshDrawInstanceBatch> {
+    return !(item instanceof Mesh);
+}
+
 /**
- * Stable draw-list result. The object and its three arrays retain their identities across builds;
+ * Stable draw-list result. The object and all arrays retain their identities across builds;
  * callers must consume their contents before the next build or reset.
  */
 export interface MeshDrawListPlan {
     readonly opaqueMeshes: readonly Mesh[];
     readonly transparentMeshes: readonly Mesh[];
     readonly instancedBatches: readonly Readonly<MeshDrawInstanceBatch>[];
+    /** Final opaque order, including direct and instanced items. */
+    readonly opaqueItems: readonly MeshDrawListItem[];
+    /** Final transparent order, including direct and instanced items. */
+    readonly transparentItems: readonly MeshDrawListItem[];
 }
 
 /** Stable diagnostics object used to verify bounded high-water storage. */
@@ -126,6 +140,8 @@ export class MeshDrawListPlanner {
     readonly #opaqueMeshes: Mesh[] = [];
     readonly #transparentMeshes: Mesh[] = [];
     readonly #instancedBatches: MutableMeshDrawInstanceBatch[] = [];
+    readonly #opaqueItems: MeshDrawListItem[] = [];
+    readonly #transparentItems: MeshDrawListItem[] = [];
     readonly #seenMeshes = new Set<Mesh>();
     readonly #owners = new Map<Mesh, OwnerRecord>();
     readonly #ownerSlots: OwnerRecord[] = [];
@@ -169,7 +185,19 @@ export class MeshDrawListPlanner {
         }
         const renderOrderA = isSpriteMesh(a) ? 0 : a.renderOrder;
         const renderOrderB = isSpriteMesh(b) ? 0 : b.renderOrder;
-        return renderOrderA - renderOrderB;
+        if (renderOrderA !== renderOrderB) return renderOrderA - renderOrderB;
+        const materialA = this.#inputMaterialOverride ?? a.material;
+        const materialB = this.#inputMaterialOverride ?? b.material;
+        if (
+            materialA?.forwardQueue === 'transparent' &&
+            materialB?.forwardQueue === 'transparent' &&
+            this.#transparentSortCamera !== null
+        ) {
+            const depthA = this.transparentDepth(a);
+            const depthB = this.transparentDepth(b);
+            if (depthA !== depthB) return depthB - depthA;
+        }
+        return 0;
     };
 
     readonly #compareOpaque = (a: Mesh, b: Mesh): number => {
@@ -200,13 +228,48 @@ export class MeshDrawListPlanner {
         if (renderOrderA !== renderOrderB) {
             return renderOrderA - renderOrderB;
         }
-        if (
-            this.#transparentSortCamera !== null &&
-            recordA.transparentDepth !== recordB.transparentDepth
-        ) {
-            return recordB.transparentDepth - recordA.transparentDepth;
-        }
         return recordA.inputIndex - recordB.inputIndex;
+    };
+
+    readonly #compareOpaqueItem = (a: MeshDrawListItem, b: MeshDrawListItem): number => {
+        const batchA = isMeshDrawInstanceBatch(a);
+        const batchB = isMeshDrawInstanceBatch(b);
+        const recordA = batchA ? null : this.requireOwnerRecord(a);
+        const recordB = batchB ? null : this.requireOwnerRecord(b);
+        const renderOrderA = batchA ? a.renderOrder : (recordA?.renderOrder ?? 0);
+        const renderOrderB = batchB ? b.renderOrder : (recordB?.renderOrder ?? 0);
+        if (renderOrderA !== renderOrderB) return renderOrderA - renderOrderB;
+        const materialA = batchA
+            ? a.material
+            : requireRecordValue(recordA?.material ?? null, 'material');
+        const materialB = batchB
+            ? b.material
+            : requireRecordValue(recordB?.material ?? null, 'material');
+        let order = compareStringIdentity(materialA.id, materialB.id);
+        if (order !== 0) return order;
+        const geometryA = batchA
+            ? a.geometry
+            : requireRecordValue(recordA?.geometry ?? null, 'geometry');
+        const geometryB = batchB
+            ? b.geometry
+            : requireRecordValue(recordB?.geometry ?? null, 'geometry');
+        order = compareStringIdentity(geometryA.id, geometryB.id);
+        if (order !== 0) return order;
+        if (batchA !== batchB) return batchA ? 1 : -1;
+        if (!batchA && !batchB) return this.#compareOpaque(a, b);
+        const mutableA = a as MutableMeshDrawInstanceBatch;
+        const mutableB = b as MutableMeshDrawInstanceBatch;
+        return mutableA.identityOrder - mutableB.identityOrder;
+    };
+
+    readonly #compareTransparentItem = (a: MeshDrawListItem, b: MeshDrawListItem): number => {
+        const inputIndexA = isMeshDrawInstanceBatch(a)
+            ? (a as MutableMeshDrawInstanceBatch).inputIndex
+            : this.requireOwnerRecord(a).inputIndex;
+        const inputIndexB = isMeshDrawInstanceBatch(b)
+            ? (b as MutableMeshDrawInstanceBatch).inputIndex
+            : this.requireOwnerRecord(b).inputIndex;
+        return inputIndexA - inputIndexB;
     };
 
     readonly #compareInstanced = (
@@ -226,7 +289,9 @@ export class MeshDrawListPlanner {
         this.#plan = Object.freeze({
             opaqueMeshes: this.#opaqueMeshes,
             transparentMeshes: this.#transparentMeshes,
-            instancedBatches: this.#instancedBatches
+            instancedBatches: this.#instancedBatches,
+            opaqueItems: this.#opaqueItems,
+            transparentItems: this.#transparentItems
         });
         const state = this.#diagnosticState;
         this.#diagnostics = Object.freeze({
@@ -290,6 +355,7 @@ export class MeshDrawListPlanner {
                 this.#transparentMeshes.sort(this.#compareTransparent);
                 this.#instancedBatches.sort(this.#compareInstanced);
             }
+            this.buildOrderedItems(sort);
             this.updateDiagnostics();
             return this.#plan;
         } finally {
@@ -309,6 +375,8 @@ export class MeshDrawListPlanner {
         if (record === undefined) return false;
         removeIdentity(this.#opaqueMeshes, mesh);
         removeIdentity(this.#transparentMeshes, mesh);
+        removeIdentity(this.#opaqueItems, mesh);
+        removeIdentity(this.#transparentItems, mesh);
         for (const batch of this.#instancedBatches) {
             if (!batch.orderPreserving) continue;
             if (!removeIdentity(batch.meshes, mesh)) continue;
@@ -434,7 +502,8 @@ export class MeshDrawListPlanner {
             mesh.useInstanced &&
             batch !== null &&
             batch.geometry === geometry &&
-            batch.material === material;
+            batch.material === material &&
+            batch.renderOrder === mesh.renderOrder;
         if (!batchMatches) {
             if (batch !== null) {
                 record.batch = null;
@@ -723,6 +792,8 @@ export class MeshDrawListPlanner {
         this.#opaqueMeshes.length = 0;
         this.#transparentMeshes.length = 0;
         this.#instancedBatches.length = 0;
+        this.#opaqueItems.length = 0;
+        this.#transparentItems.length = 0;
         this.#orderPreservingBatchCursor = 0;
         this.#orderPreservingBatchTail = null;
         this.#orderPreservingBatchTailInputIndex = -2;
@@ -743,6 +814,27 @@ export class MeshDrawListPlanner {
             index++;
         }
         if (index < this.#input.length) this.#input.sort(this.#compareInputOrder);
+    }
+
+    private transparentDepth(mesh: Mesh): number {
+        mesh.worldMatrix.getTranslation(this.#transparentPosition);
+        this.#transparentPosition.transformMat4(
+            requireRecordValue(this.#transparentSortCamera, 'transparent sort camera')
+                .viewProjectionMatrix
+        );
+        return this.#transparentPosition.z;
+    }
+
+    private buildOrderedItems(sort: boolean): void {
+        for (const mesh of this.#opaqueMeshes) this.#opaqueItems.push(mesh);
+        for (const mesh of this.#transparentMeshes) this.#transparentItems.push(mesh);
+        for (const batch of this.#instancedBatches) {
+            if (batch.transparent) this.#transparentItems.push(batch);
+            else this.#opaqueItems.push(batch);
+        }
+        if (!sort) return;
+        this.#opaqueItems.sort(this.#compareOpaqueItem);
+        this.#transparentItems.sort(this.#compareTransparentItem);
     }
 
     private advanceEpoch(): void {

--- a/src/render/renderer/MeshDrawProcessor.ts
+++ b/src/render/renderer/MeshDrawProcessor.ts
@@ -177,11 +177,11 @@ function validateMaterialPassTarget(
     if (role !== 'motion-vector') return;
     if (
         target.colorFormats.length !== 1 ||
-        target.colorFormats[0] !== 'rg16float' ||
+        target.colorFormats[0] !== 'rgba16float' ||
         target.sampleCount !== 1
     ) {
         throw new TypeError(
-            'Motion-vector mesh draws require one single-sample rg16float color target'
+            'Motion-vector mesh draws require one single-sample rgba16float color target'
         );
     }
 }
@@ -672,6 +672,7 @@ export class MeshDrawProcessor {
         const role =
             materialPass ?? (fragmentOutputMode === 'depth-only' ? 'depth-only' : 'forward');
         validateMaterialPassTarget(role, target);
+        if (role === 'motion-vector') this.uniformBlocks.markMotionVectorParticipation(mesh);
         const materialState = requireMaterialPassState(material, role);
         this.validateLighting(mesh, material, context);
         this.validateDeformation(mesh, geometry);
@@ -1213,6 +1214,9 @@ export class MeshDrawProcessor {
         const role =
             materialPass ?? (fragmentOutputMode === 'depth-only' ? 'depth-only' : 'forward');
         validateMaterialPassTarget(role, target);
+        if (role === 'motion-vector') {
+            for (const mesh of meshes) this.uniformBlocks.markMotionVectorParticipation(mesh);
+        }
         const materialState = requireMaterialPassState(material, role);
         this.validateLighting(representative, material, context);
         geometry.normalizePrimitiveTopology();

--- a/src/render/renderer/OffscreenRenderTargetRenderer.ts
+++ b/src/render/renderer/OffscreenRenderTargetRenderer.ts
@@ -18,7 +18,11 @@ import {
 } from '../rhi/core';
 import { assertRHIObjectOwnedBy } from '../rhi/core/RHIValidation';
 import type { MeshDrawProcessor } from './MeshDrawProcessor';
-import { MeshDrawListPlanner, type MeshDrawInstanceBatch } from './MeshDrawListPlanner';
+import {
+    isMeshDrawInstanceBatch,
+    MeshDrawListPlanner,
+    type MeshDrawListItem
+} from './MeshDrawListPlanner';
 import type { PreparedDraw } from './PreparedDraw';
 import type { RHIMeshDrawTargetDescriptor } from './RHIDescriptorMapping';
 import {
@@ -38,7 +42,7 @@ import { MainPassTemplate, SharedDrawPassParameters, TransparentPassTemplate } f
 const DEFAULT_CLEAR_COLOR: Readonly<RHIColor> = Object.freeze({ r: 0, g: 0, b: 0, a: 1 });
 const EMPTY_DRAWS: readonly PreparedDraw[] = Object.freeze([]);
 const EMPTY_MESHES: readonly Mesh[] = Object.freeze([]);
-const EMPTY_INSTANCE_BATCHES: readonly Readonly<MeshDrawInstanceBatch>[] = Object.freeze([]);
+const EMPTY_DRAW_ITEMS: readonly MeshDrawListItem[] = Object.freeze([]);
 const EMPTY_COPY_OPTIONS: Readonly<OffscreenColorAttachmentCopyOptions> = Object.freeze({});
 
 export interface OffscreenRenderTargetColorOperations {
@@ -122,9 +126,11 @@ interface NormalizedDrawInputs {
     transparentDraws: readonly PreparedDraw[];
     opaqueMeshes: readonly Mesh[];
     transparentMeshes: readonly Mesh[];
-    instancedBatches: readonly Readonly<MeshDrawInstanceBatch>[];
+    opaqueItems: readonly MeshDrawListItem[];
+    transparentItems: readonly MeshDrawListItem[];
     meshProcessor: MeshDrawProcessor | null;
     usesMeshes: boolean;
+    classified: boolean;
 }
 
 interface MutableMeshTargetDescriptor extends RHIMeshDrawTargetDescriptor {
@@ -208,7 +214,8 @@ function normalizeDrawInputs(
     const classified = options.classifiedMeshes;
     let opaqueMeshes = options.opaqueMeshes ?? options.meshes ?? EMPTY_MESHES;
     let transparentMeshes = options.transparentMeshes ?? EMPTY_MESHES;
-    let instancedBatches = EMPTY_INSTANCE_BATCHES;
+    let opaqueItems = EMPTY_DRAW_ITEMS;
+    let transparentItems = EMPTY_DRAW_ITEMS;
     if (classified === undefined) {
         planner.reset();
     } else {
@@ -220,15 +227,18 @@ function normalizeDrawInputs(
         );
         opaqueMeshes = plan.opaqueMeshes;
         transparentMeshes = plan.transparentMeshes;
-        instancedBatches = plan.instancedBatches;
+        opaqueItems = plan.opaqueItems;
+        transparentItems = plan.transparentItems;
     }
     result.opaqueDraws = options.opaqueDraws ?? options.draws ?? EMPTY_DRAWS;
     result.transparentDraws = options.transparentDraws ?? EMPTY_DRAWS;
     result.opaqueMeshes = opaqueMeshes;
     result.transparentMeshes = transparentMeshes;
-    result.instancedBatches = instancedBatches;
+    result.opaqueItems = opaqueItems;
+    result.transparentItems = transparentItems;
     result.meshProcessor = options.meshProcessor ?? null;
     result.usesMeshes = hasMeshInput;
+    result.classified = classified !== undefined;
     return result;
 }
 
@@ -396,9 +406,11 @@ export class OffscreenRenderTargetRenderer {
         transparentDraws: EMPTY_DRAWS,
         opaqueMeshes: EMPTY_MESHES,
         transparentMeshes: EMPTY_MESHES,
-        instancedBatches: EMPTY_INSTANCE_BATCHES,
+        opaqueItems: EMPTY_DRAW_ITEMS,
+        transparentItems: EMPTY_DRAW_ITEMS,
         meshProcessor: null,
-        usesMeshes: false
+        usesMeshes: false,
+        classified: false
     };
     readonly #meshColorFormats: (RHITextureFormat | null)[] = [];
     readonly #meshTarget: MutableMeshTargetDescriptor = {
@@ -533,14 +545,10 @@ export class OffscreenRenderTargetRenderer {
             multisampleAttachmentLifetime
         );
         const meshTarget = inputs.meshProcessor === null ? null : this.configureMeshTarget(target);
-        let hasTransparentInstanceBatch = false;
-        for (const batch of inputs.instancedBatches) {
-            if (!batch.transparent) continue;
-            hasTransparentInstanceBatch = true;
-            break;
-        }
         const hasTransparentPass = inputs.meshProcessor
-            ? inputs.transparentMeshes.length > 0 || hasTransparentInstanceBatch
+            ? inputs.classified
+                ? inputs.transparentItems.length > 0
+                : inputs.transparentMeshes.length > 0
             : inputs.transparentDraws.length > 0;
         const passes = this.acquireCompositionPassSet();
         if (inputs.meshProcessor !== null) {
@@ -562,20 +570,20 @@ export class OffscreenRenderTargetRenderer {
         );
         this.setFullTargetViewport(opaquePass, target);
         if (inputs.meshProcessor !== null && meshTarget !== null) {
-            for (const mesh of inputs.opaqueMeshes) {
-                const draw = inputs.meshProcessor.prepare(mesh, meshTarget);
-                if (meshFrameStarted) opaquePass.addDrawSnapshot(draw);
-                else opaquePass.addDraw(draw);
-            }
-            for (const batch of inputs.instancedBatches) {
-                if (batch.transparent) continue;
-                const draw = inputs.meshProcessor.prepareInstancedBatch(
-                    batch,
-                    batch.meshes,
-                    meshTarget
-                );
-                if (meshFrameStarted) opaquePass.addDrawSnapshot(draw);
-                else opaquePass.addDraw(draw);
+            if (inputs.classified) {
+                for (const item of inputs.opaqueItems) {
+                    const draw = isMeshDrawInstanceBatch(item)
+                        ? inputs.meshProcessor.prepareInstancedBatch(item, item.meshes, meshTarget)
+                        : inputs.meshProcessor.prepare(item, meshTarget);
+                    if (meshFrameStarted) opaquePass.addDrawSnapshot(draw);
+                    else opaquePass.addDraw(draw);
+                }
+            } else {
+                for (const mesh of inputs.opaqueMeshes) {
+                    const draw = inputs.meshProcessor.prepare(mesh, meshTarget);
+                    if (meshFrameStarted) opaquePass.addDrawSnapshot(draw);
+                    else opaquePass.addDraw(draw);
+                }
             }
         } else {
             for (const draw of inputs.opaqueDraws) opaquePass.addDraw(draw);
@@ -608,20 +616,24 @@ export class OffscreenRenderTargetRenderer {
             this.setFullTargetViewport(transparentPass, target);
             if (inputs.meshProcessor !== null && meshTarget !== null) {
                 inputs.meshProcessor.beginPass(context.camera, context.viewport);
-                for (const mesh of inputs.transparentMeshes) {
-                    const draw = inputs.meshProcessor.prepare(mesh, meshTarget);
-                    if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
-                    else transparentPass.addDraw(draw);
-                }
-                for (const batch of inputs.instancedBatches) {
-                    if (!batch.transparent) continue;
-                    const draw = inputs.meshProcessor.prepareInstancedBatch(
-                        batch,
-                        batch.meshes,
-                        meshTarget
-                    );
-                    if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
-                    else transparentPass.addDraw(draw);
+                if (inputs.classified) {
+                    for (const item of inputs.transparentItems) {
+                        const draw = isMeshDrawInstanceBatch(item)
+                            ? inputs.meshProcessor.prepareInstancedBatch(
+                                  item,
+                                  item.meshes,
+                                  meshTarget
+                              )
+                            : inputs.meshProcessor.prepare(item, meshTarget);
+                        if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
+                        else transparentPass.addDraw(draw);
+                    }
+                } else {
+                    for (const mesh of inputs.transparentMeshes) {
+                        const draw = inputs.meshProcessor.prepare(mesh, meshTarget);
+                        if (meshFrameStarted) transparentPass.addDrawSnapshot(draw);
+                        else transparentPass.addDraw(draw);
+                    }
                 }
             } else {
                 for (const draw of inputs.transparentDraws) transparentPass.addDraw(draw);
@@ -726,14 +738,10 @@ export class OffscreenRenderTargetRenderer {
             );
             const meshTarget =
                 inputs.meshProcessor === null ? null : this.configureMeshTarget(target);
-            let hasTransparentInstanceBatch = false;
-            for (const batch of inputs.instancedBatches) {
-                if (!batch.transparent) continue;
-                hasTransparentInstanceBatch = true;
-                break;
-            }
             const hasTransparentPass = inputs.meshProcessor
-                ? inputs.transparentMeshes.length > 0 || hasTransparentInstanceBatch
+                ? inputs.classified
+                    ? inputs.transparentItems.length > 0
+                    : inputs.transparentMeshes.length > 0
                 : inputs.transparentDraws.length > 0;
             const copyState: {
                 extractedStaging: RGBufferHandle | null;
@@ -758,18 +766,22 @@ export class OffscreenRenderTargetRenderer {
                 );
                 this.setFullTargetViewport(opaquePass, target);
                 if (inputs.meshProcessor !== null && meshTarget !== null) {
-                    for (const mesh of inputs.opaqueMeshes) {
-                        opaquePass.addDraw(inputs.meshProcessor.prepare(mesh, meshTarget));
-                    }
-                    for (const batch of inputs.instancedBatches) {
-                        if (batch.transparent) continue;
-                        opaquePass.addDraw(
-                            inputs.meshProcessor.prepareInstancedBatch(
-                                batch,
-                                batch.meshes,
-                                meshTarget
-                            )
-                        );
+                    if (inputs.classified) {
+                        for (const item of inputs.opaqueItems) {
+                            opaquePass.addDraw(
+                                isMeshDrawInstanceBatch(item)
+                                    ? inputs.meshProcessor.prepareInstancedBatch(
+                                          item,
+                                          item.meshes,
+                                          meshTarget
+                                      )
+                                    : inputs.meshProcessor.prepare(item, meshTarget)
+                            );
+                        }
+                    } else {
+                        for (const mesh of inputs.opaqueMeshes) {
+                            opaquePass.addDraw(inputs.meshProcessor.prepare(mesh, meshTarget));
+                        }
                     }
                 } else {
                     for (const draw of inputs.opaqueDraws) opaquePass.addDraw(draw);
@@ -802,18 +814,24 @@ export class OffscreenRenderTargetRenderer {
                     this.setFullTargetViewport(transparentPass, target);
                     if (inputs.meshProcessor !== null && meshTarget !== null) {
                         inputs.meshProcessor.beginPass(context.camera, context.viewport);
-                        for (const mesh of inputs.transparentMeshes) {
-                            transparentPass.addDraw(inputs.meshProcessor.prepare(mesh, meshTarget));
-                        }
-                        for (const batch of inputs.instancedBatches) {
-                            if (!batch.transparent) continue;
-                            transparentPass.addDraw(
-                                inputs.meshProcessor.prepareInstancedBatch(
-                                    batch,
-                                    batch.meshes,
-                                    meshTarget
-                                )
-                            );
+                        if (inputs.classified) {
+                            for (const item of inputs.transparentItems) {
+                                transparentPass.addDraw(
+                                    isMeshDrawInstanceBatch(item)
+                                        ? inputs.meshProcessor.prepareInstancedBatch(
+                                              item,
+                                              item.meshes,
+                                              meshTarget
+                                          )
+                                        : inputs.meshProcessor.prepare(item, meshTarget)
+                                );
+                            }
+                        } else {
+                            for (const mesh of inputs.transparentMeshes) {
+                                transparentPass.addDraw(
+                                    inputs.meshProcessor.prepare(mesh, meshTarget)
+                                );
+                            }
                         }
                     } else {
                         for (const draw of inputs.transparentDraws) {

--- a/src/render/renderer/PBRGPUMaterialRecord.ts
+++ b/src/render/renderer/PBRGPUMaterialRecord.ts
@@ -1,10 +1,27 @@
 import type PBRMaterial from '../../material/PBRMaterial';
+import type {
+    MaterialTextureChannel,
+    MaterialTextureEncoding
+} from '../../material/MaterialDefinition';
 import type Matrix3 from '../../math/Matrix3';
 
 /** @internal Stable compact layout consumed by the first shared GPU PBR material database. */
-export const PBR_GPU_MATERIAL_RECORD_LAYOUT = 'builtin-pbr-storage-v1';
-/** @internal Nine vec4 values: surface parameters plus base-color and normal UV matrices. */
-export const PBR_GPU_MATERIAL_RECORD_BYTES = 144;
+export const PBR_GPU_MATERIAL_RECORD_LAYOUT = 'builtin-pbr-storage-v2';
+
+/** @internal Common opaque PBR slots supported by the clustered storage profile. */
+export const PBR_GPU_MATERIAL_TEXTURE_SLOTS = Object.freeze([
+    'baseColor',
+    'metallic',
+    'roughness',
+    'metallicRoughness',
+    'occlusion',
+    'emission',
+    'normal'
+] as const);
+
+/** @internal Three surface vec4s plus five vec4s for every supported texture slot. */
+export const PBR_GPU_MATERIAL_RECORD_BYTES = (3 + PBR_GPU_MATERIAL_TEXTURE_SLOTS.length * 5) * 16;
+const DEFAULT_CHANNELS = Object.freeze(['r', 'g', 'b', 'a'] as const);
 
 function packUVMatrix(matrix: Matrix3 | null, target: Float32Array, offset: number): void {
     const elements = matrix?.elements;
@@ -14,6 +31,27 @@ function packUVMatrix(matrix: Matrix3 | null, target: Float32Array, offset: numb
             target[offset + column * 4 + row] = elements?.[index] ?? (column === row ? 1 : 0);
         }
         target[offset + column * 4 + 3] = 0;
+    }
+}
+
+function textureEncodingCode(encoding: MaterialTextureEncoding): number {
+    return encoding === 'linear' ? 0 : encoding === 'srgb' ? 1 : 2;
+}
+
+function textureChannelCode(channel: MaterialTextureChannel): number {
+    switch (channel) {
+        case 'r':
+            return 0;
+        case 'g':
+            return 1;
+        case 'b':
+            return 2;
+        case 'a':
+            return 3;
+        case 'zero':
+            return 4;
+        case 'one':
+            return 5;
     }
 }
 
@@ -40,6 +78,32 @@ export function packPBRGPUMaterialRecord(material: PBRMaterial, target: Uint8Arr
     values[8] = material.ior;
     values[9] = material.occlusionStrength;
     values[10] = material.normalScale;
-    packUVMatrix(material.getTextureSlot('baseColor')?.transform ?? null, values, 12);
-    packUVMatrix(material.getTextureSlot('normal')?.transform ?? null, values, 24);
+    for (let slotIndex = 0; slotIndex < PBR_GPU_MATERIAL_TEXTURE_SLOTS.length; slotIndex += 1) {
+        const name = PBR_GPU_MATERIAL_TEXTURE_SLOTS[slotIndex];
+        if (name === undefined) throw new Error('PBR GPU texture slot table is incomplete');
+        const definition = material.definition.textureSlots.find(slot => slot.name === name);
+        const binding = material.getTextureSlot(name);
+        if (binding !== null && definition === undefined) {
+            throw new Error(`PBR material definition is missing active texture slot ${name}`);
+        }
+        const slotFloatOffset = 12 + slotIndex * 20;
+        packUVMatrix(binding?.transform ?? null, values, slotFloatOffset);
+        const infoOffset = slotFloatOffset + 12;
+        values[infoOffset] = binding?.uvSet ?? definition?.uvSets[0] ?? 0;
+        values[infoOffset + 1] = textureEncodingCode(
+            binding?.encoding ??
+                definition?.encoding ??
+                (name === 'baseColor' || name === 'emission' ? 'srgb' : 'data')
+        );
+        values[infoOffset + 2] = binding === null ? 0 : 1;
+        values[infoOffset + 3] = 0;
+        const channels = binding?.channels ?? definition?.channels ?? DEFAULT_CHANNELS;
+        const channelOffset = slotFloatOffset + 16;
+        for (let component = 0; component < 4; component += 1) {
+            const channel = channels[component];
+            values[channelOffset + component] = textureChannelCode(
+                channel ?? DEFAULT_CHANNELS[component] ?? 'zero'
+            );
+        }
+    }
 }

--- a/src/shader/basic.frag
+++ b/src/shader/basic.frag
@@ -27,7 +27,7 @@ void main(void) {
             vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
             #include "./chunk/diffuse_main.frag"
             #include "./chunk/transparency_main.frag"
-            hilo_FragColor = vec4(hiloMotionVector(), 0.0, 1.0);
+            hilo_FragColor = hiloMotionData();
             #include "./chunk/logDepth_main.frag"
         }
     #else

--- a/src/shader/basic.vert
+++ b/src/shader/basic.vert
@@ -19,6 +19,8 @@ out vec4 v_objectIdColor;
 #ifdef HILO_MOTION_VECTOR_PASS
 out vec4 v_currentClipPosition;
 out vec4 v_previousClipPosition;
+out float v_currentViewDepth;
+out float v_previousViewDepth;
 flat out float v_motionHistoryValid;
 #endif
 void main(void) {
@@ -61,6 +63,9 @@ void main(void) {
         v_currentClipPosition = currentClipPosition;
         v_previousClipPosition =
             u_previousViewProjectionMatrix * u_previousModelMatrix * previousPos;
+        v_currentViewDepth = abs((u_viewMatrix * u_modelMatrix * pos).z);
+        v_previousViewDepth =
+            abs((u_previousViewMatrix * u_previousModelMatrix * previousPos).z);
         v_motionHistoryValid = min(u_cameraHistoryValid, u_modelHistoryValid);
         #ifdef HILO_JOINT_COUNT
             v_motionHistoryValid = min(v_motionHistoryValid, u_skinHistoryValid);

--- a/src/shader/chunk/motionVector.frag
+++ b/src/shader/chunk/motionVector.frag
@@ -3,15 +3,18 @@
 
     in vec4 v_currentClipPosition;
     in vec4 v_previousClipPosition;
+    in float v_currentViewDepth;
+    in float v_previousViewDepth;
     flat in float v_motionHistoryValid;
 
-    vec2 hiloMotionVector() {
+    vec4 hiloMotionData() {
+        float currentLogDepth = log2(1.0 + max(v_currentViewDepth, 0.0));
         if (
             v_motionHistoryValid < 0.5 ||
-            abs(v_currentClipPosition.w) < 1e-6 ||
-            abs(v_previousClipPosition.w) < 1e-6
+            v_currentClipPosition.w <= 1e-6 ||
+            v_previousClipPosition.w <= 1e-6
         ) {
-            return vec2(0.0);
+            return vec4(0.0, 0.0, -1.0, currentLogDepth);
         }
         vec2 currentUV = hiloRenderTargetUV(
             v_currentClipPosition.xy / v_currentClipPosition.w * 0.5 + 0.5
@@ -19,6 +22,10 @@
         vec2 previousUV = hiloRenderTargetUV(
             v_previousClipPosition.xy / v_previousClipPosition.w * 0.5 + 0.5
         );
-        return currentUV - previousUV;
+        return vec4(
+            currentUV - previousUV,
+            log2(1.0 + max(v_previousViewDepth, 0.0)),
+            currentLogDepth
+        );
     }
 #endif

--- a/src/shader/geometry.frag
+++ b/src/shader/geometry.frag
@@ -29,7 +29,7 @@ vec4 transformDataToColor(vec3 data){
 
 void main(void) {
     #ifdef HILO_MOTION_VECTOR_PASS
-        hilo_FragColor = vec4(hiloMotionVector(), 0.0, 1.0);
+        hilo_FragColor = hiloMotionData();
         #include "./chunk/logDepth_main.frag"
     #else
         #if defined(HILO_VERTEX_TYPE_POSITION)

--- a/src/shader/pbr.frag
+++ b/src/shader/pbr.frag
@@ -26,7 +26,7 @@ void main(void) {
                 color *= v_color;
             #endif
             #include "./chunk/transparency_main.frag"
-            hilo_FragColor = vec4(hiloMotionVector(), 0.0, 1.0);
+            hilo_FragColor = hiloMotionData();
             #include "./chunk/logDepth_main.frag"
         }
     #else

--- a/test/spec/renderer/BuiltInUniformBlockManager.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlockManager.test.ts
@@ -633,6 +633,7 @@ describe('BuiltInUniformBlockManager', () => {
         const render = (x: number): UniformBuffer => {
             mesh.setPosition(x, 0, 0).updateMatrixWorld(true);
             manager.beginFrame(testEnv.camera);
+            manager.markMotionVectorParticipation(mesh);
             return manager.resolveUniformBlock('ModelBlock', mesh, testEnv.material);
         };
 
@@ -649,6 +650,14 @@ describe('BuiltInUniformBlockManager', () => {
 
         block = render(4);
         expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(2);
+        manager.commit({} as never);
+
+        manager.beginFrame(testEnv.camera);
+        manager.commit({} as never);
+        manager.beginFrame(testEnv.camera);
+        block = manager.resolveUniformBlock('ModelBlock', mesh, testEnv.material);
+        expect(readFloatField(block, 'u_previousModelMatrix', 16)[12]).toBe(4);
+        expect(readFloatField(block, 'u_modelHistoryParams', 1)[0]).toBe(0);
         manager.commit({} as never);
 
         mesh.invalidateTransformHistory();

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -6,6 +6,8 @@ import BoxGeometry from '../../../src/geometry/BoxGeometry';
 import Geometry from '../../../src/geometry/Geometry';
 import GeometryData from '../../../src/geometry/GeometryData';
 import MorphGeometry from '../../../src/geometry/MorphGeometry';
+import AreaLight from '../../../src/light/AreaLight';
+import DirectionalLight from '../../../src/light/DirectionalLight';
 import PointLight from '../../../src/light/PointLight';
 import BasicMaterial from '../../../src/material/BasicMaterial';
 import PBRMaterial from '../../../src/material/PBRMaterial';
@@ -55,10 +57,10 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             'indirect-draw'
         ]);
         expect(factory.requirements.requiredLimits).toMatchObject({
-            maxBindingsPerBindGroup: 14,
+            maxBindingsPerBindGroup: 18,
             maxStorageBuffersPerShaderStage: 7,
             maxStorageTexturesPerShaderStage: 1,
-            maxSampledTexturesPerShaderStage: 7,
+            maxSampledTexturesPerShaderStage: 12,
             maxSamplersPerShaderStage: 7,
             maxComputeInvocationsPerWorkgroup: 256
         });
@@ -68,6 +70,34 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         expect(factory.requirements.requiredTextureFormats).toContainEqual({
             format: 'r32float',
             use: 'storage'
+        });
+
+        const withoutHiZ = new ClusteredForwardPlusPipelineFactory({
+            buckets: [{ geometry, material }],
+            hiZ: false,
+            tileSize: 128,
+            zSlices: 1,
+            maxViewportWidth: 9_000,
+            maxViewportHeight: 1
+        });
+        expect(withoutHiZ.requirements.requiredCapabilities).not.toContain('storage-texture');
+        expect(withoutHiZ.requirements.requiredTextureFormats).not.toContainEqual({
+            format: 'r32float',
+            use: 'storage'
+        });
+        expect(withoutHiZ.requirements.requiredLimits).toMatchObject({
+            maxBindingsPerBindGroup: 14,
+            maxSampledTexturesPerShaderStage: 7
+        });
+
+        const maximumHiZ = new ClusteredForwardPlusPipelineFactory({
+            buckets: [{ geometry, material }],
+            maxViewportWidth: 8_192,
+            maxViewportHeight: 8_192
+        });
+        expect(maximumHiZ.requirements.requiredLimits).toMatchObject({
+            maxBindingsPerBindGroup: 19,
+            maxSampledTexturesPerShaderStage: 13
         });
     });
 
@@ -443,6 +473,81 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             }
         },
         30_000
+    );
+
+    it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
+        'keeps directional lights global and routes AreaLight through exact Forward fallback',
+        async () => {
+            const geometry = new BoxGeometry();
+            const material = new PBRMaterial();
+            const factory = new ClusteredForwardPlusPipelineFactory({
+                buckets: [{ geometry, material }],
+                maxObjects: 1,
+                maxLights: 8,
+                maxLightIndices: 1,
+                maxLightsPerCluster: 1,
+                maxViewportWidth: 32,
+                maxViewportHeight: 32,
+                hiZ: false,
+                bloomStrength: 0
+            });
+            const renderer = await Renderer.create({
+                backend: 'webgpu',
+                domElement: document.createElement('canvas'),
+                width: 32,
+                height: 32,
+                antialias: false,
+                renderingProfile: 'high-end',
+                renderPipeline: factory
+            });
+            try {
+                const scene = new Node();
+                new Mesh({ geometry, material }).addTo(scene);
+                let firstDirectional: DirectionalLight | null = null;
+                for (let index = 0; index < 8; index += 1) {
+                    const light = new DirectionalLight({ amount: 0.25 }).addTo(scene);
+                    firstDirectional ??= light;
+                }
+                const camera = new PerspectiveCamera({ aspect: 1, near: 0.1, far: 20 });
+                camera.setPosition(0, 0, 6).lookAt(new Vector3(0, 0, 0));
+
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    objectCount: 1,
+                    fallbackObjectCount: 0,
+                    lightCount: 8,
+                    clusterLightIndexCount: 0,
+                    clusterOverflowCount: 0
+                });
+
+                if (firstDirectional === null) throw new Error('Expected a directional light');
+                firstDirectional.shadow = {};
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    objectCount: 0,
+                    fallbackObjectCount: 1,
+                    clusterLightIndexCount: 0
+                });
+                firstDirectional.shadow = null;
+
+                new AreaLight({ amount: 1, z: 2 }).addTo(scene);
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    objectCount: 0,
+                    fallbackObjectCount: 1,
+                    lightCount: 8,
+                    clusterLightIndexCount: 0,
+                    clusterOverflowCount: 0
+                });
+                expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
+            } finally {
+                renderer.destroy();
+            }
+        },
+        20_000
     );
 
     it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -58,7 +58,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         ]);
         expect(factory.requirements.requiredLimits).toMatchObject({
             maxBindingsPerBindGroup: 18,
-            maxStorageBuffersPerShaderStage: 7,
+            maxStorageBuffersPerShaderStage: 8,
             maxStorageTexturesPerShaderStage: 1,
             maxSampledTexturesPerShaderStage: 12,
             maxSamplersPerShaderStage: 7,
@@ -70,6 +70,18 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         expect(factory.requirements.requiredTextureFormats).toContainEqual({
             format: 'r32float',
             use: 'storage'
+        });
+
+        const withTemporalAA = new ClusteredForwardPlusPipelineFactory({
+            buckets: [{ geometry, material }],
+            temporalAA: {}
+        });
+        expect(withTemporalAA.requirements.requiredLimits).toMatchObject({
+            maxColorAttachments: 3
+        });
+        expect(withTemporalAA.requirements.requiredTextureFormats).toContainEqual({
+            format: 'r32float',
+            use: 'color-attachment'
         });
 
         const withoutHiZ = new ClusteredForwardPlusPipelineFactory({
@@ -173,6 +185,13 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                     typeof ClusteredForwardPlusPipelineFactory
                 >[0])
         ).toThrow(/hiZ must be a boolean/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    temporalAA: { varianceGamma: 8 }
+                })
+        ).toThrow(/varianceGamma/u);
     });
 
     it('requests limits for every configured cluster, geometry, and dispatch allocation', () => {
@@ -224,6 +243,103 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
     });
 
     it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
+        'renders every compacted material bucket without indirect-first-instance',
+        async () => {
+            const geometry = new BoxGeometry();
+            const materials = [
+                new PBRMaterial({
+                    baseColor: new Color(0, 0, 0),
+                    emissionFactor: new Color(3, 0, 0)
+                }),
+                new PBRMaterial({
+                    baseColor: new Color(0, 0, 0),
+                    emissionFactor: new Color(0, 3, 0)
+                }),
+                new PBRMaterial({
+                    baseColor: new Color(0, 0, 0),
+                    emissionFactor: new Color(0, 0, 3)
+                })
+            ] as const;
+            const factory = new ClusteredForwardPlusPipelineFactory({
+                buckets: materials.map(material => ({ geometry, material })),
+                maxObjects: materials.length,
+                maxLights: 1,
+                maxLightIndices: 1,
+                maxLightsPerCluster: 1,
+                maxViewportWidth: 96,
+                maxViewportHeight: 48,
+                hiZ: false,
+                bloomStrength: 0
+            });
+            const renderer = await Renderer.create({
+                backend: 'webgpu',
+                domElement: document.createElement('canvas'),
+                width: 96,
+                height: 48,
+                antialias: false,
+                renderingProfile: 'high-end',
+                renderPipeline: factory
+            });
+            const target = renderer.createRenderTarget({
+                width: 96,
+                height: 48,
+                colorAttachments: [{ format: 'rgba8unorm' }],
+                depthStencilAttachment: { format: 'depth32float', depthMode: 'reversed' }
+            });
+            try {
+                const scene = new Node();
+                for (let index = 0; index < materials.length; index += 1) {
+                    const material = materials[index];
+                    if (material === undefined) throw new Error('Expected a bucket material');
+                    new Mesh({
+                        geometry,
+                        material,
+                        x: (index - 1) * 2,
+                        frustumTest: false
+                    }).addTo(scene);
+                }
+                const camera = new PerspectiveCamera({
+                    aspect: 2,
+                    fov: 45,
+                    near: 0.1,
+                    far: 20,
+                    depthMode: 'reversed'
+                });
+                camera.setPosition(0, 0, 6).lookAt(new Vector3(0, 0, 0));
+
+                renderer.renderToTarget(target, scene, camera);
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                const readback = await target.readColorAttachment();
+                const dominant: [number, number, number] = [0, 0, 0];
+                for (let offset = 0; offset < readback.data.length; offset += 4) {
+                    const red = readback.data[offset] ?? 0;
+                    const green = readback.data[offset + 1] ?? 0;
+                    const blue = readback.data[offset + 2] ?? 0;
+                    const maximum = Math.max(red, green, blue);
+                    if (maximum < 32) continue;
+                    if (red > green * 1.5 && red > blue * 1.5) dominant[0]++;
+                    if (green > red * 1.5 && green > blue * 1.5) dominant[1]++;
+                    if (blue > red * 1.5 && blue > green * 1.5) dominant[2]++;
+                }
+
+                expect(dominant[0]).toBeGreaterThan(20);
+                expect(dominant[1]).toBeGreaterThan(20);
+                expect(dominant[2]).toBeGreaterThan(20);
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    objectCount: 3,
+                    fallbackObjectCount: 0,
+                    visibleObjectCount: 3
+                });
+            } finally {
+                target.destroy();
+                renderer.destroy();
+            }
+        },
+        20_000
+    );
+
+    it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
         'renders GPU Scene culling, indirect buckets and clustered lighting on real WebGPU',
         async () => {
             const geometry = new BoxGeometry({ widthSegments: 2 });
@@ -255,7 +371,8 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 maxLightIndices: 4_096,
                 maxLightsPerCluster: 8,
                 maxViewportWidth: 128,
-                maxViewportHeight: 128
+                maxViewportHeight: 128,
+                temporalAA: {}
             });
             const renderer = await Renderer.create({
                 backend: 'webgpu',

--- a/test/spec/renderer/ForwardRenderer.test.ts
+++ b/test/spec/renderer/ForwardRenderer.test.ts
@@ -502,6 +502,65 @@ describe.each([
         backend.destroy();
     });
 
+    it('executes direct and instanced transparent items in one global renderOrder sequence', async () => {
+        const backend = createBackend();
+        const device = backend.createDevice();
+        const surface = configuredSurface(device);
+        const renderer = new ForwardRenderer(1);
+        const sharedGeometry = new Geometry();
+        const sharedMaterial = new Material({
+            compositing: { mode: 'alpha-blend', premultiplied: true }
+        });
+        const earlyA = new Mesh({
+            geometry: sharedGeometry,
+            material: sharedMaterial,
+            renderOrder: 0,
+            useInstanced: true
+        });
+        const earlyB = new Mesh({
+            geometry: sharedGeometry,
+            material: sharedMaterial,
+            renderOrder: 0,
+            useInstanced: true
+        });
+        const direct = classifiedMesh('direct-middle', 1, true);
+        const late = new Mesh({
+            geometry: sharedGeometry,
+            material: sharedMaterial,
+            renderOrder: 2,
+            useInstanced: true
+        });
+        const earlyDraw = preparedDraw(device, 'rgba8unorm', 1, undefined, 3);
+        const directDraw = preparedDraw(device, 'rgba8unorm', 1, undefined, 6);
+        const lateDraw = preparedDraw(device, 'rgba8unorm', 1, undefined, 9);
+        const meshProcessor = meshProcessorStub({
+            beginFrame: vi.fn(),
+            prepare: vi.fn(() => directDraw),
+            prepareInstancedBatch: vi.fn((_owner: object, meshes: readonly Mesh[]) =>
+                meshes[0]?.renderOrder === 0 ? earlyDraw : lateDraw
+            ),
+            trackSubmission: vi.fn(
+                (_frameIndex: number, submission: RHISubmission) => submission.done
+            )
+        });
+
+        const result = renderer.render(frameContext(device, 4), surface, {
+            meshProcessor,
+            classifiedMeshes: [late, direct, earlyB, earlyA]
+        });
+        await complete(backend);
+        await result.submission.done;
+
+        const earlyIndex = backend.executionLog.indexOf('draw:3');
+        const directIndex = backend.executionLog.indexOf('draw:6');
+        const lateIndex = backend.executionLog.indexOf('draw:9');
+        expect(earlyIndex).toBeGreaterThan(-1);
+        expect(earlyIndex).toBeLessThan(directIndex);
+        expect(directIndex).toBeLessThan(lateIndex);
+        renderer.destroy();
+        backend.destroy();
+    });
+
     it('rolls back instanced preparation failures before surface acquire or RHI beginFrame', () => {
         const backend = createBackend();
         const device = backend.createDevice();

--- a/test/spec/renderer/InstanceBatchCompiler.test.ts
+++ b/test/spec/renderer/InstanceBatchCompiler.test.ts
@@ -428,6 +428,8 @@ describe('InstanceBatchCompiler revisions and high-water storage', () => {
         const blockRevision = block.revision;
         const storageAllocations = compiler.diagnostics.storageAllocationCount;
         const resolvedCapacity = compiler.diagnostics.resolvedInputCapacity;
+        const initialNormalRecomputes = compiler.diagnostics.normalMatrixRecomputeCount;
+        expect(initialNormalRecomputes).toBe(meshes.length);
 
         for (let iteration = 0; iteration < 32; iteration += 1) {
             const stable = compiler.compile(
@@ -450,18 +452,20 @@ describe('InstanceBatchCompiler revisions and high-water storage', () => {
         expect(block.revision).toBe(blockRevision);
         expect(compiler.diagnostics.storageAllocationCount).toBe(storageAllocations);
         expect(compiler.diagnostics.resolvedInputCapacity).toBe(resolvedCapacity);
+        expect(compiler.diagnostics.normalMatrixRecomputeCount).toBe(initialNormalRecomputes);
 
         const firstMesh = meshAt(meshes, 0);
         const secondMesh = meshAt(meshes, 1);
         const secondValues = required(values.get(secondMesh), 'second mesh values');
         secondValues.scalar = 99;
-        secondMesh.worldMatrix.set(3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 5, 0, 0, 0, 0, 1);
+        secondMesh.setScale(3, 4, 5).updateMatrixWorld(true);
         compiler.compile(owner, meshes, material, CUSTOM_INPUTS, 'webgpu', capabilities());
         expect(first.layoutRevision).toBe(layoutRevision);
         expect(first.resourceRevision).toBe(resourceRevision + 1);
         expect(floatData(source)[5]).toBe(99);
         expect(source.revision).toBeGreaterThan(sourceRevision);
         expect(block.revision).toBeGreaterThan(blockRevision);
+        expect(compiler.diagnostics.normalMatrixRecomputeCount).toBe(initialNormalRecomputes + 1);
 
         compiler.compile(
             owner,

--- a/test/spec/renderer/MeshDrawListPlanner.test.ts
+++ b/test/spec/renderer/MeshDrawListPlanner.test.ts
@@ -56,6 +56,8 @@ function expectEmpty(plan: Readonly<MeshDrawListPlan>): void {
     expect(plan.opaqueMeshes).toEqual([]);
     expect(plan.transparentMeshes).toEqual([]);
     expect(plan.instancedBatches).toEqual([]);
+    expect(plan.opaqueItems).toEqual([]);
+    expect(plan.transparentItems).toEqual([]);
 }
 
 describe('MeshDrawListPlanner', () => {
@@ -105,6 +107,8 @@ describe('MeshDrawListPlanner', () => {
             transparent: true,
             meshes: [transparentInstanced]
         });
+        expect(plan.opaqueItems).toEqual([opaqueEarly, plan.instancedBatches[0], opaqueLate]);
+        expect(plan.transparentItems).toEqual([plan.instancedBatches[1], transparentDirect]);
         for (const owner of [
             opaqueEarly,
             opaqueLate,
@@ -183,6 +187,8 @@ describe('MeshDrawListPlanner', () => {
         const opaqueArray = first.opaqueMeshes;
         const transparentArray = first.transparentMeshes;
         const batchArray = first.instancedBatches;
+        const opaqueItems = first.opaqueItems;
+        const transparentItems = first.transparentItems;
         const batch = first.instancedBatches[0];
         const batchMeshes = batch?.meshes;
         const diagnostics = planner.diagnostics();
@@ -194,6 +200,8 @@ describe('MeshDrawListPlanner', () => {
             expect(next.opaqueMeshes).toBe(opaqueArray);
             expect(next.transparentMeshes).toBe(transparentArray);
             expect(next.instancedBatches).toBe(batchArray);
+            expect(next.opaqueItems).toBe(opaqueItems);
+            expect(next.transparentItems).toBe(transparentItems);
             expect(next.instancedBatches[0]).toBe(batch);
             expect(next.instancedBatches[0]?.meshes).toBe(batchMeshes);
             expect(planner.diagnostics()).toBe(diagnostics);
@@ -239,6 +247,55 @@ describe('MeshDrawListPlanner', () => {
         expect(rebuilt.instancedBatches[0]).toBe(batch);
         expect(rebuilt.instancedBatches[0]?.meshes).toBe(batchMeshes);
         expect(diagnostics.storageAllocationCount).toBe(allocationCount);
+    });
+
+    it('preserves global transparent depth order across direct and adjacent instanced items', () => {
+        const planner = new MeshDrawListPlanner();
+        const shared = material('shared-transparent', 0, true);
+        const sharedGeometry = geometry('shared-transparent');
+        const farBatchA = mesh('far-batch-a', shared, sharedGeometry, true);
+        const farBatchB = mesh('far-batch-b', shared, sharedGeometry, true);
+        const middle = mesh(
+            'middle-direct',
+            material('middle-transparent', 0, true),
+            geometry('middle-transparent')
+        );
+        const nearBatch = mesh('near-batch', shared, sharedGeometry, true);
+        farBatchA.setPosition(0, 0, -12).updateMatrixWorld(true);
+        farBatchB.setPosition(0, 0, -11).updateMatrixWorld(true);
+        middle.setPosition(0, 0, -7).updateMatrixWorld(true);
+        nearBatch.setPosition(0, 0, -3).updateMatrixWorld(true);
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.setPosition(0, 0, 0).lookAt(new Vector3(0, 0, -1));
+        camera.updateViewProjectionMatrix();
+
+        const plan = planner.build([nearBatch, middle, farBatchB, farBatchA], null, true, camera);
+
+        expect(plan.instancedBatches).toHaveLength(2);
+        expect(plan.instancedBatches[0]?.meshes).toEqual([farBatchA, farBatchB]);
+        expect(plan.instancedBatches[1]?.meshes).toEqual([nearBatch]);
+        expect(plan.transparentItems).toEqual([
+            plan.instancedBatches[0],
+            middle,
+            plan.instancedBatches[1]
+        ]);
+    });
+
+    it('splits an opaque batch when one owner changes renderOrder', () => {
+        const planner = new MeshDrawListPlanner();
+        const shared = material('mutable-order');
+        const sharedGeometry = geometry('mutable-order');
+        const first = mesh('first', shared, sharedGeometry, true);
+        const second = mesh('second', shared, sharedGeometry, true);
+        const plan = planner.build([first, second]);
+        expect(plan.instancedBatches).toHaveLength(1);
+
+        second.renderOrder = 3;
+        planner.build([first, second]);
+
+        expect(plan.instancedBatches).toHaveLength(2);
+        expect(plan.instancedBatches.map(batch => batch.renderOrder)).toEqual([0, 3]);
+        expect(plan.opaqueItems).toEqual([plan.instancedBatches[0], plan.instancedBatches[1]]);
     });
 
     it('splits exact geometry/material groups into stable batches of at most 128 instances', () => {

--- a/test/spec/renderer/PostProcessing.test.ts
+++ b/test/spec/renderer/PostProcessing.test.ts
@@ -171,8 +171,8 @@ describe('built-in post-processing', () => {
             expect.arrayContaining([
                 { format: 'rgba16float', use: 'color-attachment' },
                 { format: 'rgba16float', use: 'filterable-sampled' },
-                { format: 'rg16float', use: 'color-attachment' },
-                { format: 'r16float', use: 'color-attachment' },
+                { format: 'r32float', use: 'color-attachment' },
+                { format: 'r32float', use: 'sampled' },
                 { format: 'rgba8unorm', use: 'color-attachment' }
             ])
         );
@@ -183,6 +183,8 @@ describe('built-in post-processing', () => {
         expect(() => new Bloom({ knee: 0 })).toThrow(/knee/u);
         expect(() => new TemporalAA({ historyWeight: 2 })).toThrow(/historyWeight/u);
         expect(() => new TemporalAA({ depthThreshold: -1 })).toThrow(/depthThreshold/u);
+        expect(() => new TemporalAA({ varianceGamma: 0 })).toThrow(/varianceGamma/u);
+        expect(() => new TemporalAA({ sharpness: 1 })).toThrow(/sharpness/u);
         expect(() => new ColorUber({ temperature: 2 }).create()).toThrow(/temperature/u);
     });
 
@@ -320,11 +322,28 @@ describe('built-in post-processing', () => {
             renderer.render(scene, camera);
             await renderer.waitForIdle();
             expect(observed.labels).toContain('TemporalAA initialize history');
+            expect(camera.projectionJitterX).toBe(0);
+            expect(camera.projectionJitterY).toBe(0);
 
             observed.labels.length = 0;
             renderer.render(scene, camera);
             await renderer.waitForIdle();
-            expect(observed.labels).toContain('TemporalAA resolve');
+            expect(observed.labels).toContain('TemporalAA production resolve');
+            expect(camera.projectionJitterX).toBe(0);
+            expect(camera.projectionJitterY).toBe(0);
+
+            observed.labels.length = 0;
+            camera.fov = 72;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA initialize history');
+            expect(camera.projectionJitterX).toBe(0);
+            expect(camera.projectionJitterY).toBe(0);
+
+            observed.labels.length = 0;
+            renderer.render(scene, camera);
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA production resolve');
 
             moving.x = 0.4;
             renderer.render(scene, camera);
@@ -403,7 +422,7 @@ describe('built-in post-processing', () => {
             observed.labels.length = 0;
             renderer.render(scene, camera);
             await renderer.waitForIdle();
-            expect(observed.labels).toContain('TemporalAA resolve');
+            expect(observed.labels).toContain('TemporalAA production resolve');
             observed.restore();
         }
     );

--- a/test/spec/renderer/RenderPerformanceArchitecture.test.ts
+++ b/test/spec/renderer/RenderPerformanceArchitecture.test.ts
@@ -261,15 +261,16 @@ describe('render hot-path architecture', () => {
         );
     });
 
-    it('uses one compact visible table and preserves indirect firstInstance bucket ranges', () => {
+    it('uses one compact visible table without requiring indirect-first-instance', () => {
         const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
 
         expect(clustered).toContain("label: 'GPU Scene visible compact table'");
         expect(clustered).toContain('byteLength: this.#visibleBucketCapacity * 4');
         expect(clustered).not.toContain('this.#visibleBucketCapacity * physicalCount * 4');
-        expect(clustered).toContain('atomicStore(&indirectArguments[bucket * 5u + 4u], offset)');
+        expect(clustered).toContain('atomicStore(&indirectArguments[bucket * 5u + 4u], 0u)');
+        expect(clustered).toContain('bucketOffsets[bucket *');
         expect(clustered).toContain(
-            'uint objectIndex = visibleIndices.values[uint(gl_InstanceIndex)]'
+            'visibleIndices.values[visibleOffset.value + uint(gl_InstanceIndex)]'
         );
     });
 
@@ -306,10 +307,10 @@ describe('render hot-path architecture', () => {
     it('shares one invariant GPU Scene clip transform across depth and color passes', () => {
         const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
 
-        expect(clustered.match(/\$\{GPU_SCENE_POSITION_TRANSFORM_SOURCE\}/gu)).toHaveLength(2);
+        expect(clustered.match(/\$\{GPU_SCENE_POSITION_TRANSFORM_SOURCE\}/gu)).toHaveLength(3);
         expect(
             clustered.match(/gl_Position = gpuSceneClipPosition\(objectBase, a_position\);/gu)
-        ).toHaveLength(2);
+        ).toHaveLength(3);
         expect(clustered).not.toContain('gl_Position = readFrameMatrix(0u) * worldPosition;');
     });
 });

--- a/test/spec/renderer/RenderPerformanceArchitecture.test.ts
+++ b/test/spec/renderer/RenderPerformanceArchitecture.test.ts
@@ -229,19 +229,78 @@ describe('render hot-path architecture', () => {
     it('keeps previous-frame Hi-Z bounds conservative for large projected objects', () => {
         const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
 
-        expect(clustered).toContain('const MAX_HIZ_OCCLUSION_DIAMETER = 1 << HIZ_LEVEL_COUNT');
+        expect(clustered).toContain('const MAX_HIZ_OCCLUSION_DIAMETER = 1 << MAX_HIZ_LEVEL_COUNT');
         expect(clustered).toContain(
             'frame.previousProjection * vec4<f32>(viewCenter.xyz + signs * radius, 1.0)'
         );
         expect(clustered).toContain('for (var cornerIndex = 0u; cornerIndex < 8u;');
         expect(clustered).toContain('(maximumUv - minimumUv) * frame.viewport.zw');
-        expect(clustered).toContain('diameter > ${String(MAX_HIZ_OCCLUSION_DIAMETER)}.0');
+        expect(clustered).toContain('const maxHiZOcclusionDiameter = 2 ** hiZLevelCount');
+        expect(clustered).toContain('diameter > ${String(maxHiZOcclusionDiameter)}.0');
         expect(clustered).toContain('ceil(log2(diameter)) - 1.0');
         expect(clustered).not.toContain('floor(log2(diameter)) - 1.0');
         expect(clustered).toContain(
             'sqrt(projectionScale * projectionScale + vec2<f32>(1.0)) * radius'
         );
         expect(clustered).toContain('mesh.frustumTest ? OBJECT_FRUSTUM_CULLING_FLAG : 0');
+        expect(clustered).toContain('const MAX_HIZ_LEVEL_COUNT = 13');
+        expect(clustered).toContain('length: options.hiZLevelCount');
+        expect(clustered).toContain('OBJECT_HIZ_STABLE_FLAG');
+        expect(clustered).toContain('const occlusionStable = transformStable && boundsStable');
+    });
+
+    it('keeps clustered allocation empty-tile aware, deterministic, and directional-global', () => {
+        const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
+
+        expect(clustered).toContain('vec2<u32>(frameData.cluster.z, 0u)');
+        expect(clustered).toContain('let previous = atomicMin(');
+        expect(clustered).not.toContain('clusterCursors');
+        expect(clustered).toContain('if (id.x >= frameData.directional.y) { return; }');
+        expect(clustered).toContain(
+            'for (uint lightIndex = 0u; lightIndex < directional.x; lightIndex += 1u)'
+        );
+    });
+
+    it('uses one compact visible table and preserves indirect firstInstance bucket ranges', () => {
+        const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
+
+        expect(clustered).toContain("label: 'GPU Scene visible compact table'");
+        expect(clustered).toContain('byteLength: this.#visibleBucketCapacity * 4');
+        expect(clustered).not.toContain('this.#visibleBucketCapacity * physicalCount * 4');
+        expect(clustered).toContain('atomicStore(&indirectArguments[bucket * 5u + 4u], offset)');
+        expect(clustered).toContain(
+            'uint objectIndex = visibleIndices.values[uint(gl_InstanceIndex)]'
+        );
+    });
+
+    it('records fallback into HDR before symmetric bloom and the single display transform', () => {
+        const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
+        const record = methodBody(clustered, 'record');
+        const display = methodBody(clustered, 'recordDisplay');
+
+        expect(record.indexOf('this.recordFallback(')).toBeLessThan(
+            record.indexOf('this.recordDisplay(')
+        );
+        expect(record).toContain("format: 'rgba16float'");
+        expect(display).toContain('BLOOM_HORIZONTAL_PASS');
+        expect(display).toContain('BLOOM_VERTICAL_PASS');
+        expect(record).toContain('const bloomEnabled = this.#options.bloomStrength > 0');
+        expect(display).toContain('this.#options.bloomStrength > 0');
+        expect(clustered).toContain('const withBloom = bloomStrength > 0');
+        expect(clustered).not.toContain('BLOOM_BLUR_PASS');
+        expect(clustered).not.toContain('fallbackPresentPass');
+    });
+
+    it('updates scene transforms without building a throwaway CPU cull for GPU-only frames', () => {
+        const clustered = sourceAt('/render/pipeline/ClusteredForwardPlus.ts');
+        const record = methodBody(clustered, 'record');
+
+        expect(record).toContain('context.prepareScene();');
+        expect(record).not.toContain('context.cull({ frustumCulling: false })');
+        expect(record.match(/context\.cull\s*\(/gu)).toHaveLength(1);
+        expect(record.indexOf('if (this.#fallbackObjectCount !== 0)')).toBeLessThan(
+            record.indexOf('fallbackCulling = context.cull()')
+        );
     });
 
     it('shares one invariant GPU Scene clip transform across depth and color passes', () => {

--- a/test/spec/renderer/SharedMaterialRecordDatabase.test.ts
+++ b/test/spec/renderer/SharedMaterialRecordDatabase.test.ts
@@ -225,6 +225,42 @@ describe('packPBRGPUMaterialRecord', () => {
     it('rejects an incompatible destination layout', () => {
         expect(() => {
             packPBRGPUMaterialRecord(new PBRMaterial(), new Uint8Array(16));
-        }).toThrow(/must be 144 bytes/u);
+        }).toThrow(`must be ${String(PBR_GPU_MATERIAL_RECORD_BYTES)} bytes`);
+    });
+
+    it('packs transform, UV set, encoding, presence, and channel mapping per texture slot', () => {
+        const transform = new Matrix3().fromRotationTranslationScale(0.25, 0.2, 0.3, 0.5, 0.75);
+        const material = new PBRMaterial({
+            baseColorMap: {
+                texture: new Texture({ uv: 1 }),
+                uvSet: 1,
+                transform,
+                encoding: 'linear',
+                channels: ['b', 'g', 'r', 'one']
+            }
+        });
+        const target = new Uint8Array(PBR_GPU_MATERIAL_RECORD_BYTES);
+
+        packPBRGPUMaterialRecord(material, target);
+
+        const values = new Float32Array(target.buffer);
+        const matrix = transform.elements;
+        expect(Array.from(values.slice(12, 24))).toEqual([
+            matrix[0],
+            matrix[1],
+            matrix[2],
+            0,
+            matrix[3],
+            matrix[4],
+            matrix[5],
+            0,
+            matrix[6],
+            matrix[7],
+            matrix[8],
+            0
+        ]);
+        expect(Array.from(values.slice(24, 28))).toEqual([1, 0, 1, 0]);
+        expect(Array.from(values.slice(28, 32))).toEqual([2, 1, 0, 5]);
+        expect(values[44]).toBe(0);
     });
 });

--- a/test/ui/clustered-forward-plus-scale.spec.ts
+++ b/test/ui/clustered-forward-plus-scale.spec.ts
@@ -43,10 +43,14 @@ test('keeps the 100k static + 10k dynamic GPU Scene scale contract GPU-only', as
         recoveredFallbackObjectCount: 0
     });
     expect(result?.visibleObjectCount).toBeGreaterThan(0);
-    expect(result?.frameMilliseconds).toHaveLength(5);
-    expect(result?.frameMilliseconds.every(value => Number.isFinite(value) && value > 0)).toBe(
-        true
-    );
+    expect(result?.cpuFrameRecordMilliseconds).toHaveLength(5);
+    expect(
+        result?.cpuFrameRecordMilliseconds.every(value => Number.isFinite(value) && value >= 0)
+    ).toBe(true);
+    expect(result?.gpuBatchCompletionMilliseconds).toHaveLength(2);
+    expect(
+        result?.gpuBatchCompletionMilliseconds.every(value => Number.isFinite(value) && value > 0)
+    ).toBe(true);
 });
 
 declare global {
@@ -59,7 +63,8 @@ declare global {
             readonly visibleObjectCount: number;
             readonly clusterOverflowCount: number;
             readonly hiZValid: boolean;
-            readonly frameMilliseconds: readonly number[];
+            readonly cpuFrameRecordMilliseconds: readonly number[];
+            readonly gpuBatchCompletionMilliseconds: readonly number[];
             readonly recoveryDeviceChanged: boolean;
             readonly recoveredObjectCount: number;
             readonly recoveredFallbackObjectCount: number;

--- a/test/ui/example-paths.contract.ts
+++ b/test/ui/example-paths.contract.ts
@@ -63,11 +63,11 @@ describe('example release matrix contract', () => {
     it('discovers every HTML entry recursively with no hand-maintained gallery omissions', () => {
         expect(examplePaths).toEqual(independentlyDiscoverHtml());
         expect(new Set(examplePaths).size).toBe(examplePaths.length);
-        expect(examplePaths).toHaveLength(76);
+        expect(examplePaths).toHaveLength(77);
     });
 
-    it('expands 76 pages into the complete 145-case backend matrix', () => {
-        expect(exampleCases).toHaveLength(145);
+    it('expands 77 pages into the complete 146-case backend matrix', () => {
+        expect(exampleCases).toHaveLength(146);
         expect(new Set(exampleCases.map(item => `${item.path}:${item.backend}`)).size).toBe(
             exampleCases.length
         );
@@ -77,6 +77,7 @@ describe('example release matrix contract', () => {
                     ? ['webgl2']
                     : path === 'bloom.html' ||
                         path === 'clustered_forward_plus_sponza.html' ||
+                        path === 'temporal_aa_observatory.html' ||
                         path === 'compute_gpu_driven.html' ||
                         path === 'compute_eclipse_shrine.html' ||
                         path === 'compute_particles.html' ||
@@ -93,7 +94,7 @@ describe('example release matrix contract', () => {
 
     it('builds complete, categorized gallery metadata with valid source links', () => {
         const catalog = createExampleCatalog(examplePaths);
-        expect(catalog).toHaveLength(74);
+        expect(catalog).toHaveLength(75);
         expect(new Set(catalog.map(entry => entry.id)).size).toBe(catalog.length);
         expect(new Set(catalog.map(entry => entry.path))).toEqual(
             new Set(examplePaths.filter(path => path !== 'index.html' && path !== 'list.html'))
@@ -103,7 +104,7 @@ describe('example release matrix contract', () => {
         );
         expect(catalog[0]?.id).toBe('quickStart');
         expect(examplesForBackend(catalog, 'webgl2')).toHaveLength(68);
-        expect(examplesForBackend(catalog, 'webgpu')).toHaveLength(73);
+        expect(examplesForBackend(catalog, 'webgpu')).toHaveLength(74);
         expect(catalog.filter(entry => entry.featured).length).toBeGreaterThan(12);
         expect(catalog.filter(entry => entry.featured).length).toBeLessThan(catalog.length);
         expect(
@@ -210,6 +211,7 @@ describe('example release matrix contract', () => {
         expect(WEBGPU_ONLY_EXAMPLE_PATHS).toEqual([
             'bloom.html',
             'clustered_forward_plus_sponza.html',
+            'temporal_aa_observatory.html',
             'compute_gpu_driven.html',
             'compute_eclipse_shrine.html',
             'compute_particles.html',
@@ -229,7 +231,7 @@ describe('example release matrix contract', () => {
         const dedicatedCases = DEDICATED_RELEASE_TEST_EXAMPLE_PATHS.flatMap(path =>
             backendsForExample(path).map(backend => ({ path, backend }))
         );
-        expect(genericCases).toHaveLength(142);
+        expect(genericCases).toHaveLength(143);
         expect(
             [...genericCases, ...dedicatedCases].map(item => `${item.path}:${item.backend}`).sort()
         ).toEqual(exampleCases.map(item => `${item.path}:${item.backend}`).sort());
@@ -252,7 +254,8 @@ describe('example release matrix contract', () => {
         });
         expect(EXAMPLE_QUERY_PARAMETERS).toEqual({
             'compute_eclipse_shrine.html': { test: '1' },
-            'glTFViewer/index.html': { url: '/examples/models/Tmall/Tmall.gltf' }
+            'glTFViewer/index.html': { url: '/examples/models/Tmall/Tmall.gltf' },
+            'temporal_aa_observatory.html': { test: '1' }
         });
         expect(exampleRequestUrl('glTFViewer/index.html', 'webgpu')).toBe(
             '/examples/glTFViewer/index.html?backend=webgpu&url=%2Fexamples%2Fmodels%2FTmall%2FTmall.gltf'

--- a/test/ui/example-paths.ts
+++ b/test/ui/example-paths.ts
@@ -17,6 +17,7 @@ export const WEBGL2_ONLY_EXAMPLE_PATHS = ['webxr.html'] as const;
 export const WEBGPU_ONLY_EXAMPLE_PATHS = [
     'bloom.html',
     'clustered_forward_plus_sponza.html',
+    'temporal_aa_observatory.html',
     'compute_gpu_driven.html',
     'compute_eclipse_shrine.html',
     'compute_particles.html',
@@ -31,6 +32,7 @@ export const EXAMPLE_QUERY_PARAMETERS: Readonly<
     Partial<Record<string, Readonly<Record<string, string>>>>
 > = {
     'compute_eclipse_shrine.html': { test: '1' },
+    'temporal_aa_observatory.html': { test: '1' },
     'glTFViewer/index.html': { url: '/examples/models/Tmall/Tmall.gltf' }
 };
 export const EXAMPLE_COMPLETION_CONTRACTS: Readonly<

--- a/test/ui/examples.spec.ts
+++ b/test/ui/examples.spec.ts
@@ -407,10 +407,10 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
                 items.map(item => (item as HTMLElement).dataset['examplePath'])
             )
         ).toEqual(expected.map(entry => entry.path));
-        await expect(page.locator('.exampleBackendBadge[data-backend="webgpu"]')).toHaveCount(6);
+        await expect(page.locator('.exampleBackendBadge[data-backend="webgpu"]')).toHaveCount(7);
         await expect(page.locator('.exampleBackendBadge[data-backend="webgl2"]')).toHaveCount(1);
         await expect(page.locator('.exampleButton[data-backend-compatible="false"]')).toHaveCount(
-            backend === 'webgl2' ? 6 : 1
+            backend === 'webgl2' ? 7 : 1
         );
 
         const exampleFrame = page.locator('#exampleFrame');

--- a/test/ui/fixtures/clustered-forward-plus-scale.ts
+++ b/test/ui/fixtures/clustered-forward-plus-scale.ts
@@ -26,7 +26,8 @@ interface ClusteredForwardPlusScaleResult {
     readonly visibleObjectCount: number;
     readonly clusterOverflowCount: number;
     readonly hiZValid: boolean;
-    readonly frameMilliseconds: readonly number[];
+    readonly cpuFrameRecordMilliseconds: readonly number[];
+    readonly gpuBatchCompletionMilliseconds: readonly number[];
     readonly recoveryDeviceChanged: boolean;
     readonly recoveredObjectCount: number;
     readonly recoveredFallbackObjectCount: number;
@@ -103,22 +104,30 @@ const camera = new PerspectiveCamera({
 });
 camera.setPosition(0, 0, 40).lookAt(new Vector3(0, 0, 0));
 
-const frameMilliseconds: number[] = [];
-const renderFrame = async (): Promise<void> => {
+const cpuFrameRecordMilliseconds: number[] = [];
+const gpuBatchCompletionMilliseconds: number[] = [];
+const recordFrame = (): void => {
     const start = performance.now();
     renderer.render(scene, camera);
+    cpuFrameRecordMilliseconds.push(performance.now() - start);
+};
+const measureSubmittedBatch = async (frameCount: number): Promise<void> => {
+    const completionStart = performance.now();
+    for (let frame = 0; frame < frameCount; frame += 1) recordFrame();
     await renderer.waitForIdle();
-    frameMilliseconds.push(performance.now() - start);
+    gpuBatchCompletionMilliseconds.push(performance.now() - completionStart);
 };
 
-await renderFrame();
-await renderFrame();
+// Warm pipelines and high-water frame storage without counting compilation/recovery startup.
+renderer.render(scene, camera);
+renderer.render(scene, camera);
+await renderer.waitForIdle();
 for (let index = 0; index < dynamicMeshes.length; index += 1) {
     const mesh = dynamicMeshes[index];
     if (mesh !== undefined) mesh.x += index % 2 === 0 ? 0.01 : -0.01;
 }
 material.roughness = 0.46;
-await renderFrame();
+await measureSubmittedBatch(3);
 const diagnostics = await factory.readDiagnostics();
 const rhi = renderer.getExtension('rhi') as { readonly device: RHIDevice } | null;
 if (rhi === null) throw new Error('GPU Scene scale acceptance requires the public RHI extension');
@@ -144,8 +153,7 @@ const deviceRestored = new Promise<void>(resolve => {
 deviceBeforeRecovery.destroy();
 await deviceLost;
 await Promise.all([renderer.waitForIdle(), deviceRestored]);
-await renderFrame();
-await renderFrame();
+await measureSubmittedBatch(2);
 const recoveredDiagnostics = await factory.readDiagnostics();
 window.__HILO3D_CLUSTERED_FORWARD_PLUS_SCALE_RESULT__ = {
     objectCount: diagnostics.objectCount,
@@ -155,7 +163,8 @@ window.__HILO3D_CLUSTERED_FORWARD_PLUS_SCALE_RESULT__ = {
     visibleObjectCount: diagnostics.visibleObjectCount,
     clusterOverflowCount: diagnostics.clusterOverflowCount,
     hiZValid: diagnostics.hiZValid,
-    frameMilliseconds,
+    cpuFrameRecordMilliseconds,
+    gpuBatchCompletionMilliseconds,
     recoveryDeviceChanged: rhi.device !== deviceBeforeRecovery,
     recoveredObjectCount: recoveredDiagnostics.objectCount,
     recoveredFallbackObjectCount: recoveredDiagnostics.fallbackObjectCount

--- a/test/ui/temporal-aa.spec.ts
+++ b/test/ui/temporal-aa.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '@playwright/test';
+import { PNG } from 'pngjs';
+
+interface PixelDifference {
+    readonly changedRatio: number;
+    readonly meanChannelDelta: number;
+}
+
+function pixelDifference(referenceBuffer: Buffer, candidateBuffer: Buffer): PixelDifference {
+    const reference = PNG.sync.read(referenceBuffer);
+    const candidate = PNG.sync.read(candidateBuffer);
+    expect(candidate.width).toBe(reference.width);
+    expect(candidate.height).toBe(reference.height);
+    let changed = 0;
+    let totalDelta = 0;
+    const pixelCount = reference.width * reference.height;
+    for (let offset = 0; offset < reference.data.length; offset += 4) {
+        const red = Math.abs((reference.data[offset] ?? 0) - (candidate.data[offset] ?? 0));
+        const green = Math.abs(
+            (reference.data[offset + 1] ?? 0) - (candidate.data[offset + 1] ?? 0)
+        );
+        const blue = Math.abs(
+            (reference.data[offset + 2] ?? 0) - (candidate.data[offset + 2] ?? 0)
+        );
+        totalDelta += red + green + blue;
+        if (Math.max(red, green, blue) > 5) changed++;
+    }
+    return {
+        changedRatio: changed / pixelCount,
+        meanChannelDelta: totalDelta / (pixelCount * 3)
+    };
+}
+
+test('keeps the fused Clustered motion/TAA example stable across convergence and camera cuts', async ({
+    page
+}) => {
+    test.setTimeout(60_000);
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    const gpuValidationErrors: string[] = [];
+    const devtools = await page.context().newCDPSession(page);
+    await devtools.send('Log.enable');
+    devtools.on('Log.entryAdded', ({ entry }) => {
+        if (entry.level === 'error' && entry.source === 'rendering') {
+            gpuValidationErrors.push(entry.text);
+        }
+    });
+    page.on('console', message => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    await page.setViewportSize({ width: 800, height: 500 });
+    const examplesOrigin = process.env['HILO3D_EXAMPLES_ORIGIN'] ?? '';
+    await page.goto(
+        `${examplesOrigin}/examples/temporal_aa_observatory.html?backend=webgpu&test=1`,
+        {
+            waitUntil: 'load'
+        }
+    );
+    await expect(page.locator('body')).toHaveAttribute('data-temporal-ready', 'true', {
+        timeout: 45_000
+    });
+    const evidence = await page.evaluate(() => window.__HILO3D_TEMPORAL_OBSERVATORY_RESULT__);
+    expect(evidence).toMatchObject({
+        backend: 'webgpu',
+        objectCount: 100,
+        fallbackObjectCount: 2,
+        hiZValid: true,
+        temporalAA: true
+    });
+    expect(evidence?.visibleObjectCount).toBeGreaterThan(0);
+
+    const canvas = page.locator('canvas');
+    await page.evaluate(async () => {
+        await window.__HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?.settle(10);
+    });
+    const converged = await canvas.screenshot({ animations: 'disabled' });
+    await page.evaluate(async () => {
+        await window.__HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?.settle(1);
+    });
+    const nextStatic = await canvas.screenshot({ animations: 'disabled' });
+    const staticDifference = pixelDifference(converged, nextStatic);
+    expect(staticDifference.changedRatio).toBeLessThan(0.035);
+    expect(staticDifference.meanChannelDelta).toBeLessThan(1.5);
+
+    await page.evaluate(async () => {
+        await window.__HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?.cutAndSettle(1);
+    });
+    const firstCutFrame = await canvas.screenshot({ animations: 'disabled' });
+    expect(pixelDifference(converged, firstCutFrame).changedRatio).toBeGreaterThan(0.04);
+    await page.evaluate(async () => {
+        await window.__HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?.settle(10);
+    });
+    const settledCut = await canvas.screenshot({ animations: 'disabled' });
+    const cutConvergence = pixelDifference(firstCutFrame, settledCut);
+    expect(cutConvergence.changedRatio).toBeLessThan(0.08);
+    expect(cutConvergence.meanChannelDelta).toBeLessThan(3);
+
+    await devtools.detach();
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+    expect(gpuValidationErrors).toEqual([]);
+});
+
+declare global {
+    interface Window {
+        __HILO3D_TEMPORAL_OBSERVATORY_RESULT__?: {
+            readonly backend: 'webgpu';
+            readonly objectCount: number;
+            readonly fallbackObjectCount: number;
+            readonly visibleObjectCount: number;
+            readonly hiZValid: boolean;
+            readonly temporalAA: true;
+        };
+        __HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?: {
+            settle(frames?: number): Promise<void>;
+            cutAndSettle(frames?: number): Promise<void>;
+            teleportAndSettle(frames?: number): Promise<void>;
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- close the documented FPC-01–FPC-16 Forward+, clustered lighting, Hi-Z, batching, and cross-device indirect-draw issues
- productionize motion-vector history and native-resolution TAA with logarithmic-depth rejection, YCoCg variance clipping, reactive weighting, sharpening, and submission-aware rollback
- integrate TAA into Clustered Forward+ with fused depth/motion output, visibility history, correct fallback composition, and stable jitter/Hi-Z ownership
- keep compact visibility O(maxObjects) while using aligned per-bucket storage offsets and zero indirect `firstInstance`, avoiding the optional WebGPU feature that caused later material buckets to disappear
- add the polished WebGPU Temporal Observatory example plus real-pixel convergence, camera-cut, material-bucket, and validation coverage

## Review and rationale

The implementation and acceptance criteria are recorded in `documentation/FORWARD_PLUS_REMEDIATION.md` and `documentation/TEMPORAL_RENDERING_REMEDIATION.md`. The temporal ABI stores current-to-previous UV velocity plus previous/current logarithmic view depth in `rgba16float`; color and depth history use `rgba16float` and `r32float`. Camera, model, deformation, visibility, resize, device-loss, and discarded-frame continuity are handled explicitly.

Unsupported area/shadow lighting and non-GPU-scene materials continue through the exact shared Forward fallback. Opaque fallback is composed in linear HDR before TAA, transparent fallback afterward, and Bloom/display remain downstream. TAAU, dynamic resolution, authored reactive masks, and transparent history stay explicitly deferred.

## Validation

- `npm run typecheck`
- `npm run lint`
- targeted renderer Vitest: 55 passed
- `npm run test:render:architecture`: 144 passed
- `npm run test:rhi`: 216 passed, 1 environment skip
- `npm run test:webgpu`: 16 passed, including 110k-object scale and real WebGPU multi-material readback
- Temporal Observatory Playwright pixel/camera-cut test: passed
- generic example release gate for Temporal Observatory: passed
- `npm run test:ui:contract`: 12 passed
- `npm run format:check`, `npm run docs:check`, `npm run examples:build`, `npm run api:check`, `npm run test:types`, and `npm run test:package`: passed

## Evidence limitations

The full Vitest run completed 1,769 tests with 1 environment skip; the existing `SharedRendererShadow` browser test alone hit its 10-second timeout under full parallel load on this host in two runs, while its isolated rerun passed in 1.2 seconds with the test body completing in 374 ms. No rendering assertion failed. The physical native-GPU lane and full `npm run validate` were not run.