### PR TITLE
fix(render): refine SSR reflections showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,14 @@
   The opt-in path adds a strict built-in `material-attributes` `rgba16float` ABI, GPU Scene MRT and
   ordinary Forward fallback coverage, RG32F min/max Hi-Z, hierarchical coarse-to-fine tracing,
   roughness radiance cones, edge/distance/roughness confidence, motion/log-depth temporal rejection
-  and HDR composition before TAA/TAAU. Keep the disabled path allocation- and pass-free, fail closed
-  without Hi-Z or TemporalAA, and reset history across camera cuts/identity changes, resize,
-  discarded frames and device recovery. Add `rg32float` to the public compute storage-texture
-  formats, add the repository-bundled Khronos Car Concept to the dedicated Nocturne Pavilion SSR
-  showcase, and cover real WebGPU on/off pixels plus GPU validation. The existing Temporal
-  Observatory remains focused on TAA/TAAU.
+  and confidence-aware depth/normal à-trous filtering before HDR composition and TAA/TAAU. Keep the
+  disabled path allocation- and pass-free, fail closed without Hi-Z or TemporalAA, and reset history
+  across camera cuts/identity changes, resize, discarded frames and device recovery. Feed ordinary
+  Forward opaque through a `depth-only` fallback prepass before current Hi-Z construction so layered
+  PBR objects are present in both the radiance source and hierarchical depth trace. Add `rg32float`
+  to the public compute storage-texture formats, add the repository-bundled Khronos Car Concept to
+  the dedicated Afterimage SSR showcase, and cover real WebGPU on/off pixels plus GPU validation.
+  The existing Temporal Observatory remains focused on TAA/TAAU.
 - Add the `TemporalAA` Forward feature with native-resolution TAA and fixed-scale TAAU. Built-in
   opaque/masked materials now expose a strict single-sample `rgba16float` motion pass containing
   current-to-previous UV velocity, expected previous logarithmic view depth, and current logarithmic

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -111,7 +111,9 @@ camera、model、instance、skin、morph 与 coverage ABI；首次出现、显�
 history 失效时写 invalid history marker，不能消费陈旧 pose。内置 `material-attributes`
 pass 固定接受 single-sample `rgba16float`，输出 octahedral view normal、perceptual
 roughness、metallic 与 reflection receiver flag；Clustered Hi-Z
-SSR 按需消费它，未启用 SSR 时不创建 attribute target 或对应 fallback pass。
+SSR 按需消费它，并用相同 attributes 与 logarithmic motion
+depth 约束 confidence-aware 多尺度空间 filter；未启用 SSR 时不创建 attribute target、filter
+target 或对应 fallback pass。
 
 portable material UBO 分为 432-byte `MaterialBlock` 与 1,920-byte
 `MaterialTextureBlock`，二者按最终 std140 bytes 独立更新。WebGPU material group 的 binding
@@ -235,7 +237,9 @@ physical-bucket 放大。所有 indexed-indirect command 的 `firstInstance` 保
 draw 通过 256-byte 对齐的只读 storage range 取得自己的 compact base，再与本地 `gl_InstanceIndex`
 相加，因此 baseline 不依赖 WebGPU 可选的 `indirect-first-instance` feature。Hi-Z 对 standard
 depth 的 RG32F Hi-Z 同时保存区块 `min/max`；previous-frame occlusion 对 standard 读取最远值
-`max`、对 reversed 读取最远值 `min`，SSR 读取完整区间。previous-frame
+`max`、对 reversed 读取最远值 `min`，SSR 读取完整区间。Previous-frame Hi-Z 和 current-frame SSR
+pyramid 都在 ordinary Forward opaque 的 `depth-only` fallback prepass 之后构建，因此未进入 GPU Scene
+bucket 的 layered PBR、alpha-mask 和其他兼容对象也拥有可追踪深度。Previous-frame
 occlusion 同时读取已提交的 previous
 view/projection/depth 参数，不把上一帧 VP 与当前帧投影约定混用。颜色阶段 load 深度预通过结果，物体 record 携带 model
 basis 的 inverse-transpose normal matrix，因此 non-uniform scale 不改变法线方向。depth

--- a/documentation/SCREEN_SPACE_REFLECTIONS.md
+++ b/documentation/SCREEN_SPACE_REFLECTIONS.md
@@ -31,13 +31,14 @@ SSR 必须和 `hiZ`、`temporalAA`
 
 生产帧的顺序是：
 
-1. shared depth/motion prepass；
+1. GPU Scene 与 ordinary Forward opaque 共用的 depth/motion prepass；
 2. current-frame RG32F Hi-Z min/max pyramid；
 3. Clustered opaque PBR color，同时写 material attributes；
 4. ordinary Forward opaque fallback color、material attributes 和 motion；
 5. HDR radiance cone pyramid；
-6. half-resolution hierarchical Hi-Z reflection trace；
-7. motion/depth rejection、3×3 neighborhood clamp 和 temporal accumulation；
+6. configurable-resolution hierarchical Hi-Z reflection trace；
+7. motion/depth rejection、3×3 neighborhood clamp、temporal accumulation 和 confidence-aware
+   depth/normal à-trous filter；
 8. 在线性 HDR 中把 reflection 合成回 opaque scene；
 9. TAA/TAAU resolve；
 10. transparent fallback、Bloom 和 display transform。
@@ -45,6 +46,10 @@ SSR 必须和 `hiZ`、`temporalAA`
 所有资源和依赖都由同一 Render
 Graph 声明；prepare 只创建可复用的 pipeline/binding，execute 才记录命令。SSR 不直接访问原生 `GPU*`
 对象，也不绕过 portable RHI。
+
+ordinary Forward opaque 必须先通过正式 `depth-only` material role 把 fallback 深度合入 current-frame
+scene depth，再构建 Hi-Z。否则 radiance 中虽能看到 fallback 物体，hierarchical
+trace 却没有对应深度可命中；Car Concept 的 layered PBR 车身就是这条回归的发布夹具。
 
 ## Material attribute ABI
 
@@ -72,6 +77,10 @@ thickness 测试。命中辐射按 roughness 与 ray distance 选择四级 HDR c
 cone。最终 confidence 同时包含 screen-edge、ray-distance 和 roughness
 fade，未命中、离屏、背景、背向或超过 roughness cutoff 的像素返回零贡献。
 
+时序结果在合成前经过多尺度 confidence-aware à-trous filter。filter 只在 receiver、roughness、view
+normal 和 logarithmic
+depth 连续的像素间传播有效命中，因此可以柔化局部 trace 空洞而不把车身、地面和背景跨边界涂抹到一起。
+
 这是纯 screen-space 效果：屏幕外、被前景完全遮挡或当前 color
 buffer 中不存在的信息没有可用命中。当前版本确定性返回零作为 fallback；它不伪装成 probe、BVH、SDF 或硬件 ray
 tracing。
@@ -93,10 +102,10 @@ recipe 重建资源，public pipeline identity 不变。
   Scene、ordinary fallback、camera cut、resize、standard/reversed depth 和 device recovery。
 - `test/ui/screen-space-reflections.spec.ts`：真实浏览器 GPU
   validation、静态 history 收敛，以及同一视角 SSR on/off 的非零像素贡献。
-- `examples/screen_space_reflections_palace.html`：使用仓库内 Khronos Car Concept、GPU
-  Scene 发光装置、ordinary Forward PBR floor、三档 roughness、TAA、Bloom 和 Hi-Z
-  SSR 的独立维护示例； `ssr=false` 可显示确定性无 SSR 对照。Car Concept 资产来源、CC BY
-  4.0 许可和 hash 记录在 `examples/models/CarConcept/README.md`。
+- `examples/screen_space_reflections_palace.html`：使用仓库内 Khronos Car Concept、镜头外 studio
+  light field、ordinary Forward PBR 烟熏漆地面、TAA、Bloom 和高精度 Hi-Z SSR 的独立维护示例；
+  `ssr=false` 可显示确定性无 SSR 对照。Car Concept 资产来源、CC BY 4.0 许可和 hash 记录在
+  `examples/models/CarConcept/README.md`。
 
 现有 `examples/temporal_aa_observatory.html` 保持为独立 TAA/TAAU 案例，不承担 SSR release evidence。
 

--- a/examples/screen_space_reflections_palace.css
+++ b/examples/screen_space_reflections_palace.css
@@ -12,8 +12,8 @@
 
 body {
     overflow: hidden;
-    color: #f5eee5;
-    background: #020205;
+    color: #f3eee8;
+    background: #050406;
 }
 
 #container,
@@ -22,232 +22,253 @@ body {
     height: 100%;
 }
 
