### PR TITLE
feat(render): add fixed-scale TAAU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,19 +25,22 @@
 
 ### Changes
 
-- Add the native-resolution `TemporalAA` Forward feature. Built-in opaque/masked materials now
-  expose a strict single-sample `rgba16float` motion pass containing current-to-previous UV
-  velocity, expected previous logarithmic view depth, and current logarithmic view depth. Camera,
-  model, instance, skin, morph, visibility, and failed-frame history are submission-aware. TAA runs
-  after opaque and before transparent/Bloom with `rgba16float` color history, `r32float`
-  logarithmic-depth history, conservative depth rejection, YCoCg variance clipping,
-  motion/luminance-reactive history weight, resolve-only sharpening,
+- Add the `TemporalAA` Forward feature with native-resolution TAA and fixed-scale TAAU. Built-in
+  opaque/masked materials now expose a strict single-sample `rgba16float` motion pass containing
+  current-to-previous UV velocity, expected previous logarithmic view depth, and current logarithmic
+  view depth. Camera, model, instance, skin, morph, visibility, and failed-frame history are
+  submission-aware. TAA runs after opaque and before transparent/Bloom with `rgba16float` color
+  history, `r32float` logarithmic-depth history, conservative depth rejection, YCoCg variance
+  clipping, motion/luminance-reactive history weight, resolve-only sharpening,
   projection-cut/resize/device-loss invalidation, and deterministic jitter rollback. Clustered
   Forward+ can opt into the same resolve; GPU Scene fuses motion output into its existing depth
   prepass, double-buffers visibility, and composes ordinary Forward fallback opaque before TAA and
   fallback transparent afterward. Add the WebGPU Temporal Observatory example and real-pixel
-  convergence/camera-cut/GPU-validation coverage. TAAU, dynamic resolution, authored reactive masks,
-  and transparent history remain deferred.
+  convergence/camera-cut/GPU-validation coverage. `TemporalAAOptions.renderScale` accepts 0.5–1;
+  sub-native modes render opaque color, depth, motion, Clustered Forward+ Hi-Z, and cluster sizing
+  at the fixed internal scale, then reconstruct Catmull-Rom current color into output-resolution
+  color/depth history and a full-resolution depth attachment before transparent composition. Dynamic
+  resolution, authored reactive masks, and transparent history remain deferred.
 
 - Add canonical built-in material definitions, stable material IDs and revisions, explicit
   forward/depth-only/shadow-caster/picking roles, role-aware shader variants, per-slot texture/UV

--- a/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
+++ b/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
@@ -250,18 +250,18 @@ default 对象而发生串改。
 
 ## 10. 当前完成度与长期路线
 
-| 工作包                       | 状态          | 当前结果 / 下一步                                                               |
-| ---------------------------- | ------------- | ------------------------------------------------------------------------------- |
-| Definition / Instance        | 已完成        | 内置与自定义材质都使用不可变结构和实例数据                                      |
-| Semantic pass                | 已完成基础    | forward/depth/shadow/picking/motion 已接生产路径；attributes 待对应渲染功能实现 |
-| Texture slot                 | 已完成        | 每槽 UV/transform/encoding/channel，glTF extensions 共用 builder                |
-| Typed semantics              | 已完成        | attribute/uniform/texture/slot 常量与联合类型公开                               |
-| UBO lowering                 | 已完成        | scalar 与 slot block 分离，双后端固定 ABI                                       |
-| Shared GPU Material Database | 已完成（PBR） | 私有 PBR table 已抽取、共享、去重，并具备 dirty upload、提交回滚与 recovery     |
-| Variant manifest / warmup    | 未完成        | 增加资产收集、异步 warmup、预算与诊断                                           |
-| Motion vectors               | 已完成首版    | opaque/masked、skin/morph/instance history 与原生分辨率 TAA；透明/TAAU 后续     |
-| Material attributes          | 未完成        | 定义 compact normal/roughness/flags ABI，按 feature 创建附件                    |
-| Advanced surface families    | 后续          | sheen/specular/dispersion、subsurface、hair 等按真实内容和预算推进              |
+| 工作包                       | 状态          | 当前结果 / 下一步                                                                 |
+| ---------------------------- | ------------- | --------------------------------------------------------------------------------- |
+| Definition / Instance        | 已完成        | 内置与自定义材质都使用不可变结构和实例数据                                        |
+| Semantic pass                | 已完成基础    | forward/depth/shadow/picking/motion 已接生产路径；attributes 待对应渲染功能实现   |
+| Texture slot                 | 已完成        | 每槽 UV/transform/encoding/channel，glTF extensions 共用 builder                  |
+| Typed semantics              | 已完成        | attribute/uniform/texture/slot 常量与联合类型公开                                 |
+| UBO lowering                 | 已完成        | scalar 与 slot block 分离，双后端固定 ABI                                         |
+| Shared GPU Material Database | 已完成（PBR） | 私有 PBR table 已抽取、共享、去重，并具备 dirty upload、提交回滚与 recovery       |
+| Variant manifest / warmup    | 未完成        | 增加资产收集、异步 warmup、预算与诊断                                             |
+| Motion vectors               | 已完成首版    | opaque/masked、skin/morph/instance history 与 TAA/固定比例 TAAU；透明时域策略后续 |
+| Material attributes          | 未完成        | 定义 compact normal/roughness/flags ABI，按 feature 创建附件                      |
+| Advanced surface families    | 后续          | sheen/specular/dispersion、subsurface、hair 等按真实内容和预算推进                |
 
 首个共享 GPU Material Database 已满足：
 

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -22,14 +22,16 @@ Draw、HDR/PBR、设备丢失恢复和严格的帧事务都已经存在。当前
    count/prefix/write allocator、有界 overflow 与 storage-aware GGX
    PBR；完整材质层、阴影、cookie/IES、精确 area-light 和透明路径仍需接入。
 4. **时域渲染框架**：recovery-aware history owner、current/previous transform、projection
-   jitter、opaque/masked motion vector 与原生分辨率 TAA 已落地；TAAU、动态分辨率、reactive
+   jitter、opaque/masked motion
+   vector、原生分辨率 TAA 与固定 0.5–1 比例 TAAU 已落地；动态分辨率、authored reactive
    mask 和透明时域策略仍未完成。
 5. **自动曝光与可控显示变换**：已有手动 EV exposure、PBR Neutral、ACES fitted、Reinhard 和 Color
    Uber，但没有 GPU 亮度统计、eye adaptation、exposure history 或参数化 filmic toe/shoulder。
 6. **现代资源与几何虚拟化**：已有 mip/array/aspect subresource graph view，但仍没有 GPU
    meshlet/LOD、纹理流送、KTX 2/Basis、虚拟纹理或虚拟阴影页系统。
 