-.ssrPanel {
+.ssrHeader,
+.ssrIntro,
+.ssrControls,
+.ssrStatus,
+.ssrHint,
+.ssrCredit {
     position: fixed;
     z-index: 4;
-    top: clamp(24px, 5.5vw, 78px);
-    left: clamp(20px, 5vw, 76px);
-    width: min(350px, calc(100vw - 40px));
-    padding: 0;
+}
+
+.ssrHeader {
+    top: clamp(24px, 3.2vw, 48px);
+    right: clamp(24px, 3.8vw, 60px);
+    left: clamp(24px, 3.8vw, 60px);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     pointer-events: none;
 }
 
-.ssrEyebrow {
-    margin: 0;
-    color: #f8bd70;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.24em;
-    text-transform: uppercase;
-    text-shadow: 0 0 24px rgb(255 164 70 / 45%);
-}
-
-.ssrPanel h1 {
-    margin: 18px 0 0;
-    color: #f7f0e8;
-    font-family: Georgia, 'Times New Roman', serif;
-    font-size: clamp(48px, 6vw, 82px);
-    font-weight: 400;
-    letter-spacing: -0.065em;
-    line-height: 0.77;
-    text-shadow: 0 8px 40px rgb(0 0 0 / 60%);
-}
-
-.ssrPanel h1 em {
-    color: #c5c2cc;
-    font-size: 0.82em;
-    font-weight: 400;
-}
-
-.ssrIntro {
-    max-width: 300px;
-    margin: 29px 0 0;
-    color: rgb(231 226 229 / 58%);
-    font-size: 11px;
-    letter-spacing: 0.025em;
-    line-height: 1.75;
-}
-
-.ssrRule {
-    width: 100%;
-    height: 1px;
-    margin: 24px 0 16px;
-    background: rgb(255 255 255 / 12%);
-}
-
-.ssrRule span {
-    display: block;
-    width: 28%;
-    height: 1px;
-    background: linear-gradient(90deg, #f8bd70, #56daf8);
-    box-shadow: 0 0 14px rgb(87 216 248 / 35%);
-}
-
-.ssrMetrics {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-    margin: 0 0 22px;
-}
-
-.ssrMetrics div {
-    min-width: 0;
-}
-
-.ssrMetrics dt {
-    color: rgb(231 226 229 / 30%);
-    font-size: 8px;
-    letter-spacing: 0.17em;
-    text-transform: uppercase;
-}
-
-.ssrMetrics dd {
-    margin: 5px 0 0;
-    color: rgb(247 240 232 / 84%);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+.ssrBrand {
+    display: inline-flex;
+    align-items: center;
+    gap: 11px;
+    color: rgb(248 242 235 / 80%);
     font-size: 10px;
-    letter-spacing: 0.04em;
-}
-
-.ssrActions {
-    display: flex;
-    gap: 8px;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-decoration: none;
+    text-transform: uppercase;
     pointer-events: auto;
 }
 
-.ssrActions button {
-    min-height: 36px;
-    padding: 0 14px;
-    border: 1px solid rgb(255 255 255 / 16%);
-    border-radius: 999px;
-    color: rgb(245 238 229 / 74%);
-    background: rgb(6 7 11 / 54%);
-    backdrop-filter: blur(15px);
-    font: inherit;
+.ssrBrandMark {
+    width: 18px;
+    height: 1px;
+    background: #c83342;
+    box-shadow: 0 0 12px rgb(200 51 66 / 42%);
+}
+
+.ssrEdition {
+    margin: 0;
+    color: rgb(225 218 212 / 32%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 8px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.ssrIntro {
+    top: 50%;
+    left: clamp(24px, 4.2vw, 68px);
+    width: min(270px, 24vw);
+    pointer-events: none;
+    transform: translateY(-58%);
+}
+
+.ssrEyebrow {
+    margin: 0 0 16px;
+    color: #d8a5a0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 8px;
     font-weight: 650;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
-    cursor: pointer;
-    transition:
-        border-color 160ms ease,
-        color 160ms ease,
-        background 160ms ease;
 }
 
-.ssrActions button:hover,
-.ssrActions button:focus-visible {
-    border-color: rgb(248 189 112 / 58%);
-    color: white;
-    background: rgb(31 24 20 / 64%);
-    outline: none;
+.ssrIntro h1 {
+    margin: 0;
+    color: #f5f0ea;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: clamp(48px, 5.1vw, 78px);
+    font-weight: 400;
+    letter-spacing: -0.075em;
+    line-height: 0.84;
+    text-shadow: 0 12px 44px rgb(0 0 0 / 62%);
 }
 
-#ssrToggle {
-    display: inline-flex;
+.ssrIntro h1 span {
+    display: block;
+    margin-left: 0.62em;
+    color: rgb(232 220 209 / 66%);
+    font-style: italic;
+}
+
+.ssrDescription {
+    max-width: 230px;
+    margin: 25px 0 0;
+    color: rgb(230 224 219 / 43%);
+    font-size: 10px;
+    letter-spacing: 0.025em;
+    line-height: 1.7;
+}
+
+.ssrControls {
+    bottom: clamp(24px, 3.6vw, 54px);
+    left: clamp(24px, 3.8vw, 60px);
+    display: flex;
+    min-height: 58px;
     align-items: center;
-    gap: 9px;
+    gap: 18px;
+    padding: 0 20px;
+    border: 1px solid rgb(255 255 255 / 10%);
+    border-radius: 14px;
+    background: rgb(8 7 9 / 58%);
+    box-shadow: 0 18px 60px rgb(0 0 0 / 30%);
+    backdrop-filter: blur(18px) saturate(115%);
+}
+
+.ssrControls button {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    padding: 0;
+    border: 0;
+    color: inherit;
+    background: none;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.ssrControls button:focus-visible {
+    outline: 1px solid #d85a63;
+    outline-offset: 6px;
+}
+
+.ssrControls small {
+    display: block;
+    margin-bottom: 3px;
+    color: rgb(232 226 219 / 30%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 7px;
+    font-weight: 500;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+}
+
+.ssrControls strong {
+    display: block;
+    color: rgb(247 241 235 / 78%);
+    font-size: 9px;
+    font-weight: 650;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
 }
 
 .ssrSwitch {
     position: relative;
-    width: 24px;
-    height: 12px;
-    border: 1px solid rgb(248 189 112 / 60%);
+    width: 29px;
+    height: 15px;
+    border: 1px solid rgb(216 90 99 / 60%);
     border-radius: 999px;
+    transition: border-color 160ms ease;
 }
 
-.ssrSwitch::after {
+.ssrSwitch span {
     position: absolute;
-    top: 2px;
-    right: 2px;
-    width: 6px;
-    height: 6px;
+    top: 3px;
+    right: 3px;
+    width: 7px;
+    height: 7px;
     border-radius: 50%;
-    content: '';
-    background: #ffd49b;
-    box-shadow: 0 0 9px #ff9d42;
+    background: #e96870;
+    box-shadow: 0 0 11px rgb(233 77 89 / 72%);
+    transition:
+        right 160ms ease,
+        background 160ms ease,
+        box-shadow 160ms ease;
 }
 
 #ssrToggle[aria-pressed='false'] .ssrSwitch {
-    border-color: rgb(255 255 255 / 20%);
+    border-color: rgb(255 255 255 / 18%);
 }
 
-#ssrToggle[aria-pressed='false'] .ssrSwitch::after {
-    right: 14px;
-    background: #797984;
+#ssrToggle[aria-pressed='false'] .ssrSwitch span {
+    right: 17px;
+    background: #77747a;
     box-shadow: none;
 }
 
-.ssrLegend {
-    position: fixed;
-    z-index: 4;
-    right: clamp(20px, 4vw, 60px);
-    top: 50%;
-    display: grid;
-    gap: 12px;
-    color: rgb(228 231 240 / 44%);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 8px;
-    letter-spacing: 0.18em;
-    text-align: right;
-    text-transform: uppercase;
-    transform: translateY(-50%);
+.ssrDivider {
+    width: 1px;
+    height: 27px;
+    background: rgb(255 255 255 / 9%);
 }
 
-.ssrLegend p {
+.ssrTechnical {
+    display: flex;
+    gap: 15px;
     margin: 0;
+    color: rgb(229 222 216 / 34%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 7px;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
 }
 
-.ssrLegend span {
-    margin-right: 9px;
-    color: #f8bd70;
+.ssrTechnical span + span::before {
+    margin-right: 15px;
+    color: rgb(216 90 99 / 56%);
+    content: '·';
 }
 
 .ssrStatus {
-    position: fixed;
-    z-index: 4;
-    bottom: clamp(24px, 5vw, 62px);
-    left: clamp(20px, 5vw, 76px);
+    right: clamp(24px, 3.8vw, 60px);
+    bottom: clamp(30px, 4vw, 60px);
     display: flex;
     align-items: center;
-    gap: 9px;
-    color: rgb(228 231 240 / 44%);
+    gap: 8px;
+    color: rgb(229 222 216 / 34%);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 8px;
-    letter-spacing: 0.13em;
+    font-size: 7px;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
 }
 
 .ssrPulse {
-    width: 5px;
-    height: 5px;
+    width: 4px;
+    height: 4px;
     border-radius: 50%;
-    background: #61e5ff;
-    box-shadow: 0 0 13px #24d8ff;
+    background: #db5660;
+    box-shadow: 0 0 10px rgb(219 86 96 / 66%);
 }
 
 .ssrHint {
-    position: fixed;
-    z-index: 4;
-    right: clamp(20px, 4vw, 60px);
-    bottom: clamp(24px, 5vw, 62px);
+    right: clamp(24px, 3.8vw, 60px);
+    top: 50%;
     margin: 0;
-    color: rgb(228 231 240 / 35%);
-    font-size: 9px;
+    color: rgb(229 222 216 / 26%);
+    font-size: 8px;
     letter-spacing: 0.05em;
+    writing-mode: vertical-rl;
+    transform: translateY(-50%);
+}
+
+.ssrHint span {
+    color: rgb(216 90 99 / 56%);
 }
 
 .ssrCredit {
-    position: fixed;
-    z-index: 4;
-    right: clamp(20px, 4vw, 60px);
-    top: clamp(22px, 4vw, 52px);
-    color: rgb(228 231 240 / 32%);
+    right: clamp(24px, 3.8vw, 60px);
+    top: clamp(52px, 6.5vw, 88px);
+    color: rgb(229 222 216 / 23%);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 7px;
-    letter-spacing: 0.14em;
+    font-size: 6px;
+    letter-spacing: 0.12em;
     text-decoration: none;
     text-transform: uppercase;
     transition: color 160ms ease;
@@ -255,58 +276,63 @@ body {
 
 .ssrCredit:hover,
 .ssrCredit:focus-visible {
-    color: #f8bd70;
+    color: #d85a63;
     outline: none;
 }
 
-.ssrVignette,
-.ssrGrain {
+.ssrAtmosphere {
     position: fixed;
     z-index: 3;
     inset: 0;
     pointer-events: none;
-}
-
-.ssrVignette {
     background:
-        radial-gradient(circle at 63% 42%, transparent 24%, rgb(1 1 4 / 10%) 58%, rgb(0 0 2 / 67%)),
-        linear-gradient(90deg, rgb(0 0 2 / 34%), transparent 35% 78%, rgb(0 0 2 / 18%));
+        radial-gradient(circle at 73% 43%, rgb(108 8 20 / 8%), transparent 34%),
+        radial-gradient(circle at 66% 47%, transparent 34%, rgb(2 2 4 / 13%) 74%),
+        linear-gradient(90deg, rgb(2 2 4 / 48%), transparent 29% 87%, rgb(2 2 4 / 24%));
 }
 
-.ssrGrain {
-    opacity: 0.035;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 120 120' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.84' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.9'/%3E%3C/svg%3E");
-    mix-blend-mode: soft-light;
-}
-
-@media (max-width: 720px) {
-    .ssrPanel {
-        top: 19px;
-        left: 18px;
-        width: min(320px, calc(100vw - 36px));
+@media (max-width: 820px) {
+    .ssrHeader {
+        top: 20px;
+        right: 20px;
+        left: 20px;
     }
 
-    .ssrPanel h1 {
-        margin-top: 12px;
-        font-size: 47px;
+    .ssrIntro {
+        top: 82px;
+        left: 20px;
+        width: auto;
+        transform: none;
     }
 
-    .ssrIntro,
-    .ssrRule,
-    .ssrMetrics,
-    .ssrLegend,
+    .ssrEyebrow {
+        margin-bottom: 10px;
+        font-size: 7px;
+    }
+
+    .ssrIntro h1 {
+        font-size: 43px;
+    }
+
+    .ssrDescription,
+    .ssrEdition,
+    .ssrCredit,
     .ssrHint,
-    .ssrCredit {
+    .ssrDesktopOnly {
         display: none;
     }
 
-    .ssrActions {
-        margin-top: 18px;
+    .ssrControls {
+        bottom: 18px;
+        left: 18px;
+        min-height: 54px;
+        gap: 14px;
+        padding: 0 16px;
     }
 
     .ssrStatus {
         right: 18px;
-        bottom: 18px;
-        left: auto;
+        bottom: 84px;
+        max-width: calc(100vw - 36px);
     }
 }

--- a/examples/screen_space_reflections_palace.html
+++ b/examples/screen_space_reflections_palace.html
@@ -6,59 +6,47 @@
             name="viewport"
             content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0"
         />
-        <title>Hilo3D Nocturne Pavilion — Screen-space Reflections</title>
+        <title>Hilo3D Afterimage — Screen-space Reflections</title>
         <link rel="stylesheet" href="./example.css" />
         <link rel="stylesheet" href="./screen_space_reflections_palace.css" />
     </head>
     <body>
         <div id="container"></div>
 
-        <main class="ssrPanel" aria-label="Screen-space reflections showcase">
-            <p class="ssrEyebrow">Hilo3D · reflection study 01</p>
-            <h1>Nocturne<br /><em>Pavilion</em></h1>
-            <p class="ssrIntro">
-                A metallic-flake concept car staged inside a rain-dark mirror hall, shaped by
-                luminous sculpture, brushed metal and temporal Hi-Z reflections.
-            </p>
+        <header class="ssrHeader">
+            <a class="ssrBrand" href="./index.html" aria-label="Back to Hilo3D examples">
+                <span class="ssrBrandMark" aria-hidden="true"></span>
+                <span>Hilo3D</span>
+            </a>
+            <p class="ssrEdition">WebGPU study · 01</p>
+        </header>
 
-            <div class="ssrRule" aria-hidden="true"><span></span></div>
-
-            <dl class="ssrMetrics">
-                <div>
-                    <dt>trace</dt>
-                    <dd>Hi-Z</dd>
-                </div>
-                <div>
-                    <dt>resolve</dt>
-                    <dd>temporal</dd>
-                </div>
-                <div>
-                    <dt>surface</dt>
-                    <dd>3 tiers</dd>
-                </div>
-            </dl>
-
-            <div class="ssrActions">
-                <button id="ssrToggle" type="button" aria-pressed="true">
-                    <span class="ssrSwitch" aria-hidden="true"></span>
-                    <span id="ssrToggleLabel">SSR active</span>
-                </button>
-                <button id="motionToggle" type="button" aria-pressed="true">pause sculpture</button>
-            </div>
+        <main class="ssrIntro" aria-label="Screen-space reflections showcase">
+            <p class="ssrEyebrow">Screen-space reflections</p>
+            <h1>After<span>image</span></h1>
+            <p class="ssrDescription">Car Concept in a smoked-lacquer study of light and motion.</p>
         </main>
 
-        <aside class="ssrLegend" aria-label="Reflection material legend">
-            <p><span>01</span> mirror</p>
-            <p><span>02</span> brushed</p>
-            <p><span>03</span> satin</p>
-        </aside>
+        <div class="ssrControls" aria-label="Reflection controls">
+            <button id="ssrToggle" type="button" aria-pressed="true">
+                <span class="ssrSwitch" aria-hidden="true"><span></span></span>
+                <span>
+                    <small>reflection</small>
+                    <strong id="ssrToggleLabel">SSR on</strong>
+                </span>
+            </button>
+            <span class="ssrDivider ssrDesktopOnly" aria-hidden="true"></span>
+            <p class="ssrTechnical ssrDesktopOnly">
+                <span>Hi-Z trace</span><span>temporal resolve</span><span>smoked lacquer</span>
+            </p>
+        </div>
 
-        <div class="ssrStatus">
+        <div class="ssrStatus" aria-live="polite">
             <span class="ssrPulse" aria-hidden="true"></span>
             <span id="statusLabel">warming reflection history</span>
         </div>
 
-        <p class="ssrHint">Drag to orbit · wheel to inspect · toggle SSR to compare</p>
+        <p class="ssrHint">Drag to orbit</p>
         <a
             class="ssrCredit"
             href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/CarConcept"
@@ -66,8 +54,7 @@
             rel="noreferrer"
             >Car Concept · DGG / Khronos · CC BY 4.0</a
         >
-        <div class="ssrVignette" aria-hidden="true"></div>
-        <div class="ssrGrain" aria-hidden="true"></div>
+        <div class="ssrAtmosphere" aria-hidden="true"></div>
 
         <script type="module" src="./screen_space_reflections_palace.ts"></script>
     </body>

--- a/examples/screen_space_reflections_palace.ts
+++ b/examples/screen_space_reflections_palace.ts
@@ -1,5 +1,5 @@
 import * as Hilo3d from '../src/Hilo3d';
-import { loadDefaultEnvironmentMaps } from './shared/defaultEnvironment';
+import { createStudioEnvironmentMaps } from './shared/studioEnvironment';
 
 interface ReflectionPalaceEvidence {
     readonly backend: 'webgpu';
@@ -9,113 +9,78 @@ interface ReflectionPalaceEvidence {
     readonly hiZValid: boolean;
     readonly screenSpaceReflections: boolean;
     readonly temporalAA: true;
-    readonly roughnessTiers: 3;
+    readonly surfaceFinish: 'smoked lacquer';
     readonly heroAsset: 'Khronos Car Concept';
 }
 
 const search = new URLSearchParams(location.search);
 const testMode = search.get('test') === '1';
 const reflectionsEnabled = search.get('ssr') !== 'false';
-const prefersReducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 function requireElement(selector: string): HTMLElement {
     const element = document.querySelector<HTMLElement>(selector);
-    if (element === null) throw new Error(`Nocturne Pavilion is missing ${selector}`);
+    if (element === null) throw new Error(`Afterimage is missing ${selector}`);
     return element;
 }
 
 const container = requireElement('#container');
 const ssrToggle = requireElement('#ssrToggle');
 const ssrToggleLabel = requireElement('#ssrToggleLabel');
-const motionToggle = requireElement('#motionToggle');
 const statusLabel = requireElement('#statusLabel');
 
-const gold = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.72, 0.38, 0.12),
-    metallic: 0.92,
-    roughness: 0.2
+statusLabel.textContent = 'loading Khronos Car Concept';
+const { diffuseEnvMap, specularEnvMap } = createStudioEnvironmentMaps();
+const brdfLUT = await new Hilo3d.TextureLoader().load({
+    src: new URL('./image/brdfLUT.png', import.meta.url).href,
+    wrapS: Hilo3d.constants.webgl.CLAMP_TO_EDGE,
+    wrapT: Hilo3d.constants.webgl.CLAMP_TO_EDGE
 });
-const obsidian = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.008, 0.01, 0.018),
-    metallic: 0.84,
-    roughness: 0.16
+const loader = new Hilo3d.GLTFLoader();
+const carModel = await loader.load({
+    src: new URL('./models/CarConcept/CarConcept.glb', import.meta.url).href,
+    ignoreTextureError: false,
+    pbrMaterialDefaults: {
+        brdfLUT,
+        diffuseEnvMap: { texture: diffuseEnvMap, encoding: 'srgb' },
+        specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
+        diffuseEnvIntensity: 0.58,
+        specularEnvIntensity: 1.02
+    }
 });
-const cyanLight = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.02, 0.28, 0.38),
-    metallic: 0.25,
-    roughness: 0.14,
-    emission: new Hilo3d.Color(0.01, 0.26, 0.42),
-    emissionFactor: new Hilo3d.Color(0.08, 1.1, 1.8)
-});
-const magentaLight = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.38, 0.025, 0.18),
-    metallic: 0.24,
-    roughness: 0.16,
-    emission: new Hilo3d.Color(0.38, 0.012, 0.2),
-    emissionFactor: new Hilo3d.Color(1.5, 0.05, 0.75)
-});
-const amberLight = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.52, 0.2, 0.035),
-    metallic: 0.36,
-    roughness: 0.13,
-    emission: new Hilo3d.Color(0.48, 0.16, 0.02),
-    emissionFactor: new Hilo3d.Color(1.6, 0.45, 0.04)
-});
-const mirror = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.045, 0.055, 0.075),
-    metallic: 0.94,
-    roughness: 0.06
-});
-const brushed = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.09, 0.075, 0.065),
-    metallic: 0.88,
-    roughness: 0.3
-});
-const satin = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.075, 0.055, 0.085),
-    metallic: 0.72,
-    roughness: 0.58
-});
+await carModel.ready;
+if (carModel.resourceErrors.length > 0) {
+    throw new AggregateError(carModel.resourceErrors, 'Khronos Car Concept has resource failures');
+}
+for (const material of carModel.materials) {
+    if (!(material instanceof Hilo3d.PBRMaterial) || !material.name?.startsWith('Paint')) continue;
+    material.normalScale = Math.min(material.normalScale, 0.16);
+    material.roughness = Math.max(material.roughness, 0.32);
+    material.iridescenceFactor = Math.min(material.iridescenceFactor, 0.05);
+    material.specularEnvIntensity = Math.min(material.specularEnvIntensity, 0.96);
+}
 
-const columnGeometry = new Hilo3d.BoxGeometry({ width: 0.42, height: 5.2, depth: 0.56 });
-const beamGeometry = new Hilo3d.BoxGeometry({ width: 11.5, height: 0.34, depth: 0.62 });
-const inlayGeometry = new Hilo3d.BoxGeometry({ width: 0.055, height: 4.35, depth: 0.035 });
-const haloGeometry = new Hilo3d.BoxGeometry({ width: 0.13, height: 0.72, depth: 0.15 });
-const bladeGeometry = new Hilo3d.BoxGeometry({ width: 0.13, height: 2.5, depth: 0.2 });
-const plinthGeometry = new Hilo3d.BoxGeometry({ width: 0.72, height: 0.14, depth: 0.84 });
-const beaconGeometry = new Hilo3d.BoxGeometry({ width: 0.065, height: 0.88, depth: 0.065 });
-const eclipseGeometry = new Hilo3d.SphereGeometry({
-    radius: 1.02,
-    widthSegments: 40,
-    heightSegments: 24
+const floorGeometry = new Hilo3d.PlaneGeometry({ width: 80, height: 80 });
+const floorMaterial = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.018, 0.015, 0.022),
+    metallic: 0.38,
+    roughness: 0.16,
+    brdfLUT,
+    diffuseEnvMap: { texture: diffuseEnvMap, encoding: 'srgb' },
+    specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
+    diffuseEnvIntensity: 0.05,
+    specularEnvIntensity: 0.12
 });
-const jewelGeometry = new Hilo3d.SphereGeometry({
-    radius: 0.2,
-    widthSegments: 18,
-    heightSegments: 12
+const gpuEvidenceGeometry = new Hilo3d.BoxGeometry({ width: 0.16, height: 0.08, depth: 0.16 });
+const gpuEvidenceMaterial = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.01, 0.009, 0.012),
+    metallic: 0.2,
+    roughness: 0.8
 });
 
 const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
-    buckets: [
-        { geometry: columnGeometry, material: gold },
-        { geometry: beamGeometry, material: gold },
-        { geometry: inlayGeometry, material: cyanLight },
-        { geometry: inlayGeometry, material: magentaLight },
-        { geometry: haloGeometry, material: amberLight },
-        { geometry: bladeGeometry, material: cyanLight },
-        { geometry: bladeGeometry, material: magentaLight },
-        { geometry: eclipseGeometry, material: obsidian },
-        { geometry: jewelGeometry, material: cyanLight },
-        { geometry: jewelGeometry, material: magentaLight },
-        { geometry: plinthGeometry, material: mirror },
-        { geometry: plinthGeometry, material: brushed },
-        { geometry: plinthGeometry, material: satin },
-        { geometry: beaconGeometry, material: cyanLight },
-        { geometry: beaconGeometry, material: magentaLight },
-        { geometry: beaconGeometry, material: amberLight }
-    ],
-    maxObjects: 160,
-    maxLights: 24,
+    buckets: [{ geometry: gpuEvidenceGeometry, material: gpuEvidenceMaterial }],
+    maxObjects: 32,
+    maxLights: 8,
     maxLightIndices: 65_536,
     maxLightsPerCluster: 48,
     tileSize: 24,