-最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 MAT0 与 T0 原生分辨率切片上推进 TAAU/reactive
+最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 MAT0 与 T0 固定比例 TAAU 切片上推进 dynamic
+resolution/authored reactive
 mask，同时继续完成 G0/L0 的剩余门禁。E0 是可独立交付的显示质量切片，可以复用已经完成的 F0/F1，但不能抢占或阻塞这些主线：
 
 ```mermaid
@@ -95,21 +97,21 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 
 ## 2. 当前渲染能力基线
 
-| 领域                                 | 当前状态      | 证据与边界                                                                                                                        |
-| ------------------------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Shared Renderer / Render Graph / RHI | 生产可用      | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                         |
-| Raster PBR / HDR                     | 生产可用      | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                              |
-| Shadow                               | 可用基线      | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow 和 PCF；缺少缓存、receiver-driven 分配和虚拟页                                   |
-| Compute / Storage / Indirect         | 底座生产可用  | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                         |
-| Material architecture                | 生产基础      | Definition/Instance、基础语义 Pass 与共享 PBR GPU record 已落地；motion/attributes、更多 family/warmup 待补                       |
-| GPU-driven ordinary scene            | high-end 切片 | 注册的不透明 indexed `Mesh` 走 dirty GPU database、Hi-Z/LOD/compact 与固定 bucket indirect；透明/变形待补                         |
-| Forward+                             | high-end 切片 | 3D cluster count/prefix/write、有界预算和 storage GGX PBR 已闭环；阴影/完整 layered PBR/透明待补                                  |
-| Temporal rendering                   | 原生 TAA 切片 | jitter/non-jitter matrix、opaque/masked velocity、depth rejection、双缓冲 history 与 invalidation 已完成；TAAU/reactive mask 待补 |
-| Exposure / display transform         | 部分可用      | 有手动 EV、固定 tone mapper 与 Color Uber；无亮度统计、eye adaptation、exposure history 或 filmic 曲线控制                        |
-| Screen-space lighting                | 部分基础      | GPU Scene 已有 previous/current Hi-Z；仍无 normal/roughness attribute buffer、GTAO、SSR、SSGI                                     |
-| Volumetrics / atmosphere             | 缺失          | 无 froxel volume、temporal reprojection、physical sky 或 volumetric cloud                                                         |
-| Geometry / texture streaming         | 缺失          | 无 GPU LOD/meshlet/cluster streaming；KTX loader 仅支持 KTX 1.1 2D 容器                                                           |
-| GPU profiling / graph debugging      | 生产基线      | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 时不创建 query                           |
+| 领域                                 | 当前状态      | 证据与边界                                                                                                                                                 |
+| ------------------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared Renderer / Render Graph / RHI | 生产可用      | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                                                  |
+| Raster PBR / HDR                     | 生产可用      | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                       |
+| Shadow                               | 可用基线      | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow 和 PCF；缺少缓存、receiver-driven 分配和虚拟页                                                            |
+| Compute / Storage / Indirect         | 底座生产可用  | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                  |
+| Material architecture                | 生产基础      | Definition/Instance、基础语义 Pass 与共享 PBR GPU record 已落地；motion/attributes、更多 family/warmup 待补                                                |
+| GPU-driven ordinary scene            | high-end 切片 | 注册的不透明 indexed `Mesh` 走 dirty GPU database、Hi-Z/LOD/compact 与固定 bucket indirect；透明/变形待补                                                  |
+| Forward+                             | high-end 切片 | 3D cluster count/prefix/write、有界预算和 storage GGX PBR 已闭环；阴影/完整 layered PBR/透明待补                                                           |
+| Temporal rendering                   | TAA/TAAU 切片 | jitter/non-jitter matrix、opaque/masked velocity、depth rejection、output-resolution history 与固定比例 TAAU 已完成；dynamic resolution/reactive mask 待补 |
+| Exposure / display transform         | 部分可用      | 有手动 EV、固定 tone mapper 与 Color Uber；无亮度统计、eye adaptation、exposure history 或 filmic 曲线控制                                                 |
+| Screen-space lighting                | 部分基础      | GPU Scene 已有 previous/current Hi-Z；仍无 normal/roughness attribute buffer、GTAO、SSR、SSGI                                                              |
+| Volumetrics / atmosphere             | 缺失          | 无 froxel volume、temporal reprojection、physical sky 或 volumetric cloud                                                                                  |
+| Geometry / texture streaming         | 缺失          | 无 GPU LOD/meshlet/cluster streaming；KTX loader 仅支持 KTX 1.1 2D 容器                                                                                    |
+| GPU profiling / graph debugging      | 生产基线      | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 时不创建 query                                                    |
 
 ### 2.1 现有实现中最关键的限制
 
@@ -130,8 +132,8 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 - Render Graph 每帧 Build/Compile，已有 pass culling 和跨帧 transient pool，但没有 compiled graph
   reuse 或同帧物理 alias。
 - Camera/mesh/instance/skin/morph current/previous transform、history-valid ABI、projection
-  jitter、motion-vector material pass 与原生分辨率 temporal
-  resolve 已完成；仍缺 TAAU、动态分辨率和 reactive mask policy。
+  jitter、motion-vector material
+  pass、原生分辨率 TAA 与固定比例 TAAU 已完成；仍缺动态分辨率和 authored reactive mask policy。
 - 当前 turnkey post-processing 提供可选 TemporalAA、Bloom 与 Color Uber；exposure 是手动 EV
   compensation，固定 tone mapper 没有参数化 filmic toe/shoulder，也没有 histogram、eye
   adaptation 或 GPU exposure history。Opaque scene texture 只能支持最低边界的屏幕空间 transmission。
@@ -450,15 +452,18 @@ light、transmission 和 device recovery 有真实 WebGPU 像素证据；overflo
 | ---------------------------------------- | --------------------------------------------------------- | ------------------------------ | ----------------------------------------- |
 | 低分辨率当前帧、velocity、depth、history | reprojection、disocclusion、clamp、reactive mask、upscale | 稳定高分辨率画面与分辨率控制器 | camera cut 无旧帧闪回，运动物体不持续拖影 |
 
-当前已交付 T0 的原生分辨率首切片：内置 opaque/masked Basic/PBR/Geometry 输出 single-sample
-`rgba16float` velocity/previous-current log-view-depth；Camera 同时保留 jittered
-raster 与 non-jittered CPU projection；`TemporalAA` 在 opaque 后、transparent/Bloom 前使用
-`rgba16float` color history、`r32float` log-view-depth history、relative-depth rejection、YCoCg
-variance clipping、motion/luminance-reactive weighting 和 resolve-only
-sharpen。普通 Forward 使用独立 motion semantic pass，Clustered Forward+ 则把 GPU Scene
-motion 融入 depth prepass并记录前一已提交帧 visibility。首次出现、显隐间断、camera/projection
+当前已交付 T0 的原生分辨率 TAA 与固定比例 TAAU 切片：内置 opaque/masked
+Basic/PBR/Geometry 输出 single-sample `rgba16float` velocity/previous-current
+log-view-depth；Camera 同时保留 jittered raster 与 non-jittered CPU projection；`TemporalAA`
+在 opaque 后、transparent/Bloom 前使用 output-resolution `rgba16float` color history、`r32float`
+log-view-depth history、relative-depth rejection、YCoCg variance clipping、motion/luminance-reactive
+weighting 和 resolve-only sharpen。 `renderScale` 可固定为 0.5–1；sub-native 模式同步缩放 opaque
+color/depth/motion、Hi-Z 和 cluster viewport，以 16-tap
+Catmull-Rom 重建当前颜色，并输出 full-resolution
+depth 供透明阶段继续组合。普通 Forward 使用独立 motion semantic pass，Clustered Forward+ 则把 GPU
+Scene motion 融入 depth prepass 并记录前一已提交帧 visibility。首次出现、显隐间断、camera/projection
 cut、resize、失败帧和 device recovery 均进入提交事务与 history invalidation 验收。transparent
-history、TAAU、动态分辨率和 authored reactive mask 保留到后续切片。
+history、动态分辨率和 authored reactive mask 保留到后续切片。
 
 - opaque/alpha-tested geometry 输出 motion vector；skinning/morph 必须有 previous pose；
 - camera jitter 不污染 CPU picking/frustum；提供 jittered 与 non-jittered matrix；
@@ -471,10 +476,10 @@ history、TAAU、动态分辨率和 authored reactive mask 保留到后续切片
 
 按以下顺序交付，避免一次性把 TSR 复杂度混在一起：
 
-1. 原生分辨率 TAA，先验证 motion/history/invalidation 正确性；
-2. 内部低分辨率到输出分辨率的 TAAU，加入 reconstruction filter 和 sharpness；
-3. 基于 GPU timestamp 的动态分辨率控制器，带迟滞、上下限和 camera/UI policy；
-4. reactive mask、transparency composition 和 history resurrection 作为质量迭代。
+1. ~~原生分辨率 TAA，先验证 motion/history/invalidation 正确性；~~ 已完成；
+2. ~~内部低分辨率到输出分辨率的 TAAU，加入 reconstruction filter 和 sharpness；~~ 已完成；
+3. 基于 GPU timestamp 的动态分辨率控制器，带迟滞、上下限、history invalidation 和 camera/UI policy；
+4. authored reactive mask、transparency composition 和 history resurrection 作为质量迭代。
 
 完成标准：静态画面收敛、运动物体不拖影、camera
 cut 不闪旧 history、动态分辨率不改变 UI 分辨率；测试同时覆盖高亮 emissive、细栅栏、alpha-test、透明、粒子和快速旋转。
@@ -671,18 +676,18 @@ flowchart TD
 
 ## 8. 主要代码落点
 
-| 领域              | 现有入口                                             | 建议增量                                                                                      |
-| ----------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Public capability | `RendererOptions.ts`、`RenderPipeline.ts`            | WebGPU high-end profile、subgroup/query/temporal/streaming requirements                       |
-| RHI core          | `src/render/rhi/core/`                               | query、debug marker、subresource view、subgroup limits；保持 native type 不越界               |
-| WebGPU backend    | `src/render/rhi/backends/webgpu/`                    | query/timestamp、feature mapping、view/cache、f16/subgroup pipeline                           |
-| Render Graph      | `src/render/graph/`、`ScriptableRenderGraph.ts`      | texture/view 分离、history/persistent texture、subresource hazard                             |
-| Shader compiler   | `src/render/shader/`、`src/render/compute/`          | exact storage layout、f16/subgroup validation、built-in storage PBR variant                   |
-| Shared renderer   | `src/render/renderer/`                               | GPUScene、Hi-Z、GPU cull/LOD、cluster lighting、motion vector、shadow residency               |
-| Pipeline features | `src/render/pipeline/`、`src/render/postprocessing/` | auto exposure、filmic display transform、TAAU、GTAO、SSR/SSGI、volumetric、dynamic resolution |
-| Camera/frame ABI  | `src/camera/`、`BuiltInUniformBlocks.ts`             | reversed-Z、jittered/non-jittered、current/previous、camera-relative origin                   |
-| Assets            | `src/loader/`、`src/texture/`、`src/geometry/`       | KTX 2/Basis、meshopt/meshlet metadata、residency and streaming budget                         |
-| Diagnostics       | `RendererDiagnostics`、RHI diagnostics               | GPU timeline、exposure/EV、graph viewer、resident bytes、overflow/culling counters            |
+| 领域              | 现有入口                                             | 建议增量                                                                                |
+| ----------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Public capability | `RendererOptions.ts`、`RenderPipeline.ts`            | WebGPU high-end profile、subgroup/query/temporal/streaming requirements                 |
+| RHI core          | `src/render/rhi/core/`                               | query、debug marker、subresource view、subgroup limits；保持 native type 不越界         |
+| WebGPU backend    | `src/render/rhi/backends/webgpu/`                    | query/timestamp、feature mapping、view/cache、f16/subgroup pipeline                     |
+| Render Graph      | `src/render/graph/`、`ScriptableRenderGraph.ts`      | texture/view 分离、history/persistent texture、subresource hazard                       |
+| Shader compiler   | `src/render/shader/`、`src/render/compute/`          | exact storage layout、f16/subgroup validation、built-in storage PBR variant             |
+| Shared renderer   | `src/render/renderer/`                               | GPUScene、Hi-Z、GPU cull/LOD、cluster lighting、motion vector、shadow residency         |
+| Pipeline features | `src/render/pipeline/`、`src/render/postprocessing/` | auto exposure、filmic display transform、GTAO、SSR/SSGI、volumetric、dynamic resolution |
+| Camera/frame ABI  | `src/camera/`、`BuiltInUniformBlocks.ts`             | reversed-Z、jittered/non-jittered、current/previous、camera-relative origin             |
+| Assets            | `src/loader/`、`src/texture/`、`src/geometry/`       | KTX 2/Basis、meshopt/meshlet metadata、residency and streaming budget                   |
+| Diagnostics       | `RendererDiagnostics`、RHI diagnostics               | GPU timeline、exposure/EV、graph viewer、resident bytes、overflow/culling counters      |
 
 任何公共 API 变更仍需遵循仓库规则：测试、TypeDoc、`CHANGELOG.md`、API
 report、类型消费和 package 验证必须同版本完成。
@@ -737,7 +742,7 @@ time、确定的资源预算和失败时的可观察行为。
 5. MAT0：把 G0/L0 的 material
    record/variant/surface 原型抽取为共享 Definition/Instance、语义 Pass 和 material
    ABI（基础已完成）；
-6. 原生分辨率 TAA，再扩为 TAAU/dynamic resolution；
+6. 原生分辨率 TAA 与固定比例 TAAU（已完成），下一步接 dynamic resolution/reactive mask；
 7. 完成 G0/L0 的透明、变形、阴影、完整 layered PBR 与物理性能门禁；
 8. Auto exposure + exposure history + 参数化 filmic display
    transform；该 M 级切片可在 F0/F1 之后并行，但不能阻塞 D0/G0/L0/T0；
@@ -753,7 +758,7 @@ flowchart LR
   F0 --> F1["F1 Capability / GPU Timeline"]
   F0 --> E0["E0 Auto Exposure / Filmic"]
   F1 --> E0
-  D0 --> T0["T0 TAAU / Dynamic Resolution"]
+  D0 --> T0["T0 Dynamic Resolution / Reactive Mask"]
   D0 --> G0["G0 GPU Scene / Hi-Z"]
   F1 --> G0
   G0 --> L0["L0 Clustered Forward+"]

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -102,18 +102,24 @@ ray；volume 根据折射方向修正光程，再用 Beer-Lambert attenuation �
 
 `TemporalAA` 是可选的 `after-opaque` feature。它先用内置材质的 `motion-vector` semantic
 pass 把 opaque/masked 的 current-to-previous UV velocity、expected previous
-log-view-depth 与 current log-view-depth 写入 single-sample `rgba16float`。resolve 使用上一帧
-`rgba16float` color history 与 `r32float` log-view-depth history 做原生分辨率 reprojection、保守 2×2
-relative-depth disocclusion、YCoCg 3×3 variance clipping、motion/luminance-reactive history
+log-view-depth 与 current log-view-depth 写入 single-sample `rgba16float`。默认 `renderScale=1`
+使用原生分辨率；0.5–1 的固定 sub-native scale 会让 opaque scene
+color/depth/motion 在内部尺寸渲染，再用 16-tap
+Catmull-Rom 重建当前颜色。resolve 使用上一帧 output-resolution `rgba16float` color history 与
+`r32float` log-view-depth history 做 reprojection、保守 2×2 relative-depth disocclusion、YCoCg 3×3
+variance clipping、motion/luminance-reactive history
 weight 和只作用于输出的轻量 sharpen；未经 sharpen 的 resolved
 color 才回写 history，避免逐帧反馈过锐。history 双缓冲只在有效 submission 后轮换；camera
 cut、显著 projection 变化、resize、显隐间断、显式 transform invalidation 和 device
 recovery 会让下一帧重新初始化，失败帧保留上一份已提交 history 和 jitter index。
 
 Camera 同时维护 jittered raster projection 与 non-jittered CPU
-projection；frustum、picking、project/unproject 不读取 jitter。TAA
-resolve 只处理 opaque 结果，transparent/transmission 在它之后合成，Bloom 再消费完整线性 HDR 颜色。TAAU、动态分辨率和 reactive
-mask 不属于当前首版；当前 luminance reactive
+projection；frustum、picking、project/unproject 不读取 jitter。TAA/TAAU
+resolve 只处理 opaque 结果；TAAU 同时重建 full-resolution
+depth，供 transparent/transmission 在输出尺寸继续合成，Bloom 再消费完整线性 HDR 颜色。重建深度使用对应 internal
+texel；带 stencil 的目标会在 TAAU 输出深度上把 stencil 清零，因此依赖 opaque
+stencil 值的透明自定义 pass 应保持 `renderScale=1`。动态分辨率和 authored reactive
+mask 不属于当前切片；当前 luminance reactive
 response 是 resolve 内部启发式，不等同于材质提供的 authored reactive mask。
 
 `ClusteredForwardPlusPipelineFactory` 通过 `temporalAA` 显式 opt-in 同一 resolve。GPU

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -184,10 +184,13 @@ transfer。
 `rgba16float`，opaque queue 完成后由 graph `TextureCopyPass` 捕获 opaque scene
 texture，再把该 texture 作为 pass-global binding 交给 transparent PBR transmission/volume draw。可选
 `TemporalAA` 在 opaque 后记录 `rgba16float` motion/log-depth，并用 `rgba16float` 双缓冲 color
-history 和 `r32float` 双缓冲 log-view-depth history 完成原生分辨率 reprojection、relative-depth
-disocclusion、YCoCg variance clipping 与 reactive resolve。resolved opaque
-color 随后才接受 transparent composition，因此透明不写入 TAA history。Clustered Forward+ opt-in
-TAA 时把 GPU Scene motion 融入 depth prepass，以前一已提交帧的 visibility
+history 和 `r32float` 双缓冲 log-view-depth history 完成 reprojection、relative-depth
+disocclusion、YCoCg variance clipping 与 reactive resolve。默认 `renderScale=1`
+是原生分辨率 TAA；固定 0.5–1 的 sub-native scale 会同步缩放 opaque
+color/depth/motion、Hi-Z 与 cluster viewport，用 Catmull-Rom 重建当前帧，并写 output-resolution
+color/depth history、resolved color 和供后续 scene pass 使用的 full-resolution depth。resolved
+opaque color 随后才接受 transparent composition，因此透明不写入 TAA/TAAU history。Clustered Forward+
+opt-in TAA 时把 GPU Scene motion 融入 depth prepass，以前一已提交帧的 visibility
 buffer 拒绝重现物体的陈旧 history；fallback opaque/masked 在 resolve 前补写同一 motion
 target，fallback transparent 在 resolve 后合成。之后 `Bloom` 在 tone mapping 前记录 soft-knee/Karis
 prefilter、13-tap downsample pyramid、tent upsample 与线性 composite；`ColorUber`

--- a/documentation/TEMPORAL_RENDERING_REMEDIATION.md
+++ b/documentation/TEMPORAL_RENDERING_REMEDIATION.md
@@ -1,6 +1,6 @@
 # Motion Vector 与 TemporalAA 上线整改规范
 
-本文记录 2026-08 在最新 `origin/dev` 基线上对 Motion Vector、TemporalAA、Clustered
+本文记录 2026-08 在最新 `origin/dev` 基线上对 Motion Vector、TemporalAA、固定比例 TAAU、Clustered
 Forward+ 时域集成、Hi-Z 显隐连续性和兼容 Forward
 fallback 的专项审查。目标不是增加一个仅在 demo 中可用的滤镜，而是形成可回滚、可恢复、可验证且默认无性能回归的生产合同。
 
@@ -11,8 +11,12 @@ fallback 的专项审查。目标不是增加一个仅在 demo 中可用的滤�
   generation 不能推进 camera、model、instance、skin、morph、GPU Scene object 或 visibility history。
 - Camera 的 raster jitter 不改变 CPU
   frustum、picking、project/unproject；成功和失败路径都必须在 frame 边界清零 jitter。
-- TAA
-  history 只包含 opaque/masked 线性 HDR 结果。transparent/transmission 在 resolve 后合成，Bloom/display 再消费完整场景。
+- TAA/TAAU
+  history 只包含 opaque/masked 线性 HDR 结果。transparent/transmission 在 resolve 后以 output
+  resolution 合成，Bloom/display 再消费完整场景。
+- `renderScale` 是 0.5–1 的固定配置。sub-native 模式同步缩放 scene
+  color、depth、motion、Hi-Z 和 cluster viewport，但 color/depth
+  history、resolve 与后续透明组合保持 output resolution。
 - Clustered GPU Scene 复用已有 depth prepass 输出 motion，不为 GPU-managed
   object 增加第二次几何 replay；ordinary Forward 与 Clustered fallback 继续使用材质 `motion-vector`
   pass。
@@ -54,7 +58,7 @@ revision 不连续或上一提交未参与 motion pass 时，Z 必须写 `-1`，
 
 ## 帧序
 
-启用 Clustered TAA 后，一个 camera frame 的关键顺序是：
+启用 Clustered TAA/TAAU 后，一个 camera frame 的关键顺序是：
 
 1. 更新 stable camera/scene transform，并暂存 jitter；
 2. GPU frustum/Hi-Z cull、bucket prefix 与 visible compact，同时写 current visibility；
@@ -62,7 +66,8 @@ revision 不连续或上一提交未参与 motion pass 时，Z 必须写 `-1`，
 4. Cluster allocation 与 Clustered PBR opaque；
 5. ordinary Forward fallback opaque 写入同一 HDR/depth，随后用材质 motion role 补写同一 motion
    target；
-6. TAA initialize 或 resolve，写 current color/depth history 与未进入 history 的 sharpened output；
+6. TAA initialize 或 resolve；TAAU 先以 Catmull-Rom 重建当前颜色，并写 output-resolution color/depth
+   history、未进入 history 的 sharpened output 与 full-resolution scene depth；
 7. ordinary Forward fallback transparent/transmission 合成；
 8. Bloom、display transform、present；
 9. 只有 queue 接受 submission 后才轮换 color/depth/visibility history 并提交 previous transforms。
@@ -80,26 +85,31 @@ index 和 previous transform 都保持最后成功状态。
 - 大 motion 最多只保留 60%
   history；当前/上一亮度差进一步降低 weight。该 response 是安全默认，不是 authored reactive
   mask 的替代品。
-- transparent、particle、UI 不写当前 history。它们保持清晰的当前帧 composition，后续 TAAU 工作包再定义单独的 reactive/composition
-  policy。
+- transparent、particle、UI 不写当前 history。它们在 TAAU 后保持 output-resolution 的当前帧 composition；per-material
+  reactive/composition policy 仍是后续质量切片。
+- TAAU full-resolution depth 使用对应 internal depth texel；stencil 从零开始。依赖 opaque
+  stencil 标记的透明自定义 pass 必须保持原生 `renderScale=1`。
 
 ## 性能与内存
 
-TAA 是明确 opt-in。以不含 backend row-pitch/alignment 的格式字节估算：
+TAA/TAAU 是明确 opt-in。以不含 backend row-pitch/alignment 的格式字节估算：
 
-| 资源/工作          | ordinary Forward                                        | Clustered Forward+                                                                    |
-| ------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Motion target      | `8 B/pixel` transient；额外 opaque/masked motion replay | `8 B/pixel` transient；GPU object 融入已有 depth prepass，只有 fallback opaque replay |
-| Color history      | 双缓冲 `rgba16float`，合计 `16 B/pixel` persistent      | 相同                                                                                  |
-| Depth history      | 双缓冲 `r32float`，合计 `8 B/pixel` persistent          | 相同                                                                                  |
-| Resolved target    | `8 B/pixel` transient                                   | 相同                                                                                  |
-| Visibility history | 无                                                      | 双缓冲 `uint`，合计 `8 B/object`；只在启用时存在                                      |
+| 资源/工作           | ordinary Forward                                                     | Clustered Forward+                                                                             |
+| ------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Motion target       | `8 B/internal pixel` transient；额外 opaque/masked motion replay     | `8 B/internal pixel` transient；GPU object 融入已有 depth prepass，只有 fallback opaque replay |
+| Color history       | 双缓冲 output-resolution `rgba16float`，合计 `16 B/pixel` persistent | 相同                                                                                           |
+| Depth history       | 双缓冲 output-resolution `r32float`，合计 `8 B/pixel` persistent     | 相同                                                                                           |
+| Resolved target     | output-resolution `8 B/pixel` transient                              | 相同                                                                                           |
+| TAAU resolved depth | sub-native 模式额外一张 output-resolution depth transient            | 相同                                                                                           |
+| Visibility history  | 无                                                                   | 双缓冲 `uint`，合计 `8 B/object`；只在启用时存在                                               |
 
-1080p 下，上述 history 加 motion/resolved 的理论额外峰值约 83 MB；其中约 50 MB 是跨帧 persistent
-history。resolve 每像素读取 3×3 current neighborhood、一个 color history、一个 motion
-sample 和最多四个 depth history texel，并输出三张 attachment。它适合 high-end/native-resolution
-profile，不应在内存受限设备上默认开启。TAAU、动态分辨率、history packing 或 half-resolution
-variant 必须作为独立质量档设计，不能偷偷改变当前 ABI。
+原生 1080p 下，上述 history 加 motion/resolved 的理论额外峰值约 83 MB；其中约 50
+MB 是跨帧 persistent history。TAAU 的 current scene/motion/depth 成本按 `renderScale²`
+下降，但 output history、resolved color 与新增 resolved depth 不缩放。原生 resolve 每像素读取 3×3
+current neighborhood；TAAU 额外用 16-tap Catmull-Rom 重建当前颜色。两者还读取一个 color
+history、一个 motion sample 和最多四个 depth history texel，并输出三张 color
+attachment。它适合 high-end profile，不应在内存受限设备上默认开启。动态分辨率、history
+packing 或更低质量 tier 必须作为独立设计，不能偷偷改变当前 ABI。
 
 ## 自动化验收
 
@@ -114,12 +124,12 @@ variant 必须作为独立质量档设计，不能偷偷改变当前 ABI。
 用于人工审阅和自动化像素验收的页面是
 [`examples/temporal_aa_observatory.html`](../examples/temporal_aa_observatory.html)。它同时覆盖 100 个 GPU
 Scene object、ordinary Forward opaque/transmission fallback、动态局部光、Hi-Z、Bloom、camera
-cut 和 motion pause，测试模式固定内部 640×360 以保持软件 WebGPU 的确定性。
+cut 和 motion pause；测试模式固定 output 640×360，并以 `renderScale=0.75` 覆盖 TAAU。
 
 ## 明确保留到后续版本
 
 - transparent/particle history 与 per-material authored reactive mask；
-- TAAU、动态分辨率、exposure-compensated history 和 resolution-scale controller；
+- 动态分辨率、exposure-compensated history 和 resolution-scale controller；
 - normal/material ID rejection、velocity dilation 和专用 thin-feature reconstruction；
 - memory-constrained quality tier 与 history format packing。
 

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -1948,6 +1948,7 @@ export interface ForwardRenderFeatureContext {
 export interface ForwardRenderFeatureRequirements extends RenderPipelineRequirements {
     readonly sampledDepth: boolean;
     readonly sampledSceneColor: boolean;
+    readonly sceneScale?: number;
 }
 
 // @public
@@ -1993,6 +1994,7 @@ export interface ForwardRenderPipelineResources {
     readonly colorEncoding: RenderColorEncoding;
     readonly depth: RenderGraphTextureHandle | null;
     replaceColor(texture: RenderGraphTextureHandle, encoding: RenderColorEncoding): void;
+    replaceDepth(texture: RenderGraphTextureHandle): void;
 }
 
 // @public
@@ -8129,32 +8131,14 @@ export class TemporalAA implements ForwardRenderPipelineFeature {
     // (undocumented)
     readonly name = "temporal-aa";
     // (undocumented)
-    readonly requirements: Readonly<{
-        requiredLimits: Readonly<{
-            maxColorAttachments: 3;
-        }>;
-        requiredTextureFormats: readonly (Readonly<{
-            format: "rgba16float";
-            use: "color-attachment";
-        }> | Readonly<{
-            format: "rgba16float";
-            use: "filterable-sampled";
-        }> | Readonly<{
-            format: "r32float";
-            use: "color-attachment";
-        }> | Readonly<{
-            format: "r32float";
-            use: "sampled";
-        }>)[];
-        sampledSceneColor: true;
-        sampledDepth: true;
-    }>;
+    readonly requirements: Readonly<ForwardRenderFeatureRequirements>;
 }
 
 // @public
 export interface TemporalAAOptions {
     readonly depthThreshold?: number;
     readonly historyWeight?: number;
+    readonly renderScale?: number;
     readonly sharpness?: number;
     readonly varianceGamma?: number;
 }

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -126,7 +126,7 @@ const DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'clustered_forward_plus_sponza.html':
         'Explore Khronos Sponza under 192 animated local lights, GPU Scene culling, clustered shading, HDR bloom, and a cinematic camera tour.',
     'temporal_aa_observatory.html':
-        'Stress fused motion vectors, visibility-aware history, logarithmic depth rejection, and native-resolution TAA in a kinetic WebGPU constellation.',
+        'Stress fused motion vectors, visibility-aware history, logarithmic depth rejection, and fixed-scale TAAU in a kinetic WebGPU constellation.',
     'compute_eclipse_shrine.html':
         'Orbit a cinematic eclipse built from 65,536 compute-simulated bodies, three indirect spectral layers, PBR relics, HDR bloom, and interactive gravity.',
     'compute_particles.html':

--- a/examples/temporal_aa_observatory.html
+++ b/examples/temporal_aa_observatory.html
@@ -25,7 +25,7 @@
             <dl class="temporalMetrics">
                 <div>
                     <dt>resolve</dt>
-                    <dd>native</dd>
+                    <dd>75% TAAU</dd>
                 </div>
                 <div>
                     <dt>history</dt>

--- a/examples/temporal_aa_observatory.ts
+++ b/examples/temporal_aa_observatory.ts
@@ -15,6 +15,7 @@ interface TemporalObservatoryEvidence {
     readonly visibleObjectCount: number;
     readonly hiZValid: boolean;
     readonly temporalAA: true;
+    readonly renderScale: 0.75;
 }
 
 const search = new URLSearchParams(location.search);
@@ -91,6 +92,7 @@ const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
     bloomStrength: 0.45,
     exposure: 1,
     temporalAA: {
+        renderScale: 0.75,
         historyWeight: 0.92,
         depthThreshold: 0.02,
         varianceGamma: 1.25,
@@ -335,7 +337,8 @@ window.__HILO3D_TEMPORAL_OBSERVATORY_RESULT__ = {
     fallbackObjectCount: diagnostics.fallbackObjectCount,
     visibleObjectCount: diagnostics.visibleObjectCount,
     hiZValid: diagnostics.hiZValid,
-    temporalAA: true
+    temporalAA: true,
+    renderScale: 0.75
 };
 window.__HILO3D_TEMPORAL_OBSERVATORY_TEST_API__ = {
     async settle(frames = 8): Promise<void> {

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -2356,6 +2356,7 @@ class ScriptablePassSlot {
             owner.appendRendererListDraws(
                 list,
                 this.draw,
+                this.executionViewport,
                 this.targetDescriptor,
                 this.#sceneStorageVariant,
                 this.#sceneStoragePreparation,
@@ -5086,6 +5087,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
     appendRendererListDraws(
         handle: RendererListHandle,
         drawPass: SharedDrawPassParameters,
+        viewport: Readonly<RHIViewport>,
         target: RHIMeshDrawTargetDescriptor,
         storageVariant: Readonly<SceneStorageShaderVariant> | null,
         storagePreparation: StorageScenePreparationState,
@@ -5112,7 +5114,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         this.services.fireScriptableBeforeScene(beforeEventMeshes, this.#fireEvent, false);
         const context = this.services.createScriptableFrameContext(
             camera,
-            this.rhiViewport,
+            viewport,
             this.frameIndex
         );
         this.services.beginScriptableMeshPass(context);

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -99,6 +99,7 @@ import type {
     RenderPipelineColorAttachment,
     RenderPipelineDepthStencilAttachment,
     RenderPipelineHistoryTextureDescriptor,
+    RenderPipelineTextureDescriptor,
     ScriptableRenderPass,
     ScriptableRenderPassBuilder,
     ScriptableRenderPassContext
@@ -106,9 +107,9 @@ import type {
 import {
     TEMPORAL_AA_REQUIREMENTS,
     TEMPORAL_MOTION_CLEAR,
-    TEMPORAL_MOTION_DESCRIPTOR,
     TemporalResolveController,
     snapshotTemporalAAOptions,
+    temporalMotionDescriptor,
     type TemporalAAOptions,
     type TemporalAASettings
 } from '../postprocessing/TemporalAA';
@@ -200,7 +201,7 @@ export interface ClusteredForwardPlusPipelineOptions {
     readonly bloomStrength?: number;
     /** Exposure multiplier applied before the ACES display transform. Defaults to 1. */
     readonly exposure?: number;
-    /** Integrated native-resolution temporal AA. Disabled by default; `false` explicitly disables it. */
+    /** Integrated temporal AA/TAAU. Disabled by default; `false` explicitly disables it. */
     readonly temporalAA?: Readonly<TemporalAAOptions> | false;
 }
 
@@ -2829,6 +2830,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #hizDescriptors: readonly Readonly<RenderPipelineHistoryTextureDescriptor>[];
     readonly #hizCullPass: ComputeRenderPass | null;
     readonly #temporal: TemporalResolveController | null;
+    readonly #temporalMotionDescriptor: Readonly<RenderPipelineTextureDescriptor> | null;
     readonly #clearPass = new ClearBuffersPass();
     readonly #clearPool = new RenderPassParameterPool(
         () => new ClearBuffersParameters(),
@@ -2964,6 +2966,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#onDestroy = onDestroy;
         this.#temporal =
             options.temporalAA === null ? null : new TemporalResolveController(options.temporalAA);
+        this.#temporalMotionDescriptor =
+            options.temporalAA === null
+                ? null
+                : temporalMotionDescriptor(options.temporalAA.renderScale);
         this.#hizKeys = Object.freeze(
             Array.from({ length: options.hiZLevelCount }, () => Object.freeze({}))
         );
@@ -3143,7 +3149,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                     format: 'r32float' as const,
                     extent: Object.freeze({
                         relativeTo: 'output' as const,
-                        scale: 1 / 2 ** (index + 1),
+                        scale: (options.temporalAA?.renderScale ?? 1) / 2 ** (index + 1),
                         minWidth: 1,
                         minHeight: 1
                     }),
@@ -3201,6 +3207,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         // visibility ownership; a CPU cull is built only when fallback meshes actually exist.
         context.prepareScene();
         const temporalFrame = this.#temporal?.begin(context) ?? null;
+        const sceneScale = this.#options.temporalAA?.renderScale ?? 1;
+        const renderWidth = Math.max(1, Math.floor(context.output.width * sceneScale));
+        const renderHeight = Math.max(1, Math.floor(context.output.height * sceneScale));
         this.refreshGPUCompatibility();
         this.collectScene(context);
         let fallbackCulling: CullingResultsHandle | null = null;
@@ -3210,27 +3219,31 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         this.#materialDatabase.stage(context);
         this.syncGeometryDatabases(context);
-        const frame = this.packFrame(context);
+        const frame = this.packFrame(context, renderWidth, renderHeight);
         context.writeStorageBuffer(this.#frameData, 0, new Uint8Array(this.#frameBytes));
 
         const output = context.graph.importOutput();
         const outputColor = output.color(0);
         const sceneColor = context.graph.createTexture('Clustered Forward+ HDR scene', {
             format: 'rgba16float',
-            extent: { relativeTo: 'output', scale: 1 },
+            extent: { relativeTo: 'output', scale: sceneScale },
             sampleCount: 1
         });
         const sceneDepth = context.graph.createTexture('GPU Scene depth', {
             format: 'depth32float',
-            extent: { relativeTo: 'output', scale: 1 },
+            extent: { relativeTo: 'output', scale: sceneScale },
             sampleCount: 1
         });
+        const motionDescriptor = this.#temporalMotionDescriptor;
+        if (temporalFrame !== null && motionDescriptor === null) {
+            throw new Error('Clustered Forward+ temporal motion descriptor is missing');
+        }
         const temporalMotion =
-            temporalFrame === null
+            temporalFrame === null || motionDescriptor === null
                 ? null
                 : context.graph.createTexture(
                       'Clustered Forward+ temporal motion and view depth',
-                      TEMPORAL_MOTION_DESCRIPTOR
+                      motionDescriptor
                   );
         const bloomEnabled = this.#options.bloomStrength > 0;
         const createBloomTexture = (label: string): RenderGraphTextureHandle | null =>
@@ -3356,7 +3369,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             previousVisibility,
             temporalMotion
         });
-        this.recordCurrentHiZ(context, frameBuffer, sceneDepth, histories.current);
+        this.recordCurrentHiZ(
+            context,
+            frameBuffer,
+            sceneDepth,
+            histories.current,
+            renderWidth,
+            renderHeight
+        );
         this.recordClusterAllocation(context, {
             frame,
             frameBuffer,
@@ -3387,20 +3407,28 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             this.recordFallbackOpaque(context, fallbackCulling, sceneColor, sceneDepth);
         }
         let resolvedSceneColor = sceneColor;
+        let resolvedSceneDepth = sceneDepth;
         if (temporalFrame !== null && temporalMotion !== null) {
             if (fallbackCulling !== null && this.#fallbackHasOpaque) {
                 this.recordFallbackMotion(context, fallbackCulling, temporalMotion, sceneDepth);
             }
-            resolvedSceneColor =
-                this.#temporal?.resolve(context, temporalFrame, sceneColor, temporalMotion) ??
-                sceneColor;
+            const resolved = this.#temporal?.resolve(
+                context,
+                temporalFrame,
+                sceneColor,
+                temporalMotion,
+                sceneDepth,
+                'depth32float'
+            );
+            resolvedSceneColor = resolved?.color ?? sceneColor;
+            resolvedSceneDepth = resolved?.depth ?? sceneDepth;
         }
         if (fallbackCulling !== null && this.#fallbackHasTransparent) {
             this.recordFallbackTransparent(
                 context,
                 fallbackCulling,
                 resolvedSceneColor,
-                sceneDepth
+                resolvedSceneDepth
             );
         }
         this.recordDisplay(context, resolvedSceneColor, bloomA, bloomB, bloomC, outputColor);
@@ -4272,7 +4300,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         return source.revision;
     }
 
-    private packFrame(context: RenderPipelineContext): Readonly<{
+    private packFrame(
+        context: RenderPipelineContext,
+        renderWidth: number,
+        renderHeight: number
+    ): Readonly<{
         tilesX: number;
         tilesY: number;
         clusterCount: number;
@@ -4280,8 +4312,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const camera = context.camera;
         const near = camera instanceof PerspectiveCamera ? camera.near : 0.1;
         const far = this.cameraFar(camera);
-        const tilesX = Math.ceil(context.output.width / this.#options.tileSize);
-        const tilesY = Math.ceil(context.output.height / this.#options.tileSize);
+        const tilesX = Math.ceil(renderWidth / this.#options.tileSize);
+        const tilesY = Math.ceil(renderHeight / this.#options.tileSize);
         const clusterCount = tilesX * tilesY * this.#options.zSlices;
         matrixElements(camera.jitteredViewProjectionMatrix, this.#frameFloats, 0);
         const cameraRevision = getTransformHistoryRevision(camera);
@@ -4307,8 +4339,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         matrixElements(camera.projectionMatrix, this.#frameFloats, 48);
         this.#frameFloats[96] = context.viewport[0];
         this.#frameFloats[97] = context.viewport[1];
-        this.#frameFloats[98] = context.output.width;
-        this.#frameFloats[99] = context.output.height;
+        this.#frameFloats[98] = renderWidth;
+        this.#frameFloats[99] = renderHeight;
         this.#frameFloats[100] = near;
         this.#frameFloats[101] = far;
         this.#frameFloats[102] = Math.log(far / near);
@@ -4466,7 +4498,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         context: RenderPipelineContext,
         frameBuffer: RenderGraphBufferHandle,
         sceneDepth: RenderGraphTextureHandle,
-        current: readonly RenderGraphTextureHandle[]
+        current: readonly RenderGraphTextureHandle[],
+        renderWidth: number,
+        renderHeight: number
     ): void {
         if (!this.#options.hiZ) return;
         let source: RenderGraphTextureAccessHandle = sceneDepth;
@@ -4479,8 +4513,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.setTexture(0, source);
             parameters.setTexture(1, destination);
             parameters.setDispatch(
-                Math.max(1, Math.ceil(context.output.width / 2 ** (index + 1) / 8)),
-                Math.max(1, Math.ceil(context.output.height / 2 ** (index + 1) / 8))
+                Math.max(1, Math.ceil(renderWidth / 2 ** (index + 1) / 8)),
+                Math.max(1, Math.ceil(renderHeight / 2 ** (index + 1) / 8))
             );
             context.graph.addPass(
                 index === 0 ? HIZ_DEPTH_REDUCE_PASS : HIZ_FLOAT_REDUCE_PASS,

--- a/src/render/pipeline/ForwardRenderPipeline.ts
+++ b/src/render/pipeline/ForwardRenderPipeline.ts
@@ -41,8 +41,7 @@ import type {
     RenderPipelineColorAttachment,
     RenderPipelineDepthStencilAttachment,
     RenderPipelineExtent,
-    RenderPipelineTargetResources,
-    RenderPipelineTextureDescriptor
+    RenderPipelineTargetResources
 } from './ScriptableRenderGraph';
 import { depthClearValue } from '../renderer/DepthConvention';
 
@@ -62,11 +61,13 @@ export type ForwardRenderInjectionPoint =
 export interface ForwardRenderFeatureRequirements extends RenderPipelineRequirements {
     /** Route scene color through a linearly filterable sampled graph texture. */
     readonly sampledSceneColor: boolean;
-    /**
-     * Reserved scene-depth sampling requirement. `true` is rejected until the public fullscreen
-     * binding ABI supports portable non-filtering depth sampling end to end.
-     */
+    /** Route scene depth through a single-sample graph texture that feature passes may sample. */
     readonly sampledDepth: boolean;
+    /**
+     * Fixed built-in scene color/depth resolution relative to the physical output. Omit or use one
+     * for native resolution. Conflicting sub-native requests are rejected by the factory.
+     */
+    readonly sceneScale?: number;
 }
 
 /** Renderer-local feature state created by a reusable feature configuration. */
@@ -110,6 +111,8 @@ export interface ForwardRenderPipelineResources {
     readonly depth: RenderGraphTextureHandle | null;
     /** Replace attachment-zero scene color for subsequent features and final output. */
     replaceColor(texture: RenderGraphTextureHandle, encoding: RenderColorEncoding): void;
+    /** Replace scene depth for subsequent scene passes, for example after temporal upscaling. */
+    replaceDepth(texture: RenderGraphTextureHandle): void;
 }
 
 /** Callback-scoped inputs passed to one forward feature runtime. */
@@ -169,9 +172,11 @@ interface MutableDepthStencilAttachment extends RenderPipelineDepthStencilAttach
     stencilClearValue?: number;
 }
 
-interface MutableTextureDescriptor extends RenderPipelineTextureDescriptor {
+interface MutableTextureDescriptor {
     format: RenderTargetColorFormat | RenderTargetDepthStencilFormat;
+    extent: RenderPipelineExtent;
     sampleCount: RenderTargetSampleCount;
+    mipLevelCount: number;
 }
 
 type MutableOutputDepthStencilAttachment = {
@@ -397,6 +402,11 @@ class ForwardFeatureState {
         return this.#colorEncoding;
     }
 
+    get currentDepth(): RenderGraphTextureHandle | null {
+        this.assertFrameActive();
+        return this.#depth;
+    }
+
     readPipeline(lease: ForwardFeatureCallbackLease): RenderPipelineContext {
         this.assertCallbackActive(lease);
         return this.assertFrameActive();
@@ -445,6 +455,17 @@ class ForwardFeatureState {
         this.#colorEncoding = encodingCandidate;
     }
 
+    replaceDepth(lease: ForwardFeatureCallbackLease, texture: RenderGraphTextureHandle): void {
+        this.assertCallbackActive(lease);
+        if (!this.#replacementAllowed) {
+            throw new Error('Forward scene depth cannot be replaced before opaque rendering');
+        }
+        if (!Number.isSafeInteger(texture) || texture <= 0) {
+            throw new TypeError('Forward scene depth replacement requires a graph texture handle');
+        }
+        this.#depth = texture;
+    }
+
     assertCallbackActive(lease: ForwardFeatureCallbackLease): void {
         if (this.#activeCallbackLease !== lease) {
             throw new Error(
@@ -487,6 +508,10 @@ class ForwardFeatureResourcesLease implements ForwardRenderPipelineResources {
 
     replaceColor(texture: RenderGraphTextureHandle, encoding: RenderColorEncoding): void {
         this.#state.replaceColor(this.#lease, texture, encoding);
+    }
+
+    replaceDepth(texture: RenderGraphTextureHandle): void {
+        this.#state.replaceDepth(this.#lease, texture);
     }
 }
 
@@ -549,6 +574,17 @@ function snapshotFeature(feature: ForwardRenderPipelineFeature): FeatureSnapshot
             `Forward render feature ${feature.name} must declare sampledSceneColor and sampledDepth`
         );
     }
+    const sceneScale = feature.requirements.sceneScale ?? 1;
+    if (!Number.isFinite(sceneScale) || sceneScale <= 0 || sceneScale > 1) {
+        throw new RangeError(
+            `Forward render feature ${feature.name} sceneScale must be finite and greater than zero up to one`
+        );
+    }
+    if (sceneScale < 1 && (!sampledSceneColor || !sampledDepth)) {
+        throw new Error(
+            `Forward render feature ${feature.name} must sample scene color and depth to use a sub-native sceneScale`
+        );
+    }
     if (
         sampledSceneColor &&
         injectionPointIndex(injectionPoint) < injectionPointIndex('after-opaque')
@@ -560,7 +596,8 @@ function snapshotFeature(feature: ForwardRenderPipelineFeature): FeatureSnapshot
     const requirements = Object.freeze({
         ...snapshotRenderPipelineRequirements(feature.requirements),
         sampledSceneColor,
-        sampledDepth
+        sampledDepth,
+        sceneScale
     });
     const create = feature.create.bind(feature);
     return Object.freeze({
@@ -717,7 +754,7 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
     readonly #surfaceCompositionColorFormats: RenderTargetColorFormat[] = ['rgba8unorm'];
     readonly #surfaceCompositionDescriptor: {
         readonly label: string;
-        readonly extent: RenderPipelineExtent;
+        extent: RenderPipelineExtent;
         readonly colorFormats: RenderTargetColorFormat[];
         depthStencilFormat?: RenderTargetDepthStencilFormat;
         depthStencilSampled?: boolean;
@@ -735,6 +772,8 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
     readonly #splitScene: boolean;
     readonly #sceneColorFormat: RenderTargetColorFormat | null;
     readonly #opaqueTextureEnabled: boolean;
+    readonly #sceneScale: number;
+    readonly #sceneExtent: RenderPipelineExtent;
     #destroyed = false;
 
     constructor(
@@ -743,6 +782,7 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
         options: Readonly<{
             sceneColorFormat: RenderTargetColorFormat | null;
             opaqueTexture: boolean;
+            sceneScale: number;
         }>
     ) {
         const compiled: CompiledFeature[] = [];
@@ -770,6 +810,14 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
         }
         this.#sceneColorFormat = options.sceneColorFormat;
         this.#opaqueTextureEnabled = options.opaqueTexture;
+        this.#sceneScale = options.sceneScale;
+        this.#sceneExtent = Object.freeze({
+            relativeTo: 'output' as const,
+            scale: this.#sceneScale
+        });
+        this.#depthDescriptor.extent = this.#sceneExtent;
+        this.#opaqueTextureDescriptor.extent = this.#sceneExtent;
+        this.#surfaceCompositionDescriptor.extent = this.#sceneExtent;
         sampledColor ||= options.opaqueTexture || options.sceneColorFormat !== null;
         samplesBetweenQueues ||= options.opaqueTexture;
         this.#compiledFeatures = Object.freeze(compiled);
@@ -846,7 +894,7 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
                     context,
                     output,
                     transparent,
-                    depth,
+                    this.#featureState.currentDepth,
                     false,
                     true,
                     sceneSampleCount,
@@ -1209,7 +1257,7 @@ class ScriptableForwardRenderPipeline implements RenderPipeline {
         if (descriptor === undefined) {
             descriptor = {
                 format,
-                extent: OUTPUT_EXTENT,
+                extent: this.#sceneExtent,
                 sampleCount,
                 mipLevelCount: 1
             };
@@ -1235,6 +1283,7 @@ export class ForwardRenderPipelineFactory implements RenderPipelineFactory {
     readonly sceneColorFormat: RenderTargetColorFormat | null;
     /** Whether the forward pipeline captures opaque scene color for transparent materials. */
     readonly opaqueTexture: boolean;
+    readonly #sceneScale: number;
 
     constructor(options: ForwardRenderPipelineFactoryOptions = {}) {
         const features = (options.features ?? []).map(snapshotFeature);
@@ -1246,6 +1295,15 @@ export class ForwardRenderPipelineFactory implements RenderPipelineFactory {
             names.add(feature.name);
         }
         this.features = Object.freeze(features);
+        const requestedSceneScales = new Set<number>();
+        for (const feature of features) {
+            const sceneScale = feature.requirements.sceneScale ?? 1;
+            if (sceneScale < 1) requestedSceneScales.add(sceneScale);
+        }
+        if (requestedSceneScales.size > 1) {
+            throw new Error('Forward render features request conflicting sub-native scene scales');
+        }
+        this.#sceneScale = requestedSceneScales.values().next().value ?? 1;
         const sceneColorFormat: unknown = options.sceneColorFormat ?? null;
         if (
             sceneColorFormat !== null &&
@@ -1332,7 +1390,8 @@ export class ForwardRenderPipelineFactory implements RenderPipelineFactory {
             }
             return new ScriptableForwardRenderPipeline(features, runtimes, {
                 sceneColorFormat: this.sceneColorFormat,
-                opaqueTexture: this.opaqueTexture
+                opaqueTexture: this.opaqueTexture,
+                sceneScale: this.#sceneScale
             });
         } catch (creationError) {
             const failures: unknown[] = [creationError];

--- a/src/render/postprocessing/PostProcessRenderPipeline.ts
+++ b/src/render/postprocessing/PostProcessRenderPipeline.ts
@@ -14,7 +14,7 @@ import { TemporalAA, type TemporalAAOptions } from './TemporalAA';
 
 /** Turnkey HDR forward/post-processing pipeline configuration. */
 export interface PostProcessRenderPipelineOptions {
-    /** Native-resolution temporal anti-aliasing settings, or false to omit TAA. */
+    /** Temporal anti-aliasing/upscaling settings, or false to omit the temporal pass. */
     readonly temporalAA?: Readonly<TemporalAAOptions> | false;
     /** Bloom settings, or false to omit bloom. Bloom is enabled by default. */
     readonly bloom?: Readonly<BloomOptions> | false;

--- a/src/render/postprocessing/TemporalAA.ts
+++ b/src/render/postprocessing/TemporalAA.ts
@@ -3,9 +3,11 @@ import { getTransformHistoryRevision } from '../../core/TransformHistory';
 import { DEFAULT_MATERIAL_PIPELINE_STATE } from '../../material/MaterialDefinition';
 import Shader from '../../shader/Shader';
 import UniformBuffer from '../UniformBuffer';
-import { renderTargetFormatHasStencil } from '../RenderTarget';
+import { renderTargetFormatHasStencil, type RenderTargetDepthStencilFormat } from '../RenderTarget';
+import { depthClearValue } from '../renderer/DepthConvention';
 import type {
     ForwardRenderFeatureContext,
+    ForwardRenderFeatureRequirements,
     ForwardRenderPipelineFeature,
     ForwardRenderPipelineFeatureRuntime
 } from '../pipeline/ForwardRenderPipeline';
@@ -24,7 +26,9 @@ import type {
     RenderGraphTextureHandle,
     RenderPipelineColorAttachment,
     RenderPipelineDepthStencilAttachment,
-    RenderPipelineHistoryTextureResources
+    RenderPipelineExtent,
+    RenderPipelineHistoryTextureResources,
+    RenderPipelineTextureDescriptor
 } from '../pipeline/ScriptableRenderGraph';
 import { createStd140Layout } from '../ubo/Std140Layout';
 import { registerUniformBlockBinding } from '../ubo/UniformBlockBindings';
@@ -161,6 +165,184 @@ void main() {
     historyDepth = motion.w;
 }`;
 