@@ -123,27 +88,27 @@ const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
     maxViewportWidth: testMode ? 960 : 2560,
     maxViewportHeight: testMode ? 600 : 1440,
     hiZ: true,
-    bloomStrength: 0.62,
-    exposure: 1.04,
+    bloomStrength: 0.14,
+    exposure: 1.08,
     temporalAA: {
         renderScale: 1,
-        historyWeight: 0.9,
+        historyWeight: 0.94,
         depthThreshold: 0.02,
-        varianceGamma: 1.2,
-        sharpness: 0.06
+        varianceGamma: 1,
+        sharpness: 0.025
     },
     screenSpaceReflections: reflectionsEnabled
         ? {
-              resolutionScale: 0.5,
-              maxRayDistance: 64,
-              thickness: 0.2,
-              stride: 0.08,
-              maxSteps: 72,
-              roughnessCutoff: 0.76,
-              edgeFade: 0.07,
-              historyWeight: 0.92,
-              depthThreshold: 0.025,
-              intensity: 1.25
+              resolutionScale: 1,
+              maxRayDistance: 56,
+              thickness: 0.18,
+              stride: 0.06,
+              maxSteps: 96,
+              roughnessCutoff: 0.28,
+              edgeFade: 0.1,
+              historyWeight: 0.95,
+              depthThreshold: 0.03,
+              intensity: 1.55
           }
         : false
 });
@@ -152,7 +117,7 @@ const initialWidth = testMode ? 960 : innerWidth;
 const initialHeight = testMode ? 600 : innerHeight;
 const camera = new Hilo3d.PerspectiveCamera({
     aspect: initialWidth / Math.max(initialHeight, 1),
-    fov: 39,
+    fov: 32,
     near: 0.05,
     far: 90,
     depthMode: 'reversed'
@@ -168,318 +133,123 @@ const stage = await Hilo3d.Stage.create<'webgpu'>({
     pixelRatio: testMode ? 1 : Math.min(devicePixelRatio, 1.5),
     antialias: false,
     alpha: false,
-    clearColor: new Hilo3d.Color(0.0015, 0.001, 0.004),
+    clearColor: new Hilo3d.Color(0.0012, 0.001, 0.0018),
     renderingProfile: 'high-end',
     renderPipeline: factory
 });
-document.body.dataset['ssrPhase'] = 'building-pavilion';
+document.body.dataset['ssrPhase'] = 'building-atelier';
 
 new Hilo3d.AmbientLight({
-    amount: 0.28,
-    color: new Hilo3d.Color(0.2, 0.24, 0.36)
+    amount: 0.18,
+    color: new Hilo3d.Color(0.25, 0.28, 0.36)
 }).addTo(stage);
 new Hilo3d.DirectionalLight({
-    amount: 2.8,
-    color: new Hilo3d.Color(1, 0.78, 0.6),
-    direction: new Hilo3d.Vector3(-0.48, -0.84, -0.26)
+    amount: 2.4,
+    color: new Hilo3d.Color(1, 0.86, 0.76),
+    direction: new Hilo3d.Vector3(-0.34, -0.91, -0.2)
 }).addTo(stage);
 
-const lightPalette = [
-    new Hilo3d.Color(0.08, 0.72, 1),
-    new Hilo3d.Color(1, 0.08, 0.48),
-    new Hilo3d.Color(1, 0.45, 0.09)
-] as const;
-const lightPositions = [
-    [-3.5, 0.8, 1.2],
-    [3.5, 0.8, 1.2],
-    [-3.7, 0.9, -3.0],
-    [3.7, 0.9, -3.0],
-    [0, 1.2, -6.5]
-] as const;
-for (let index = 0; index < lightPositions.length; index += 1) {
-    const position = lightPositions[index];
-    const color = lightPalette[index % lightPalette.length];
-    if (position === undefined || color === undefined) throw new Error('Light plan is incomplete');
-    new Hilo3d.PointLight({
-        amount: index === lightPositions.length - 1 ? 5.4 : 3.8,
-        range: index === lightPositions.length - 1 ? 10 : 7,
-        color,
-        x: position[0],
-        y: position[1],
-        z: position[2]
-    }).addTo(stage);
-}
-new Hilo3d.PointLight({
-    amount: 5.8,
-    range: 9,
-    color: new Hilo3d.Color(0.75, 0.9, 1),
-    x: 1.8,
-    y: 2.2,
-    z: 1.2
-}).addTo(stage);
-new Hilo3d.PointLight({
-    amount: 4.6,
-    range: 8,
-    color: new Hilo3d.Color(1, 0.28, 0.16),
-    x: -2.7,
-    y: 0.5,
-    z: -1.8
-}).addTo(stage);
-
-const archDepths = [-0.9, -4.5, -8.1] as const;
-for (const z of archDepths) {
-    for (const side of [-1, 1] as const) {
-        new Hilo3d.Mesh({
-            geometry: columnGeometry,
-            material: gold,
-            x: side * 5.65,
-            y: 0.84,
-            z,
-            pointerEnabled: false
-        }).addTo(stage);
-        new Hilo3d.Mesh({
-            geometry: inlayGeometry,
-            material: side > 0 ? magentaLight : cyanLight,
-            x: side * 5.39,
-            y: 0.78,
-            z: z + 0.3,
-            pointerEnabled: false
-        }).addTo(stage);
+const lightPlan = [
+    { amount: 5.2, range: 12, color: new Hilo3d.Color(1, 0.78, 0.64), x: 3.8, y: 3.2, z: 1.6 },
+    {
+        amount: 2.7,
+        range: 10,
+        color: new Hilo3d.Color(0.32, 0.47, 0.86),
+        x: -4.6,
+        y: 1.4,
+        z: -4.2
+    },
+    {
+        amount: 3.2,
+        range: 11,
+        color: new Hilo3d.Color(1, 0.08, 0.035),
+        x: -0.8,
+        y: 0.65,
+        z: -8.6
     }
-    new Hilo3d.Mesh({
-        geometry: beamGeometry,
-        material: gold,
-        x: 0,
-        y: 3.34,
-        z,
-        pointerEnabled: false
-    }).addTo(stage);
+] as const;
+for (const light of lightPlan) {
+    new Hilo3d.PointLight(light).addTo(stage);
 }
 
 const floor = new Hilo3d.Mesh({
-    geometry: new Hilo3d.PlaneGeometry({ width: 22, height: 27 }),
-    material: new Hilo3d.PBRMaterial({
-        baseColor: new Hilo3d.Color(0.004, 0.006, 0.012),
-        metallic: 0.96,
-        roughness: 0.12
-    }),
-    y: -1.78,
-    z: -2.2,
+    geometry: floorGeometry,
+    material: floorMaterial,
+    y: -1.76,
+    z: -4.4,
     rotationX: -90,
     pointerEnabled: false,
     frustumTest: false
 }).addTo(stage);
 floor.receiveShadows = false;
 
-statusLabel.textContent = 'loading Khronos Car Concept';
-const [{ diffuseEnvMap, specularEnvMap }, brdfLUT] = await Promise.all([
-    loadDefaultEnvironmentMaps(),
-    new Hilo3d.TextureLoader().load({
-        src: new URL('./image/brdfLUT.png', import.meta.url).href,
-        wrapS: Hilo3d.constants.webgl.CLAMP_TO_EDGE,
-        wrapT: Hilo3d.constants.webgl.CLAMP_TO_EDGE
-    })
-]);
-const loader = new Hilo3d.GLTFLoader();
-const carModel = await loader.load({
-    src: new URL('./models/CarConcept/CarConcept.glb', import.meta.url).href,
-    ignoreTextureError: false,
-    pbrMaterialDefaults: {
-        brdfLUT,
-        diffuseEnvMap: { texture: diffuseEnvMap, encoding: 'srgb' },
-        specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
-        diffuseEnvIntensity: 0.6,
-        specularEnvIntensity: 1.05
-    }
-});
-await carModel.ready;
-if (carModel.resourceErrors.length > 0) {
-    throw new AggregateError(carModel.resourceErrors, 'Khronos Car Concept has resource failures');
-}
+new Hilo3d.Mesh({
+    geometry: gpuEvidenceGeometry,
+    material: gpuEvidenceMaterial,
+    y: -1.94,
+    z: -5.4,
+    pointerEnabled: false
+}).addTo(stage);
+
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.SphereGeometry({ radius: 30, widthSegments: 64, heightSegments: 32 }),
+    material: new Hilo3d.PBRMaterial({
+        unlit: true,
+        baseColor: new Hilo3d.Color(0.008, 0.0068, 0.01),
+        metallic: 0,
+        roughness: 1,
+        cullMode: 'front'
+    }),
+    y: 0.5,
+    z: -5.4,
+    pointerEnabled: false,
+    frustumTest: false
+}).addTo(stage);
+
 const carBounds = carModel.node.getBounds();
-if (carBounds === undefined) {
-    throw new Error('Khronos Car Concept has no renderable bounds');
-}
+if (carBounds === undefined) throw new Error('Khronos Car Concept has no renderable bounds');
 const carLargestDimension = Math.max(carBounds.width, carBounds.height, carBounds.depth);
 if (!Number.isFinite(carLargestDimension) || carLargestDimension <= 0) {
     throw new RangeError('Khronos Car Concept has invalid bounds');
 }
-const carScale = 8 / carLargestDimension;
+const carScale = 7.7 / carLargestDimension;
 carModel.node.setScale(carScale);
 carModel.node.setPosition(
     -carBounds.x * carScale + 1.05,
-    -carBounds.y * carScale + carBounds.height * carScale * 0.5 - 1.7,
-    -carBounds.z * carScale - 2.55
+    -carBounds.y * carScale + carBounds.height * carScale * 0.5 - 1.69,
+    -carBounds.z * carScale - 5.4
 );
-carModel.node.rotationY = 168;
+carModel.node.rotationY = 164;
 for (const mesh of carModel.meshes) {
     mesh.pointerEnabled = false;
     mesh.frustumTest = false;
 }
 carModel.node.addTo(stage);
 
-new Hilo3d.Mesh({
-    geometry: new Hilo3d.BoxGeometry({ width: 12.8, height: 7.2, depth: 0.35 }),
-    material: new Hilo3d.PBRMaterial({
-        baseColor: new Hilo3d.Color(0.006, 0.007, 0.013),
-        metallic: 0.2,
-        roughness: 0.72
-    }),
-    y: 0.9,
-    z: -10.2,
-    pointerEnabled: false,
-    frustumTest: false
-}).addTo(stage);
-
-const halo: Hilo3d.Mesh[] = [];
-for (let index = 0; index < 32; index += 1) {
-    const angle = (index / 32) * Math.PI * 2;
-    const segment = new Hilo3d.Mesh({
-        geometry: haloGeometry,
-        material: amberLight,
-        x: Math.cos(angle) * 1.78,
-        y: 0.38 + Math.sin(angle) * 1.78,
-        z: -7.6,
-        rotationZ: 90 - (angle * 180) / Math.PI,
-        pointerEnabled: false
-    }).addTo(stage);
-    segment.setScale(0.72 + (index % 4) * 0.09);
-    halo.push(segment);
-}
-
-const eclipse = new Hilo3d.Mesh({
-    geometry: eclipseGeometry,
-    material: obsidian,
-    y: 0.38,
-    z: -7.3,
-    pointerEnabled: false
-}).addTo(stage);
-
-const bladeRows = [
-    { x: -3.45, material: cyanLight, phase: 0 },
-    { x: 3.45, material: magentaLight, phase: Math.PI }
-] as const;
-const blades: Hilo3d.Mesh[] = [];
-for (const row of bladeRows) {
-    for (let index = 0; index < 5; index += 1) {
-        const blade = new Hilo3d.Mesh({
-            geometry: bladeGeometry,
-            material: row.material,
-            x: row.x + (index - 2) * 0.26,
-            y: -0.28 + Math.abs(index - 2) * 0.12,
-            z: -3.65 + Math.abs(index - 2) * 0.16,
-            rotationZ: (index - 2) * 7,
-            pointerEnabled: false
-        }).addTo(stage);
-        blade.setScale(0.58);
-        blades.push(blade);
-    }
-}
-
-const tierMaterials = [mirror, brushed, satin] as const;
-const tierLights = [cyanLight, amberLight, magentaLight] as const;
-for (let index = 0; index < tierMaterials.length; index += 1) {
-    const x = 4.15;
-    const z = 0.3 - index * 1.25;
-    new Hilo3d.Mesh({
-        geometry: plinthGeometry,
-        material: tierMaterials[index] ?? mirror,
-        x,
-        y: -1.63,
-        z,
-        pointerEnabled: false
-    }).addTo(stage);
-    new Hilo3d.Mesh({
-        geometry: beaconGeometry,
-        material: tierLights[index] ?? amberLight,
-        x,
-        y: -1.27,
-        z,
-        rotationZ: index === 1 ? 0 : (index - 1) * 9,
-        pointerEnabled: false
-    }).addTo(stage);
-}
-
-const jewels: { readonly mesh: Hilo3d.Mesh; readonly phase: number }[] = [];
-for (let index = 0; index < 12; index += 1) {
-    const angle = (index / 12) * Math.PI * 2;
-    jewels.push({
-        mesh: new Hilo3d.Mesh({
-            geometry: jewelGeometry,
-            material: index % 2 === 0 ? cyanLight : magentaLight,
-            x: Math.cos(angle) * 2.1,
-            y: 0.35 + Math.sin(angle) * 1.05,
-            z: -5.4 + Math.sin(angle * 2) * 0.28,
-            pointerEnabled: false
-        }).addTo(stage),
-        phase: angle
-    });
-}
-
 const controls = new Hilo3d.OrbitControls(stage, {
     camera,
-    target: new Hilo3d.Vector3(-0.65, -0.45, -3.2),
+    target: new Hilo3d.Vector3(0.72, -0.64, -5.35),
     enablePan: false,
-    minDistance: 8,
-    maxDistance: 20,
-    minPolarAngle: Math.PI * 0.31,
-    maxPolarAngle: Math.PI * 0.62,
-    rotateSpeed: 0.5,
-    zoomSpeed: 0.72
+    enableZoom: false,
+    minDistance: 12.5,
+    maxDistance: 18,
+    minPolarAngle: Math.PI * 0.39,
+    maxPolarAngle: Math.PI * 0.52,
+    rotateSpeed: 0.42,
+    zoomSpeed: 0.68
 });
-const heroView = new Hilo3d.Vector3(7.7, 1.42, 7.65);
-const heroTarget = new Hilo3d.Vector3(-0.65, -0.5, -2.9);
+const heroView = new Hilo3d.Vector3(9.85, 0.82, 5.45);
+const heroTarget = new Hilo3d.Vector3(0.72, -0.64, -5.35);
 controls.setView(heroView, heroTarget);
 
-let time = 0;
-let motionEnabled = !testMode && !prefersReducedMotion && search.get('motion') !== 'false';
-
-function updateScene(deltaMilliseconds: number): void {
-    if (motionEnabled) time += Math.min(deltaMilliseconds, 50) * 0.001;
-    eclipse.rotationY = time * 11;
-    eclipse.rotationX = Math.sin(time * 0.37) * 8;
-    carModel.node.rotationY = 168 + Math.sin(time * 0.22) * 3;
-    for (let index = 0; index < halo.length; index += 1) {
-        const segment = halo[index];
-        if (segment === undefined) continue;
-        segment.rotationY = Math.sin(time * 0.5 + index * 0.34) * 16;
-    }
-    for (const jewel of jewels) {
-        const angle = jewel.phase + time * 0.18;
-        jewel.mesh.x = Math.cos(angle) * 2.1;
-        jewel.mesh.y = 0.35 + Math.sin(angle) * 1.05;
-        jewel.mesh.z = -5.4 + Math.sin(angle * 2) * 0.28;
-    }
-    for (let index = 0; index < blades.length; index += 1) {
-        const blade = blades[index];
-        if (blade === undefined) continue;
-        blade.rotationY = Math.sin(time * 0.42 + index * 0.38) * 24;
-    }
-}
-
 const ticker = new Hilo3d.Ticker(60);
-const simulation: Hilo3d.Tickable = { tick: updateScene };
-ticker.addTick(simulation);
 ticker.addTick(stage);
 
-function setMotion(value: boolean): void {
-    motionEnabled = value;
-    motionToggle.setAttribute('aria-pressed', String(value));
-    motionToggle.textContent = value ? 'pause sculpture' : 'resume sculpture';
-}
-
-async function stepFrames(frameCount: number, advanceMotion = false): Promise<void> {
+async function stepFrames(frameCount: number): Promise<void> {
     ticker.stop();
-    const previousMotion = motionEnabled;
-    if (!advanceMotion) motionEnabled = false;
-    try {
-        for (let frame = 0; frame < frameCount; frame += 1) {
-            updateScene(1000 / 60);
-            stage.tick(1000 / 60);
-            await stage.renderer.waitForIdle();
-        }
-    } finally {
-        motionEnabled = previousMotion;
+    for (let frame = 0; frame < frameCount; frame += 1) {
+        stage.tick(1000 / 60);
+        await stage.renderer.waitForIdle();
     }
 }
 
@@ -491,11 +261,8 @@ function toggleReflections(): void {
 }
 
 ssrToggle.setAttribute('aria-pressed', String(reflectionsEnabled));
-ssrToggleLabel.textContent = reflectionsEnabled ? 'SSR active' : 'SSR disabled';
+ssrToggleLabel.textContent = reflectionsEnabled ? 'SSR on' : 'SSR off';
 ssrToggle.addEventListener('click', toggleReflections);
-motionToggle.addEventListener('click', () => {
-    setMotion(!motionEnabled);
-});
 
 const resize = (): void => {
     if (testMode) return;
@@ -504,10 +271,8 @@ const resize = (): void => {
 };
 window.addEventListener('resize', resize);
 
-setMotion(motionEnabled);
-updateScene(0);
 document.body.dataset['ssrPhase'] = 'warming-history';
-await stepFrames(reflectionsEnabled ? 20 : 4, false);
+await stepFrames(reflectionsEnabled ? 20 : 4);
 const diagnostics = await factory.readDiagnostics();
 window.__HILO3D_SSR_PALACE_RESULT__ = {
     backend: 'webgpu',
@@ -517,20 +282,15 @@ window.__HILO3D_SSR_PALACE_RESULT__ = {
     hiZValid: diagnostics.hiZValid,
     screenSpaceReflections: reflectionsEnabled,
     temporalAA: true,
-    roughnessTiers: 3,
+    surfaceFinish: 'smoked lacquer',
     heroAsset: 'Khronos Car Concept'
 };
 window.__HILO3D_SSR_PALACE_TEST_API__ = {
     async settle(frames = 8): Promise<void> {
-        await stepFrames(frames, false);
-    },
-    async advance(frames = 1): Promise<void> {
-        await stepFrames(frames, true);
+        await stepFrames(frames);
     }
 };
-statusLabel.textContent = reflectionsEnabled
-    ? `${String(diagnostics.visibleObjectCount)} forms · reflection history stable`
-    : `${String(diagnostics.visibleObjectCount)} forms · direct light only`;
+statusLabel.textContent = reflectionsEnabled ? 'reflection history stable' : 'direct light only';
 document.body.dataset['ssrReady'] = 'true';
 document.body.dataset['ssrPhase'] = 'ready';
 if (!testMode) ticker.start();
@@ -551,7 +311,6 @@ declare global {
         __HILO3D_SSR_PALACE_RESULT__?: ReflectionPalaceEvidence;
         __HILO3D_SSR_PALACE_TEST_API__?: {
             settle(frames?: number): Promise<void>;
-            advance(frames?: number): Promise<void>;
         };
     }
 }

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -100,7 +100,7 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'webgl_support.html': 'Graphics Backend Support',
     'compute_gpu_driven.html': 'WebGPU Compute & GPU-Driven Rendering',
     'clustered_forward_plus_sponza.html': 'Sponza Clustered Forward+ Lighting Lab',
-    'screen_space_reflections_palace.html': 'Nocturne Pavilion — Screen-space Reflections',
+    'screen_space_reflections_palace.html': 'Afterimage — Screen-space Reflections',
     'temporal_aa_observatory.html': 'Temporal Observatory — Signals in Deep Time',
     'compute_eclipse_shrine.html': 'Eclipse Shrine — WebGPU Compute Installation',
     'compute_particles.html': 'Hilo3D Compute Particle Field',
@@ -127,7 +127,7 @@ const DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'clustered_forward_plus_sponza.html':
         'Explore Khronos Sponza under 192 animated local lights, GPU Scene culling, clustered shading, HDR bloom, and a cinematic camera tour.',
     'screen_space_reflections_palace.html':
-        'Stage the Khronos Car Concept in a cinematic mirror hall with hierarchical ray tracing, temporal reflection resolve, and three visible roughness tiers.',
+        'Stage the Khronos Car Concept in a seamless smoked-lacquer studio with hierarchical ray tracing, confidence filtering, and temporal reflection resolve.',
     'temporal_aa_observatory.html':
         'Stress fused motion vectors, visibility-aware history, logarithmic depth rejection, and fixed-scale TAAU in a kinetic WebGPU constellation.',
     'compute_eclipse_shrine.html':

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -2619,6 +2619,17 @@ class MutableFallbackSceneParameters implements SceneRenderPassParameters {
     }
 }
 
+class MutableFallbackDepthParameters implements SceneRenderPassParameters {
+    rendererList = INVALID_RENDERER_LIST;
+    readonly colorAttachments = Object.freeze([]);
+    depthStencilAttachment?: RenderPipelineDepthStencilAttachment;
+
+    reset(): void {
+        this.rendererList = INVALID_RENDERER_LIST;
+        delete this.depthStencilAttachment;
+    }
+}
+
 class MutableFallbackTextureCopyParameters implements TextureCopyPassParameters {
     source = INVALID_TEXTURE;
     destination = INVALID_TEXTURE;
@@ -2954,6 +2965,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.reset();
         }
     );
+    readonly #fallbackDepthPool = new RenderPassParameterPool(
+        () => new MutableFallbackDepthParameters(),
+        parameters => {
+            parameters.reset();
+        }
+    );
     readonly #fallbackCopyPool = new RenderPassParameterPool(
         () => new MutableFallbackTextureCopyParameters(),
         parameters => {
@@ -2964,6 +2981,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #depthBatchPass = new GPUDrivenRenderBatchPass('GPU Scene depth buckets');
     readonly #colorBatchPass = new GPUDrivenRenderBatchPass('Clustered PBR buckets');
     readonly #fallbackPass = new SceneRenderPass('Clustered Forward+ compatibility fallback');
+    readonly #fallbackDepthPass = new SceneRenderPass('Clustered Forward+ fallback depth prepass');
     readonly #fallbackMotionPass = new SceneRenderPass(
         'Clustered Forward+ fallback temporal motion'
     );
@@ -2977,6 +2995,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         cullingResults: INVALID_CULLING_RESULTS,
         queue: 'opaque',
         sorting: 'material-front-to-back',
+        excludeMeshes: this.#gpuManagedMeshes
+    };
+    readonly #fallbackDepthListDescriptor: MutableFallbackRendererListDescriptor = {
+        cullingResults: INVALID_CULLING_RESULTS,
+        queue: 'opaque',
+        sorting: 'material-front-to-back',
+        materialPass: 'depth-only',
         excludeMeshes: this.#gpuManagedMeshes
     };
     readonly #fallbackTransparentListDescriptor: MutableFallbackRendererListDescriptor = {