+const TAAU_RECONSTRUCTION = `
+vec4 sampleReconstructedScene(vec2 uv) {
+    ivec2 dimensions = textureSize(u_scene, 0);
+    vec2 position = uv * vec2(dimensions) - 0.5;
+    ivec2 base = ivec2(floor(position));
+    vec2 fraction = fract(position);
+    vec4 weightX = vec4(
+        -0.5 * fraction.x + fraction.x * fraction.x - 0.5 * fraction.x * fraction.x * fraction.x,
+        1.0 - 2.5 * fraction.x * fraction.x + 1.5 * fraction.x * fraction.x * fraction.x,
+        0.5 * fraction.x + 2.0 * fraction.x * fraction.x - 1.5 * fraction.x * fraction.x * fraction.x,
+        -0.5 * fraction.x * fraction.x + 0.5 * fraction.x * fraction.x * fraction.x
+    );
+    vec4 weightY = vec4(
+        -0.5 * fraction.y + fraction.y * fraction.y - 0.5 * fraction.y * fraction.y * fraction.y,
+        1.0 - 2.5 * fraction.y * fraction.y + 1.5 * fraction.y * fraction.y * fraction.y,
+        0.5 * fraction.y + 2.0 * fraction.y * fraction.y - 1.5 * fraction.y * fraction.y * fraction.y,
+        -0.5 * fraction.y * fraction.y + 0.5 * fraction.y * fraction.y * fraction.y
+    );
+    vec4 result = vec4(0.0);
+    for (int y = 0; y < 4; y++) {
+        for (int x = 0; x < 4; x++) {
+            ivec2 coordinate = clamp(
+                base + ivec2(x - 1, y - 1),
+                ivec2(0),
+                dimensions - ivec2(1)
+            );
+            result += texelFetch(u_scene, coordinate, 0) * weightX[x] * weightY[y];
+        }
+    }
+    return result;
+}
+
+ivec2 currentPixel(vec2 uv) {
+    ivec2 dimensions = textureSize(u_scene, 0);
+    return clamp(ivec2(uv * vec2(dimensions)), ivec2(0), dimensions - ivec2(1));
+}`;
+
+const TAAU_INITIALIZE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_velocity;
+uniform sampler2D u_sceneDepth;
+layout(location = 0) out vec4 historyColor;
+layout(location = 1) out vec4 resolvedColor;
+layout(location = 2) out float historyDepth;
+${TAAU_RECONSTRUCTION}
+void main() {
+    ivec2 pixel = currentPixel(v_uv);
+    vec4 current = sampleReconstructedScene(v_uv);
+    vec4 motion = texelFetch(u_velocity, pixel, 0);
+    historyColor = vec4(max(current.rgb, vec3(0.0)), clamp(current.a, 0.0, 1.0));
+    resolvedColor = historyColor;
+    historyDepth = motion.w;
+    gl_FragDepth = texelFetch(u_sceneDepth, pixel, 0).r;
+}`;
+
+const TAAU_RESOLVE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_history;
+uniform sampler2D u_velocity;
+uniform sampler2D u_historyDepth;
+uniform sampler2D u_sceneDepth;
+${TEMPORAL_AA_BLOCK}
+layout(location = 0) out vec4 historyColor;
+layout(location = 1) out vec4 resolvedColor;
+layout(location = 2) out float historyDepth;
+${TAAU_RECONSTRUCTION}
+
+vec3 rgbToYCoCg(vec3 value) {
+    return vec3(
+        dot(value, vec3(0.25, 0.5, 0.25)),
+        dot(value, vec3(0.5, 0.0, -0.5)),
+        dot(value, vec3(-0.25, 0.5, -0.25))
+    );
+}
+
+vec3 yCoCgToRgb(vec3 value) {
+    return vec3(value.x + value.y - value.z, value.x + value.z, value.x - value.y - value.z);
+}
+
+float relativeDepthError(float historyLogDepth, float expectedLogDepth) {
+    float historyLinear = exp2(max(historyLogDepth, 0.0)) - 1.0;
+    float expectedLinear = exp2(max(expectedLogDepth, 0.0)) - 1.0;
+    return abs(historyLinear - expectedLinear) / max(expectedLinear, 1e-3);
+}
+
+float minimumHistoryDepthError(vec2 historyUV, float expectedLogDepth) {
+    ivec2 dimensions = textureSize(u_historyDepth, 0);
+    vec2 samplePosition = historyUV * vec2(dimensions) - 0.5;
+    ivec2 base = ivec2(floor(samplePosition));
+    float error = 1e20;
+    for (int y = 0; y <= 1; y++) {
+        for (int x = 0; x <= 1; x++) {
+            ivec2 coordinate = clamp(base + ivec2(x, y), ivec2(0), dimensions - ivec2(1));
+            error = min(
+                error,
+                relativeDepthError(texelFetch(u_historyDepth, coordinate, 0).r, expectedLogDepth)
+            );
+        }
+    }
+    return error;
+}
+
+void main() {
+    ivec2 currentDimensions = textureSize(u_scene, 0);
+    ivec2 historyDimensions = textureSize(u_history, 0);
+    ivec2 pixel = currentPixel(v_uv);
+    vec4 current = sampleReconstructedScene(v_uv);
+    vec4 motion = texelFetch(u_velocity, pixel, 0);
+    vec2 historyUV = v_uv - motion.xy;
+    vec2 halfHistoryTexel = 0.5 / vec2(historyDimensions);
+    bool inside = all(greaterThanEqual(historyUV, halfHistoryTexel)) &&
+        all(lessThanEqual(historyUV, vec2(1.0) - halfHistoryTexel));
+
+    vec3 currentWorking = rgbToYCoCg(current.rgb);
+    vec3 neighborhoodMin = currentWorking;
+    vec3 neighborhoodMax = currentWorking;
+    vec3 moment1 = currentWorking;
+    vec3 moment2 = currentWorking * currentWorking;
+    vec3 crossSum = vec3(0.0);
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            if (x == 0 && y == 0) continue;
+            ivec2 coordinate = clamp(
+                pixel + ivec2(x, y),
+                ivec2(0),
+                currentDimensions - ivec2(1)
+            );
+            vec3 sampleWorking = rgbToYCoCg(texelFetch(u_scene, coordinate, 0).rgb);
+            neighborhoodMin = min(neighborhoodMin, sampleWorking);
+            neighborhoodMax = max(neighborhoodMax, sampleWorking);
+            moment1 += sampleWorking;
+            moment2 += sampleWorking * sampleWorking;
+            if (abs(x) + abs(y) == 1) crossSum += sampleWorking;
+        }
+    }
+
+    vec3 mean = moment1 / 9.0;
+    vec3 deviation = sqrt(max(moment2 / 9.0 - mean * mean, vec3(0.0)));
+    vec3 clipMin = max(neighborhoodMin, mean - deviation * u_varianceGamma);
+    vec3 clipMax = min(neighborhoodMax, mean + deviation * u_varianceGamma);
+    vec2 sampledHistoryUV = clamp(
+        historyUV,
+        halfHistoryTexel,
+        vec2(1.0) - halfHistoryTexel
+    );
+    vec4 sampledPrevious = textureLod(u_history, sampledHistoryUV, 0.0);
+    vec4 previous = inside ? sampledPrevious : current;
+    vec3 previousWorking = clamp(rgbToYCoCg(previous.rgb), clipMin, clipMax);
+
+    bool velocityValid = motion.z >= 0.0;
+    float depthError = velocityValid && inside
+        ? minimumHistoryDepthError(historyUV, motion.z)
+        : 1e20;
+    float accepted = velocityValid && inside && depthError <= u_depthThreshold ? 1.0 : 0.0;
+    float velocityPixels = length(motion.xy * vec2(historyDimensions));
+    float motionResponse = clamp(velocityPixels / 32.0, 0.0, 1.0);
+    float temporalWeight = mix(u_historyWeight, min(u_historyWeight, 0.6), motionResponse);
+    float luminanceDelta = abs(previousWorking.x - currentWorking.x) /
+        max(max(abs(previousWorking.x), abs(currentWorking.x)), 0.1);
+    float reactive = clamp(luminanceDelta * 1.5, 0.0, 1.0);
+    temporalWeight *= 1.0 - reactive * 0.8;
+
+    vec3 resolvedWorking = mix(currentWorking, previousWorking, temporalWeight * accepted);
+    vec3 resolved = max(yCoCgToRgb(resolvedWorking), vec3(0.0));
+    vec3 crossAverage = crossSum * 0.25;
+    vec3 sharpenedWorking = resolvedWorking +
+        (resolvedWorking - crossAverage) * u_sharpness;
+    vec3 sharpened = max(yCoCgToRgb(sharpenedWorking), vec3(0.0));
+    historyColor = vec4(resolved, clamp(current.a, 0.0, 1.0));
+    resolvedColor = vec4(sharpened, clamp(current.a, 0.0, 1.0));
+    historyDepth = motion.w;
+    gl_FragDepth = texelFetch(u_sceneDepth, pixel, 0).r;
+}`;
+
 registerUniformBlockBinding('TemporalAABlock');
 
 const temporalAALayout = createStd140Layout({
@@ -170,12 +352,27 @@ const temporalAALayout = createStd140Layout({
     u_sharpness: 'float'
 });
 
-const OUTPUT_EXTENT = Object.freeze({ relativeTo: 'output' as const, scale: 1 });
-/** @internal Motion XY, expected previous log2 view depth, and current log2 view depth. */
-export const TEMPORAL_MOTION_DESCRIPTOR = Object.freeze({
-    format: 'rgba16float' as const,
-    extent: OUTPUT_EXTENT
+const OUTPUT_EXTENT: RenderPipelineExtent = Object.freeze({
+    relativeTo: 'output' as const,
+    scale: 1
 });
+/** @internal Return the fixed internal extent used by one temporal configuration. */
+export function temporalInputExtent(renderScale: number): RenderPipelineExtent {
+    return Object.freeze({ relativeTo: 'output' as const, scale: renderScale });
+}
+
+/** @internal Return the motion/depth descriptor matching one temporal input scale. */
+export function temporalMotionDescriptor(
+    renderScale: number
+): Readonly<RenderPipelineTextureDescriptor> {
+    return Object.freeze({
+        format: 'rgba16float' as const,
+        extent: temporalInputExtent(renderScale)
+    });
+}
+
+/** @internal Motion XY, expected previous log2 view depth, and current log2 view depth. */
+export const TEMPORAL_MOTION_DESCRIPTOR = temporalMotionDescriptor(1);
 const RESOLVED_DESCRIPTOR = Object.freeze({
     format: 'rgba16float' as const,
     extent: OUTPUT_EXTENT
@@ -278,6 +475,16 @@ interface MutableTemporalColorAttachment extends RenderPipelineColorAttachment {
     texture: RenderGraphTextureHandle;
 }
 
+interface MutableTemporalDepthAttachment extends RenderPipelineDepthStencilAttachment {
+    texture: RenderGraphTextureHandle;
+    depthLoadOp: 'clear';
+    depthStoreOp: 'store';
+    depthClearValue: number;
+    stencilLoadOp?: 'clear';
+    stencilStoreOp?: 'store';
+    stencilClearValue?: number;
+}
+
 class TemporalResolveParameters implements FullscreenRenderPassParameters {
     readonly inputTextures: RenderGraphTextureAccessHandle[] = [];
     readonly colorAttachments: MutableTemporalColorAttachment[] = [
@@ -300,12 +507,22 @@ class TemporalResolveParameters implements FullscreenRenderPassParameters {
             clearValue: CLEAR_ZERO
         }
     ];
+    readonly #resolvedDepth: MutableTemporalDepthAttachment = {
+        texture: 0 as RenderGraphTextureHandle,
+        depthLoadOp: 'clear',
+        depthStoreOp: 'store',
+        depthClearValue: 1
+    };
+    depthStencilAttachment?: MutableTemporalDepthAttachment;
 
     configure(
         inputs: readonly RenderGraphTextureAccessHandle[],
         colorHistory: RenderGraphTextureHandle,
         resolved: RenderGraphTextureHandle,
-        depthHistory: RenderGraphTextureHandle
+        depthHistory: RenderGraphTextureHandle,
+        resolvedDepth: RenderGraphTextureHandle | null,
+        resolvedDepthFormat: RenderTargetDepthStencilFormat | null,
+        resolvedDepthClearValue: number
     ): void {
         this.inputTextures.length = inputs.length;
         for (let index = 0; index < inputs.length; index += 1) {
@@ -327,15 +544,38 @@ class TemporalResolveParameters implements FullscreenRenderPassParameters {
         colorAttachment.texture = colorHistory;
         resolvedAttachment.texture = resolved;
         depthAttachment.texture = depthHistory;
+        if (resolvedDepth === null || resolvedDepthFormat === null) {
+            delete this.depthStencilAttachment;
+            return;
+        }
+        const attachment = this.#resolvedDepth;
+        attachment.texture = resolvedDepth;
+        attachment.depthClearValue = resolvedDepthClearValue;
+        if (renderTargetFormatHasStencil(resolvedDepthFormat)) {
+            attachment.stencilLoadOp = 'clear';
+            attachment.stencilStoreOp = 'store';
+            attachment.stencilClearValue = 0;
+        } else {
+            delete attachment.stencilLoadOp;
+            delete attachment.stencilStoreOp;
+            delete attachment.stencilClearValue;
+        }
+        this.depthStencilAttachment = attachment;
     }
 
     reset(): void {
         this.inputTextures.length = 0;
+        delete this.depthStencilAttachment;
     }
 }
 
-/** Native-resolution temporal resolve controls. */
+/** Temporal anti-aliasing and fixed-resolution temporal-upscaling controls. */
 export interface TemporalAAOptions {
+    /**
+     * Fixed internal scene resolution relative to the output. Values below one enable TAAU.
+     * Defaults to 1 and is currently constrained to the inclusive range 0.5–1.
+     */
+    readonly renderScale?: number;
     /** Maximum accepted history contribution after rejection. Defaults to 0.92. */
     readonly historyWeight?: number;
     /** Maximum relative previous-view-depth error. Defaults to 0.02. */
@@ -348,6 +588,7 @@ export interface TemporalAAOptions {
 
 /** @internal Immutable temporal settings shared by Forward and GPU Scene pipelines. */
 export interface TemporalAASettings {
+    readonly renderScale: number;
     readonly historyWeight: number;
     readonly depthThreshold: number;
     readonly varianceGamma: number;
@@ -368,6 +609,7 @@ export function snapshotTemporalAAOptions(
     options: Readonly<TemporalAAOptions>
 ): TemporalAASettings {
     return Object.freeze({
+        renderScale: finiteRange(options.renderScale ?? 1, 0.5, 1, 'TemporalAA renderScale'),
         historyWeight: finiteRange(options.historyWeight ?? 0.92, 0, 1, 'TemporalAA historyWeight'),
         depthThreshold: finiteRange(
             options.depthThreshold ?? 0.02,
@@ -418,6 +660,18 @@ export class TemporalResolveController {
     readonly #block: UniformBuffer<typeof temporalAALayout.schema>;
     readonly #initializePass: FullscreenRenderPass;
     readonly #resolvePass: FullscreenRenderPass;
+    readonly #upscaleInitializePass: FullscreenRenderPass;
+    readonly #upscaleResolvePass: FullscreenRenderPass;
+    readonly #renderScale: number;
+    readonly #resolvedDepthDescriptor: {
+        format: RenderTargetDepthStencilFormat;
+        readonly extent: RenderPipelineExtent;
+        readonly sampleCount: 1;
+    } = {
+        format: 'depth24plus',
+        extent: OUTPUT_EXTENT,
+        sampleCount: 1
+    };
     readonly #resolveParameters = new RenderPassParameterPool(
         () => new TemporalResolveParameters(),
         parameters => {
@@ -432,26 +686,44 @@ export class TemporalResolveController {
     #submissionIndex = 0;
 
     constructor(settings: TemporalAASettings) {
+        this.#renderScale = settings.renderScale;
         this.#block = UniformBuffer.fromSchema(temporalAALayout, {
             u_historyWeight: settings.historyWeight,
             u_depthThreshold: settings.depthThreshold,
             u_varianceGamma: settings.varianceGamma,
             u_sharpness: settings.sharpness
         });
-        const pass = (name: string, fs: string, uniformBuffers: readonly UniformBuffer[]) =>
+        const pass = (
+            name: string,
+            fs: string,
+            uniformBuffers: readonly UniformBuffer[],
+            writesDepth = false
+        ) =>
             new FullscreenRenderPass({
                 name,
                 shader: new Shader({ vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE, fs }),
                 pipelineState: {
                     ...DEFAULT_MATERIAL_PIPELINE_STATE,
                     depthTest: false,
-                    depthWrite: false,
+                    depthWrite: writesDepth,
                     cullMode: 'none'
                 },
                 uniformBuffers
             });
         this.#initializePass = pass('TemporalAA initialize history', INITIALIZE_FRAGMENT, []);
         this.#resolvePass = pass('TemporalAA production resolve', RESOLVE_FRAGMENT, [this.#block]);
+        this.#upscaleInitializePass = pass(
+            'TemporalAA upscale initialize history',
+            TAAU_INITIALIZE_FRAGMENT,
+            [],
+            true
+        );
+        this.#upscaleResolvePass = pass(
+            'TemporalAA temporal upscale',
+            TAAU_RESOLVE_FRAGMENT,
+            [this.#block],
+            true
+        );
     }
 
     begin(context: RenderPipelineContext): TemporalResolveFrame {
@@ -466,7 +738,9 @@ export class TemporalResolveController {
             throw new Error('TemporalAA currently requires a full-output viewport');
         }
         this.sweepInactiveStates(context, context.camera);
-        const state = this.stageCamera(context.camera, context.frameIndex, width, height);
+        const inputWidth = Math.max(1, Math.floor(width * this.#renderScale));
+        const inputHeight = Math.max(1, Math.floor(height * this.#renderScale));
+        const state = this.stageCamera(context.camera, context.frameIndex, inputWidth, inputHeight);
         const transformRevision = getTransformHistoryRevision(context.camera);
         const discontinuous =
             state.committedSubmission >= 0 &&
@@ -498,8 +772,10 @@ export class TemporalResolveController {
         context: RenderPipelineContext,
         frame: TemporalResolveFrame,
         scene: RenderGraphTextureHandle,
-        velocity: RenderGraphTextureHandle
-    ): RenderGraphTextureHandle {
+        velocity: RenderGraphTextureHandle,
+        depth: RenderGraphTextureHandle,
+        depthFormat: RenderTargetDepthStencilFormat
+    ): TemporalResolveResult {
         if (frame.state.pendingFrame !== context.frameIndex) {
             throw new Error('TemporalAA resolve frame belongs to another application frame');
         }
@@ -507,20 +783,43 @@ export class TemporalResolveController {
             'TemporalAA resolved color',
             RESOLVED_DESCRIPTOR
         );
+        const upscales = this.#renderScale < 1;
+        this.#resolvedDepthDescriptor.format = depthFormat;
+        const resolvedDepth = upscales
+            ? context.graph.createTexture(
+                  'TemporalAA resolved full-resolution depth',
+                  this.#resolvedDepthDescriptor
+              )
+            : null;
         const parameters = context.acquirePassParameters(this.#resolveParameters);
         parameters.configure(
             frame.historyValid
-                ? [scene, frame.colorHistory.history(), velocity, frame.depthHistory.history()]
-                : [scene, velocity],
+                ? [
+                      scene,
+                      frame.colorHistory.history(),
+                      velocity,
+                      frame.depthHistory.history(),
+                      ...(upscales ? [depth] : [])
+                  ]
+                : [scene, velocity, ...(upscales ? [depth] : [])],
             frame.colorHistory.current,
             resolved,
-            frame.depthHistory.current
+            frame.depthHistory.current,
+            resolvedDepth,
+            upscales ? depthFormat : null,
+            depthClearValue(context.camera.depthMode)
         );
         context.graph.addPass(
-            frame.historyValid ? this.#resolvePass : this.#initializePass,
+            upscales
+                ? frame.historyValid
+                    ? this.#upscaleResolvePass
+                    : this.#upscaleInitializePass
+                : frame.historyValid
+                  ? this.#resolvePass
+                  : this.#initializePass,
             parameters
         );
-        return resolved;
+        return Object.freeze({ color: resolved, depth: resolvedDepth ?? depth });
     }
 
     frameSubmitted(frameIndex: number): void {
@@ -631,10 +930,17 @@ export class TemporalResolveController {
     }
 }
 
+/** @internal Full-resolution temporal resolve outputs. */
+export interface TemporalResolveResult {
+    readonly color: RenderGraphTextureHandle;
+    readonly depth: RenderGraphTextureHandle;
+}
+
 class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
     readonly #resolve: TemporalResolveController;
     readonly #velocityPass = new SceneRenderPass('TemporalAA motion vectors');
     readonly #velocityParameters = new RenderPassParameterPool(() => new VelocityPassParameters());
+    readonly #motionDescriptor: Readonly<RenderPipelineTextureDescriptor>;
     readonly #rendererListDescriptor: {
         cullingResults: CullingResultsHandle;
         readonly queue: 'opaque';
@@ -649,6 +955,7 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
 
     constructor(settings: TemporalAASettings) {
         this.#resolve = new TemporalResolveController(settings);
+        this.#motionDescriptor = temporalMotionDescriptor(settings.renderScale);
     }
 
     record(context: ForwardRenderFeatureContext): void {
@@ -661,7 +968,7 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
         const frame = this.#resolve.begin(pipeline);
         const velocity = pipeline.graph.createTexture(
             'TemporalAA rgba16float motion and view depth',
-            TEMPORAL_MOTION_DESCRIPTOR
+            this.#motionDescriptor
         );
         this.#rendererListDescriptor.cullingResults = context.cullingResults;
         const velocityList = pipeline.createRendererList(this.#rendererListDescriptor);
@@ -674,10 +981,16 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
                 renderTargetFormatHasStencil(pipeline.output.depthStencilFormat)
         );
         pipeline.graph.addPass(this.#velocityPass, velocityParameters);
-        context.resources.replaceColor(
-            this.#resolve.resolve(pipeline, frame, scene, velocity),
-            'linear'
+        const resolved = this.#resolve.resolve(
+            pipeline,
+            frame,
+            scene,
+            velocity,
+            depth,
+            pipeline.output.depthStencilFormat ?? 'depth24plus'
         );
+        context.resources.replaceColor(resolved.color, 'linear');
+        if (resolved.depth !== depth) context.resources.replaceDepth(resolved.depth);
     }
 
     frameSubmitted(frameIndex: number): void {
@@ -694,7 +1007,7 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
 }
 
 /**
- * Native-resolution temporal anti-aliasing feature.
+ * Temporal anti-aliasing and fixed-resolution temporal-upscaling feature.
  *
  * The feature records built-in opaque/masked motion and logarithmic view-depth data after opaque
  * shading, resolves only opaque scene color, then lets transparent rendering and Bloom compose
@@ -704,15 +1017,17 @@ class TemporalAARuntime implements ForwardRenderPipelineFeatureRuntime {
 export class TemporalAA implements ForwardRenderPipelineFeature {
     readonly name = 'temporal-aa';
     readonly injectionPoint = 'after-opaque' as const;
-    readonly requirements = Object.freeze({
-        sampledSceneColor: true,
-        sampledDepth: true,
-        ...TEMPORAL_AA_REQUIREMENTS
-    });
+    readonly requirements: Readonly<ForwardRenderFeatureRequirements>;
     readonly #settings: TemporalAASettings;
 
     constructor(options: Readonly<TemporalAAOptions> = {}) {
         this.#settings = snapshotTemporalAAOptions(options);
+        this.requirements = Object.freeze({
+            sampledSceneColor: true,
+            sampledDepth: true,
+            sceneScale: this.#settings.renderScale,
+            ...TEMPORAL_AA_REQUIREMENTS
+        });
     }
 
     create(): ForwardRenderPipelineFeatureRuntime {

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -372,7 +372,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 maxLightsPerCluster: 8,
                 maxViewportWidth: 128,
                 maxViewportHeight: 128,
-                temporalAA: {}
+                temporalAA: { renderScale: 0.75 }
             });
             const renderer = await Renderer.create({
                 backend: 'webgpu',

--- a/test/spec/renderer/PostProcessing.test.ts
+++ b/test/spec/renderer/PostProcessing.test.ts
@@ -185,11 +185,13 @@ describe('built-in post-processing', () => {
         expect(() => new TemporalAA({ depthThreshold: -1 })).toThrow(/depthThreshold/u);
         expect(() => new TemporalAA({ varianceGamma: 0 })).toThrow(/varianceGamma/u);
         expect(() => new TemporalAA({ sharpness: 1 })).toThrow(/sharpness/u);
+        expect(() => new TemporalAA({ renderScale: 0.49 })).toThrow(/renderScale/u);
+        expect(() => new TemporalAA({ renderScale: 1.01 })).toThrow(/renderScale/u);
         expect(() => new ColorUber({ temperature: 2 }).create()).toThrow(/temperature/u);
     });
 
     it.each(['webgl2', 'webgpu'] as const)(
-        'renders HDR bloom and a transmissive volume through the opaque scene texture on %s',
+        'renders fixed-scale TAAU, HDR bloom, and transmissive composition on %s',
         async backend => {
             const renderer = await Renderer.create({
                 backend,
@@ -198,7 +200,7 @@ describe('built-in post-processing', () => {
                 height: 24,
                 antialias: false,
                 renderPipeline: new PostProcessRenderPipelineFactory({
-                    temporalAA: {},
+                    temporalAA: { renderScale: 0.75 },
                     bloom: {
                         threshold: 0.7,
                         intensity: 0.8,
@@ -280,13 +282,20 @@ describe('built-in post-processing', () => {
                 })
             );
             const camera = new PerspectiveCamera({ aspect: 4 / 3, z: 3 });
+            const observed = observePassLabels(rhiDevice(renderer));
 
             expect(() => {
                 renderer.render(scene, camera);
             }).not.toThrow();
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA upscale initialize history');
+            observed.labels.length = 0;
             expect(() => {
                 renderer.render(scene, camera);
             }).not.toThrow();
+            await renderer.waitForIdle();
+            expect(observed.labels).toContain('TemporalAA temporal upscale');
+            observed.restore();
             expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
         }
     );

--- a/test/spec/renderer/PostProcessing.test.ts
+++ b/test/spec/renderer/PostProcessing.test.ts
@@ -31,6 +31,9 @@ import type { RHIDevice } from '../../../src/render/rhi/core';
 declare const __HILO3D_GITHUB_ACTIONS_COVERAGE__: boolean;
 
 const activeRenderers: Renderer[] = [];
+const taaIntegrationBackends = __HILO3D_GITHUB_ACTIONS_COVERAGE__
+    ? (['webgl2'] as const)
+    : (['webgl2', 'webgpu'] as const);
 
 interface TemporalFailureParameters {
     readonly attachment: RenderPipelineColorAttachment;
@@ -190,7 +193,7 @@ describe('built-in post-processing', () => {
         expect(() => new ColorUber({ temperature: 2 }).create()).toThrow(/temperature/u);
     });
 
-    it.each(['webgl2', 'webgpu'] as const)(
+    it.each(taaIntegrationBackends)(
         'renders fixed-scale TAAU, HDR bloom, and transmissive composition on %s',
         async backend => {
             const renderer = await Renderer.create({

--- a/test/spec/renderer/ScriptableRenderPipeline.test.ts
+++ b/test/spec/renderer/ScriptableRenderPipeline.test.ts
@@ -2790,6 +2790,45 @@ describe('Scriptable render pipeline', () => {
         expect(() => new ForwardRenderPipelineFactory({ features: [feature] })).not.toThrow();
     });
 
+    it('validates fixed sub-native scene scale ownership across forward features', () => {
+        const feature = (name: string, sceneScale: number): ForwardRenderPipelineFeature => ({
+            name,
+            injectionPoint: 'after-opaque',
+            requirements: {
+                sampledSceneColor: true,
+                sampledDepth: true,
+                sceneScale
+            },
+            create(): ForwardRenderPipelineFeatureRuntime {
+                return new CountingForwardFeatureRuntime();
+            }
+        });
+        expect(
+            () => new ForwardRenderPipelineFactory({ features: [feature('valid', 0.75)] })
+        ).not.toThrow();
+        expect(() => new ForwardRenderPipelineFactory({ features: [feature('zero', 0)] })).toThrow(
+            /sceneScale/u
+        );
+        expect(
+            () =>
+                new ForwardRenderPipelineFactory({
+                    features: [feature('three-quarter', 0.75), feature('half', 0.5)]
+                })
+        ).toThrow(/conflicting sub-native scene scales/u);
+
+        const missingDepth: ForwardRenderPipelineFeature = {
+            ...feature('missing-depth', 0.75),
+            requirements: {
+                sampledSceneColor: true,
+                sampledDepth: false,
+                sceneScale: 0.75
+            }
+        };
+        expect(() => new ForwardRenderPipelineFactory({ features: [missingDepth] })).toThrow(
+            /must sample scene color and depth/u
+        );
+    });
+
     it('rejects scene-color sampling before opaque rendering initializes it', () => {
         const feature: ForwardRenderPipelineFeature = {
             name: 'early-scene-color-feature',

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -24,6 +24,7 @@ import {
     SceneRenderPass,
     Stage,
     StorageGraphicsShader,
+    TemporalAA,
     Texture,
     Tween,
     Vector3,
@@ -68,6 +69,7 @@ import {
     type RendererListHandle,
     type StorageBuffer,
     type StorageBufferReadback,
+    type TemporalAAOptions,
     type ShaderTextureSampleType,
     type ShaderTextureViewDimension,
     type ScriptableRenderGraph,
@@ -270,6 +272,9 @@ const persistentTargetReleased: boolean = scriptableGraph.releasePersistentTarge
     Object.freeze({})
 );
 const featureCullingResults: CullingResultsHandle = forwardFeatureContext.cullingResults;
+forwardFeatureContext.resources.replaceDepth(graphMipChain);
+const temporalAAOptions = { renderScale: 0.75, sharpness: 0.1 } satisfies TemporalAAOptions;
+const temporalAA = new TemporalAA(temporalAAOptions);
 const outputColorPolicy: Readonly<RenderPipelineOutputColorAttachment> =
     pipelineOutput.colorAttachment(0);
 const outputDepthStencilPolicy: Readonly<RenderPipelineOutputDepthStencilAttachment> | null =
@@ -509,6 +514,7 @@ void webglIdlePromise;
 void webgpuIdlePromise;
 void persistentTargetReleased;
 void featureCullingResults;
+void temporalAA;
 void outputColorPolicy;
 void outputDepthStencilPolicy;
 void rawTextureStorage;

--- a/test/ui/temporal-aa.spec.ts
+++ b/test/ui/temporal-aa.spec.ts
@@ -31,7 +31,7 @@ function pixelDifference(referenceBuffer: Buffer, candidateBuffer: Buffer): Pixe
     };
 }
 
-test('keeps the fused Clustered motion/TAA example stable across convergence and camera cuts', async ({
+test('keeps the fused Clustered motion/TAAU example stable across convergence and camera cuts', async ({
     page
 }) => {
     test.setTimeout(60_000);
@@ -67,7 +67,8 @@ test('keeps the fused Clustered motion/TAA example stable across convergence and
         objectCount: 100,
         fallbackObjectCount: 2,
         hiZValid: true,
-        temporalAA: true
+        temporalAA: true,
+        renderScale: 0.75
     });
     expect(evidence?.visibleObjectCount).toBeGreaterThan(0);
 
@@ -112,6 +113,7 @@ declare global {
             readonly visibleObjectCount: number;
             readonly hiZValid: boolean;
             readonly temporalAA: true;
+            readonly renderScale: 0.75;
         };
         __HILO3D_TEMPORAL_OBSERVATORY_TEST_API__?: {
             settle(frames?: number): Promise<void>;


### PR DESCRIPTION
## Summary

- add fixed internal render scaling through `TemporalAAOptions.renderScale` in the inclusive range 0.5–1
- reconstruct sub-native opaque color with a 16-tap Catmull-Rom filter into output-resolution temporal color/depth history
- produce a full-resolution depth attachment before transparent/transmission composition
- scale Forward and Clustered Forward+ scene color, depth, motion, Hi-Z, cluster sizing, and semantic viewports consistently
- update the Temporal Observatory to exercise 75% TAAU and synchronize the rendering architecture, roadmap, changelog, and API report

## Why

The temporal roadmap had native-resolution TAA but no production path for rendering opaque work below output resolution. A simple post-process upscale would leave motion/depth, Clustered Hi-Z, cluster allocation, transparent composition, and submission-aware history at incompatible resolutions. This change establishes a shared fixed-scale TAAU contract across ordinary Forward and GPU Scene paths without bypassing the Render Graph or RHI.

## Developer impact

`renderScale` defaults to 1, preserving existing native-resolution behavior. Values below 1 enable fixed-scale TAAU. Dynamic resolution control, authored reactive masks, and transparent history remain deferred.

TAAU reconstructs full-resolution depth from the corresponding internal texel. Stencil is reset on the reconstructed depth attachment, so transparent custom passes that depend on opaque stencil values should keep `renderScale=1`.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run api:update && npm run api:check`
- `npm run test:types`
- `npm run test:package`
- targeted renderer Vitest: 69 passed
- `npm run test:render:architecture`: 144 passed
- `npm run test:rhi`: 216 passed, 1 environment-dependent test skipped
- `npm run docs:check`
- `npm run test:webgpu`: 16 browser tests passed
- Temporal Observatory Playwright acceptance: 1 passed

Not run: full `npm run validate` and the physical-GPU-only `npm run test:webgpu:native` lane.