@@ -3453,6 +3478,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             previousVisibility,
             temporalMotion
         });
+        if (fallbackCulling !== null && this.#fallbackHasOpaque) {
+            this.recordFallbackDepthPrepass(context, fallbackCulling, sceneDepth);
+        }
         this.recordCurrentHiZ(
             context,
             frameBuffer,
@@ -4920,6 +4948,24 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             sceneDepth,
             null
         );
+    }
+
+    private recordFallbackDepthPrepass(
+        context: RenderPipelineContext,
+        cullingResults: CullingResultsHandle,
+        sceneDepth: RenderGraphTextureHandle
+    ): void {
+        this.#fallbackDepthListDescriptor.cullingResults = cullingResults;
+        const rendererList = context.createRendererList(this.#fallbackDepthListDescriptor);
+        const parameters = context.acquirePassParameters(this.#fallbackDepthPool);
+        parameters.rendererList = rendererList;
+        parameters.depthStencilAttachment = {
+            texture: sceneDepth,
+            depthLoadOp: 'load',
+            depthStoreOp: 'store',
+            depthClearValue: depthClearValue(context.camera.depthMode)
+        };
+        context.graph.addPass(this.#fallbackDepthPass, parameters);
     }
 
     private recordFallbackTransparent(

--- a/src/render/postprocessing/ScreenSpaceReflections.ts
+++ b/src/render/postprocessing/ScreenSpaceReflections.ts
@@ -27,6 +27,7 @@ const INVALID_TEXTURE = 0 as RenderGraphTextureHandle;
 const TRACE_WORKGROUP_SIZE = 8;
 const MAX_TRACE_HIZ_LEVELS = 8;
 const COLOR_PYRAMID_LEVELS = 4;
+const SPATIAL_FILTER_STEPS = Object.freeze([1, 2, 4, 8] as const);
 
 /** Production controls for the WebGPU high-end hierarchical screen-space reflection path. */
 export interface ScreenSpaceReflectionsOptions {
@@ -618,6 +619,156 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     );
 }
 
+function spatialFilterPass(
+    step: number,
+    settings: Readonly<ScreenSpaceReflectionsSettings>
+): ComputeRenderPass {
+    const taps = [
+        [-1, -1, 1],
+        [0, -1, 2],
+        [1, -1, 1],
+        [-1, 0, 2],
+        [0, 0, 36],
+        [1, 0, 2],
+        [-1, 1, 1],
+        [0, 1, 2],
+        [1, 1, 1]
+    ] as const;
+    const tapSource = taps
+        .map(
+            ([x, y, weight]) => `
+    {
+        let neighborCoordinate = clamp(
+            pixel + vec2<i32>(${String(x * step)}, ${String(y * step)}),
+            vec2<i32>(0),
+            vec2<i32>(outputSize) - vec2<i32>(1)
+        );
+        let neighbor = textureLoad(sourceReflection, neighborCoordinate, 0);
+        if (neighbor.a > 0.0001) {
+            let neighborUv = (vec2<f32>(neighborCoordinate) + vec2<f32>(0.5)) /
+                vec2<f32>(outputSize);
+            let neighborAttributes = textureLoad(
+                materialAttributes,
+                pixelFor(materialAttributes, neighborUv),
+                0
+            );
+            let neighborPacked = u32(max(round(neighborAttributes.w), 0.0));
+            if (
+                (neighborPacked & 1u) != 0u &&
+                neighborAttributes.z < ${String(settings.roughnessCutoff)}
+            ) {
+                let neighborNormal = decodeOctahedralNormal(neighborAttributes.xy);
+                let neighborLogDepth = textureLoad(
+                    motionDepth,
+                    pixelFor(motionDepth, neighborUv),
+                    0
+                ).w;
+                let normalWeight = pow(max(dot(centerNormal, neighborNormal), 0.0), 24.0);
+                let depthWeight = exp2(-abs(centerLogDepth - neighborLogDepth) * 24.0);
+                let roughnessWeight = exp2(
+                    -abs(centerAttributes.z - neighborAttributes.z) * 16.0
+                );
+                let confidenceWeight = clamp(0.25 + neighbor.a, 0.0, 1.0);
+                let weight = ${String(weight)}.0 * normalWeight * depthWeight *
+                    roughnessWeight * confidenceWeight;
+                accumulation += neighbor * weight;
+                totalWeight += weight;
+            }
+        }
+    }`
+        )
+        .join('\n');
+    return computePass(
+        new ComputeShader({
+            label: `Screen-space reflections confidence filter step ${String(step)}`,
+            source: `
+@group(0) @binding(0) var sourceReflection: texture_2d<f32>;
+@group(0) @binding(1) var motionDepth: texture_2d<f32>;
+@group(0) @binding(2) var materialAttributes: texture_2d<f32>;
+@group(0) @binding(3) var destination: texture_storage_2d<rgba16float, write>;
+fn pixelFor(source: texture_2d<f32>, uv: vec2<f32>) -> vec2<i32> {
+    let dimensions = textureDimensions(source);
+    return clamp(
+        vec2<i32>(uv * vec2<f32>(dimensions)),
+        vec2<i32>(0),
+        vec2<i32>(dimensions) - vec2<i32>(1)
+    );
+}
+fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
+    var normal = vec3<f32>(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
+    if (normal.z < 0.0) {
+        let original = normal.xy;
+        normal.x = (1.0 - abs(original.y)) * select(-1.0, 1.0, original.x >= 0.0);
+        normal.y = (1.0 - abs(original.x)) * select(-1.0, 1.0, original.y >= 0.0);
+    }
+    return normalize(normal);
+}
+@compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let outputSize = textureDimensions(destination);
+    if (any(id.xy >= outputSize)) { return; }
+    let pixel = vec2<i32>(id.xy);
+    let uv = (vec2<f32>(id.xy) + vec2<f32>(0.5)) / vec2<f32>(outputSize);
+    let centerAttributes = textureLoad(
+        materialAttributes,
+        pixelFor(materialAttributes, uv),
+        0
+    );
+    let centerPacked = u32(max(round(centerAttributes.w), 0.0));
+    if (
+        (centerPacked & 1u) == 0u ||
+        centerAttributes.z >= ${String(settings.roughnessCutoff)}
+    ) {
+        textureStore(destination, pixel, vec4<f32>(0.0));
+        return;
+    }
+    let centerNormal = decodeOctahedralNormal(centerAttributes.xy);
+    let centerLogDepth = textureLoad(motionDepth, pixelFor(motionDepth, uv), 0).w;
+    var accumulation = vec4<f32>(0.0);
+    var totalWeight = 0.0;
+${tapSource}
+    if (totalWeight > 0.0001) {
+        textureStore(destination, pixel, accumulation / totalWeight);
+    } else {
+        textureStore(destination, pixel, vec4<f32>(0.0));
+    }
+}`,
+            workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
+            bindings: [
+                {
+                    name: 'sourceReflection',
+                    group: 0,
+                    binding: 0,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'motionDepth',
+                    group: 0,
+                    binding: 1,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'materialAttributes',
+                    group: 0,
+                    binding: 2,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'destination',
+                    group: 0,
+                    binding: 3,
+                    kind: 'storage-texture',
+                    access: 'write-only',
+                    format: 'rgba16float'
+                }
+            ]
+        })
+    );
+}
+
 function compositePass(intensity: number): FullscreenRenderPass {
     return new FullscreenRenderPass({
         name: 'Screen-space reflections linear HDR composite',
@@ -715,6 +866,7 @@ export class ScreenSpaceReflectionsController {
     readonly #traceHiZLevelCount: number;
     readonly #tracePass: ComputeRenderPass;
     readonly #temporalResolvePass: ComputeRenderPass;
+    readonly #spatialFilterPasses: readonly ComputeRenderPass[];
     readonly #compositePass: FullscreenRenderPass;
     readonly #colorHistoryKey = Object.freeze({});
     readonly #depthHistoryKey = Object.freeze({});
@@ -732,6 +884,9 @@ export class ScreenSpaceReflectionsController {
     );
     readonly #resolvePool = new RenderPassParameterPool(
         () => new MutableComputeParameters(0, 6, 1)
+    );
+    readonly #spatialFilterPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(0, 4, 0)
     );
     readonly #compositePool = new RenderPassParameterPool(
         () => new MutableFullscreenParameters(),
@@ -754,6 +909,9 @@ export class ScreenSpaceReflectionsController {
         }
         this.#tracePass = computePass(traceShader(settings, this.#traceHiZLevelCount));
         this.#temporalResolvePass = temporalResolvePass(settings);
+        this.#spatialFilterPasses = Object.freeze(
+            SPATIAL_FILTER_STEPS.map(step => spatialFilterPass(step, settings))
+        );
         this.#compositePass = compositePass(settings.intensity);
         this.#tracePool = new RenderPassParameterPool(
             () =>
@@ -916,6 +1074,29 @@ export class ScreenSpaceReflectionsController {
             context.graph.addPass(TEMPORAL_INITIALIZE_PASS, initialize);
         }
 
+        let reflectionForComposite: RenderGraphTextureHandle = colorHistory.current;
+        for (let index = 0; index < this.#spatialFilterPasses.length; index += 1) {
+            const filterPass = this.#spatialFilterPasses[index];
+            if (filterPass === undefined) {
+                throw new Error('Screen-space reflections spatial filter pass is missing');
+            }
+            const filtered = context.graph.createTexture(
+                `Screen-space reflections confidence filter ${String(index + 1)}`,
+                this.#reflectionDescriptor
+            );
+            const filter = context.acquirePassParameters(this.#spatialFilterPool);
+            filter.setTexture(0, reflectionForComposite);
+            filter.setTexture(1, resources.motionDepth);
+            filter.setTexture(2, resources.materialAttributes);
+            filter.setTexture(3, filtered);
+            filter.setDispatch(
+                Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
+                Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
+            );
+            context.graph.addPass(filterPass, filter);
+            reflectionForComposite = filtered;
+        }
+
         const composited = context.graph.createTexture(
             'Screen-space reflections composited HDR scene',
             this.#compositeDescriptor
@@ -923,7 +1104,7 @@ export class ScreenSpaceReflectionsController {
         const composite = context.acquirePassParameters(this.#compositePool);
         composite.inputTextures.length = 2;
         composite.inputTextures[0] = resources.sceneColor;
-        composite.inputTextures[1] = colorHistory.current;
+        composite.inputTextures[1] = reflectionForComposite;
         composite.colorAttachments[0] = {
             texture: composited,
             loadOp: 'clear',

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -15,6 +15,10 @@ import Color from '../../../src/math/Color';
 import Matrix3 from '../../../src/math/Matrix3';
 import Vector3 from '../../../src/math/Vector3';
 import Renderer from '../../../src/render/Renderer';
+import {
+    registerRendererDiagnostics,
+    unregisterRendererDiagnostics
+} from '../../../src/render/diagnostics/RendererDiagnosticsRegistry';
 import { ClusteredForwardPlusPipelineFactory } from '../../../src/render/pipeline/ClusteredForwardPlus';
 import type { RHIDevice } from '../../../src/render/rhi/core';
 import Texture from '../../../src/texture/Texture';
@@ -417,9 +421,11 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 temporalAA: { renderScale: 0.75 },
                 screenSpaceReflections: { resolutionScale: 0.5, maxSteps: 8 }
             });
+            const canvas = document.createElement('canvas');
+            const rendererDiagnostics = registerRendererDiagnostics(canvas);
             const renderer = await Renderer.create({
                 backend: 'webgpu',
-                domElement: document.createElement('canvas'),
+                domElement: canvas,
                 width: 128,
                 height: 96,
                 antialias: false,
@@ -473,6 +479,17 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 expect(diagnostics.clusterOverflowCount).toBe(0);
                 expect(diagnostics.hiZValid).toBe(true);
                 expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
+                const passNames = rendererDiagnostics
+                    .snapshot()
+                    .renderGraph?.passes.map(pass => pass.name);
+                expect(passNames).toBeDefined();
+                const fallbackDepthIndex =
+                    passNames?.indexOf('Clustered Forward+ fallback depth prepass') ?? -1;
+                const currentHiZIndex =
+                    passNames?.indexOf('GPU Scene current depth Hi-Z min/max mip zero') ?? -1;
+                expect(fallbackDepthIndex).toBeGreaterThan(-1);
+                expect(currentHiZIndex).toBeGreaterThan(fallbackDepthIndex);
+                expect(passNames).toContain('Screen-space reflections confidence filter step 8');
 
                 camera.setPosition(0.25, 0, 8).lookAt(new Vector3(0, 0, 0));
                 renderer.render(scene, camera);
@@ -630,6 +647,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 });
             } finally {
                 renderer.destroy();
+                unregisterRendererDiagnostics(canvas, rendererDiagnostics);
             }
         },
         30_000

--- a/test/ui/screen-space-reflections.spec.ts
+++ b/test/ui/screen-space-reflections.spec.ts
@@ -31,9 +31,7 @@ function pixelDifference(referenceBuffer: Buffer, candidateBuffer: Buffer): Pixe
     };
 }
 
-test('renders a stable and visually material SSR contribution in Nocturne Pavilion', async ({
-    page
-}) => {
+test('renders a stable and visually material SSR contribution in Afterimage', async ({ page }) => {
     test.setTimeout(120_000);
     const consoleErrors: string[] = [];
     const pageErrors: string[] = [];
@@ -65,12 +63,11 @@ test('renders a stable and visually material SSR contribution in Nocturne Pavili
         hiZValid: true,
         screenSpaceReflections: true,
         temporalAA: true,
-        roughnessTiers: 3,
+        surfaceFinish: 'smoked lacquer',
         heroAsset: 'Khronos Car Concept'
     });
-    expect(evidence?.objectCount).toBeGreaterThan(50);
+    expect(evidence?.objectCount).toBeGreaterThan(0);
     expect(evidence?.fallbackObjectCount).toBeGreaterThan(0);
-    expect(evidence?.visibleObjectCount).toBeGreaterThan(0);
 
     const canvas = page.locator('canvas');
     await page.evaluate(async () => {
@@ -120,12 +117,11 @@ declare global {
             readonly hiZValid: boolean;
             readonly screenSpaceReflections: boolean;
             readonly temporalAA: true;
-            readonly roughnessTiers: 3;
+            readonly surfaceFinish: 'smoked lacquer';
             readonly heroAsset: 'Khronos Car Concept';
         };
         __HILO3D_SSR_PALACE_TEST_API__?: {
             settle(frames?: number): Promise<void>;
-            advance(frames?: number): Promise<void>;
         };
     }
 }


### PR DESCRIPTION
## Summary

- rebuild the SSR example as a restrained seamless automotive studio while retaining the Khronos Car Concept
- make ordinary Forward opaque meshes contribute depth before current-frame Hi-Z construction
- add confidence-aware depth/normal à-trous filtering to reduce SSR holes, block artifacts, and temporal shimmer
- update the example UI, catalog metadata, architecture docs, changelog, and regression coverage

## Root cause

The car rendered through the ordinary Forward fallback path after the current-frame Hi-Z pyramid had already been built. Its color was present in the radiance source, but its depth was absent from hierarchical tracing, so the floor could not reliably hit the vehicle. Very sharp receiver materials also exposed trace misses as black blocks, while SSR on the low-roughness car paint amplified self-reflection noise.

## Impact

The example now presents a static smoked-lacquer automotive studio without the previous visible light-gate clutter. Fallback opaque depth is available to clustered depth consumers, and SSR output receives surface-aware spatial filtering before HDR composition.

## Validation

- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run format:check`
- `npx vitest run test/spec/renderer/ClusteredForwardPlus.test.ts`
- `npm run test:render:architecture`
- `npm run test:rhi`
- `npx playwright test test/ui/screen-space-reflections.spec.ts --project=chromium`
- `npm run test:webgpu` — 16/17 passed in the combined run; the 110k-object scale case timed out during initialization
- `npx playwright test test/ui/clustered-forward-plus-scale.spec.ts --project=chromium` — passed on isolated rerun
