### PR TITLE
feat(particles): complete P6 authoring workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,25 @@
   supported portable opaque/masked mesh output. Add fail-closed advanced quality gates instead of
   silently degrading unsupported tiers. Allow the built-in opaque GPU particle boundary to request
   opaque/transparent Forward splitting only on frames that actually draw eligible particles.
+- Add the first particle P6 authoring slice with normalized versioned JSON serialization, strict
+  parsing and compiler validation, sequential application-owned upgrades, document-local shared
+  parameter identities, and stable application-resolved Texture/Geometry references. Reject future
+  versions, missing or skipped upgrades, unknown schema fields/tags, and unresolved or wrong-kind
+  resources before runtime construction.
+- Add versioned reusable in-memory particle simulation checkpoints. Capture and restore CPU SoA,
+  fixed-step scheduler, pending manual emission, bounded events, playback/budget/culling state, and
+  stateless GPU absolute time without production-loop readback. Bind checkpoints to definition,
+  compiled plan, seed, parameter identity/revision, and event capacity; reject stateful GPU capture
+  until an explicit asynchronous device-state transfer contract exists.
+- Add bounded deterministic particle baking APIs. Export stable-ID/generation-sorted frame-major
+  mesh instance caches with motion/orientation inputs and bounds, and pack application-rendered,
+  tightly packed render-target readbacks into native-format flipbook atlases. Restore the caller's
+  simulation checkpoint after success or failure, bound frame/particle/atlas work, and reject
+  stateful GPU baking rather than introducing synchronous device-state readback.
+- Complete particle P6 external authoring with a published fixed-module graph JSON Schema,
+  deterministic definition-to-graph conversion, strict ownership/compiler validation,
+  node-addressable diagnostics, normalized inspector IR, and a versioned preview controller for
+  compile/play/pause/restart/seek/step/inspect/dispose without GPU particle readback.
 - Allow a Forward feature runtime to request sampled single-sample scene depth per frame before
   attachment allocation, so scene-dependent effects do not force unrelated RenderTarget frames
   through an intermediate depth path.

--- a/documentation/PARTICLE_SYSTEM.md
+++ b/documentation/PARTICLE_SYSTEM.md
@@ -1,14 +1,18 @@
 # Particle system
 
 Hilo3D exposes one versioned particle asset model for portable CPU simulation, stateful WebGPU
-simulation, and lightweight stateless reconstruction. P0-P5 are implemented: immutable definitions
-compile to a liveness-based SoA plan, CPU emitters render through one instanced `Mesh`, WebGPU
-stateful emitters record persistent simulation and storage raster through the Render Graph, and
-stateless emitters rebuild renderer attributes from absolute time without cross-frame particle
-state. P4 adds analytic/depth interaction, soft particles, bounded events, typed channels, and
-GPU-resident sub-emitter routing. P5 adds mesh buckets, ribbon/trail topology, controlled Lambert
-scene lighting, per-view ordering, temporal composition rules, and opt-in opaque/masked mesh motion
-vectors.
+simulation, and lightweight stateless reconstruction. The P0-P5 runtime and P6 authoring workflow
+are implemented: immutable definitions compile to a liveness-based SoA plan, CPU emitters render
+through one instanced `Mesh`, WebGPU stateful emitters record persistent simulation and storage
+raster through the Render Graph, and stateless emitters rebuild renderer attributes from absolute
+time without cross-frame particle state. P4 adds analytic/depth interaction, soft particles, bounded
+events, typed channels, and GPU-resident sub-emitter routing. P5 adds mesh buckets, ribbon/trail
+topology, controlled Lambert scene lighting, per-view ordering, temporal composition rules, and
+opt-in opaque/masked mesh motion vectors. P6 now adds versioned JSON and external fixed-module graph
+documents, sequential application-owned upgrades, shared parameter identity, stable resource
+references, addressable compile diagnostics, normalized inspector IR, and a deterministic preview
+protocol. It also provides reusable in-memory simulation checkpoints for deterministic
+branching/replay and offline flipbook/mesh-cache output.
 
 ## Public workflow
 
@@ -69,6 +73,172 @@ particles
     .simulate(1 / 60)
     .play();
 ```
+
+## Versioned JSON and upgrades
+
+`serializeParticleSystemDefinition()` emits a deeply frozen, normalized document identified by
+`PARTICLE_DEFINITION_SCHEMA` and `PARTICLE_DEFINITION_VERSION`. Defaults materialized by the
+immutable definition are included, ordinary record keys are canonicalized, curves and gradients use
+explicit tagged values, and shared `ParticleParameter` tokens are declared once in a document-local
+parameter table. Deserialization recreates the same shared token identity before it constructs and
+compiles the definition, so a parameter used by multiple spawn fields remains one runtime binding.
+
+`Texture` and `Geometry` objects are deliberately not embedded and their generated runtime IDs are
+not asset identities. Definitions containing either resource require `getResourceId` during
+serialization and `resolveResource` during deserialization:
+
+```ts
+import { parseParticleSystemDefinitionJSON, serializeParticleSystemDefinition } from 'hilo3d';
+
+const document = serializeParticleSystemDefinition(definition, {
+    getResourceId: (resource, kind) => assetRegistry.idFor(resource, kind)
+});
+const source = JSON.stringify(document);
+
+const restored = parseParticleSystemDefinitionJSON(source, {
+    resolveResource: (kind, id) => assetRegistry.resolve(kind, id),
+    upgrades: particleDefinitionUpgrades
+});
+```
+
+Each `ParticleDefinitionUpgrade` advances exactly one integer version. Missing transitions,
+duplicate upgrade sources, version skips, future versions, unknown schema fields/tags, unresolved or
+wrong-kind resources, and definitions rejected by the normal compiler all fail before a runtime
+system is created. Upgrade callbacks receive and return deeply frozen/plain JSON documents; they do
+not receive engine objects or run in the particle loop.
+
+## External authoring and preview
+
+`createParticleAuthoringGraph()` converts the ordinary immutable definition into a deeply frozen,
+pure-JSON document identified by `PARTICLE_AUTHORING_SCHEMA` and `PARTICLE_AUTHORING_VERSION`.
+`PARTICLE_AUTHORING_JSON_SCHEMA` lets an external tool validate the transport shape before sending
+it to the engine. Nodes are limited to system, emitter, fixed module, and renderer payloads. Edges
+only express ordered ownership through `emitters`, `modules`, and `renderers`; they are not an
+executable data-flow language. Opaque graph/node metadata may store editor layout without entering
+the runtime definition or hash.
+
+```ts
+import {
+    compileParticleAuthoringGraph,
+    createParticleAuthoringGraph,
+    ParticleAuthoringPreviewController
+} from 'hilo3d';
+
+const graph = createParticleAuthoringGraph(definition);
+const compiled = compileParticleAuthoringGraph(graph, {
+    resolveResource: (kind, id) => assetRegistry.resolve(kind, id),
+    compilationEnvironment: { backend: 'webgpu' }
+});
+
+if (!compiled.success) {
+    showDiagnostics(compiled.diagnostics);
+}
+
+const preview = new ParticleAuthoringPreviewController();
+preview.handle({
+    protocolVersion: 1,
+    requestId: 'compile-1',
+    command: 'compile',
+    graph,
+    seed: 42
+});
+```
+
+`compileParticleAuthoringGraph()` rejects unknown fields, malformed or multiply owned topology,
+non-contiguous child ordering, invalid module payloads, unresolved resources, and backend-ineligible
+definitions before exposing a runtime object. Successful results include the normal immutable
+definition/compiled plan and a normalized IR with hashes, plan kinds, layouts, node ownership, and
+stateless eligibility. Diagnostics include stable codes and graph paths plus a node ID whenever the
+compiler can address the failure to one submitted node.
+
+`ParticleAuthoringPreviewController` accepts the versioned `compile`, `play`, `pause`, `restart`,
+`seek`, `step`, `inspect`, and `dispose` requests. It owns deterministic simulation time but does
+not create a second renderer or read GPU particle state. A host attaches `controller.system` to its
+ordinary scene and renders it through `Renderer`/`Stage`; custom construction and release hooks
+connect that lifecycle to the host. Failed replacement compilation keeps the previous preview alive,
+and every response carries compact hashes/counts plus structured diagnostics.
+
+## Deterministic simulation checkpoints
+
+`captureSimulation()` returns a frozen, reusable `ParticleSimulationCache`. `restoreSimulation()`
+reinstates the playback state and time scale, system clock, completion state, frame-wide quality
+budget, culling clock, pending manual emission, CPU fixed-step scheduler, dense particle storage,
+and bounded application/CPU event queues. Restoring the same cache repeatedly therefore creates the
+same simulation branch:
+
+```ts
+const checkpoint = particles.captureSimulation();
+
+particles.simulate(0.5);
+const firstResult = particles.stateHash();
+
+particles.restoreSimulation(checkpoint).simulate(0.5);
+console.assert(particles.stateHash() === firstResult);
+```
+
+A cache can restore another system only when it shares the exact immutable definition and
+`ParticleParameterSet` identities, compiled-plan hash, seed, parameter revision, and event-readback
+capacity. Changing a parameter after capture makes the checkpoint stale and fails closed. The cache
+does not capture the particle node transform; restoring at another transform intentionally creates a
+new world-space continuation from the restored scheduler state.
+
+This contract stays off the production GPU readback path. CPU emitters copy their complete SoA
+storage, while a pure stateless WebGPU emitter records only its authoritative absolute time and
+invalidates generated renderer data on restore. A system containing a stateful GPU emitter rejects
+capture because its authoritative storage is device-resident. `ParticleSimulationCache` is an
+in-memory runtime checkpoint, not a JSON/persistent asset or flipbook/mesh bake.
+
+## Flipbook and mesh-cache baking
+
+Both baking APIs own a deterministic fixed-rate timeline and restore the system's exact simulation
+checkpoint in `finally`, including when validation or an asynchronous capture fails. The default
+timeline samples the half-open interval `[startTime, startTime + duration)`; `includeEnd` adds one
+exact terminal sample. `maxFrames`, `maxSampledParticles`, `maxTextureSize`, and
+`maxAtlasByteLength` bound offline work before an artifact is returned.
+
+`bakeMeshCache()` restarts authored simulation, honors prewarm, and records each mesh emitter as
+stable-ID/generation-sorted frame-major instance streams. Frame offsets delimit variable live
+ranges; position, previous position, velocity, size, rotation, color, mesh bucket, and conservative
+frame bounds preserve the inputs required by the current rotation/velocity orientation and motion
+vector contracts:
+
+```ts
+const meshCache = particles.bakeMeshCache({
+    duration: 2,
+    frameRate: 30,
+    includeEnd: true,
+    maxSampledParticles: 500_000
+});
+```
+
+CPU and CPU-materialized stateless emitters use the same artifact. A named emitter must contain a
+mesh renderer; omitting `emitter` bakes every mesh emitter. The result contains typed-array payloads
+and stable definition/seed/timeline metadata, but deliberately does not embed `Geometry` or texture
+resources.
+
+`bakeFlipbook()` advances the same timeline and delegates only actual rendering/readback to an
+asynchronous `captureFrame` callback. The callback returns the public, tightly packed
+`RenderTargetColorAttachmentReadback`; all frames must share one extent, native color format, and
+bytes-per-pixel contract. The baker copies every callback buffer before packing a row-major atlas,
+so capture implementations may safely reuse staging memory:
+
+```ts
+const flipbook = await particles.bakeFlipbook({
+    duration: 2,
+    frameRate: 24,
+    columns: 8,
+    captureFrame: async () => {
+        renderer.renderToTarget(target, scene, camera, false);
+        return target.readColorAttachment();
+    }
+});
+```
+
+The application still owns the camera, scene, renderer, target, color encoding, and readback
+synchronization, so the engine never substitutes a software approximation for authored particle
+materials. Stateful GPU systems remain rejected because baking begins with a restorable checkpoint;
+pure stateless GPU flipbooks remain valid because absolute time is authoritative and rendering stays
+on the normal Render Graph path.
 
 ## Maintained visual examples
 
@@ -272,11 +442,13 @@ contains no sampled-depth/attachment feedback edge.
 
 ## Current boundary
 
-P6 remains outside this implementation. In particular, there is no serialization upgrade pipeline,
-capture cache, baking API, or graph editor yet. GPU event observation is intentionally limited to
-resident routing; application-visible GPU diagnostics remain aggregate and asynchronous rather than
-a production-loop particle readback. The public fixed module union rejects arbitrary callbacks and
-arbitrary shader source by design.
+P6 serialization, upgrades, external graph schema/IR/diagnostics/preview, deterministic in-memory
+simulation checkpoints, and flipbook/mesh-cache baking are implemented. A visual graph editor
+remains a separate application project. GPU event observation is intentionally limited to resident
+routing; application-visible GPU diagnostics remain aggregate and asynchronous rather than a
+production-loop particle readback. The public fixed module union rejects arbitrary simulation
+callbacks and arbitrary shader source by design; the offline flipbook capture callback operates only
+at bounded frame/readback boundaries.
 
 The existing [`compute_particles.ts`](../examples/compute_particles.ts) showcase intentionally keeps
 its specialized implementation for now. It will be migrated only after the remaining particle

--- a/documentation/PARTICLE_SYSTEM_IMPLEMENTATION_PLAN.md
+++ b/documentation/PARTICLE_SYSTEM_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Hilo3D 粒子系统实现计划
 
-状态：P0、P1、P2、P3、P4 运行时已实现；示例迁移延后；P5-P6 规划中
+状态：P0-P5 运行时与 P6 的序列化、capture/cache、baking、外部创作协议均已实现；示例迁移延后
 
 调研基线：2026-08-14
 
@@ -13,7 +13,19 @@ absolute-time reconstruction、无持久 state 的 WebGPU generator artifact、�
 manager 与短促 effect pool；实现边界见
 [`PARTICLE_SYSTEM.md`](./PARTICLE_SYSTEM.md)。P4 已加入解析碰撞/trigger、WebGPU scene-depth
 collision、只读深度 Soft Particle、CPU 紧凑事件、GPU 常驻 sub-emitter route、typed
-`ParticleEventChannel` 与有界异步 aggregate readback。
+`ParticleEventChannel` 与有界异步 aggregate readback。P5 已完成 mesh
+bucket、ribbon/trail、受控 Lambert 光照、per-view ordering、时域合成和受限 motion
+vector。P6 已加入带 schema/version 的规范 JSON、逐版本 application-owned upgrade、共享 parameter
+identity table、稳定资源引用回调和反序列化后的 compiler
+validation，并加入绑定 definition/plan/seed/parameter revision 的可复用内存 checkpoint。CPU
+cache 复制完整 SoA、调度器和事件；stateless GPU 只保存绝对时间；stateful
+GPU 因无同步 readback 合同而 fail-closed。P6 baking 复用同一 checkpoint/timeline：mesh
+cache 输出 stable ID/generation 排序的 frame-major instance streams；flipbook 由应用在离线 frame
+boundary 提供真实 RenderTarget
+readback，核心只验证并打包 atlas，不伪造软件材质渲染。外部创作使用固定 system/emitter/module/renderer
+ownership graph、可发布 JSON Schema、规范化 inspector IR、node-addressable
+diagnostics 和版本化 deterministic preview command
+protocol；它不会引入任意可执行 graph，也不会在 runtime 解释编辑器 metadata。
 
 ## 结论先行
 
@@ -948,18 +960,41 @@ pass。默认关闭 diagnostics 时不能引入逐粒子计数、GPU query 或 r
 
 交付：
 
-- versioned JSON definition 与 upgrade pipeline；
-- deterministic capture/simulation cache；
-- flipbook/mesh cache baking 接口；
-- 外部 graph authoring 所需的 schema、IR、compile diagnostics 和 preview protocol。
+- [x] versioned JSON definition 与逐版本 upgrade pipeline；
+- [x] deterministic capture/simulation cache；
+- [x] flipbook/mesh cache baking 接口；
+- [x] 外部 graph authoring 所需的 schema、IR、compile diagnostics 和 preview protocol。
 
-只有 P0-P5 的 IR、错误和版本合同稳定后，才单独立项可视化编辑器。编辑器应输出同一
-`ParticleSystemDefinition`，运行时不解释 UI graph。
+已实现的 JSON 合同保留共享 `ParticleParameter` identity，以应用提供的稳定 ID 引用
+`Texture`/`Geometry`，不持久化运行时对象 ID；未知字段/tag、未来版本、缺失/跳级 upgrade、资源类型不匹配和 compiler
+validation 失败均 fail-closed。JSON upgrade 只处理 plain data，不解释 UI graph，也不承担 simulation
+cache 或 baking 职责。Simulation cache 是独立的版本化内存对象：绑定相同 immutable
+definition/compiled plan、seed、parameter set identity/revision 和 event capacity；捕获 CPU
+fixed-step/SoA/event/manual queue 以及系统 playback/budget/culling 状态；纯 stateless
+GPU 仅捕获绝对时间；stateful GPU 明确拒绝，不引入生产循环同步 readback。
+
+Baking 同样拒绝 stateful GPU，以保证结束或失败时能恢复调用者 checkpoint。Mesh
+cache 面向 CPU/CPU-materialized stateless mesh
+emitter，输出 position、previous-position、velocity、size、rotation、color、mesh-index、stable
+identity、frame offsets 与 bounds；flipbook
+callback 返回公共 RenderTarget 紧凑 readback，所有帧 extent/format 一致后打包 atlas。两者使用 half-open
+fixed-rate timeline，并以 frame/particle/texture/byte limits 限制离线内存和工作量。
+
+外部 authoring contract 已完成：versioned JSON Schema 限定 system/emitter/module/renderer
+node 与有序 ownership edge，compiler 重建并验证同一 `ParticleSystemDefinition`，normalized
+IR 暴露 plan/layout/hash，diagnostics 定位 graph path/node，preview protocol 提供 deterministic
+compile/play/pause/restart/seek/step/inspect/dispose。可视化编辑器仍单独立项；运行时不解释 UI
+metadata，也不支持任意可执行 graph。
 
 ## 16. 建议目录
 
 ```text
 src/particle/
+  ParticleAuthoring.ts
+  ParticleAuthoringPreview.ts
+  ParticleBaking.ts
+  ParticleDefinitionSerialization.ts
+  ParticleSimulationCache.ts
   ParticleSystem.ts
   ParticleSystemDefinition.ts
   ParticleEmitterDefinition.ts

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,25 +6,25 @@ committed.
 
 ## Start here
 
-| Document                                                                        | Purpose                                                                                                                    |
-| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| [Rendering architecture](./RENDERING_ARCHITECTURE.md)                           | Current production rendering path: shared renderer, Render Graph, portable RHI, and WebGPU/WebGL2 backends                 |
-| [PBR, HDR, and post-processing](./PBR_AND_POST_PROCESSING.md)                   | Layered glTF materials, modern PBR lighting, opaque scene texture, Bloom, Color Uber, and linear color contracts           |
-| [Material system modernization](./MATERIAL_SYSTEM_MODERNIZATION.md)             | Current Definition/Instance architecture, semantic passes, typed bindings, texture-slot ABI, breaking changes, and roadmap |
-| [Modern WebGPU rendering roadmap](./MODERN_WEBGPU_RENDERING_ROADMAP.md)         | Current rendering gaps and an actionable GPU Scene, temporal, lighting, virtualization, and high-end WebGPU roadmap        |
-| [Temporal rendering remediation](./TEMPORAL_RENDERING_REMEDIATION.md)           | Production Motion Vector/TAA ABI, history validity, Clustered integration, performance contract, and release evidence      |
-| [Screen-space reflections](./SCREEN_SPACE_REFLECTIONS.md)                       | Production WebGPU Hi-Z SSR, material attribute ABI, temporal rejection, lifecycle rules, limitations, and release evidence |
-| [Ground-truth ambient occlusion](./GROUND_TRUTH_AMBIENT_OCCLUSION.md)           | Portable Forward GTAO, Clustered integration, bent-normal/visibility packing, temporal lifecycle, and release boundaries   |
-| [Screen-space global illumination](./SCREEN_SPACE_GLOBAL_ILLUMINATION.md)       | Portable Forward/Clustered SSGI, radiance tracing, temporal denoise, lifecycle, quality budgets, and release boundaries    |
-| [Froxel volumetric lighting](./VOLUMETRIC_LIGHTING.md)                          | WebGPU Clustered froxels, height/local fog, light injection, radiative integration, temporal lifecycle, and quality tiers  |
-| [Physical atmosphere and weather](./PHYSICAL_ATMOSPHERE_AND_WEATHER.md)         | GPU histogram exposure, filmic display, atmosphere LUTs, temporal volumetric clouds, cloud shadows, and integration order  |
-| [2D rendering and multi-camera composition](./2D_RENDERING.md)                  | Sprite batching, frame animation, Canvas text, pointer input, camera priority, clear policy, and layer masks               |
-| [Particle system](./PARTICLE_SYSTEM.md)                                         | Implemented P0-P2 public API, CPU/WebGPU execution policy, fixed modules, renderer integration, and current boundaries     |
-| [Particle system implementation plan](./PARTICLE_SYSTEM_IMPLEMENTATION_PLAN.md) | Unity 6.5/UE 5.8.1 feature analysis and a phased portable CPU, WebGPU stateful, and stateless particle architecture        |
-| [Compute/storage implementation](./COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md)      | Implemented Direct WGSL compute, storage resources, GPU-driven raster contract, first-release boundaries, and evidence     |
-| [Scriptable Render Pipeline design](./SCRIPTABLE_RENDER_PIPELINE_PLAN.md)       | SRP API, implemented architecture, migration record, release performance gates, and compute/storage integration            |
-| [Engineering modernization](./ENGINEERING_MODERNIZATION.md)                     | TypeScript, ESM, tooling, packaging, examples, testing, API documentation, and release baseline                            |
-| [RHI refactor plan](./RHI_REFACTOR_PLAN.md)                                     | RHI design goals, invariants, migration phases, and acceptance criteria                                                    |
+| Document                                                                        | Purpose                                                                                                                             |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Rendering architecture](./RENDERING_ARCHITECTURE.md)                           | Current production rendering path: shared renderer, Render Graph, portable RHI, and WebGPU/WebGL2 backends                          |
+| [PBR, HDR, and post-processing](./PBR_AND_POST_PROCESSING.md)                   | Layered glTF materials, modern PBR lighting, opaque scene texture, Bloom, Color Uber, and linear color contracts                    |
+| [Material system modernization](./MATERIAL_SYSTEM_MODERNIZATION.md)             | Current Definition/Instance architecture, semantic passes, typed bindings, texture-slot ABI, breaking changes, and roadmap          |
+| [Modern WebGPU rendering roadmap](./MODERN_WEBGPU_RENDERING_ROADMAP.md)         | Current rendering gaps and an actionable GPU Scene, temporal, lighting, virtualization, and high-end WebGPU roadmap                 |
+| [Temporal rendering remediation](./TEMPORAL_RENDERING_REMEDIATION.md)           | Production Motion Vector/TAA ABI, history validity, Clustered integration, performance contract, and release evidence               |
+| [Screen-space reflections](./SCREEN_SPACE_REFLECTIONS.md)                       | Production WebGPU Hi-Z SSR, material attribute ABI, temporal rejection, lifecycle rules, limitations, and release evidence          |
+| [Ground-truth ambient occlusion](./GROUND_TRUTH_AMBIENT_OCCLUSION.md)           | Portable Forward GTAO, Clustered integration, bent-normal/visibility packing, temporal lifecycle, and release boundaries            |
+| [Screen-space global illumination](./SCREEN_SPACE_GLOBAL_ILLUMINATION.md)       | Portable Forward/Clustered SSGI, radiance tracing, temporal denoise, lifecycle, quality budgets, and release boundaries             |
+| [Froxel volumetric lighting](./VOLUMETRIC_LIGHTING.md)                          | WebGPU Clustered froxels, height/local fog, light injection, radiative integration, temporal lifecycle, and quality tiers           |
+| [Physical atmosphere and weather](./PHYSICAL_ATMOSPHERE_AND_WEATHER.md)         | GPU histogram exposure, filmic display, atmosphere LUTs, temporal volumetric clouds, cloud shadows, and integration order           |
+| [2D rendering and multi-camera composition](./2D_RENDERING.md)                  | Sprite batching, frame animation, Canvas text, pointer input, camera priority, clear policy, and layer masks                        |
+| [Particle system](./PARTICLE_SYSTEM.md)                                         | Implemented P0-P5 runtime and complete P6 JSON/graph authoring, diagnostics/preview, deterministic checkpoints and baking contracts |
+| [Particle system implementation plan](./PARTICLE_SYSTEM_IMPLEMENTATION_PLAN.md) | Unity 6.5/UE 5.8.1 feature analysis and a phased portable CPU, WebGPU stateful, and stateless particle architecture                 |
+| [Compute/storage implementation](./COMPUTE_STORAGE_IMPLEMENTATION_PLAN.md)      | Implemented Direct WGSL compute, storage resources, GPU-driven raster contract, first-release boundaries, and evidence              |
+| [Scriptable Render Pipeline design](./SCRIPTABLE_RENDER_PIPELINE_PLAN.md)       | SRP API, implemented architecture, migration record, release performance gates, and compute/storage integration                     |
+| [Engineering modernization](./ENGINEERING_MODERNIZATION.md)                     | TypeScript, ESM, tooling, packaging, examples, testing, API documentation, and release baseline                                     |
+| [RHI refactor plan](./RHI_REFACTOR_PLAN.md)                                     | RHI design goals, invariants, migration phases, and acceptance criteria                                                             |
 
 ## Source-of-truth order
 

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -942,6 +942,9 @@ export interface ColorUberOptions {
 }
 
 // @public
+export function compileParticleAuthoringGraph(source: unknown, options?: Readonly<ParticleAuthoringCompileOptions>): ParticleAuthoringCompileResult;
+
+// @public
 export function compileParticleSystemDefinition(definition: ParticleSystemDefinition, environment?: Readonly<ParticleCompilationEnvironment>): Readonly<ParticleCompiledPlan>;
 
 // @public
@@ -1731,6 +1734,9 @@ export const constants: {
 // @public (undocumented)
 export function createEmptyGLTFRoot(): GLTFRoot;
 
+// @public
+export function createParticleAuthoringGraph(definition: ParticleSystemDefinition, options?: Readonly<ParticleDefinitionSerializationOptions>): Readonly<ParticleAuthoringGraph>;
+
 // @public (undocumented)
 export function createStd140Layout<const Schema extends Std140Schema>(schema: Schema): Std140Layout<Schema>;
 
@@ -1834,6 +1840,9 @@ export const DEFAULT_MATERIAL_TEXTURE_CHANNELS: readonly ["r", "g", "b", "a"];
 
 // @public (undocumented)
 const DEPTH$1 = "DEPTH";
+
+// @public
+export function deserializeParticleSystemDefinition(source: unknown, options?: Readonly<ParticleDefinitionDeserializationOptions>): ParticleSystemDefinition;
 
 // @public
 export function detectBrowserFeatures(): BrowserFeatures;
@@ -5294,10 +5303,34 @@ export interface OrthographicCameraParameters extends CameraParameters {
 }
 
 // @public
+export function parseParticleSystemDefinitionJSON(source: string, options?: Readonly<ParticleDefinitionDeserializationOptions>): ParticleSystemDefinition;
+
+// @public
 export function parseRadianceHDR(input: ArrayBuffer | Uint8Array): RadianceHDRImage;
 
 // @public
+export const PARTICLE_AUTHORING_JSON_SCHEMA: Readonly<ParticleDefinitionJSONRecord>;
+
+// @public
+export const PARTICLE_AUTHORING_SCHEMA: "hilo3d.particle-authoring";
+
+// @public
+export const PARTICLE_AUTHORING_VERSION: 1;
+
+// @public
+export const PARTICLE_BAKE_VERSION: 1;
+
+// @public
+export const PARTICLE_DEFINITION_SCHEMA: "hilo3d.particle-system";
+
+// @public
 export const PARTICLE_DEFINITION_VERSION: 1;
+
+// @public
+export const PARTICLE_PREVIEW_PROTOCOL_VERSION: 1;
+
+// @public
+export const PARTICLE_SIMULATION_CACHE_VERSION: 1;
 
 // @public
 export interface ParticleAdvancedQualityPlan {
@@ -5363,9 +5396,291 @@ export interface ParticleAttributeLayout {
 export type ParticleAttributeName = 'stable-id' | 'generation' | 'alive' | 'age' | 'lifetime' | 'normalized-age' | 'position' | 'previous-position' | 'spawn-position' | 'velocity' | 'size' | 'base-size' | 'rotation' | 'base-rotation' | 'color' | 'base-color' | 'sprite-frame' | 'mass' | 'noise-offset' | 'collision-state' | 'mesh-index' | 'ribbon-id' | `custom:${string}`;
 
 // @public
+export interface ParticleAuthoringCompileFailure {
+    // (undocumented)
+    readonly diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[];
+    // (undocumented)
+    readonly success: false;
+}
+
+// @public
+export type ParticleAuthoringCompileOptions = ParticleDefinitionDeserializationOptions;
+
+// @public
+export type ParticleAuthoringCompileResult = ParticleAuthoringCompileSuccess | ParticleAuthoringCompileFailure;
+
+// @public
+export interface ParticleAuthoringCompileSuccess {
+    // (undocumented)
+    readonly compiledPlan: Readonly<ParticleCompiledPlan>;
+    // (undocumented)
+    readonly definition: ParticleSystemDefinition;
+    // (undocumented)
+    readonly diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[];
+    // (undocumented)
+    readonly graph: Readonly<ParticleAuthoringGraph>;
+    // (undocumented)
+    readonly ir: Readonly<ParticleAuthoringIR>;
+    // (undocumented)
+    readonly success: true;
+}
+
+// @public
+export interface ParticleAuthoringDiagnostic {
+    // (undocumented)
+    readonly code: string;
+    // (undocumented)
+    readonly message: string;
+    // (undocumented)
+    readonly nodeId?: string;
+    readonly path: string;
+    // (undocumented)
+    readonly severity: 'error' | 'warning' | 'info';
+}
+
+// @public
+export interface ParticleAuthoringEdge {
+    // (undocumented)
+    readonly from: string;
+    // (undocumented)
+    readonly id: string;
+    // (undocumented)
+    readonly order: number;
+    // (undocumented)
+    readonly port: ParticleAuthoringPort;
+    // (undocumented)
+    readonly to: string;
+}
+
+// @public
+export interface ParticleAuthoringEmitterIR {
+    // (undocumented)
+    readonly attributes: readonly Readonly<ParticleAttributeLayout>[];
+    // (undocumented)
+    readonly emitterId: number;
+    // (undocumented)
+    readonly layoutHash: string;
+    // (undocumented)
+    readonly moduleNodeIds: readonly string[];
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly nodeId: string;
+    // (undocumented)
+    readonly planKind: 'cpu-stateful' | 'gpu-stateful' | 'stateless';
+    // (undocumented)
+    readonly rendererNodeIds: readonly string[];
+    // (undocumented)
+    readonly statelessDiagnostics: readonly string[];
+    // (undocumented)
+    readonly statelessEligible: boolean;
+}
+
+// @public
+export interface ParticleAuthoringGraph {
+    // (undocumented)
+    readonly definitionSchema: typeof PARTICLE_DEFINITION_SCHEMA;
+    // (undocumented)
+    readonly definitionVersion: typeof PARTICLE_DEFINITION_VERSION;
+    // (undocumented)
+    readonly edges: readonly Readonly<ParticleAuthoringEdge>[];
+    readonly metadata?: ParticleDefinitionJSONRecord;
+    // (undocumented)
+    readonly nodes: readonly Readonly<ParticleAuthoringNode>[];
+    // (undocumented)
+    readonly parameters: readonly ParticleDefinitionJSONParameter[];
+    // (undocumented)
+    readonly schema: typeof PARTICLE_AUTHORING_SCHEMA;
+    // (undocumented)
+    readonly version: typeof PARTICLE_AUTHORING_VERSION;
+}
+
+// @public
+export interface ParticleAuthoringIR {
+    // (undocumented)
+    readonly compiledPlanHash: string;
+    // (undocumented)
+    readonly definitionHash: string;
+    // (undocumented)
+    readonly definitionJSON: Readonly<ParticleSystemDefinitionJSON>;
+    // (undocumented)
+    readonly emitters: readonly Readonly<ParticleAuthoringEmitterIR>[];
+    // (undocumented)
+    readonly schema: typeof PARTICLE_AUTHORING_SCHEMA;
+    // (undocumented)
+    readonly systemNodeId: string;
+    // (undocumented)
+    readonly version: typeof PARTICLE_AUTHORING_VERSION;
+}
+
+// @public
+export interface ParticleAuthoringNode {
+    // (undocumented)
+    readonly data: ParticleDefinitionJSONRecord;
+    // (undocumented)
+    readonly id: string;
+    // (undocumented)
+    readonly kind: ParticleAuthoringNodeKind;
+    readonly metadata?: ParticleDefinitionJSONRecord;
+}
+
+// @public
+export type ParticleAuthoringNodeKind = 'system' | 'emitter' | 'module' | 'renderer';
+
+// @public
+export type ParticleAuthoringPort = 'emitters' | 'modules' | 'renderers';
+
+// @public
+export type ParticleAuthoringPreviewCommand = 'compile' | 'play' | 'pause' | 'restart' | 'seek' | 'step' | 'inspect' | 'dispose';
+
+// Warning: (ae-forgotten-export) The symbol "ParticleAuthoringPreviewRequestBase" needs to be exported by the entry point Hilo3d.d.ts
+//
+// @public
+export interface ParticleAuthoringPreviewCompileRequest extends ParticleAuthoringPreviewRequestBase {
+    // (undocumented)
+    readonly command: 'compile';
+    // (undocumented)
+    readonly graph: Readonly<ParticleAuthoringGraph>;
+    // (undocumented)
+    readonly seed?: number;
+}
+
+// @public
+export class ParticleAuthoringPreviewController {
+    constructor(options?: Readonly<ParticleAuthoringPreviewControllerOptions>);
+    handle(request: unknown): Readonly<ParticleAuthoringPreviewResponse>;
+    get system(): ParticleSystem | null;
+}
+
+// @public
+export interface ParticleAuthoringPreviewControllerOptions {
+    // (undocumented)
+    readonly compileOptions?: Readonly<ParticleAuthoringCompileOptions>;
+    // (undocumented)
+    readonly createSystem?: ParticleAuthoringPreviewSystemFactory;
+    readonly disposeSystem?: (system: ParticleSystem) => void;
+}
+
+// @public
+export interface ParticleAuthoringPreviewControlRequest extends ParticleAuthoringPreviewRequestBase {
+    // (undocumented)
+    readonly command: 'play' | 'pause' | 'restart' | 'inspect' | 'dispose';
+}
+
+// @public
+export type ParticleAuthoringPreviewRequest = ParticleAuthoringPreviewCompileRequest | ParticleAuthoringPreviewControlRequest | ParticleAuthoringPreviewSeekRequest | ParticleAuthoringPreviewStepRequest;
+
+// @public (undocumented)
+interface ParticleAuthoringPreviewRequestBase {
+    // (undocumented)
+    readonly command: ParticleAuthoringPreviewCommand;
+    // (undocumented)
+    readonly protocolVersion: typeof PARTICLE_PREVIEW_PROTOCOL_VERSION;
+    // (undocumented)
+    readonly requestId: string;
+}
+
+// @public
+export interface ParticleAuthoringPreviewResponse {
+    // (undocumented)
+    readonly command: ParticleAuthoringPreviewCommand | 'invalid';
+    // (undocumented)
+    readonly diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[];
+    readonly ir?: Readonly<ParticleAuthoringIR>;
+    // (undocumented)
+    readonly protocolVersion: typeof PARTICLE_PREVIEW_PROTOCOL_VERSION;
+    // (undocumented)
+    readonly requestId: string;
+    // (undocumented)
+    readonly state: Readonly<ParticleAuthoringPreviewState>;
+    // (undocumented)
+    readonly success: boolean;
+}
+
+// @public
+export interface ParticleAuthoringPreviewSeekRequest extends ParticleAuthoringPreviewRequestBase {
+    // (undocumented)
+    readonly command: 'seek';
+    // (undocumented)
+    readonly timeSeconds: number;
+}
+
+// @public
+export interface ParticleAuthoringPreviewState {
+    // (undocumented)
+    readonly aliveCount: number;
+    // (undocumented)
+    readonly compiledPlanHash: string | null;
+    // (undocumented)
+    readonly definitionHash: string | null;
+    // (undocumented)
+    readonly seed: number | null;
+    // (undocumented)
+    readonly stateHash: string | null;
+    // (undocumented)
+    readonly status: 'empty' | 'ready' | 'playing' | 'completed' | 'disposed';
+    // (undocumented)
+    readonly timeSeconds: number;
+}
+
+// @public
+export interface ParticleAuthoringPreviewStepRequest extends ParticleAuthoringPreviewRequestBase {
+    // (undocumented)
+    readonly command: 'step';
+    // (undocumented)
+    readonly deltaSeconds: number;
+}
+
+// @public
+export type ParticleAuthoringPreviewSystemFactory = (definition: ParticleSystemDefinition, seed: number, compilationEnvironment?: Readonly<ParticleCompilationEnvironment>) => ParticleSystem;
+
+// @public
 export interface ParticleAutomaticBounds {
     // (undocumented)
     readonly mode: 'automatic';
+}
+
+// @public
+export interface ParticleBakedMeshEmitter {
+    // (undocumented)
+    readonly capacity: number;
+    // (undocumented)
+    readonly colors: Float32Array;
+    // (undocumented)
+    readonly emitterId: number;
+    readonly frameBounds: Float32Array;
+    readonly frameOffsets: Uint32Array;
+    // (undocumented)
+    readonly generations: Uint32Array;
+    // (undocumented)
+    readonly meshIndices: Uint32Array;
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly positions: Float32Array;
+    // (undocumented)
+    readonly previousPositions: Float32Array;
+    // (undocumented)
+    readonly rotations: Float32Array;
+    // (undocumented)
+    readonly simulationSpace: ParticleSimulationSpace;
+    // (undocumented)
+    readonly sizes: Float32Array;
+    // (undocumented)
+    readonly stableIds: Uint32Array;
+    // (undocumented)
+    readonly storageByteLength: number;
+    // (undocumented)
+    readonly velocities: Float32Array;
+}
+
+// @public
+export interface ParticleBakeTimelineOptions {
+    readonly duration: number;
+    readonly frameRate: number;
+    readonly includeEnd?: boolean;
+    readonly maxFrames?: number;
+    readonly startTime?: number;
 }
 
 // @public
@@ -5687,6 +6002,47 @@ export interface ParticleCustomChannelModule {
 }
 
 // @public
+export interface ParticleDefinitionDeserializationOptions {
+    readonly compilationEnvironment?: Readonly<ParticleCompilationEnvironment>;
+    readonly resolveResource?: (kind: ParticleDefinitionResourceKind, id: string) => ParticleDefinitionResource;
+    readonly upgrades?: readonly ParticleDefinitionUpgrade[];
+}
+
+// @public
+export interface ParticleDefinitionJSONParameter extends ParticleDefinitionJSONRecord {
+    readonly defaultValue: ParticleDefinitionJSONValue;
+    readonly id: string;
+    readonly name: string;
+    readonly type: ParticleParameterType;
+}
+
+// @public
+export interface ParticleDefinitionJSONRecord {
+    // (undocumented)
+    readonly [key: string]: ParticleDefinitionJSONValue;
+}
+
+// @public
+export type ParticleDefinitionJSONValue = null | boolean | number | string | ParticleDefinitionJSONRecord | readonly ParticleDefinitionJSONValue[];
+
+// @public
+export type ParticleDefinitionResource = Texture<unknown> | Geometry;
+
+// @public
+export type ParticleDefinitionResourceKind = 'texture' | 'geometry';
+
+// @public
+export interface ParticleDefinitionSerializationOptions {
+    readonly getResourceId?: (resource: ParticleDefinitionResource, kind: ParticleDefinitionResourceKind) => string;
+}
+
+// @public
+export interface ParticleDefinitionUpgrade {
+    readonly fromVersion: number;
+    readonly upgrade: (document: Readonly<ParticleDefinitionJSONRecord>) => Readonly<ParticleDefinitionJSONRecord>;
+}
+
+// @public
 export interface ParticleDragModule {
     // (undocumented)
     readonly coefficient: number;
@@ -5887,6 +6243,67 @@ export interface ParticleEventRecord {
 export type ParticleExecutionMode = 'auto' | 'cpu' | 'gpu' | 'stateless';
 
 // @public
+export interface ParticleFlipbook {
+    // (undocumented)
+    readonly bytesPerPixel: number;
+    // (undocumented)
+    readonly columns: number;
+    // (undocumented)
+    readonly data: Uint8Array;
+    // (undocumented)
+    readonly definitionHash: string;
+    // (undocumented)
+    readonly duration: number;
+    // (undocumented)
+    readonly format: RenderTargetColorFormat;
+    // (undocumented)
+    readonly frameCount: number;
+    // (undocumented)
+    readonly frameHeight: number;
+    // (undocumented)
+    readonly frameRate: number;
+    // (undocumented)
+    readonly frameTimes: Float32Array;
+    readonly frameUVs: Float32Array;
+    // (undocumented)
+    readonly frameWidth: number;
+    // (undocumented)
+    readonly height: number;
+    // (undocumented)
+    readonly includeEnd: boolean;
+    // (undocumented)
+    readonly rows: number;
+    // (undocumented)
+    readonly seed: number;
+    // (undocumented)
+    readonly startTime: number;
+    // (undocumented)
+    readonly storageByteLength: number;
+    // (undocumented)
+    readonly version: typeof PARTICLE_BAKE_VERSION;
+    // (undocumented)
+    readonly width: number;
+}
+
+// @public
+export interface ParticleFlipbookFrameContext {
+    // (undocumented)
+    readonly frameIndex: number;
+    // (undocumented)
+    readonly system: ParticleSystem;
+    // (undocumented)
+    readonly timeSeconds: number;
+}
+
+// @public
+export interface ParticleFlipbookOptions extends ParticleBakeTimelineOptions {
+    readonly captureFrame: (context: Readonly<ParticleFlipbookFrameContext>) => RenderTargetColorAttachmentReadback | PromiseLike<RenderTargetColorAttachmentReadback>;
+    readonly columns?: number;
+    readonly maxAtlasByteLength?: number;
+    readonly maxTextureSize?: number;
+}
+
+// @public
 export interface ParticleForceModule {
     // (undocumented)
     readonly force: ParticleVector3Value;
@@ -6025,6 +6442,38 @@ export interface ParticleMeshAsset {
     readonly geometry: Geometry;
     // (undocumented)
     readonly texture?: Texture<unknown> | null;
+}
+
+// @public
+export interface ParticleMeshCache {
+    // (undocumented)
+    readonly definitionHash: string;
+    // (undocumented)
+    readonly duration: number;
+    // (undocumented)
+    readonly emitters: readonly Readonly<ParticleBakedMeshEmitter>[];
+    // (undocumented)
+    readonly frameCount: number;
+    // (undocumented)
+    readonly frameRate: number;
+    // (undocumented)
+    readonly frameTimes: Float32Array;
+    // (undocumented)
+    readonly includeEnd: boolean;
+    // (undocumented)
+    readonly seed: number;
+    // (undocumented)
+    readonly startTime: number;
+    // (undocumented)
+    readonly storageByteLength: number;
+    // (undocumented)
+    readonly version: typeof PARTICLE_BAKE_VERSION;
+}
+
+// @public
+export interface ParticleMeshCacheOptions extends ParticleBakeTimelineOptions {
+    readonly emitter?: string;
+    readonly maxSampledParticles?: number;
 }
 
 // @public
@@ -6222,6 +6671,25 @@ export interface ParticleShapeBase {
 export type ParticleShapeDefinition = ParticlePointShape | ParticleLineShape | ParticleBoxShape | ParticleCircleShape | ParticleSphereShape | ParticleConeShape | ParticleTorusShape;
 
 // @public
+export interface ParticleSimulationCache {
+    // (undocumented)
+    readonly compiledPlanHash: string;
+    // (undocumented)
+    readonly definitionHash: string;
+    // (undocumented)
+    readonly elapsedSeconds: number;
+    // (undocumented)
+    readonly emitterCount: number;
+    // (undocumented)
+    readonly parameterRevision: number;
+    // (undocumented)
+    readonly seed: number;
+    readonly storageByteLength: number;
+    // (undocumented)
+    readonly version: typeof PARTICLE_SIMULATION_CACHE_VERSION;
+}
+
+// @public
 export type ParticleSimulationSpace = 'local' | 'world';
 
 // @public
@@ -6316,10 +6784,13 @@ export class ParticleSystem extends Node_2 {
     get aliveCount(): number;
     // @internal
     applyBudgetDecisions(decisions: readonly Readonly<ParticleBudgetDecision>[]): this;
+    bakeFlipbook(options: Readonly<ParticleFlipbookOptions>): Promise<ParticleFlipbook>;
+    bakeMeshCache(options: Readonly<ParticleMeshCacheOptions>): ParticleMeshCache;
     // (undocumented)
     readonly budgetId: string;
     // (undocumented)
     readonly budgetPriority: number;
+    captureSimulation(): ParticleSimulationCache;
     // (undocumented)
     className: string;
     // (undocumented)
@@ -6373,6 +6844,7 @@ export class ParticleSystem extends Node_2 {
     resetForPool(parameters: Readonly<ParticleSystemParameters>): this;
     // (undocumented)
     restart(): this;
+    restoreSimulation(cache: ParticleSimulationCache): this;
     // (undocumented)
     readonly seed: number;
     sendEvent(name: string, payload?: unknown): this;
@@ -6407,6 +6879,14 @@ export interface ParticleSystemDefinitionInput {
     readonly emitters: readonly ParticleEmitterDefinitionInput[];
     // (undocumented)
     readonly version?: typeof PARTICLE_DEFINITION_VERSION;
+}
+
+// @public
+export interface ParticleSystemDefinitionJSON extends ParticleDefinitionJSONRecord {
+    readonly emitters: readonly ParticleDefinitionJSONRecord[];
+    readonly parameters: readonly ParticleDefinitionJSONParameter[];
+    readonly schema: typeof PARTICLE_DEFINITION_SCHEMA;
+    readonly version: typeof PARTICLE_DEFINITION_VERSION;
 }
 
 // @public
@@ -8733,6 +9213,9 @@ export interface SemanticRenderer {
     // (undocumented)
     width: number;
 }
+
+// @public
+export function serializeParticleSystemDefinition(definition: ParticleSystemDefinition, options?: Readonly<ParticleDefinitionSerializationOptions>): Readonly<ParticleSystemDefinitionJSON>;
 
 // @public
 export class Shader {

--- a/src/Hilo3d.ts
+++ b/src/Hilo3d.ts
@@ -70,6 +70,64 @@ export {
     type ParticleAdvancedQualityPlan,
     type ParticleCompilationEnvironment
 } from './particle/ParticleCompiler';
+export {
+    compileParticleAuthoringGraph,
+    createParticleAuthoringGraph,
+    PARTICLE_AUTHORING_JSON_SCHEMA,
+    PARTICLE_AUTHORING_SCHEMA,
+    PARTICLE_AUTHORING_VERSION,
+    type ParticleAuthoringCompileFailure,
+    type ParticleAuthoringCompileOptions,
+    type ParticleAuthoringCompileResult,
+    type ParticleAuthoringCompileSuccess,
+    type ParticleAuthoringDiagnostic,
+    type ParticleAuthoringEdge,
+    type ParticleAuthoringEmitterIR,
+    type ParticleAuthoringGraph,
+    type ParticleAuthoringIR,
+    type ParticleAuthoringNode,
+    type ParticleAuthoringNodeKind,
+    type ParticleAuthoringPort
+} from './particle/ParticleAuthoring';
+export {
+    PARTICLE_PREVIEW_PROTOCOL_VERSION,
+    ParticleAuthoringPreviewController,
+    type ParticleAuthoringPreviewCommand,
+    type ParticleAuthoringPreviewCompileRequest,
+    type ParticleAuthoringPreviewControllerOptions,
+    type ParticleAuthoringPreviewControlRequest,
+    type ParticleAuthoringPreviewRequest,
+    type ParticleAuthoringPreviewResponse,
+    type ParticleAuthoringPreviewSeekRequest,
+    type ParticleAuthoringPreviewState,
+    type ParticleAuthoringPreviewStepRequest,
+    type ParticleAuthoringPreviewSystemFactory
+} from './particle/ParticleAuthoringPreview';
+export {
+    PARTICLE_BAKE_VERSION,
+    type ParticleBakedMeshEmitter,
+    type ParticleBakeTimelineOptions,
+    type ParticleFlipbook,
+    type ParticleFlipbookFrameContext,
+    type ParticleFlipbookOptions,
+    type ParticleMeshCache,
+    type ParticleMeshCacheOptions
+} from './particle/ParticleBaking';
+export {
+    deserializeParticleSystemDefinition,
+    parseParticleSystemDefinitionJSON,
+    PARTICLE_DEFINITION_SCHEMA,
+    serializeParticleSystemDefinition,
+    type ParticleDefinitionDeserializationOptions,
+    type ParticleDefinitionJSONParameter,
+    type ParticleDefinitionJSONRecord,
+    type ParticleDefinitionJSONValue,
+    type ParticleDefinitionResource,
+    type ParticleDefinitionResourceKind,
+    type ParticleDefinitionSerializationOptions,
+    type ParticleDefinitionUpgrade,
+    type ParticleSystemDefinitionJSON
+} from './particle/ParticleDefinitionSerialization';
 export type {
     ParticleAttributeLayout,
     ParticleAttributeName,
@@ -107,6 +165,10 @@ export {
     type ParticleParameterType,
     type ParticleParameterValue
 } from './particle/ParticleParameter';
+export {
+    PARTICLE_SIMULATION_CACHE_VERSION,
+    type ParticleSimulationCache
+} from './particle/ParticleSimulationCache';
 export {
     default as ParticleSystem,
     type ParticleSystemEmitCommand,

--- a/src/particle/ParticleAuthoring.ts
+++ b/src/particle/ParticleAuthoring.ts
@@ -1,0 +1,955 @@
+import { compileParticleSystemDefinition } from './ParticleCompiler';
+import type { ParticleAttributeLayout, ParticleCompiledPlan } from './ParticleCompiledPlan';
+import {
+    deserializeParticleSystemDefinition,
+    PARTICLE_DEFINITION_SCHEMA,
+    serializeParticleSystemDefinition,
+    type ParticleDefinitionDeserializationOptions,
+    type ParticleDefinitionJSONParameter,
+    type ParticleDefinitionJSONRecord,
+    type ParticleDefinitionJSONValue,
+    type ParticleDefinitionSerializationOptions,
+    type ParticleSystemDefinitionJSON
+} from './ParticleDefinitionSerialization';
+import type ParticleSystemDefinition from './ParticleSystemDefinition';
+import { PARTICLE_DEFINITION_VERSION } from './ParticleTypes';
+
+/** Stable external fixed-module graph document family. */
+export const PARTICLE_AUTHORING_SCHEMA = 'hilo3d.particle-authoring' as const;
+
+/** Current external fixed-module graph and normalized IR version. */
+export const PARTICLE_AUTHORING_VERSION = 1 as const;
+
+/** Closed node kinds understood by the external authoring compiler. */
+export type ParticleAuthoringNodeKind = 'system' | 'emitter' | 'module' | 'renderer';
+
+/** Closed ownership ports; edges do not represent arbitrary executable data flow. */
+export type ParticleAuthoringPort = 'emitters' | 'modules' | 'renderers';
+
+/** One JSON node in the external fixed-module authoring graph. */
+export interface ParticleAuthoringNode {
+    readonly id: string;
+    readonly kind: ParticleAuthoringNodeKind;
+    readonly data: ParticleDefinitionJSONRecord;
+    /** Opaque JSON retained for an external editor and ignored by runtime compilation. */
+    readonly metadata?: ParticleDefinitionJSONRecord;
+}
+
+/** One ordered ownership edge in the external authoring graph. */
+export interface ParticleAuthoringEdge {
+    readonly id: string;
+    readonly from: string;
+    readonly to: string;
+    readonly port: ParticleAuthoringPort;
+    readonly order: number;
+}
+
+/** Versioned pure-JSON graph consumed by the external authoring compiler. */
+export interface ParticleAuthoringGraph {
+    readonly schema: typeof PARTICLE_AUTHORING_SCHEMA;
+    readonly version: typeof PARTICLE_AUTHORING_VERSION;
+    readonly definitionSchema: typeof PARTICLE_DEFINITION_SCHEMA;
+    readonly definitionVersion: typeof PARTICLE_DEFINITION_VERSION;
+    readonly parameters: readonly ParticleDefinitionJSONParameter[];
+    readonly nodes: readonly Readonly<ParticleAuthoringNode>[];
+    readonly edges: readonly Readonly<ParticleAuthoringEdge>[];
+    /** Opaque graph-level JSON retained for external editor layout/project data. */
+    readonly metadata?: ParticleDefinitionJSONRecord;
+}
+
+/** Structured compiler feedback addressable to one graph path/node. */
+export interface ParticleAuthoringDiagnostic {
+    readonly severity: 'error' | 'warning' | 'info';
+    readonly code: string;
+    readonly message: string;
+    /** Stable graph path; node-addressed paths use the submitted node id. */
+    readonly path: string;
+    readonly nodeId?: string;
+}
+
+/** Compiler-derived emitter data used by inspectors and preview hosts. */
+export interface ParticleAuthoringEmitterIR {
+    readonly nodeId: string;
+    readonly name: string;
+    readonly emitterId: number;
+    readonly planKind: 'cpu-stateful' | 'gpu-stateful' | 'stateless';
+    readonly layoutHash: string;
+    readonly attributes: readonly Readonly<ParticleAttributeLayout>[];
+    readonly moduleNodeIds: readonly string[];
+    readonly rendererNodeIds: readonly string[];
+    readonly statelessEligible: boolean;
+    readonly statelessDiagnostics: readonly string[];
+}
+
+/** Normalized fixed-module IR; runtime still consumes the embedded ordinary definition. */
+export interface ParticleAuthoringIR {
+    readonly schema: typeof PARTICLE_AUTHORING_SCHEMA;
+    readonly version: typeof PARTICLE_AUTHORING_VERSION;
+    readonly systemNodeId: string;
+    readonly definitionJSON: Readonly<ParticleSystemDefinitionJSON>;
+    readonly definitionHash: string;
+    readonly compiledPlanHash: string;
+    readonly emitters: readonly Readonly<ParticleAuthoringEmitterIR>[];
+}
+
+/** Environment/resource policy for compiling an external authoring graph. */
+export type ParticleAuthoringCompileOptions = ParticleDefinitionDeserializationOptions;
+
+/** Successful external authoring compilation. */
+export interface ParticleAuthoringCompileSuccess {
+    readonly success: true;
+    readonly diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[];
+    readonly graph: Readonly<ParticleAuthoringGraph>;
+    readonly ir: Readonly<ParticleAuthoringIR>;
+    readonly definition: ParticleSystemDefinition;
+    readonly compiledPlan: Readonly<ParticleCompiledPlan>;
+}
+
+/** Failed external authoring compilation; no partial runtime definition escapes. */
+export interface ParticleAuthoringCompileFailure {
+    readonly success: false;
+    readonly diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[];
+}
+
+/** Fail-closed result returned to external authoring and preview hosts. */
+export type ParticleAuthoringCompileResult =
+    ParticleAuthoringCompileSuccess | ParticleAuthoringCompileFailure;
+
+type UnknownRecord = Record<string, unknown>;
+
+const ID_PATTERN = /^[A-Za-z_][A-Za-z0-9_.:-]*$/u;
+const ROOT_KEYS = new Set([
+    'schema',
+    'version',
+    'definitionSchema',
+    'definitionVersion',
+    'parameters',
+    'nodes',
+    'edges',
+    'metadata'
+]);
+const NODE_KEYS = new Set(['id', 'kind', 'data', 'metadata']);
+const EDGE_KEYS = new Set(['id', 'from', 'to', 'port', 'order']);
+const NODE_KINDS = new Set<ParticleAuthoringNodeKind>(['system', 'emitter', 'module', 'renderer']);
+const PORTS = new Set<ParticleAuthoringPort>(['emitters', 'modules', 'renderers']);
+
+function isJSONArray(value: unknown): value is readonly ParticleDefinitionJSONValue[] {
+    return isUnknownArray(value) && value.every(item => isJSONValue(item));
+}
+
+function isUnknownArray(value: unknown): value is readonly unknown[] {
+    return Array.isArray(value);
+}
+
+function deepFreezeJSON<T extends ParticleDefinitionJSONValue>(value: T): T {
+    if (isJSONArray(value)) {
+        for (const item of value) deepFreezeJSON(item);
+        return Object.freeze(value);
+    }
+    if (isRecord(value)) {
+        for (const child of Object.values(value)) {
+            if (isJSONValue(child)) deepFreezeJSON(child);
+        }
+        return Object.freeze(value) as T;
+    }
+    return value;
+}
+
+function cloneJSON(value: ParticleDefinitionJSONValue): ParticleDefinitionJSONValue {
+    if (isJSONArray(value)) {
+        return Object.freeze(value.map(item => cloneJSON(item)));
+    }
+    if (isRecord(value)) {
+        const result: Record<string, ParticleDefinitionJSONValue> = {};
+        for (const key of Object.keys(value).sort()) {
+            const child = value[key];
+            if (child !== undefined) result[key] = cloneJSON(child);
+        }
+        return Object.freeze(result);
+    }
+    return value;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const prototype = Object.getPrototypeOf(value) as unknown;
+    return prototype === Object.prototype || prototype === null;
+}
+
+function isJSONValue(
+    value: unknown,
+    seen = new Set<object>()
+): value is ParticleDefinitionJSONValue {
+    if (
+        value === null ||
+        typeof value === 'boolean' ||
+        typeof value === 'string' ||
+        (typeof value === 'number' && Number.isFinite(value))
+    ) {
+        return true;
+    }
+    if (typeof value !== 'object' || seen.has(value)) return false;
+    seen.add(value);
+    const valid = isUnknownArray(value)
+        ? value.every(item => isJSONValue(item, seen))
+        : isRecord(value) && Object.values(value).every(item => isJSONValue(item, seen));
+    seen.delete(value);
+    return valid;
+}
+
+function diagnostic(
+    severity: ParticleAuthoringDiagnostic['severity'],
+    code: string,
+    message: string,
+    path: string,
+    nodeId?: string
+): Readonly<ParticleAuthoringDiagnostic> {
+    return Object.freeze({
+        severity,
+        code,
+        message,
+        path,
+        ...(nodeId === undefined ? {} : { nodeId })
+    });
+}
+
+function unknownKeys(record: UnknownRecord, allowed: ReadonlySet<string>): readonly string[] {
+    return Object.keys(record).filter(key => !allowed.has(key));
+}
+
+function canonicalRecord(
+    record: Readonly<ParticleDefinitionJSONRecord>
+): ParticleDefinitionJSONRecord {
+    return cloneJSON(record) as ParticleDefinitionJSONRecord;
+}
+
+function recordWithout(
+    record: Readonly<ParticleDefinitionJSONRecord>,
+    excluded: ReadonlySet<string>
+): ParticleDefinitionJSONRecord {
+    const result: Record<string, ParticleDefinitionJSONValue> = {};
+    for (const [key, value] of Object.entries(record)) {
+        if (!excluded.has(key)) result[key] = value;
+    }
+    return canonicalRecord(result);
+}
+
+/**
+ * JSON Schema for graph transport and editor-side structural validation. Definition node payloads
+ * remain governed by `PARTICLE_DEFINITION_SCHEMA` and are revalidated by the engine compiler.
+ */
+export const PARTICLE_AUTHORING_JSON_SCHEMA: Readonly<ParticleDefinitionJSONRecord> =
+    deepFreezeJSON({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: 'https://hilo3d.dev/schema/particle-authoring-v1.json',
+        type: 'object',
+        additionalProperties: false,
+        required: [
+            'schema',
+            'version',
+            'definitionSchema',
+            'definitionVersion',
+            'parameters',
+            'nodes',
+            'edges'
+        ],
+        properties: {
+            schema: { const: PARTICLE_AUTHORING_SCHEMA },
+            version: { const: PARTICLE_AUTHORING_VERSION },
+            definitionSchema: { const: PARTICLE_DEFINITION_SCHEMA },
+            definitionVersion: { const: PARTICLE_DEFINITION_VERSION },
+            parameters: { type: 'array', items: { type: 'object' } },
+            nodes: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['id', 'kind', 'data'],
+                    properties: {
+                        id: { type: 'string', pattern: '^[A-Za-z_][A-Za-z0-9_.:-]*$' },
+                        kind: { enum: ['system', 'emitter', 'module', 'renderer'] },
+                        data: { type: 'object' },
+                        metadata: { type: 'object' }
+                    }
+                }
+            },
+            edges: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['id', 'from', 'to', 'port', 'order'],
+                    properties: {
+                        id: { type: 'string', pattern: '^[A-Za-z_][A-Za-z0-9_.:-]*$' },
+                        from: { type: 'string' },
+                        to: { type: 'string' },
+                        port: { enum: ['emitters', 'modules', 'renderers'] },
+                        order: { type: 'integer', minimum: 0 }
+                    }
+                }
+            },
+            metadata: { type: 'object' }
+        }
+    });
+
+/** Convert one immutable definition into a deterministic editable fixed-module graph. */
+export function createParticleAuthoringGraph(
+    definition: ParticleSystemDefinition,
+    options: Readonly<ParticleDefinitionSerializationOptions> = {}
+): Readonly<ParticleAuthoringGraph> {
+    const serialized = serializeParticleSystemDefinition(definition, options);
+    const nodes: ParticleAuthoringNode[] = [
+        Object.freeze({ id: 'system', kind: 'system', data: Object.freeze({}) })
+    ];
+    const edges: ParticleAuthoringEdge[] = [];
+    for (let emitterIndex = 0; emitterIndex < serialized.emitters.length; emitterIndex += 1) {
+        const emitter = serialized.emitters[emitterIndex];
+        if (emitter === undefined) throw new Error('Serialized particle emitter is unavailable');
+        const emitterId = `emitter:${String(emitterIndex)}`;
+        const modules = emitter['modules'];
+        const renderers = emitter['renderers'];
+        if (!isJSONArray(modules) || !isJSONArray(renderers)) {
+            throw new TypeError('Serialized particle emitter topology is unavailable');
+        }
+        nodes.push(
+            Object.freeze({
+                id: emitterId,
+                kind: 'emitter',
+                data: recordWithout(emitter, new Set(['modules', 'renderers']))
+            })
+        );
+        edges.push(
+            Object.freeze({
+                id: `edge:${emitterId}`,
+                from: emitterId,
+                to: 'system',
+                port: 'emitters',
+                order: emitterIndex
+            })
+        );
+        for (let moduleIndex = 0; moduleIndex < modules.length; moduleIndex += 1) {
+            const module = modules[moduleIndex];
+            if (!isRecord(module) || !isJSONValue(module)) {
+                throw new TypeError('Serialized particle module is invalid');
+            }
+            const moduleId = `${emitterId}:module:${String(moduleIndex)}`;
+            nodes.push(
+                Object.freeze({ id: moduleId, kind: 'module', data: canonicalRecord(module) })
+            );
+            edges.push(
+                Object.freeze({
+                    id: `edge:${moduleId}`,
+                    from: moduleId,
+                    to: emitterId,
+                    port: 'modules',
+                    order: moduleIndex
+                })
+            );
+        }
+        for (let rendererIndex = 0; rendererIndex < renderers.length; rendererIndex += 1) {
+            const renderer = renderers[rendererIndex];
+            if (!isRecord(renderer) || !isJSONValue(renderer)) {
+                throw new TypeError('Serialized particle renderer is invalid');
+            }
+            const rendererId = `${emitterId}:renderer:${String(rendererIndex)}`;
+            nodes.push(
+                Object.freeze({
+                    id: rendererId,
+                    kind: 'renderer',
+                    data: canonicalRecord(renderer)
+                })
+            );
+            edges.push(
+                Object.freeze({
+                    id: `edge:${rendererId}`,
+                    from: rendererId,
+                    to: emitterId,
+                    port: 'renderers',
+                    order: rendererIndex
+                })
+            );
+        }
+    }
+    return Object.freeze({
+        schema: PARTICLE_AUTHORING_SCHEMA,
+        version: PARTICLE_AUTHORING_VERSION,
+        definitionSchema: PARTICLE_DEFINITION_SCHEMA,
+        definitionVersion: PARTICLE_DEFINITION_VERSION,
+        parameters: serialized.parameters,
+        nodes: Object.freeze(nodes),
+        edges: Object.freeze(edges)
+    });
+}
+
+interface ValidatedGraph {
+    readonly graph: Readonly<ParticleAuthoringGraph>;
+    readonly nodes: ReadonlyMap<string, Readonly<ParticleAuthoringNode>>;
+    readonly system: Readonly<ParticleAuthoringNode>;
+}
+
+function validateGraph(
+    source: unknown,
+    diagnostics: Readonly<ParticleAuthoringDiagnostic>[]
+): ValidatedGraph | null {
+    if (!isRecord(source)) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.document.type',
+                'Authoring graph must be a plain object',
+                ''
+            )
+        );
+        return null;
+    }
+    for (const key of unknownKeys(source, ROOT_KEYS)) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.document.unknown-field',
+                `Unknown authoring graph field ${key}`,
+                `/${key}`
+            )
+        );
+    }
+    if (source['schema'] !== PARTICLE_AUTHORING_SCHEMA) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.document.schema',
+                `Authoring graph schema must be ${PARTICLE_AUTHORING_SCHEMA}`,
+                '/schema'
+            )
+        );
+    }
+    if (source['version'] !== PARTICLE_AUTHORING_VERSION) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.document.version',
+                `Authoring graph version must be ${String(PARTICLE_AUTHORING_VERSION)}`,
+                '/version'
+            )
+        );
+    }
+    if (source['definitionSchema'] !== PARTICLE_DEFINITION_SCHEMA) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.definition.schema',
+                `Definition schema must be ${PARTICLE_DEFINITION_SCHEMA}`,
+                '/definitionSchema'
+            )
+        );
+    }
+    if (source['definitionVersion'] !== PARTICLE_DEFINITION_VERSION) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.definition.version',
+                `Definition version must be ${String(PARTICLE_DEFINITION_VERSION)}`,
+                '/definitionVersion'
+            )
+        );
+    }
+    const rawParameters = source['parameters'];
+    const rawNodes = source['nodes'];
+    const rawEdges = source['edges'];
+    if (!isJSONArray(rawParameters)) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.parameters.type',
+                'Authoring parameters must be a JSON array',
+                '/parameters'
+            )
+        );
+    }
+    if (!isUnknownArray(rawNodes)) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.nodes.type',
+                'Authoring nodes must be an array',
+                '/nodes'
+            )
+        );
+    }
+    if (!isUnknownArray(rawEdges)) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.edges.type',
+                'Authoring edges must be an array',
+                '/edges'
+            )
+        );
+    }
+    const metadata = source['metadata'];
+    if (metadata !== undefined && (!isRecord(metadata) || !isJSONValue(metadata))) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.metadata.type',
+                'Authoring metadata must be a plain JSON object',
+                '/metadata'
+            )
+        );
+    }
+    if (!isJSONArray(rawParameters) || !isUnknownArray(rawNodes) || !isUnknownArray(rawEdges))
+        return null;
+
+    const nodes = new Map<string, Readonly<ParticleAuthoringNode>>();
+    const nodeList: Readonly<ParticleAuthoringNode>[] = [];
+    for (let index = 0; index < rawNodes.length; index += 1) {
+        const rawNode = rawNodes[index];
+        const path = `/nodes/${String(index)}`;
+        if (!isRecord(rawNode)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.type',
+                    'Authoring node must be a plain object',
+                    path
+                )
+            );
+            continue;
+        }
+        for (const key of unknownKeys(rawNode, NODE_KEYS)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.unknown-field',
+                    `Unknown authoring node field ${key}`,
+                    `${path}/${key}`
+                )
+            );
+        }
+        const id = rawNode['id'];
+        const kind = rawNode['kind'];
+        const data = rawNode['data'];
+        if (typeof id !== 'string' || !ID_PATTERN.test(id)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.id',
+                    'Authoring node id is invalid',
+                    `${path}/id`
+                )
+            );
+            continue;
+        }
+        if (nodes.has(id)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.duplicate',
+                    `Duplicate authoring node id ${id}`,
+                    `${path}/id`,
+                    id
+                )
+            );
+            continue;
+        }
+        if (typeof kind !== 'string' || !NODE_KINDS.has(kind as ParticleAuthoringNodeKind)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.kind',
+                    `Authoring node ${id} has an invalid kind`,
+                    `${path}/kind`,
+                    id
+                )
+            );
+            continue;
+        }
+        if (!isRecord(data) || !isJSONValue(data)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.data',
+                    `Authoring node ${id} data must be a plain JSON object`,
+                    `${path}/data`,
+                    id
+                )
+            );
+            continue;
+        }
+        const nodeMetadata = rawNode['metadata'];
+        if (nodeMetadata !== undefined && (!isRecord(nodeMetadata) || !isJSONValue(nodeMetadata))) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.metadata',
+                    `Authoring node ${id} metadata must be a plain JSON object`,
+                    `${path}/metadata`,
+                    id
+                )
+            );
+            continue;
+        }
+        const node: Readonly<ParticleAuthoringNode> = Object.freeze({
+            id,
+            kind: kind as ParticleAuthoringNodeKind,
+            data: canonicalRecord(data),
+            ...(nodeMetadata === undefined ? {} : { metadata: canonicalRecord(nodeMetadata) })
+        });
+        nodes.set(id, node);
+        nodeList.push(node);
+    }
+
+    const edges: Readonly<ParticleAuthoringEdge>[] = [];
+    const edgeIds = new Set<string>();
+    const ownedSources = new Set<string>();
+    for (let index = 0; index < rawEdges.length; index += 1) {
+        const rawEdge = rawEdges[index];
+        const path = `/edges/${String(index)}`;
+        if (!isRecord(rawEdge)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.type',
+                    'Authoring edge must be a plain object',
+                    path
+                )
+            );
+            continue;
+        }
+        for (const key of unknownKeys(rawEdge, EDGE_KEYS)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.unknown-field',
+                    `Unknown authoring edge field ${key}`,
+                    `${path}/${key}`
+                )
+            );
+        }
+        const id = rawEdge['id'];
+        const from = rawEdge['from'];
+        const to = rawEdge['to'];
+        const port = rawEdge['port'];
+        const order = rawEdge['order'];
+        if (typeof id !== 'string' || !ID_PATTERN.test(id) || edgeIds.has(id)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.id',
+                    'Authoring edge id is invalid or duplicated',
+                    `${path}/id`
+                )
+            );
+            continue;
+        }
+        edgeIds.add(id);
+        if (
+            typeof from !== 'string' ||
+            typeof to !== 'string' ||
+            !nodes.has(from) ||
+            !nodes.has(to)
+        ) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.endpoint',
+                    `Authoring edge ${id} has a missing endpoint`,
+                    path
+                )
+            );
+            continue;
+        }
+        if (typeof port !== 'string' || !PORTS.has(port as ParticleAuthoringPort)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.port',
+                    `Authoring edge ${id} has an invalid port`,
+                    `${path}/port`,
+                    from
+                )
+            );
+            continue;
+        }
+        if (!Number.isSafeInteger(order) || (order as number) < 0) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.order',
+                    `Authoring edge ${id} order is invalid`,
+                    `${path}/order`,
+                    from
+                )
+            );
+            continue;
+        }
+        if (ownedSources.has(from)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.multiple-owners',
+                    `Authoring node ${from} has multiple owners`,
+                    path,
+                    from
+                )
+            );
+            continue;
+        }
+        const sourceNode = nodes.get(from);
+        const targetNode = nodes.get(to);
+        const validTopology =
+            (port === 'emitters' &&
+                sourceNode?.kind === 'emitter' &&
+                targetNode?.kind === 'system') ||
+            (port === 'modules' &&
+                sourceNode?.kind === 'module' &&
+                targetNode?.kind === 'emitter') ||
+            (port === 'renderers' &&
+                sourceNode?.kind === 'renderer' &&
+                targetNode?.kind === 'emitter');
+        if (!validTopology) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.topology',
+                    `Authoring edge ${id} violates fixed ownership topology`,
+                    path,
+                    from
+                )
+            );
+            continue;
+        }
+        ownedSources.add(from);
+        edges.push(
+            Object.freeze({
+                id,
+                from,
+                to,
+                port,
+                order: order as number
+            })
+        );
+    }
+
+    const systems = nodeList.filter(node => node.kind === 'system');
+    if (systems.length !== 1) {
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.system.count',
+                'Authoring graph requires exactly one system node',
+                '/nodes'
+            )
+        );
+    }
+    for (const node of nodeList) {
+        if (node.kind === 'system') {
+            if (Object.keys(node.data).length !== 0)
+                diagnostics.push(
+                    diagnostic(
+                        'error',
+                        'authoring.system.data',
+                        'System node data must be empty',
+                        `/nodes/${node.id}/data`,
+                        node.id
+                    )
+                );
+        } else if (!ownedSources.has(node.id)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.unowned',
+                    `Authoring node ${node.id} has no owner`,
+                    `/nodes/${node.id}`,
+                    node.id
+                )
+            );
+        }
+        if (node.kind === 'emitter' && ('modules' in node.data || 'renderers' in node.data)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.emitter.inline-topology',
+                    'Emitter topology must be represented by edges',
+                    `/nodes/${node.id}/data`,
+                    node.id
+                )
+            );
+        }
+        if (
+            (node.kind === 'module' || node.kind === 'renderer') &&
+            typeof node.data['type'] !== 'string'
+        ) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.node.payload-type',
+                    `${node.kind} node ${node.id} requires data.type`,
+                    `/nodes/${node.id}/data/type`,
+                    node.id
+                )
+            );
+        }
+    }
+    const groups = new Map<string, number[]>();
+    for (const edge of edges) {
+        const key = `${edge.to}:${edge.port}`;
+        const orders = groups.get(key) ?? [];
+        orders.push(edge.order);
+        groups.set(key, orders);
+    }
+    for (const [key, orders] of groups) {
+        orders.sort((left, right) => left - right);
+        if (orders.some((value, index) => value !== index)) {
+            diagnostics.push(
+                diagnostic(
+                    'error',
+                    'authoring.edge.order-gap',
+                    `Ownership orders for ${key} must be contiguous from zero`,
+                    '/edges'
+                )
+            );
+        }
+    }
+    if (diagnostics.some(item => item.severity === 'error') || systems[0] === undefined)
+        return null;
+    const graph: Readonly<ParticleAuthoringGraph> = Object.freeze({
+        schema: PARTICLE_AUTHORING_SCHEMA,
+        version: PARTICLE_AUTHORING_VERSION,
+        definitionSchema: PARTICLE_DEFINITION_SCHEMA,
+        definitionVersion: PARTICLE_DEFINITION_VERSION,
+        parameters: cloneJSON(rawParameters) as readonly ParticleDefinitionJSONParameter[],
+        nodes: Object.freeze(nodeList),
+        edges: Object.freeze(edges),
+        ...(metadata === undefined
+            ? {}
+            : { metadata: canonicalRecord(metadata as ParticleDefinitionJSONRecord) })
+    });
+    return { graph, nodes, system: systems[0] };
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+/** Validate topology, rebuild the ordinary definition, compile it, and expose normalized IR. */
+export function compileParticleAuthoringGraph(
+    source: unknown,
+    options: Readonly<ParticleAuthoringCompileOptions> = {}
+): ParticleAuthoringCompileResult {
+    const diagnostics: Readonly<ParticleAuthoringDiagnostic>[] = [];
+    const validated = validateGraph(source, diagnostics);
+    if (validated === null) {
+        return Object.freeze({ success: false, diagnostics: Object.freeze(diagnostics) });
+    }
+    const orderedChildren = (
+        target: string,
+        port: ParticleAuthoringPort
+    ): readonly Readonly<ParticleAuthoringNode>[] =>
+        validated.graph.edges
+            .filter(edge => edge.to === target && edge.port === port)
+            .sort((left, right) => left.order - right.order)
+            .map(edge => validated.nodes.get(edge.from))
+            .filter((node): node is Readonly<ParticleAuthoringNode> => node !== undefined);
+    const emitterNodes = orderedChildren(validated.system.id, 'emitters');
+    const emitters = emitterNodes.map(emitterNode => {
+        const modules = orderedChildren(emitterNode.id, 'modules').map(node => node.data);
+        const renderers = orderedChildren(emitterNode.id, 'renderers').map(node => node.data);
+        return canonicalRecord({ ...emitterNode.data, modules, renderers });
+    });
+    const definitionJSON: Readonly<ParticleSystemDefinitionJSON> = Object.freeze({
+        schema: PARTICLE_DEFINITION_SCHEMA,
+        version: PARTICLE_DEFINITION_VERSION,
+        parameters: validated.graph.parameters,
+        emitters: Object.freeze(emitters)
+    });
+    let definition: ParticleSystemDefinition;
+    let compiledPlan: Readonly<ParticleCompiledPlan>;
+    try {
+        definition = deserializeParticleSystemDefinition(definitionJSON, {
+            ...(options.resolveResource === undefined
+                ? {}
+                : { resolveResource: options.resolveResource }),
+            ...(options.upgrades === undefined ? {} : { upgrades: options.upgrades }),
+            ...(options.compilationEnvironment === undefined
+                ? {}
+                : { compilationEnvironment: options.compilationEnvironment })
+        });
+        compiledPlan = compileParticleSystemDefinition(definition, options.compilationEnvironment);
+    } catch (error) {
+        const message = errorMessage(error);
+        const emitterMatch = /emitters?\[(\d+)\]/u.exec(message);
+        const emitterIndex = emitterMatch?.[1] === undefined ? -1 : Number(emitterMatch[1]);
+        const namedEmitter = emitterNodes.find(node => {
+            const name = node.data['name'];
+            return typeof name === 'string' && message.includes(name);
+        });
+        const emitterNode = emitterNodes[emitterIndex] ?? namedEmitter;
+        let errorNode = emitterNode;
+        if (emitterNode !== undefined) {
+            const moduleMatch = /modules?\[(\d+)\]/u.exec(message);
+            const rendererMatch = /renderers?\[(\d+)\]/u.exec(message);
+            if (moduleMatch?.[1] !== undefined) {
+                errorNode = orderedChildren(emitterNode.id, 'modules')[Number(moduleMatch[1])];
+            } else if (rendererMatch?.[1] !== undefined) {
+                errorNode = orderedChildren(emitterNode.id, 'renderers')[Number(rendererMatch[1])];
+            }
+        }
+        diagnostics.push(
+            diagnostic(
+                'error',
+                'authoring.definition.compile',
+                message,
+                errorNode === undefined ? '/nodes' : `/nodes/${errorNode.id}/data`,
+                errorNode?.id
+            )
+        );
+        return Object.freeze({ success: false, diagnostics: Object.freeze(diagnostics) });
+    }
+    const emitterIR = compiledPlan.emitters.map((plan, index) => {
+        const emitterNode = emitterNodes[index];
+        if (emitterNode === undefined)
+            throw new Error('Compiled authoring emitter node is unavailable');
+        const moduleNodeIds = orderedChildren(emitterNode.id, 'modules').map(node => node.id);
+        const rendererNodeIds = orderedChildren(emitterNode.id, 'renderers').map(node => node.id);
+        if (plan.statelessDiagnostics.length > 0 && plan.definition.execution === 'auto') {
+            diagnostics.push(
+                diagnostic(
+                    'info',
+                    'authoring.stateless.ineligible',
+                    `Emitter ${plan.definition.name} uses a stateful plan: ${plan.statelessDiagnostics.join(', ')}`,
+                    `/nodes/${emitterNode.id}`,
+                    emitterNode.id
+                )
+            );
+        }
+        return Object.freeze({
+            nodeId: emitterNode.id,
+            name: plan.definition.name,
+            emitterId: plan.emitterId,
+            planKind: plan.kind,
+            layoutHash: plan.layoutHash,
+            attributes: plan.attributes,
+            moduleNodeIds: Object.freeze(moduleNodeIds),
+            rendererNodeIds: Object.freeze(rendererNodeIds),
+            statelessEligible: plan.statelessEligible,
+            statelessDiagnostics: plan.statelessDiagnostics
+        });
+    });
+    const ir: Readonly<ParticleAuthoringIR> = Object.freeze({
+        schema: PARTICLE_AUTHORING_SCHEMA,
+        version: PARTICLE_AUTHORING_VERSION,
+        systemNodeId: validated.system.id,
+        definitionJSON,
+        definitionHash: definition.hash,
+        compiledPlanHash: compiledPlan.hash,
+        emitters: Object.freeze(emitterIR)
+    });
+    return Object.freeze({
+        success: true,
+        diagnostics: Object.freeze(diagnostics),
+        graph: validated.graph,
+        ir,
+        definition,
+        compiledPlan
+    });
+}

--- a/src/particle/ParticleAuthoringPreview.ts
+++ b/src/particle/ParticleAuthoringPreview.ts
@@ -1,0 +1,422 @@
+import type { ParticleCompilationEnvironment } from './ParticleCompiler';
+import {
+    compileParticleAuthoringGraph,
+    type ParticleAuthoringCompileOptions,
+    type ParticleAuthoringDiagnostic,
+    type ParticleAuthoringGraph,
+    type ParticleAuthoringIR
+} from './ParticleAuthoring';
+import ParticleSystem from './ParticleSystem';
+import type ParticleSystemDefinition from './ParticleSystemDefinition';
+
+/** Current deterministic external particle preview command protocol. */
+export const PARTICLE_PREVIEW_PROTOCOL_VERSION = 1 as const;
+
+/** Commands accepted by `ParticleAuthoringPreviewController`. */
+export type ParticleAuthoringPreviewCommand =
+    'compile' | 'play' | 'pause' | 'restart' | 'seek' | 'step' | 'inspect' | 'dispose';
+
+interface ParticleAuthoringPreviewRequestBase {
+    readonly protocolVersion: typeof PARTICLE_PREVIEW_PROTOCOL_VERSION;
+    readonly requestId: string;
+    readonly command: ParticleAuthoringPreviewCommand;
+}
+
+/** Compile and install one external authoring graph for preview. */
+export interface ParticleAuthoringPreviewCompileRequest extends ParticleAuthoringPreviewRequestBase {
+    readonly command: 'compile';
+    readonly graph: Readonly<ParticleAuthoringGraph>;
+    readonly seed?: number;
+}
+
+/** Playback/control request without a numeric payload. */
+export interface ParticleAuthoringPreviewControlRequest extends ParticleAuthoringPreviewRequestBase {
+    readonly command: 'play' | 'pause' | 'restart' | 'inspect' | 'dispose';
+}
+
+/** Deterministically seek from authored start/prewarm state. */
+export interface ParticleAuthoringPreviewSeekRequest extends ParticleAuthoringPreviewRequestBase {
+    readonly command: 'seek';
+    readonly timeSeconds: number;
+}
+
+/** Advance one explicit preview step regardless of play/pause state. */
+export interface ParticleAuthoringPreviewStepRequest extends ParticleAuthoringPreviewRequestBase {
+    readonly command: 'step';
+    readonly deltaSeconds: number;
+}
+
+/** Closed request union transported between an external editor and preview host. */
+export type ParticleAuthoringPreviewRequest =
+    | ParticleAuthoringPreviewCompileRequest
+    | ParticleAuthoringPreviewControlRequest
+    | ParticleAuthoringPreviewSeekRequest
+    | ParticleAuthoringPreviewStepRequest;
+
+/** Compact backend-neutral preview state; no GPU particle readback is performed. */
+export interface ParticleAuthoringPreviewState {
+    readonly status: 'empty' | 'ready' | 'playing' | 'completed' | 'disposed';
+    readonly timeSeconds: number;
+    readonly definitionHash: string | null;
+    readonly compiledPlanHash: string | null;
+    readonly seed: number | null;
+    readonly aliveCount: number;
+    readonly stateHash: string | null;
+}
+
+/** Structured response returned for every accepted or rejected preview command. */
+export interface ParticleAuthoringPreviewResponse {
+    readonly protocolVersion: typeof PARTICLE_PREVIEW_PROTOCOL_VERSION;
+    readonly requestId: string;
+    readonly command: ParticleAuthoringPreviewCommand | 'invalid';
+    readonly success: boolean;
+    readonly diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[];
+    readonly state: Readonly<ParticleAuthoringPreviewState>;
+    /** Present after successful compilation so external inspectors can rebuild without runtime access. */
+    readonly ir?: Readonly<ParticleAuthoringIR>;
+}
+
+/** Factory used when a preview host needs custom ParticleSystem construction/attachment. */
+export type ParticleAuthoringPreviewSystemFactory = (
+    definition: ParticleSystemDefinition,
+    seed: number,
+    compilationEnvironment?: Readonly<ParticleCompilationEnvironment>
+) => ParticleSystem;
+
+/** Preview host integration hooks and compiler resource/environment policy. */
+export interface ParticleAuthoringPreviewControllerOptions {
+    readonly compileOptions?: Readonly<ParticleAuthoringCompileOptions>;
+    readonly createSystem?: ParticleAuthoringPreviewSystemFactory;
+    /** Release renderer/scene ownership when a compiled preview is replaced or disposed. */
+    readonly disposeSystem?: (system: ParticleSystem) => void;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const COMMANDS = new Set<ParticleAuthoringPreviewCommand>([
+    'compile',
+    'play',
+    'pause',
+    'restart',
+    'seek',
+    'step',
+    'inspect',
+    'dispose'
+]);
+const REQUEST_KEYS: Readonly<Record<ParticleAuthoringPreviewCommand, ReadonlySet<string>>> =
+    Object.freeze({
+        compile: new Set(['protocolVersion', 'requestId', 'command', 'graph', 'seed']),
+        play: new Set(['protocolVersion', 'requestId', 'command']),
+        pause: new Set(['protocolVersion', 'requestId', 'command']),
+        restart: new Set(['protocolVersion', 'requestId', 'command']),
+        seek: new Set(['protocolVersion', 'requestId', 'command', 'timeSeconds']),
+        step: new Set(['protocolVersion', 'requestId', 'command', 'deltaSeconds']),
+        inspect: new Set(['protocolVersion', 'requestId', 'command']),
+        dispose: new Set(['protocolVersion', 'requestId', 'command'])
+    });
+
+function isRecord(value: unknown): value is UnknownRecord {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function previewDiagnostic(
+    code: string,
+    diagnosticMessage: string,
+    path: string
+): Readonly<ParticleAuthoringDiagnostic> {
+    return Object.freeze({ severity: 'error', code, message: diagnosticMessage, path });
+}
+
+function message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Deterministic preview command adapter. The controller owns simulation time and never renders;
+ * hosts render the current `system` through the ordinary Renderer/Stage contract.
+ */
+export class ParticleAuthoringPreviewController {
+    readonly #options: Readonly<ParticleAuthoringPreviewControllerOptions>;
+    #system: ParticleSystem | null = null;
+    #timeSeconds = 0;
+    #playing = false;
+    #disposed = false;
+
+    constructor(options: Readonly<ParticleAuthoringPreviewControllerOptions> = {}) {
+        this.#options = Object.freeze({ ...options });
+    }
+
+    /** Current preview node for host-owned scene attachment/rendering. */
+    get system(): ParticleSystem | null {
+        return this.#system;
+    }
+
+    /** Validate and execute one protocol request without throwing authoring errors. */
+    handle(request: unknown): Readonly<ParticleAuthoringPreviewResponse> {
+        const parsed = this.parseRequest(request);
+        if ('diagnostic' in parsed) {
+            return this.response(parsed.requestId, parsed.command, false, [parsed.diagnostic]);
+        }
+        const command = parsed.request.command;
+        if (this.#disposed) {
+            return this.response(parsed.request.requestId, command, false, [
+                previewDiagnostic(
+                    'preview.disposed',
+                    'Particle preview controller is disposed',
+                    '/command'
+                )
+            ]);
+        }
+        try {
+            switch (parsed.request.command) {
+                case 'compile':
+                    return this.compile(parsed.request);
+                case 'play':
+                    return this.withSystem(parsed.request.requestId, command, system => {
+                        this.#playing = !system.completed;
+                    });
+                case 'pause':
+                    return this.withSystem(parsed.request.requestId, command, () => {
+                        this.#playing = false;
+                    });
+                case 'restart':
+                    return this.withSystem(parsed.request.requestId, command, system => {
+                        system.restart().pause();
+                        this.#timeSeconds = 0;
+                        this.#playing = false;
+                    });
+                case 'seek': {
+                    const timeSeconds = parsed.request.timeSeconds;
+                    return this.withSystem(parsed.request.requestId, command, system => {
+                        system.restart().pause().simulate(timeSeconds);
+                        this.#timeSeconds = Math.fround(timeSeconds);
+                        this.#playing = false;
+                    });
+                }
+                case 'step': {
+                    const deltaSeconds = parsed.request.deltaSeconds;
+                    return this.withSystem(parsed.request.requestId, command, system => {
+                        system.simulate(deltaSeconds);
+                        this.#timeSeconds = Math.fround(this.#timeSeconds + deltaSeconds);
+                        if (system.completed) this.#playing = false;
+                    });
+                }
+                case 'inspect':
+                    return this.response(parsed.request.requestId, command, true, []);
+                case 'dispose':
+                    this.releaseSystem();
+                    this.#disposed = true;
+                    this.#playing = false;
+                    this.#timeSeconds = 0;
+                    return this.response(parsed.request.requestId, command, true, []);
+            }
+        } catch (error) {
+            return this.response(parsed.request.requestId, command, false, [
+                previewDiagnostic('preview.command.failed', message(error), '/command')
+            ]);
+        }
+    }
+
+    private compile(
+        request: Readonly<ParticleAuthoringPreviewCompileRequest>
+    ): Readonly<ParticleAuthoringPreviewResponse> {
+        const result = compileParticleAuthoringGraph(request.graph, this.#options.compileOptions);
+        if (!result.success) {
+            return this.response(request.requestId, request.command, false, result.diagnostics);
+        }
+        const seed = request.seed ?? 0;
+        const compilationEnvironment = this.#options.compileOptions?.compilationEnvironment;
+        const system = this.#options.createSystem
+            ? this.#options.createSystem(result.definition, seed, compilationEnvironment)
+            : new ParticleSystem({
+                  definition: result.definition,
+                  seed,
+                  autoPlay: false,
+                  ...(compilationEnvironment === undefined ? {} : { compilationEnvironment })
+              });
+        if (!(system instanceof ParticleSystem)) {
+            throw new TypeError('Particle preview system factory must return a ParticleSystem');
+        }
+        system.restart().pause();
+        this.releaseSystem();
+        this.#system = system;
+        this.#timeSeconds = 0;
+        this.#playing = false;
+        return this.response(
+            request.requestId,
+            request.command,
+            true,
+            result.diagnostics,
+            result.ir
+        );
+    }
+
+    private withSystem(
+        requestId: string,
+        command: ParticleAuthoringPreviewCommand,
+        operation: (system: ParticleSystem) => void
+    ): Readonly<ParticleAuthoringPreviewResponse> {
+        if (this.#system === null) {
+            return this.response(requestId, command, false, [
+                previewDiagnostic(
+                    'preview.system.missing',
+                    'Compile a particle graph before preview control',
+                    '/command'
+                )
+            ]);
+        }
+        operation(this.#system);
+        return this.response(requestId, command, true, []);
+    }
+
+    private releaseSystem(): void {
+        if (this.#system !== null) this.#options.disposeSystem?.(this.#system);
+        this.#system = null;
+    }
+
+    private state(): Readonly<ParticleAuthoringPreviewState> {
+        const system = this.#system;
+        const status: ParticleAuthoringPreviewState['status'] = this.#disposed
+            ? 'disposed'
+            : system === null
+              ? 'empty'
+              : system.completed
+                ? 'completed'
+                : this.#playing
+                  ? 'playing'
+                  : 'ready';
+        return Object.freeze({
+            status,
+            timeSeconds: this.#timeSeconds,
+            definitionHash: system?.definition.hash ?? null,
+            compiledPlanHash: system?.compiledPlan.hash ?? null,
+            seed: system?.seed ?? null,
+            aliveCount: system?.aliveCount ?? 0,
+            stateHash: system?.stateHash() ?? null
+        });
+    }
+
+    private response(
+        requestId: string,
+        command: ParticleAuthoringPreviewCommand | 'invalid',
+        success: boolean,
+        diagnostics: readonly Readonly<ParticleAuthoringDiagnostic>[],
+        ir?: Readonly<ParticleAuthoringIR>
+    ): Readonly<ParticleAuthoringPreviewResponse> {
+        return Object.freeze({
+            protocolVersion: PARTICLE_PREVIEW_PROTOCOL_VERSION,
+            requestId,
+            command,
+            success,
+            diagnostics: Object.freeze([...diagnostics]),
+            state: this.state(),
+            ...(ir === undefined ? {} : { ir })
+        });
+    }
+
+    private parseRequest(request: unknown):
+        | { readonly request: Readonly<ParticleAuthoringPreviewRequest> }
+        | {
+              readonly requestId: string;
+              readonly command: ParticleAuthoringPreviewCommand | 'invalid';
+              readonly diagnostic: Readonly<ParticleAuthoringDiagnostic>;
+          } {
+        if (!isRecord(request)) {
+            return {
+                requestId: '<invalid>',
+                command: 'invalid',
+                diagnostic: previewDiagnostic(
+                    'preview.request.type',
+                    'Particle preview request must be an object',
+                    ''
+                )
+            };
+        }
+        const requestId =
+            typeof request['requestId'] === 'string' ? request['requestId'] : '<invalid>';
+        const rawCommand = request['command'];
+        const command: ParticleAuthoringPreviewCommand | 'invalid' =
+            typeof rawCommand === 'string' &&
+            COMMANDS.has(rawCommand as ParticleAuthoringPreviewCommand)
+                ? (rawCommand as ParticleAuthoringPreviewCommand)
+                : 'invalid';
+        const fail = (
+            code: string,
+            text: string,
+            path: string
+        ): {
+            readonly requestId: string;
+            readonly command: ParticleAuthoringPreviewCommand | 'invalid';
+            readonly diagnostic: Readonly<ParticleAuthoringDiagnostic>;
+        } => ({ requestId, command, diagnostic: previewDiagnostic(code, text, path) });
+        if (request['protocolVersion'] !== PARTICLE_PREVIEW_PROTOCOL_VERSION) {
+            return fail(
+                'preview.request.version',
+                `Particle preview protocol version must be ${String(PARTICLE_PREVIEW_PROTOCOL_VERSION)}`,
+                '/protocolVersion'
+            );
+        }
+        if (!/^[A-Za-z0-9_.:-]+$/u.test(requestId)) {
+            return fail(
+                'preview.request.id',
+                'Particle preview request id is invalid',
+                '/requestId'
+            );
+        }
+        if (command === 'invalid') {
+            return fail(
+                'preview.request.command',
+                'Particle preview command is invalid',
+                '/command'
+            );
+        }
+        const allowed = REQUEST_KEYS[command];
+        const extra = Object.keys(request).find(key => !allowed.has(key));
+        if (extra !== undefined) {
+            return fail(
+                'preview.request.unknown-field',
+                `Unknown particle preview request field ${extra}`,
+                `/${extra}`
+            );
+        }
+        if (command === 'compile') {
+            if (!isRecord(request['graph'])) {
+                return fail(
+                    'preview.request.graph',
+                    'Compile request requires a graph object',
+                    '/graph'
+                );
+            }
+            const seed = request['seed'];
+            if (
+                seed !== undefined &&
+                (!Number.isSafeInteger(seed) ||
+                    (seed as number) < 0 ||
+                    (seed as number) > 0xffff_ffff)
+            ) {
+                return fail('preview.request.seed', 'Compile request seed must be uint32', '/seed');
+            }
+        }
+        if (command === 'seek') {
+            const time = request['timeSeconds'];
+            if (typeof time !== 'number' || !Number.isFinite(time) || time < 0) {
+                return fail(
+                    'preview.request.time',
+                    'Seek time must be finite and non-negative',
+                    '/timeSeconds'
+                );
+            }
+        }
+        if (command === 'step') {
+            const delta = request['deltaSeconds'];
+            if (typeof delta !== 'number' || !Number.isFinite(delta) || delta < 0) {
+                return fail(
+                    'preview.request.delta',
+                    'Step delta must be finite and non-negative',
+                    '/deltaSeconds'
+                );
+            }
+        }
+        return { request: request as unknown as Readonly<ParticleAuthoringPreviewRequest> };
+    }
+}

--- a/src/particle/ParticleBaking.ts
+++ b/src/particle/ParticleBaking.ts
@@ -1,0 +1,489 @@
+import type {
+    RenderTargetColorAttachmentReadback,
+    RenderTargetColorFormat
+} from '../render/RenderTarget';
+import type { ParticleCompiledEmitterPlan } from './ParticleCompiledPlan';
+import type ParticleSystem from './ParticleSystem';
+import type { ParticleSimulationSpace } from './ParticleTypes';
+import type { ParticleCPUState } from './cpu/ParticleCPUState';
+
+/** Current deterministic particle baking artifact format. */
+export const PARTICLE_BAKE_VERSION = 1 as const;
+
+/** Shared fixed-rate, half-open timeline used by particle baking. */
+export interface ParticleBakeTimelineOptions {
+    /** Sampled duration in seconds. */
+    readonly duration: number;
+    /** Samples per second. */
+    readonly frameRate: number;
+    /** Seconds simulated before the first captured frame. Defaults to zero. */
+    readonly startTime?: number;
+    /** Add one exact sample at `startTime + duration`. Defaults to false. */
+    readonly includeEnd?: boolean;
+    /** Safety limit for generated frames. Defaults to 4096. */
+    readonly maxFrames?: number;
+}
+
+/** Options for deterministic CPU particle instance-stream baking. */
+export interface ParticleMeshCacheOptions extends ParticleBakeTimelineOptions {
+    /** Optional named emitter. Omit to bake every emitter containing a mesh renderer. */
+    readonly emitter?: string;
+    /** Safety limit across all materialized emitter/frame particle records. Defaults to 1048576. */
+    readonly maxSampledParticles?: number;
+}
+
+/** One emitter's frame-major particle instance streams. */
+export interface ParticleBakedMeshEmitter {
+    readonly name: string;
+    readonly emitterId: number;
+    readonly capacity: number;
+    readonly simulationSpace: ParticleSimulationSpace;
+    /** Per-frame record boundaries; frame N occupies `[offsets[N], offsets[N + 1])`. */
+    readonly frameOffsets: Uint32Array;
+    readonly stableIds: Uint32Array;
+    readonly generations: Uint32Array;
+    readonly positions: Float32Array;
+    readonly previousPositions: Float32Array;
+    readonly velocities: Float32Array;
+    readonly sizes: Float32Array;
+    readonly rotations: Float32Array;
+    readonly colors: Float32Array;
+    readonly meshIndices: Uint32Array;
+    /** Per-frame `[xMin, yMin, zMin, xMax, yMax, zMax]`, or zeros for an empty frame. */
+    readonly frameBounds: Float32Array;
+    readonly storageByteLength: number;
+}
+
+/** Portable frame-major instance data baked from CPU or CPU-materialized stateless simulation. */
+export interface ParticleMeshCache {
+    readonly version: typeof PARTICLE_BAKE_VERSION;
+    readonly definitionHash: string;
+    readonly seed: number;
+    readonly duration: number;
+    readonly frameRate: number;
+    readonly startTime: number;
+    readonly includeEnd: boolean;
+    readonly frameCount: number;
+    readonly frameTimes: Float32Array;
+    readonly emitters: readonly Readonly<ParticleBakedMeshEmitter>[];
+    readonly storageByteLength: number;
+}
+
+/** Context supplied to an offline flipbook renderer/readback callback. */
+export interface ParticleFlipbookFrameContext {
+    readonly system: ParticleSystem;
+    readonly frameIndex: number;
+    readonly timeSeconds: number;
+}
+
+/** Options for packing real render-target captures into one flipbook atlas. */
+export interface ParticleFlipbookOptions extends ParticleBakeTimelineOptions {
+    /** Render and asynchronously read one tightly packed color attachment. */
+    readonly captureFrame: (
+        context: Readonly<ParticleFlipbookFrameContext>
+    ) => RenderTargetColorAttachmentReadback | PromiseLike<RenderTargetColorAttachmentReadback>;
+    /** Atlas column count. Defaults to a near-square layout. */
+    readonly columns?: number;
+    /** Safety limit for either atlas dimension. Defaults to 16384. */
+    readonly maxTextureSize?: number;
+    /** Safety limit for the packed atlas payload. Defaults to 256 MiB. */
+    readonly maxAtlasByteLength?: number;
+}
+
+/** One tightly packed native-format flipbook atlas produced from real rendered frames. */
+export interface ParticleFlipbook {
+    readonly version: typeof PARTICLE_BAKE_VERSION;
+    readonly definitionHash: string;
+    readonly seed: number;
+    readonly duration: number;
+    readonly frameRate: number;
+    readonly startTime: number;
+    readonly includeEnd: boolean;
+    readonly frameCount: number;
+    readonly frameTimes: Float32Array;
+    readonly frameWidth: number;
+    readonly frameHeight: number;
+    readonly columns: number;
+    readonly rows: number;
+    readonly width: number;
+    readonly height: number;
+    readonly format: RenderTargetColorFormat;
+    readonly bytesPerPixel: number;
+    readonly data: Uint8Array;
+    /** Top-left atlas-space `[uMin, vMin, uMax, vMax]` for each frame. */
+    readonly frameUVs: Float32Array;
+    readonly storageByteLength: number;
+}
+
+/** @internal */
+export interface ParticleBakeTimeline {
+    readonly duration: number;
+    readonly frameRate: number;
+    readonly startTime: number;
+    readonly includeEnd: boolean;
+    readonly times: readonly number[];
+    readonly frameTimes: Float32Array;
+}
+
+function requireFiniteNonNegative(value: number, label: string): number {
+    if (!Number.isFinite(value) || value < 0) {
+        throw new RangeError(`${label} must be finite and non-negative`);
+    }
+    return value;
+}
+
+function requirePositive(value: number, label: string): number {
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new RangeError(`${label} must be finite and positive`);
+    }
+    return value;
+}
+
+function requirePositiveSafeInteger(value: number, label: string): number {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new RangeError(`${label} must be a positive safe integer`);
+    }
+    return value;
+}
+
+/** @internal */
+export function createParticleBakeTimeline(
+    options: Readonly<ParticleBakeTimelineOptions>
+): Readonly<ParticleBakeTimeline> {
+    const duration = requirePositive(options.duration, 'Particle bake duration');
+    const frameRate = requirePositive(options.frameRate, 'Particle bake frame rate');
+    const startTime = requireFiniteNonNegative(options.startTime ?? 0, 'Particle bake start time');
+    const maxFrames = requirePositiveSafeInteger(
+        options.maxFrames ?? 4096,
+        'Particle bake maximum frame count'
+    );
+    if (!Number.isFinite(startTime + duration)) {
+        throw new RangeError('Particle bake timeline end must be finite');
+    }
+    const regularFrameCount = Math.max(1, Math.ceil(duration * frameRate - 1e-9));
+    const frameCount = regularFrameCount + (options.includeEnd === true ? 1 : 0);
+    if (!Number.isSafeInteger(frameCount) || frameCount > maxFrames) {
+        throw new RangeError(
+            `Particle bake frame count ${String(frameCount)} exceeds limit ${String(maxFrames)}`
+        );
+    }
+    const times: number[] = [];
+    for (let index = 0; index < regularFrameCount; index += 1) {
+        times.push(startTime + index / frameRate);
+    }
+    if (options.includeEnd === true) times.push(startTime + duration);
+    return Object.freeze({
+        duration,
+        frameRate,
+        startTime,
+        includeEnd: options.includeEnd === true,
+        times: Object.freeze(times),
+        frameTimes: Float32Array.from(times, value => Math.fround(value))
+    });
+}
+
+function appendVector(
+    values: number[],
+    source: Float32Array,
+    offset: number,
+    components: number
+): void {
+    for (let component = 0; component < components; component += 1) {
+        values.push(source[offset + component] ?? 0);
+    }
+}
+
+/** Accumulates one stable-ID-sorted frame-major mesh emitter stream. @internal */
+export class ParticleMeshCacheBuilder {
+    readonly #plan: Readonly<ParticleCompiledEmitterPlan>;
+    readonly #frameOffsets: number[] = [0];
+    readonly #stableIds: number[] = [];
+    readonly #generations: number[] = [];
+    readonly #positions: number[] = [];
+    readonly #previousPositions: number[] = [];
+    readonly #velocities: number[] = [];
+    readonly #sizes: number[] = [];
+    readonly #rotations: number[] = [];
+    readonly #colors: number[] = [];
+    readonly #meshIndices: number[] = [];
+    readonly #frameBounds: number[] = [];
+
+    constructor(plan: Readonly<ParticleCompiledEmitterPlan>) {
+        if (!plan.definition.renderers.some(renderer => renderer.type === 'mesh')) {
+            throw new TypeError(
+                `Particle emitter ${plan.definition.name} has no mesh renderer to bake`
+            );
+        }
+        this.#plan = plan;
+    }
+
+    append(state: ParticleCPUState): number {
+        const required = [
+            'stable-id',
+            'generation',
+            'position',
+            'previous-position',
+            'velocity',
+            'size',
+            'rotation',
+            'color',
+            'mesh-index'
+        ] as const;
+        for (const name of required) {
+            if (!state.has(name)) {
+                throw new TypeError(
+                    `Particle mesh cache attribute ${name} is unavailable for ${this.#plan.definition.name}`
+                );
+            }
+        }
+        const stableIds = state.u32('stable-id');
+        const generations = state.u32('generation');
+        const positions = state.f32('position');
+        const previousPositions = state.f32('previous-position');
+        const velocities = state.f32('velocity');
+        const sizes = state.f32('size');
+        const rotations = state.f32('rotation');
+        const colors = state.f32('color');
+        const meshIndices = state.u32('mesh-index');
+        const indices = Array.from({ length: state.aliveCount }, (_value, index) => index);
+        indices.sort((left, right) => {
+            const generationDifference = (generations[left] ?? 0) - (generations[right] ?? 0);
+            return generationDifference !== 0
+                ? generationDifference
+                : (stableIds[left] ?? 0) - (stableIds[right] ?? 0);
+        });
+        let xMin = Number.POSITIVE_INFINITY;
+        let yMin = Number.POSITIVE_INFINITY;
+        let zMin = Number.POSITIVE_INFINITY;
+        let xMax = Number.NEGATIVE_INFINITY;
+        let yMax = Number.NEGATIVE_INFINITY;
+        let zMax = Number.NEGATIVE_INFINITY;
+        for (const index of indices) {
+            const offset3 = index * 3;
+            const offset4 = index * 4;
+            const size = sizes[index] ?? 1;
+            const radius = size * 0.5;
+            const x = positions[offset3] ?? 0;
+            const y = positions[offset3 + 1] ?? 0;
+            const z = positions[offset3 + 2] ?? 0;
+            this.#stableIds.push(stableIds[index] ?? 0);
+            this.#generations.push(generations[index] ?? 0);
+            appendVector(this.#positions, positions, offset3, 3);
+            appendVector(this.#previousPositions, previousPositions, offset3, 3);
+            appendVector(this.#velocities, velocities, offset3, 3);
+            this.#sizes.push(size);
+            this.#rotations.push(rotations[index] ?? 0);
+            appendVector(this.#colors, colors, offset4, 4);
+            this.#meshIndices.push(meshIndices[index] ?? 0);
+            xMin = Math.min(xMin, x - radius);
+            yMin = Math.min(yMin, y - radius);
+            zMin = Math.min(zMin, z - radius);
+            xMax = Math.max(xMax, x + radius);
+            yMax = Math.max(yMax, y + radius);
+            zMax = Math.max(zMax, z + radius);
+        }
+        if (indices.length === 0) {
+            this.#frameBounds.push(0, 0, 0, 0, 0, 0);
+        } else {
+            this.#frameBounds.push(xMin, yMin, zMin, xMax, yMax, zMax);
+        }
+        this.#frameOffsets.push(this.#stableIds.length);
+        return indices.length;
+    }
+
+    finish(): Readonly<ParticleBakedMeshEmitter> {
+        const frameOffsets = Uint32Array.from(this.#frameOffsets);
+        const stableIds = Uint32Array.from(this.#stableIds);
+        const generations = Uint32Array.from(this.#generations);
+        const positions = Float32Array.from(this.#positions, value => Math.fround(value));
+        const previousPositions = Float32Array.from(this.#previousPositions, value =>
+            Math.fround(value)
+        );
+        const velocities = Float32Array.from(this.#velocities, value => Math.fround(value));
+        const sizes = Float32Array.from(this.#sizes, value => Math.fround(value));
+        const rotations = Float32Array.from(this.#rotations, value => Math.fround(value));
+        const colors = Float32Array.from(this.#colors, value => Math.fround(value));
+        const meshIndices = Uint32Array.from(this.#meshIndices);
+        const frameBounds = Float32Array.from(this.#frameBounds, value => Math.fround(value));
+        const storageByteLength =
+            frameOffsets.byteLength +
+            stableIds.byteLength +
+            generations.byteLength +
+            positions.byteLength +
+            previousPositions.byteLength +
+            velocities.byteLength +
+            sizes.byteLength +
+            rotations.byteLength +
+            colors.byteLength +
+            meshIndices.byteLength +
+            frameBounds.byteLength;
+        return Object.freeze({
+            name: this.#plan.definition.name,
+            emitterId: this.#plan.emitterId,
+            capacity: this.#plan.definition.capacity,
+            simulationSpace: this.#plan.definition.simulationSpace,
+            frameOffsets,
+            stableIds,
+            generations,
+            positions,
+            previousPositions,
+            velocities,
+            sizes,
+            rotations,
+            colors,
+            meshIndices,
+            frameBounds,
+            storageByteLength
+        });
+    }
+}
+
+/** @internal */
+export function createParticleMeshCache(
+    definitionHash: string,
+    seed: number,
+    timeline: Readonly<ParticleBakeTimeline>,
+    emitters: readonly Readonly<ParticleBakedMeshEmitter>[]
+): Readonly<ParticleMeshCache> {
+    const storageByteLength =
+        timeline.frameTimes.byteLength +
+        emitters.reduce((total, emitter) => total + emitter.storageByteLength, 0);
+    return Object.freeze({
+        version: PARTICLE_BAKE_VERSION,
+        definitionHash,
+        seed,
+        duration: timeline.duration,
+        frameRate: timeline.frameRate,
+        startTime: timeline.startTime,
+        includeEnd: timeline.includeEnd,
+        frameCount: timeline.times.length,
+        frameTimes: timeline.frameTimes,
+        emitters: Object.freeze([...emitters]),
+        storageByteLength
+    });
+}
+
+function validateFlipbookFrame(
+    frame: Readonly<RenderTargetColorAttachmentReadback>,
+    first?: Readonly<RenderTargetColorAttachmentReadback>
+): void {
+    if (
+        !Number.isSafeInteger(frame.width) ||
+        frame.width <= 0 ||
+        !Number.isSafeInteger(frame.height) ||
+        frame.height <= 0 ||
+        !Number.isSafeInteger(frame.bytesPerPixel) ||
+        frame.bytesPerPixel <= 0 ||
+        frame.bytesPerRow !== frame.width * frame.bytesPerPixel ||
+        frame.data.length !== frame.bytesPerRow * frame.height
+    ) {
+        throw new TypeError('Particle flipbook capture must be a tightly packed color readback');
+    }
+    if (
+        first !== undefined &&
+        (frame.width !== first.width ||
+            frame.height !== first.height ||
+            frame.format !== first.format ||
+            frame.bytesPerPixel !== first.bytesPerPixel)
+    ) {
+        throw new TypeError('Particle flipbook frames must use one extent and color format');
+    }
+}
+
+/** Pack validated real render-target readbacks into a row-major atlas. @internal */
+export function createParticleFlipbook(
+    definitionHash: string,
+    seed: number,
+    timeline: Readonly<ParticleBakeTimeline>,
+    frames: readonly Readonly<RenderTargetColorAttachmentReadback>[],
+    options: Readonly<
+        Pick<ParticleFlipbookOptions, 'columns' | 'maxTextureSize' | 'maxAtlasByteLength'>
+    >
+): Readonly<ParticleFlipbook> {
+    if (frames.length !== timeline.times.length || frames.length === 0) {
+        throw new RangeError('Particle flipbook capture count does not match its timeline');
+    }
+    const first = frames[0];
+    if (first === undefined) throw new Error('Particle flipbook first frame is unavailable');
+    validateFlipbookFrame(first);
+    for (const frame of frames) validateFlipbookFrame(frame, first);
+    const columns = requirePositiveSafeInteger(
+        options.columns ?? Math.ceil(Math.sqrt(frames.length)),
+        'Particle flipbook column count'
+    );
+    if (columns > frames.length) {
+        throw new RangeError('Particle flipbook column count cannot exceed its frame count');
+    }
+    const rows = Math.ceil(frames.length / columns);
+    const width = first.width * columns;
+    const height = first.height * rows;
+    if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height)) {
+        throw new RangeError('Particle flipbook atlas extent exceeds the safe integer range');
+    }
+    const maxTextureSize = requirePositiveSafeInteger(
+        options.maxTextureSize ?? 16_384,
+        'Particle flipbook maximum texture size'
+    );
+    if (width > maxTextureSize || height > maxTextureSize) {
+        throw new RangeError(
+            `Particle flipbook atlas ${String(width)}x${String(height)} exceeds ${String(maxTextureSize)}`
+        );
+    }
+    const byteLength = width * height * first.bytesPerPixel;
+    if (!Number.isSafeInteger(byteLength)) {
+        throw new RangeError('Particle flipbook atlas byte length exceeds the safe integer range');
+    }
+    const maxAtlasByteLength = requirePositiveSafeInteger(
+        options.maxAtlasByteLength ?? 268_435_456,
+        'Particle flipbook maximum atlas byte length'
+    );
+    if (byteLength > maxAtlasByteLength) {
+        throw new RangeError(
+            `Particle flipbook atlas byte length ${String(byteLength)} exceeds ${String(maxAtlasByteLength)}`
+        );
+    }
+    const data = new Uint8Array(byteLength);
+    const frameUVs = new Float32Array(frames.length * 4);
+    for (let frameIndex = 0; frameIndex < frames.length; frameIndex += 1) {
+        const frame = frames[frameIndex];
+        if (frame === undefined) throw new Error('Particle flipbook frame is unavailable');
+        const column = frameIndex % columns;
+        const row = Math.floor(frameIndex / columns);
+        for (let y = 0; y < first.height; y += 1) {
+            const sourceOffset = y * frame.bytesPerRow;
+            const destinationOffset =
+                ((row * first.height + y) * width + column * first.width) * first.bytesPerPixel;
+            data.set(
+                frame.data.subarray(sourceOffset, sourceOffset + frame.bytesPerRow),
+                destinationOffset
+            );
+        }
+        const uvOffset = frameIndex * 4;
+        frameUVs[uvOffset] = column / columns;
+        frameUVs[uvOffset + 1] = row / rows;
+        frameUVs[uvOffset + 2] = (column + 1) / columns;
+        frameUVs[uvOffset + 3] = (row + 1) / rows;
+    }
+    return Object.freeze({
+        version: PARTICLE_BAKE_VERSION,
+        definitionHash,
+        seed,
+        duration: timeline.duration,
+        frameRate: timeline.frameRate,
+        startTime: timeline.startTime,
+        includeEnd: timeline.includeEnd,
+        frameCount: timeline.times.length,
+        frameTimes: timeline.frameTimes,
+        frameWidth: first.width,
+        frameHeight: first.height,
+        columns,
+        rows,
+        width,
+        height,
+        format: first.format,
+        bytesPerPixel: first.bytesPerPixel,
+        data,
+        frameUVs,
+        storageByteLength: timeline.frameTimes.byteLength + data.byteLength + frameUVs.byteLength
+    });
+}

--- a/src/particle/ParticleDefinitionSerialization.ts
+++ b/src/particle/ParticleDefinitionSerialization.ts
@@ -1,0 +1,996 @@
+import Geometry from '../geometry/Geometry';
+import Texture from '../texture/Texture';
+import {
+    compileParticleSystemDefinition,
+    type ParticleCompilationEnvironment
+} from './ParticleCompiler';
+import ParticleCurve, { type ParticleCurveKeyframe } from './ParticleCurve';
+import ParticleGradient, { type ParticleGradientKey } from './ParticleGradient';
+import {
+    ParticleParameter,
+    type ParticleParameterType,
+    type ParticleParameterValue
+} from './ParticleParameter';
+import ParticleSystemDefinition from './ParticleSystemDefinition';
+import {
+    PARTICLE_DEFINITION_VERSION,
+    type ParticleEmitterDefinitionInput,
+    type ParticleSystemDefinitionInput
+} from './ParticleTypes';
+
+/** Stable identifier stored at the root of every serialized particle definition. */
+export const PARTICLE_DEFINITION_SCHEMA = 'hilo3d.particle-system' as const;
+
+/** JSON value accepted by the version upgrade and definition serialization APIs. */
+export type ParticleDefinitionJSONValue =
+    | null
+    | boolean
+    | number
+    | string
+    | ParticleDefinitionJSONRecord
+    | readonly ParticleDefinitionJSONValue[];
+
+/** JSON object accepted by the version upgrade and definition serialization APIs. */
+export interface ParticleDefinitionJSONRecord {
+    readonly [key: string]: ParticleDefinitionJSONValue;
+}
+
+/** One serialized parameter declaration referenced by stable document-local identity. */
+export interface ParticleDefinitionJSONParameter extends ParticleDefinitionJSONRecord {
+    /** Stable document-local identity used by parameter reference tags. */
+    readonly id: string;
+    /** Public runtime parameter name. */
+    readonly name: string;
+    /** Runtime value kind enforced when the parameter token is recreated. */
+    readonly type: ParticleParameterType;
+    /** Tagged JSON representation of the immutable default value. */
+    readonly defaultValue: ParticleDefinitionJSONValue;
+}
+
+/** Current versioned JSON representation of an immutable particle-system definition. */
+export interface ParticleSystemDefinitionJSON extends ParticleDefinitionJSONRecord {
+    /** Stable particle document family identifier. */
+    readonly schema: typeof PARTICLE_DEFINITION_SCHEMA;
+    /** Current particle document schema version. */
+    readonly version: typeof PARTICLE_DEFINITION_VERSION;
+    /** Shared parameter declarations referenced by emitters. */
+    readonly parameters: readonly ParticleDefinitionJSONParameter[];
+    /** Serialized emitter authoring records. */
+    readonly emitters: readonly ParticleDefinitionJSONRecord[];
+}
+
+/** Opaque engine resource kinds represented by stable application-owned asset identifiers. */
+export type ParticleDefinitionResourceKind = 'texture' | 'geometry';
+
+/** Opaque engine resources that require application-owned identifiers in JSON. */
+export type ParticleDefinitionResource = Texture<unknown> | Geometry;
+
+/** Options used while converting a runtime definition into portable JSON data. */
+export interface ParticleDefinitionSerializationOptions {
+    /** Return a stable asset identifier for every Texture or Geometry encountered. */
+    readonly getResourceId?: (
+        resource: ParticleDefinitionResource,
+        kind: ParticleDefinitionResourceKind
+    ) => string;
+}
+
+/** One sequential JSON schema upgrade. The returned document must use `fromVersion + 1`. */
+export interface ParticleDefinitionUpgrade {
+    /** Source version accepted by this step. */
+    readonly fromVersion: number;
+    /** Produce a plain JSON document whose version is exactly `fromVersion + 1`. */
+    readonly upgrade: (
+        document: Readonly<ParticleDefinitionJSONRecord>
+    ) => Readonly<ParticleDefinitionJSONRecord>;
+}
+
+/** Options used while upgrading and materializing a serialized definition. */
+export interface ParticleDefinitionDeserializationOptions {
+    /** Resolve stable asset identifiers without embedding runtime object IDs in the document. */
+    readonly resolveResource?: (
+        kind: ParticleDefinitionResourceKind,
+        id: string
+    ) => ParticleDefinitionResource;
+    /** Sequential application-owned upgrades for schema versions older than the engine version. */
+    readonly upgrades?: readonly ParticleDefinitionUpgrade[];
+    /** Optional compile target used for backend-specific definition validation. */
+    readonly compilationEnvironment?: Readonly<ParticleCompilationEnvironment>;
+}
+
+type MutableJSONRecord = Record<string, ParticleDefinitionJSONValue>;
+
+const PARAMETER_TYPES = new Set<ParticleParameterType>([
+    'float',
+    'uint',
+    'boolean',
+    'vector2',
+    'vector3',
+    'vector4',
+    'color',
+    'texture',
+    'curve',
+    'gradient'
+]);
+
+function isParticleParameter(value: unknown): value is ParticleParameter {
+    return value instanceof ParticleParameter;
+}
+
+const EMITTER_KEYS = new Set([
+    'name',
+    'capacity',
+    'execution',
+    'duration',
+    'looping',
+    'startDelay',
+    'prewarm',
+    'fixedStep',
+    'maxCatchUpSteps',
+    'simulationSpace',
+    'overflow',
+    'culling',
+    'eventCapacity',
+    'eventOverflow',
+    'bounds',
+    'emission',
+    'shape',
+    'initialize',
+    'modules',
+    'renderers'
+]);
+
+const MODULE_KEYS: Readonly<Record<string, ReadonlySet<string>>> = Object.freeze({
+    'velocity-over-lifetime': new Set(['type', 'velocity', 'space']),
+    'force-over-lifetime': new Set(['type', 'force', 'space']),
+    gravity: new Set(['type', 'force', 'space']),
+    wind: new Set(['type', 'force', 'space']),
+    drag: new Set(['type', 'coefficient']),
+    'limit-velocity': new Set(['type', 'limit', 'dampen']),
+    'inherit-emitter-velocity': new Set(['type', 'multiplier']),
+    noise: new Set([
+        'type',
+        'mode',
+        'field',
+        'strength',
+        'frequency',
+        'octaves',
+        'lacunarity',
+        'persistence',
+        'scrollVelocity',
+        'damping',
+        'space',
+        'seedOffset'
+    ]),
+    'alpha-over-lifetime': new Set(['type', 'curve', 'cycles']),
+    'size-over-lifetime': new Set(['type', 'curve', 'cycles']),
+    'rotation-over-lifetime': new Set(['type', 'curve', 'cycles']),
+    'frame-over-lifetime': new Set(['type', 'curve', 'cycles']),
+    'color-over-lifetime': new Set(['type', 'gradient']),
+    'size-by-speed': new Set(['type', 'speedRange', 'curve']),
+    'rotation-by-speed': new Set(['type', 'speedRange', 'curve']),
+    'color-by-speed': new Set(['type', 'speedRange', 'gradient']),
+    'texture-sheet': new Set(['type', 'mode', 'rows', 'columns', 'cycles', 'fps', 'speedRange']),
+    'radial-force': new Set(['type', 'center', 'strength', 'axis']),
+    'orbital-force': new Set(['type', 'center', 'strength', 'axis']),
+    'vortex-force': new Set(['type', 'center', 'strength', 'axis']),
+    'point-attraction': new Set(['type', 'point', 'lineStart', 'lineEnd', 'strength']),
+    'line-attraction': new Set(['type', 'point', 'lineStart', 'lineEnd', 'strength']),
+    'rotate-around-point': new Set(['type', 'center', 'axis', 'angularSpeed']),
+    'conform-sphere': new Set(['type', 'center', 'radius', 'strength']),
+    'lifetime-by-emitter-speed': new Set(['type', 'speedRange', 'lifetimeRange']),
+    'kill-speed': new Set(['type', 'range']),
+    'kill-distance': new Set(['type', 'range']),
+    'kill-plane': new Set(['type', 'center', 'size', 'radius', 'normal', 'offset', 'mode']),
+    'kill-box': new Set(['type', 'center', 'size', 'radius', 'normal', 'offset', 'mode']),
+    'kill-sphere': new Set(['type', 'center', 'size', 'radius', 'normal', 'offset', 'mode']),
+    'camera-offset': new Set(['type', 'range', 'scale']),
+    'camera-fade': new Set(['type', 'range', 'scale']),
+    'screen-space-size': new Set(['type', 'range', 'scale']),
+    'custom-channel': new Set(['type', 'name', 'valueType', 'value']),
+    'vector-field': new Set(['type', 'texture', 'strength']),
+    collision: new Set([
+        'type',
+        'colliders',
+        'bounce',
+        'friction',
+        'radiusScale',
+        'lifetimeLoss',
+        'event'
+    ]),
+    trigger: new Set(['type', 'volumes', 'events']),
+    'scene-depth-collision': new Set(['type', 'thickness', 'bounce', 'friction', 'event']),
+    'sub-emitter': new Set(['type', 'event', 'emitter', 'count', 'inheritVelocity'])
+});
+
+const SURFACE_KEYS = [
+    'texture',
+    'coverage',
+    'alphaCutoff',
+    'blend',
+    'lighting',
+    'depthTest',
+    'depthWrite',
+    'sort',
+    'renderOrder',
+    'composition'
+] as const;
+
+const RENDERER_KEYS: Readonly<Record<string, ReadonlySet<string>>> = Object.freeze({
+    sprite: new Set([
+        'type',
+        'texture',
+        'alignment',
+        'blend',
+        'depthTest',
+        'depthWrite',
+        'sort',
+        'renderOrder',
+        'pivot',
+        'stretchScale',
+        'softParticle'
+    ]),
+    mesh: new Set(['type', 'meshes', 'orientation', 'motionVectors', ...SURFACE_KEYS]),
+    ribbon: new Set([
+        'type',
+        'facing',
+        'widthScale',
+        'uvMode',
+        'tilesPerUnit',
+        'softParticle',
+        ...SURFACE_KEYS
+    ]),
+    trail: new Set([
+        'type',
+        'facing',
+        'widthScale',
+        'uvMode',
+        'tilesPerUnit',
+        'softParticle',
+        ...SURFACE_KEYS
+    ])
+});
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Readonly<Record<string, unknown>> {
+    if (!isRecord(value)) throw new TypeError(`${label} must be an object`);
+    return value;
+}
+
+function requireString(value: unknown, label: string): string {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`${label} must be a non-empty string`);
+    }
+    return value;
+}
+
+function requireExactKeys(
+    record: Readonly<Record<string, unknown>>,
+    allowed: ReadonlySet<string>,
+    label: string
+): void {
+    for (const key of Object.keys(record)) {
+        if (!allowed.has(key)) throw new TypeError(`${label}.${key} is not part of the schema`);
+    }
+}
+
+function requireArray(value: unknown, label: string): readonly unknown[] {
+    if (!Array.isArray(value)) throw new TypeError(`${label} must be an array`);
+    return value;
+}
+
+function snapshotJSON(
+    value: unknown,
+    label: string,
+    seen = new Set<object>()
+): ParticleDefinitionJSONValue {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) throw new TypeError(`${label} must contain finite numbers`);
+        return value;
+    }
+    if (typeof value !== 'object') throw new TypeError(`${label} contains a non-JSON value`);
+    if (seen.has(value)) throw new TypeError(`${label} contains a cycle`);
+    seen.add(value);
+    try {
+        if (Array.isArray(value)) {
+            return Object.freeze(
+                value.map((item, index) => snapshotJSON(item, `${label}[${String(index)}]`, seen))
+            );
+        }
+        const prototype = Object.getPrototypeOf(value) as object | null;
+        if (prototype !== Object.prototype && prototype !== null) {
+            throw new TypeError(`${label} must contain only JSON objects`);
+        }
+        const source = value as Readonly<Record<string, unknown>>;
+        const result: MutableJSONRecord = {};
+        for (const key of Object.keys(source).sort()) {
+            result[key] = snapshotJSON(source[key], `${label}.${key}`, seen);
+        }
+        return Object.freeze(result);
+    } finally {
+        seen.delete(value);
+    }
+}
+
+function requireJSONRecord(
+    value: ParticleDefinitionJSONValue,
+    label: string
+): Readonly<ParticleDefinitionJSONRecord> {
+    if (value === null || Array.isArray(value) || typeof value !== 'object') {
+        throw new TypeError(`${label} must be a JSON object`);
+    }
+    return value as Readonly<ParticleDefinitionJSONRecord>;
+}
+
+function requireVersion(record: Readonly<ParticleDefinitionJSONRecord>, label: string): number {
+    const version = record['version'];
+    if (!Number.isSafeInteger(version) || typeof version !== 'number' || version < 0) {
+        throw new TypeError(`${label}.version must be a non-negative safe integer`);
+    }
+    return version;
+}
+
+function upgradeDocument(
+    source: unknown,
+    upgrades: readonly ParticleDefinitionUpgrade[]
+): Readonly<ParticleDefinitionJSONRecord> {
+    let document = requireJSONRecord(
+        snapshotJSON(source, 'Particle definition JSON'),
+        'Particle definition JSON'
+    );
+    let version = requireVersion(document, 'Particle definition JSON');
+    if (version > PARTICLE_DEFINITION_VERSION) {
+        throw new RangeError(
+            `Particle definition version ${String(version)} is newer than supported version ${String(PARTICLE_DEFINITION_VERSION)}`
+        );
+    }
+    const steps = new Map<number, ParticleDefinitionUpgrade>();
+    for (const step of upgrades) {
+        if (!Number.isSafeInteger(step.fromVersion) || step.fromVersion < 0) {
+            throw new TypeError(
+                'Particle definition upgrade fromVersion must be a non-negative safe integer'
+            );
+        }
+        if (steps.has(step.fromVersion)) {
+            throw new TypeError(
+                `Particle definition has duplicate upgrade from version ${String(step.fromVersion)}`
+            );
+        }
+        steps.set(step.fromVersion, step);
+    }
+    while (version < PARTICLE_DEFINITION_VERSION) {
+        const step = steps.get(version);
+        if (!step) {
+            throw new RangeError(
+                `Particle definition has no upgrade from version ${String(version)}`
+            );
+        }
+        const upgraded = requireJSONRecord(
+            snapshotJSON(step.upgrade(document), `Particle definition upgrade ${String(version)}`),
+            `Particle definition upgrade ${String(version)}`
+        );
+        const nextVersion = requireVersion(
+            upgraded,
+            `Particle definition upgrade ${String(version)}`
+        );
+        if (nextVersion !== version + 1) {
+            throw new RangeError(
+                `Particle definition upgrade ${String(version)} must produce version ${String(version + 1)}`
+            );
+        }
+        document = upgraded;
+        version = nextVersion;
+    }
+    return document;
+}
+
+function normalizedEmitterRecord(emitter: ParticleSystemDefinition['emitters'][number]): object {
+    return {
+        name: emitter.name,
+        capacity: emitter.capacity,
+        execution: emitter.execution,
+        duration: emitter.duration,
+        looping: emitter.looping,
+        startDelay: emitter.startDelay,
+        prewarm: emitter.prewarm,
+        fixedStep: emitter.fixedStep,
+        maxCatchUpSteps: emitter.maxCatchUpSteps,
+        simulationSpace: emitter.simulationSpace,
+        overflow: emitter.overflow,
+        culling: emitter.culling,
+        eventCapacity: emitter.eventCapacity,
+        eventOverflow: emitter.eventOverflow,
+        bounds: emitter.bounds,
+        emission: emitter.emission,
+        shape: emitter.shape,
+        initialize: emitter.initialize,
+        modules: emitter.modules,
+        renderers: emitter.renderers
+    };
+}
+
+interface EncodeContext {
+    readonly options: Readonly<ParticleDefinitionSerializationOptions>;
+    readonly parameterIds: Map<ParticleParameter, string>;
+    readonly parameters: ParticleDefinitionJSONParameter[];
+    readonly resources: Map<string, ParticleDefinitionResource>;
+    readonly seen: Set<object>;
+}
+
+function requireResourceId(
+    resource: ParticleDefinitionResource,
+    kind: ParticleDefinitionResourceKind,
+    context: EncodeContext
+): string {
+    const getResourceId = context.options.getResourceId;
+    if (!getResourceId) {
+        throw new TypeError(
+            `Particle definition contains a ${kind} resource; getResourceId is required for serialization`
+        );
+    }
+    const id = requireString(getResourceId(resource, kind), `Particle ${kind} resource id`);
+    const key = `${kind}\u0000${id}`;
+    const previous = context.resources.get(key);
+    if (previous !== undefined && previous !== resource) {
+        throw new TypeError(`Particle ${kind} resource id ${id} refers to multiple objects`);
+    }
+    context.resources.set(key, resource);
+    return id;
+}
+
+function encodeValue(
+    value: unknown,
+    context: EncodeContext,
+    label: string
+): ParticleDefinitionJSONValue {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) throw new TypeError(`${label} must be finite`);
+        return value;
+    }
+    if (isParticleParameter(value)) {
+        let id = context.parameterIds.get(value);
+        if (id === undefined) {
+            id = `p${String(context.parameters.length)}`;
+            context.parameterIds.set(value, id);
+            const defaultValue = encodeValue(value.defaultValue, context, `${label}.defaultValue`);
+            context.parameters.push(
+                Object.freeze({ id, name: value.name, type: value.type, defaultValue })
+            );
+        }
+        return Object.freeze({ $type: 'parameter', id });
+    }
+    if (value instanceof ParticleCurve) {
+        return Object.freeze({
+            $type: 'curve',
+            wrap: value.wrap,
+            interpolation: value.interpolation,
+            keys: encodeValue(value.keys, context, `${label}.keys`)
+        });
+    }
+    if (value instanceof ParticleGradient) {
+        return Object.freeze({
+            $type: 'gradient',
+            keys: encodeValue(value.keys, context, `${label}.keys`)
+        });
+    }
+    if (value instanceof Texture) {
+        return Object.freeze({
+            $type: 'resource',
+            kind: 'texture',
+            id: requireResourceId(value, 'texture', context)
+        });
+    }
+    if (value instanceof Geometry) {
+        return Object.freeze({
+            $type: 'resource',
+            kind: 'geometry',
+            id: requireResourceId(value, 'geometry', context)
+        });
+    }
+    if (typeof value !== 'object') {
+        throw new TypeError(`${label} contains a non-JSON value`);
+    }
+    if (context.seen.has(value)) throw new TypeError(`${label} contains a cycle`);
+    context.seen.add(value);
+    try {
+        if (Array.isArray(value)) {
+            return Object.freeze(
+                value.map((item, index) => encodeValue(item, context, `${label}[${String(index)}]`))
+            );
+        }
+        const prototype = Object.getPrototypeOf(value) as object | null;
+        if (prototype !== Object.prototype && prototype !== null) {
+            throw new TypeError(`${label} contains an unsupported object`);
+        }
+        const source = value as Readonly<Record<string, unknown>>;
+        if ('$type' in source) throw new TypeError(`${label} uses reserved key $type`);
+        const result: MutableJSONRecord = {};
+        for (const key of Object.keys(source).sort()) {
+            result[key] = encodeValue(source[key], context, `${label}.${key}`);
+        }
+        return Object.freeze(result);
+    } finally {
+        context.seen.delete(value);
+    }
+}
+
+interface DecodeContext {
+    readonly parameters: ReadonlyMap<string, ParticleParameter>;
+    readonly options: Readonly<ParticleDefinitionDeserializationOptions>;
+    readonly resources: Map<string, ParticleDefinitionResource>;
+}
+
+function decodeCurve(record: Readonly<Record<string, unknown>>, label: string): ParticleCurve {
+    requireExactKeys(record, new Set(['$type', 'wrap', 'interpolation', 'keys']), label);
+    const wrap = record['wrap'];
+    if (wrap !== 'clamp' && wrap !== 'loop' && wrap !== 'ping-pong') {
+        throw new TypeError(`${label}.wrap is invalid`);
+    }
+    const interpolation = record['interpolation'];
+    if (interpolation !== 'linear' && interpolation !== 'smooth') {
+        throw new TypeError(`${label}.interpolation is invalid`);
+    }
+    const keys = requireArray(record['keys'], `${label}.keys`).map((value, index) => {
+        const key = requireRecord(value, `${label}.keys[${String(index)}]`);
+        requireExactKeys(key, new Set(['time', 'value']), `${label}.keys[${String(index)}]`);
+        return { time: key['time'], value: key['value'] } as ParticleCurveKeyframe;
+    });
+    return new ParticleCurve(keys, {
+        wrap,
+        interpolation
+    });
+}
+
+function decodeGradient(
+    record: Readonly<Record<string, unknown>>,
+    label: string
+): ParticleGradient {
+    requireExactKeys(record, new Set(['$type', 'keys']), label);
+    const keys = requireArray(record['keys'], `${label}.keys`).map((value, index) => {
+        const key = requireRecord(value, `${label}.keys[${String(index)}]`);
+        requireExactKeys(key, new Set(['time', 'color']), `${label}.keys[${String(index)}]`);
+        return { time: key['time'], color: key['color'] } as ParticleGradientKey;
+    });
+    return new ParticleGradient(keys);
+}
+
+function decodeResource(
+    record: Readonly<Record<string, unknown>>,
+    context: DecodeContext,
+    label: string
+): ParticleDefinitionResource {
+    requireExactKeys(record, new Set(['$type', 'kind', 'id']), label);
+    const kind = record['kind'];
+    if (kind !== 'texture' && kind !== 'geometry') throw new TypeError(`${label}.kind is invalid`);
+    const id = requireString(record['id'], `${label}.id`);
+    const cacheKey = `${kind}\u0000${id}`;
+    const cached = context.resources.get(cacheKey);
+    if (cached) return cached;
+    const resolveResource = context.options.resolveResource;
+    if (!resolveResource) {
+        throw new TypeError(
+            `Particle definition references ${kind} resource ${id}; resolveResource is required`
+        );
+    }
+    const resource = resolveResource(kind, id);
+    if (kind === 'texture' ? !(resource instanceof Texture) : !(resource instanceof Geometry)) {
+        throw new TypeError(`Particle ${kind} resource ${id} resolved to the wrong object type`);
+    }
+    context.resources.set(cacheKey, resource);
+    return resource;
+}
+
+function decodeValue(value: unknown, context: DecodeContext, label: string): unknown {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) throw new TypeError(`${label} must be finite`);
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.map((item, index) => decodeValue(item, context, `${label}[${String(index)}]`));
+    }
+    const record = requireRecord(value, label);
+    if ('$type' in record) {
+        const type = record['$type'];
+        if (type === 'curve') return decodeCurve(record, label);
+        if (type === 'gradient') return decodeGradient(record, label);
+        if (type === 'resource') return decodeResource(record, context, label);
+        if (type === 'parameter') {
+            requireExactKeys(record, new Set(['$type', 'id']), label);
+            const id = requireString(record['id'], `${label}.id`);
+            const parameter = context.parameters.get(id);
+            if (!parameter) throw new TypeError(`${label} references unknown parameter ${id}`);
+            return parameter;
+        }
+        throw new TypeError(`${label} has unknown tagged value ${String(type)}`);
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(record)) {
+        result[key] = decodeValue(record[key], context, `${label}.${key}`);
+    }
+    return result;
+}
+
+function requireDiscriminatedRecord(
+    value: unknown,
+    keySets: Readonly<Record<string, ReadonlySet<string>>>,
+    label: string
+): Readonly<Record<string, unknown>> {
+    const record = requireRecord(value, label);
+    const type = requireString(record['type'], `${label}.type`);
+    const keys = keySets[type];
+    if (!keys) throw new TypeError(`${label}.type ${type} is unsupported`);
+    requireExactKeys(record, keys, label);
+    return record;
+}
+
+function requireOptionalEnum(
+    record: Readonly<Record<string, unknown>>,
+    key: string,
+    values: ReadonlySet<string>,
+    label: string
+): void {
+    const value = record[key];
+    if (value !== undefined && (typeof value !== 'string' || !values.has(value))) {
+        throw new TypeError(`${label}.${key} is invalid`);
+    }
+}
+
+function validateRangeRecord(value: unknown, label: string): void {
+    if (
+        !isRecord(value) ||
+        value instanceof ParticleParameter ||
+        value instanceof ParticleCurve ||
+        value instanceof ParticleGradient ||
+        value instanceof Texture ||
+        value instanceof Geometry
+    ) {
+        return;
+    }
+    requireExactKeys(value, new Set(['min', 'max']), label);
+    if (!('min' in value) || !('max' in value)) {
+        throw new TypeError(`${label} range must contain min and max`);
+    }
+}
+
+function validateModuleRecord(module: Readonly<Record<string, unknown>>, label: string): void {
+    const type = module['type'];
+    requireOptionalEnum(module, 'space', new Set(['local', 'world']), label);
+    switch (type) {
+        case 'velocity-over-lifetime':
+            validateRangeRecord(module['velocity'], `${label}.velocity`);
+            return;
+        case 'force-over-lifetime':
+        case 'gravity':
+        case 'wind':
+            validateRangeRecord(module['force'], `${label}.force`);
+            return;
+        case 'limit-velocity':
+            validateRangeRecord(module['limit'], `${label}.limit`);
+            return;
+        case 'noise':
+            requireOptionalEnum(module, 'mode', new Set(['position-offset', 'force']), label);
+            requireOptionalEnum(module, 'field', new Set(['vector', 'curl']), label);
+            validateRangeRecord(module['strength'], `${label}.strength`);
+            return;
+        case 'texture-sheet':
+            requireOptionalEnum(module, 'mode', new Set(['lifetime', 'speed', 'fps']), label);
+            return;
+        case 'radial-force':
+        case 'orbital-force':
+        case 'vortex-force':
+        case 'point-attraction':
+        case 'line-attraction':
+            validateRangeRecord(module['strength'], `${label}.strength`);
+            return;
+        case 'rotate-around-point':
+            validateRangeRecord(module['angularSpeed'], `${label}.angularSpeed`);
+            return;
+        case 'kill-plane':
+        case 'kill-box':
+        case 'kill-sphere':
+            requireOptionalEnum(module, 'mode', new Set(['inside', 'outside']), label);
+            return;
+        case 'custom-channel':
+            requireOptionalEnum(
+                module,
+                'valueType',
+                new Set(['float', 'vec2', 'vec3', 'vec4', 'color']),
+                label
+            );
+            return;
+    }
+}
+
+function validateRendererRecord(renderer: Readonly<Record<string, unknown>>, label: string): void {
+    requireOptionalEnum(
+        renderer,
+        'blend',
+        new Set(['alpha', 'premultiplied-alpha', 'additive']),
+        label
+    );
+    requireOptionalEnum(
+        renderer,
+        'sort',
+        new Set(['none', 'distance', 'youngest', 'oldest']),
+        label
+    );
+    requireOptionalEnum(renderer, 'coverage', new Set(['opaque', 'masked', 'transparent']), label);
+    requireOptionalEnum(renderer, 'lighting', new Set(['unlit', 'lambert']), label);
+    requireOptionalEnum(renderer, 'composition', new Set(['scene']), label);
+    if (renderer['type'] === 'sprite') {
+        requireOptionalEnum(
+            renderer,
+            'alignment',
+            new Set(['view', 'world-up', 'stretched', 'velocity']),
+            label
+        );
+    } else if (renderer['type'] === 'mesh') {
+        requireOptionalEnum(renderer, 'orientation', new Set(['rotation', 'velocity']), label);
+    } else {
+        requireOptionalEnum(renderer, 'facing', new Set(['view', 'world-up']), label);
+        requireOptionalEnum(renderer, 'uvMode', new Set(['stretch', 'repeat']), label);
+    }
+}
+
+function validateColliderRecords(value: unknown, label: string): void {
+    const keys: Readonly<Record<string, ReadonlySet<string>>> = {
+        plane: new Set(['type', 'normal', 'offset']),
+        sphere: new Set(['type', 'center', 'radius']),
+        box: new Set(['type', 'center', 'size']),
+        capsule: new Set(['type', 'start', 'end', 'radius'])
+    };
+    for (const [index, collider] of requireArray(value, label).entries()) {
+        requireDiscriminatedRecord(collider, keys, `${label}[${String(index)}]`);
+    }
+}
+
+function validateDecodedEmitter(value: unknown, index: number): void {
+    const label = `Particle definition emitters[${String(index)}]`;
+    const emitter = requireRecord(value, label);
+    requireExactKeys(emitter, EMITTER_KEYS, label);
+    requireOptionalEnum(emitter, 'execution', new Set(['auto', 'cpu', 'gpu', 'stateless']), label);
+    requireOptionalEnum(emitter, 'simulationSpace', new Set(['local', 'world']), label);
+    requireOptionalEnum(emitter, 'overflow', new Set(['drop-new', 'replace-oldest']), label);
+    requireOptionalEnum(
+        emitter,
+        'culling',
+        new Set(['render-only', 'pause', 'pause-and-catch-up', 'stop']),
+        label
+    );
+    requireOptionalEnum(emitter, 'eventOverflow', new Set(['drop-new', 'drop-oldest']), label);
+    if (emitter['bounds'] !== undefined) {
+        const boundsKeys: Readonly<Record<string, ReadonlySet<string>>> = {
+            automatic: new Set(['mode']),
+            dynamic: new Set(['mode']),
+            manual: new Set(['mode', 'min', 'max'])
+        };
+        const bounds = requireRecord(emitter['bounds'], `${label}.bounds`);
+        const mode = requireString(bounds['mode'], `${label}.bounds.mode`);
+        const keys = boundsKeys[mode];
+        if (!keys) throw new TypeError(`${label}.bounds.mode ${mode} is unsupported`);
+        requireExactKeys(bounds, keys, `${label}.bounds`);
+    }
+    if (emitter['emission'] !== undefined) {
+        const emission = requireRecord(emitter['emission'], `${label}.emission`);
+        requireExactKeys(
+            emission,
+            new Set(['rateOverTime', 'rateOverDistance', 'bursts']),
+            `${label}.emission`
+        );
+        validateRangeRecord(emission['rateOverTime'], `${label}.emission.rateOverTime`);
+        validateRangeRecord(emission['rateOverDistance'], `${label}.emission.rateOverDistance`);
+        if (emission['bursts'] !== undefined) {
+            for (const [burstIndex, burstValue] of requireArray(
+                emission['bursts'],
+                `${label}.emission.bursts`
+            ).entries()) {
+                requireExactKeys(
+                    requireRecord(burstValue, `${label}.emission.bursts[${String(burstIndex)}]`),
+                    new Set(['time', 'count', 'cycles', 'interval']),
+                    `${label}.emission.bursts[${String(burstIndex)}]`
+                );
+            }
+        }
+    }
+    if (emitter['initialize'] !== undefined) {
+        const initialize = requireRecord(emitter['initialize'], `${label}.initialize`);
+        requireExactKeys(
+            initialize,
+            new Set([
+                'lifetime',
+                'position',
+                'direction',
+                'speed',
+                'color',
+                'size',
+                'rotation',
+                'mass',
+                'meshIndex',
+                'ribbonId'
+            ]),
+            `${label}.initialize`
+        );
+        for (const key of Object.keys(initialize)) {
+            validateRangeRecord(initialize[key], `${label}.initialize.${key}`);
+        }
+    }
+    const shapeKeys: Readonly<Record<string, ReadonlySet<string>>> = {
+        point: new Set(['type', 'distribution', 'arc', 'thickness']),
+        line: new Set(['type', 'start', 'end', 'distribution', 'arc', 'thickness']),
+        edge: new Set(['type', 'start', 'end', 'distribution', 'arc', 'thickness']),
+        box: new Set(['type', 'size', 'distribution', 'arc', 'thickness']),
+        circle: new Set(['type', 'radius', 'distribution', 'arc', 'thickness']),
+        disc: new Set(['type', 'radius', 'distribution', 'arc', 'thickness']),
+        sphere: new Set(['type', 'radius', 'distribution', 'arc', 'thickness']),
+        hemisphere: new Set(['type', 'radius', 'distribution', 'arc', 'thickness']),
+        cone: new Set(['type', 'radius', 'angle', 'length', 'distribution', 'arc', 'thickness']),
+        torus: new Set(['type', 'radius', 'tubeRadius', 'distribution', 'arc', 'thickness']),
+        donut: new Set(['type', 'radius', 'tubeRadius', 'distribution', 'arc', 'thickness'])
+    };
+    if (emitter['shape'] !== undefined)
+        requireDiscriminatedRecord(emitter['shape'], shapeKeys, `${label}.shape`);
+    if (emitter['shape'] !== undefined) {
+        requireOptionalEnum(
+            requireRecord(emitter['shape'], `${label}.shape`),
+            'distribution',
+            new Set(['surface', 'volume']),
+            `${label}.shape`
+        );
+    }
+    if (emitter['modules'] !== undefined) {
+        for (const [moduleIndex, moduleValue] of requireArray(
+            emitter['modules'],
+            `${label}.modules`
+        ).entries()) {
+            const moduleLabel = `${label}.modules[${String(moduleIndex)}]`;
+            const module = requireDiscriminatedRecord(moduleValue, MODULE_KEYS, moduleLabel);
+            validateModuleRecord(module, moduleLabel);
+            if (module['type'] === 'collision')
+                validateColliderRecords(module['colliders'], `${moduleLabel}.colliders`);
+            if (module['type'] === 'trigger')
+                validateColliderRecords(module['volumes'], `${moduleLabel}.volumes`);
+            if (module['type'] === 'trigger' && module['events'] !== undefined) {
+                requireExactKeys(
+                    requireRecord(module['events'], `${moduleLabel}.events`),
+                    new Set(['inside', 'enter', 'exit']),
+                    `${moduleLabel}.events`
+                );
+            }
+        }
+    }
+    for (const [rendererIndex, rendererValue] of requireArray(
+        emitter['renderers'],
+        `${label}.renderers`
+    ).entries()) {
+        const rendererLabel = `${label}.renderers[${String(rendererIndex)}]`;
+        const renderer = requireDiscriminatedRecord(rendererValue, RENDERER_KEYS, rendererLabel);
+        validateRendererRecord(renderer, rendererLabel);
+        if (renderer['softParticle'] !== undefined) {
+            requireExactKeys(
+                requireRecord(renderer['softParticle'], `${rendererLabel}.softParticle`),
+                new Set(['distance', 'contrast']),
+                `${rendererLabel}.softParticle`
+            );
+        }
+        if (renderer['type'] === 'mesh') {
+            for (const [assetIndex, asset] of requireArray(
+                renderer['meshes'],
+                `${rendererLabel}.meshes`
+            ).entries()) {
+                requireExactKeys(
+                    requireRecord(asset, `${rendererLabel}.meshes[${String(assetIndex)}]`),
+                    new Set(['geometry', 'texture']),
+                    `${rendererLabel}.meshes[${String(assetIndex)}]`
+                );
+            }
+        }
+    }
+}
+
+/** Convert an immutable runtime definition into a deeply frozen, versioned JSON document. */
+export function serializeParticleSystemDefinition(
+    definition: ParticleSystemDefinition,
+    options: Readonly<ParticleDefinitionSerializationOptions> = {}
+): Readonly<ParticleSystemDefinitionJSON> {
+    if (!(definition instanceof ParticleSystemDefinition)) {
+        throw new TypeError(
+            'serializeParticleSystemDefinition requires a ParticleSystemDefinition'
+        );
+    }
+    const context: EncodeContext = {
+        options,
+        parameterIds: new Map(),
+        parameters: [],
+        resources: new Map(),
+        seen: new Set()
+    };
+    const emitters = definition.emitters.map((emitter, index) =>
+        requireJSONRecord(
+            encodeValue(normalizedEmitterRecord(emitter), context, `emitters[${String(index)}]`),
+            `emitters[${String(index)}]`
+        )
+    );
+    return Object.freeze({
+        schema: PARTICLE_DEFINITION_SCHEMA,
+        version: PARTICLE_DEFINITION_VERSION,
+        parameters: Object.freeze(context.parameters),
+        emitters: Object.freeze(emitters)
+    });
+}
+
+/** Upgrade, strictly decode, validate, and snapshot a particle JSON document. */
+export function deserializeParticleSystemDefinition(
+    source: unknown,
+    options: Readonly<ParticleDefinitionDeserializationOptions> = {}
+): ParticleSystemDefinition {
+    const document = upgradeDocument(source, options.upgrades ?? []);
+    requireExactKeys(
+        document,
+        new Set(['schema', 'version', 'parameters', 'emitters']),
+        'Particle definition JSON'
+    );
+    if (document['schema'] !== PARTICLE_DEFINITION_SCHEMA) {
+        throw new TypeError(`Particle definition schema must be ${PARTICLE_DEFINITION_SCHEMA}`);
+    }
+    if (document['version'] !== PARTICLE_DEFINITION_VERSION) {
+        throw new RangeError(
+            `Particle definition version must be ${String(PARTICLE_DEFINITION_VERSION)}`
+        );
+    }
+    const parameterRecords = requireArray(
+        document['parameters'],
+        'Particle definition JSON.parameters'
+    );
+    const parameters = new Map<string, ParticleParameter>();
+    const context: DecodeContext = { parameters, options, resources: new Map() };
+    for (const [index, value] of parameterRecords.entries()) {
+        const label = `Particle definition JSON.parameters[${String(index)}]`;
+        const record = requireRecord(value, label);
+        requireExactKeys(record, new Set(['id', 'name', 'type', 'defaultValue']), label);
+        const id = requireString(record['id'], `${label}.id`);
+        if (parameters.has(id))
+            throw new TypeError(`Particle definition has duplicate parameter id ${id}`);
+        const name = requireString(record['name'], `${label}.name`);
+        const type = record['type'];
+        if (typeof type !== 'string' || !PARAMETER_TYPES.has(type as ParticleParameterType)) {
+            throw new TypeError(`${label}.type is invalid`);
+        }
+        const defaultValue = decodeValue(record['defaultValue'], context, `${label}.defaultValue`);
+        parameters.set(
+            id,
+            new ParticleParameter(
+                name,
+                type as ParticleParameterType,
+                defaultValue as ParticleParameterValue
+            )
+        );
+    }
+    const emitterValues = requireArray(
+        document['emitters'],
+        'Particle definition JSON.emitters'
+    ).map((value, index) =>
+        decodeValue(value, context, `Particle definition emitters[${String(index)}]`)
+    );
+    emitterValues.forEach(validateDecodedEmitter);
+    const definition = ParticleSystemDefinition.create({
+        version: PARTICLE_DEFINITION_VERSION,
+        emitters: emitterValues as readonly ParticleEmitterDefinitionInput[]
+    } satisfies ParticleSystemDefinitionInput);
+    compileParticleSystemDefinition(definition, options.compilationEnvironment);
+    return definition;
+}
+
+/** Parse JSON text before applying the same upgrade, resource, and validation contract. */
+export function parseParticleSystemDefinitionJSON(
+    source: string,
+    options: Readonly<ParticleDefinitionDeserializationOptions> = {}
+): ParticleSystemDefinition {
+    if (typeof source !== 'string')
+        throw new TypeError('Particle definition JSON source must be a string');
+    return deserializeParticleSystemDefinition(JSON.parse(source) as unknown, options);
+}

--- a/src/particle/ParticleSimulationCache.ts
+++ b/src/particle/ParticleSimulationCache.ts
@@ -1,0 +1,108 @@
+import type ParticleSystemDefinition from './ParticleSystemDefinition';
+import type { ParticleParameterSet } from './ParticleParameter';
+import type { ParticleEventRecord } from './cpu/ParticleCPUEventBuffer';
+import type { ParticleCPUSimulatorSnapshot } from './cpu/ParticleCPUSimulator';
+import type { ParticleStatelessRuntimeSnapshot } from './stateless/ParticleStatelessRuntime';
+
+/** Current in-memory deterministic particle simulation cache format. */
+export const PARTICLE_SIMULATION_CACHE_VERSION = 1 as const;
+
+interface ParticleEmitterSimulationSnapshotBase {
+    readonly emitterId: number;
+    readonly definitionHash: string;
+    readonly layoutHash: string;
+    readonly statelessAge: number;
+    readonly budgetEnabled: boolean;
+    readonly budgetParticleLimit: number;
+    readonly budgetSpawnRateScale: number;
+    readonly budgetSorting: boolean;
+    readonly budgetSoftParticles: boolean;
+    readonly budgetCollision: boolean;
+    readonly budgetRibbons: boolean;
+    readonly culledSeconds: number;
+    readonly stoppedByCulling: boolean;
+    readonly storageByteLength: number;
+}
+
+/** @internal */
+export type ParticleEmitterSimulationSnapshot =
+    | (ParticleEmitterSimulationSnapshotBase & {
+          readonly runtimeKind: 'cpu-stateful';
+          readonly simulation: Readonly<ParticleCPUSimulatorSnapshot>;
+      })
+    | (ParticleEmitterSimulationSnapshotBase & {
+          readonly runtimeKind: 'stateless-cpu';
+          readonly simulation: Readonly<ParticleStatelessRuntimeSnapshot>;
+      })
+    | (ParticleEmitterSimulationSnapshotBase & {
+          readonly runtimeKind: 'stateless-gpu';
+          readonly simulation: null;
+      });
+
+/** @internal */
+export interface ParticleSystemSimulationSnapshot {
+    readonly definition: ParticleSystemDefinition;
+    readonly parameters: ParticleParameterSet;
+    readonly definitionHash: string;
+    readonly compiledPlanHash: string;
+    readonly seed: number;
+    readonly parameterRevision: number;
+    readonly eventReadbackCapacity: number;
+    readonly playing: boolean;
+    readonly timeScale: number;
+    readonly elapsedSeconds: number;
+    readonly completed: boolean;
+    readonly eventQueue: readonly Readonly<ParticleEventRecord>[];
+    readonly eventDroppedCount: number;
+    readonly emitters: readonly Readonly<ParticleEmitterSimulationSnapshot>[];
+    readonly storageByteLength: number;
+}
+
+/**
+ * Opaque reusable in-memory checkpoint for deterministic particle replay.
+ *
+ * A cache is intentionally bound to the immutable definition, compiled plan, seed, parameter-set
+ * identity/revision, and event-readback capacity from which it was captured. It is not a serialized
+ * asset; use definition serialization for persistence and particle baking for portable output.
+ */
+export interface ParticleSimulationCache {
+    readonly version: typeof PARTICLE_SIMULATION_CACHE_VERSION;
+    readonly definitionHash: string;
+    readonly compiledPlanHash: string;
+    readonly seed: number;
+    readonly parameterRevision: number;
+    readonly elapsedSeconds: number;
+    readonly emitterCount: number;
+    /** Copied typed-array storage retained by this cache, excluding JavaScript metadata. */
+    readonly storageByteLength: number;
+}
+
+const simulationSnapshots = new WeakMap<
+    ParticleSimulationCache,
+    Readonly<ParticleSystemSimulationSnapshot>
+>();
+
+/** @internal */
+export function createParticleSimulationCache(
+    snapshot: Readonly<ParticleSystemSimulationSnapshot>
+): ParticleSimulationCache {
+    const cache: ParticleSimulationCache = Object.freeze({
+        version: PARTICLE_SIMULATION_CACHE_VERSION,
+        definitionHash: snapshot.definitionHash,
+        compiledPlanHash: snapshot.compiledPlanHash,
+        seed: snapshot.seed,
+        parameterRevision: snapshot.parameterRevision,
+        elapsedSeconds: snapshot.elapsedSeconds,
+        emitterCount: snapshot.emitters.length,
+        storageByteLength: snapshot.storageByteLength
+    });
+    simulationSnapshots.set(cache, snapshot);
+    return cache;
+}
+
+/** @internal */
+export function readParticleSimulationCache(
+    cache: ParticleSimulationCache
+): Readonly<ParticleSystemSimulationSnapshot> | undefined {
+    return simulationSnapshots.get(cache);
+}

--- a/src/particle/ParticleSystem.ts
+++ b/src/particle/ParticleSystem.ts
@@ -5,6 +5,7 @@ import Sphere from '../math/Sphere';
 import Vector3 from '../math/Vector3';
 import type { Renderer } from '../render/Renderer';
 import type { RendererContract } from '../render/RendererCore';
+import type { RenderTargetColorAttachmentReadback } from '../render/RenderTarget';
 import type { RenderPipelineContext } from '../render/pipeline/RenderPipeline';
 import type { RenderGraphTextureHandle } from '../render/pipeline/ScriptableRenderGraph';
 import {
@@ -13,8 +14,25 @@ import {
 } from './ParticleCompiler';
 import type { ParticleCompiledEmitterPlan, ParticleCompiledPlan } from './ParticleCompiledPlan';
 import type { ParticleBudgetDecision, ParticleBudgetRequest } from './ParticleBudget';
+import {
+    createParticleBakeTimeline,
+    createParticleFlipbook,
+    createParticleMeshCache,
+    ParticleMeshCacheBuilder,
+    type ParticleFlipbook,
+    type ParticleFlipbookOptions,
+    type ParticleMeshCache,
+    type ParticleMeshCacheOptions
+} from './ParticleBaking';
 import type ParticleSystemDefinition from './ParticleSystemDefinition';
 import { ParticleParameterSet, resolveParticleParameter } from './ParticleParameter';
+import {
+    createParticleSimulationCache,
+    readParticleSimulationCache,
+    type ParticleEmitterSimulationSnapshot,
+    type ParticleSimulationCache,
+    type ParticleSystemSimulationSnapshot
+} from './ParticleSimulationCache';
 import type { ParticleScalarSource, ParticleVector3 } from './ParticleTypes';
 import { createParticleCPUWriters, type ParticleCPUWriter } from './cpu/ParticleCPUWriter';
 import {
@@ -128,6 +146,18 @@ function particleNodeParameters(
     return nodeParameters;
 }
 
+function snapshotParticleEvent(
+    event: Readonly<ParticleEventRecord>
+): Readonly<ParticleEventRecord> {
+    return Object.freeze({
+        name: event.name,
+        emitter: event.emitter,
+        stableId: event.stableId,
+        position: Object.freeze([...event.position] as ParticleVector3),
+        velocity: Object.freeze([...event.velocity] as ParticleVector3)
+    });
+}
+
 /** Runtime scene node for immutable compiled particle-system definitions. */
 class ParticleSystem extends Node {
     static override readonly typeName = 'ParticleSystem';
@@ -153,6 +183,7 @@ class ParticleSystem extends Node {
     #completed = false;
     #gpuRenderer: RendererContract | null = null;
     #eventDroppedCount = 0;
+    #baking = false;
 
     constructor(parameters: Readonly<ParticleSystemParameters>) {
         const input: unknown = parameters;
@@ -584,7 +615,355 @@ class ParticleSystem extends Node {
             .join(':');
     }
 
+    /**
+     * Bake stable-ID-sorted frame-major instance streams for authored mesh emitters.
+     *
+     * The system is restored to its exact simulation checkpoint after the synchronous bake.
+     */
+    bakeMeshCache(options: Readonly<ParticleMeshCacheOptions>): ParticleMeshCache {
+        if (this.#baking) throw new Error('ParticleSystem already has an active bake');
+        const timeline = createParticleBakeTimeline(options);
+        const maxSampledParticles = options.maxSampledParticles ?? 1_048_576;
+        if (
+            !Number.isSafeInteger(maxSampledParticles) ||
+            maxSampledParticles <= 0 ||
+            maxSampledParticles > 0xffff_ffff
+        ) {
+            throw new RangeError(
+                'Particle mesh cache maximum sampled particle count must fit uint32 offsets'
+            );
+        }
+        const checkpoint = this.captureSimulation();
+        this.#baking = true;
+        try {
+            this.restart().pause();
+            const selected =
+                options.emitter === undefined
+                    ? this.#runtimes.filter(runtime =>
+                          runtime.plan.definition.renderers.some(
+                              renderer => renderer.type === 'mesh'
+                          )
+                      )
+                    : this.#runtimes.filter(
+                          runtime => runtime.plan.definition.name === options.emitter
+                      );
+            if (selected.length === 0) {
+                throw new RangeError(
+                    options.emitter === undefined
+                        ? 'Particle system has no mesh emitter to bake'
+                        : `Particle emitter ${options.emitter} is unavailable`
+                );
+            }
+            const builders = selected.map(runtime => {
+                if (runtime.statelessGPUActive) {
+                    runtime.statelessGPUActive = false;
+                    this.materializeStatelessCPU(runtime);
+                }
+                if (runtime.simulator === null) {
+                    throw new TypeError(
+                        `Particle mesh cache requires CPU-readable emitter ${runtime.plan.definition.name}`
+                    );
+                }
+                return Object.freeze({
+                    runtime,
+                    builder: new ParticleMeshCacheBuilder(runtime.plan)
+                });
+            });
+            let currentTime = 0;
+            let sampledParticles = 0;
+            for (const time of timeline.times) {
+                this.simulate(Math.max(0, time - currentTime));
+                currentTime = time;
+                for (const entry of builders) {
+                    const simulator = entry.runtime.simulator;
+                    if (simulator === null) {
+                        throw new Error('Validated particle bake runtime is unavailable');
+                    }
+                    sampledParticles += simulator.state.aliveCount;
+                    if (sampledParticles > maxSampledParticles) {
+                        throw new RangeError(
+                            `Particle mesh cache sampled particle count exceeds ${String(maxSampledParticles)}`
+                        );
+                    }
+                    entry.builder.append(simulator.state);
+                }
+            }
+            return createParticleMeshCache(
+                this.definition.hash,
+                this.seed,
+                timeline,
+                builders.map(entry => entry.builder.finish())
+            );
+        } finally {
+            try {
+                this.restoreSimulation(checkpoint);
+            } finally {
+                this.#baking = false;
+            }
+        }
+    }
+
+    /**
+     * Bake real render-target readbacks into a tightly packed flipbook atlas.
+     *
+     * The callback owns rendering and asynchronous readback; the system owns deterministic timeline
+     * advancement and restores its exact checkpoint after completion or failure.
+     */
+    async bakeFlipbook(options: Readonly<ParticleFlipbookOptions>): Promise<ParticleFlipbook> {
+        if (this.#baking) throw new Error('ParticleSystem already has an active bake');
+        const timeline = createParticleBakeTimeline(options);
+        const checkpoint = this.captureSimulation();
+        this.#baking = true;
+        try {
+            this.restart().pause();
+            const frames: RenderTargetColorAttachmentReadback[] = [];
+            let currentTime = 0;
+            for (let frameIndex = 0; frameIndex < timeline.times.length; frameIndex += 1) {
+                const time = timeline.times[frameIndex];
+                if (time === undefined) throw new Error('Particle flipbook time is unavailable');
+                this.simulate(Math.max(0, time - currentTime));
+                currentTime = time;
+                const captured = await options.captureFrame(
+                    Object.freeze({ system: this, frameIndex, timeSeconds: time })
+                );
+                frames.push(
+                    Object.freeze({
+                        data: captured.data.slice(),
+                        format: captured.format,
+                        width: captured.width,
+                        height: captured.height,
+                        bytesPerPixel: captured.bytesPerPixel,
+                        bytesPerRow: captured.bytesPerRow
+                    })
+                );
+            }
+            return createParticleFlipbook(
+                this.definition.hash,
+                this.seed,
+                timeline,
+                frames,
+                options
+            );
+        } finally {
+            try {
+                this.restoreSimulation(checkpoint);
+            } finally {
+                this.#baking = false;
+            }
+        }
+    }
+
+    /**
+     * Capture one reusable deterministic replay checkpoint without GPU readback.
+     *
+     * Stateful GPU emitters are rejected because their authoritative state is device-resident.
+     * Stateless GPU emitters capture only absolute reconstruction time.
+     */
+    captureSimulation(): ParticleSimulationCache {
+        const gpuStateful = this.#runtimes.find(runtime => runtime.gpuController !== null);
+        if (gpuStateful !== undefined) {
+            throw new Error(
+                `Particle simulation capture does not support stateful GPU emitter ${gpuStateful.plan.definition.name}`
+            );
+        }
+        let storageByteLength = 0;
+        const emitters: Readonly<ParticleEmitterSimulationSnapshot>[] = this.#runtimes.map(
+            runtime => {
+                const common = {
+                    emitterId: runtime.plan.emitterId,
+                    definitionHash: runtime.plan.definition.hash,
+                    layoutHash: runtime.plan.layoutHash,
+                    statelessAge: runtime.statelessAge,
+                    budgetEnabled: runtime.budgetEnabled,
+                    budgetParticleLimit: runtime.budgetParticleLimit,
+                    budgetSpawnRateScale: runtime.budgetSpawnRateScale,
+                    budgetSorting: runtime.budgetSorting,
+                    budgetSoftParticles: runtime.budgetSoftParticles,
+                    budgetCollision: runtime.budgetCollision,
+                    budgetRibbons: runtime.budgetRibbons,
+                    culledSeconds: runtime.culledSeconds,
+                    stoppedByCulling: runtime.stoppedByCulling
+                } as const;
+                if (runtime.statelessGPUActive) {
+                    return Object.freeze({
+                        ...common,
+                        runtimeKind: 'stateless-gpu',
+                        simulation: null,
+                        storageByteLength: 0
+                    });
+                }
+                const simulator = runtime.simulator;
+                if (simulator instanceof ParticleCPUSimulator) {
+                    const simulation = simulator.capture();
+                    storageByteLength += simulation.byteLength;
+                    return Object.freeze({
+                        ...common,
+                        runtimeKind: 'cpu-stateful',
+                        simulation,
+                        storageByteLength: simulation.byteLength
+                    });
+                }
+                if (simulator instanceof ParticleStatelessRuntime) {
+                    const simulation = simulator.capture();
+                    storageByteLength += simulation.byteLength;
+                    return Object.freeze({
+                        ...common,
+                        runtimeKind: 'stateless-cpu',
+                        simulation,
+                        storageByteLength: simulation.byteLength
+                    });
+                }
+                throw new Error(
+                    `Particle emitter ${runtime.plan.definition.name} has no capturable runtime`
+                );
+            }
+        );
+        const snapshot: Readonly<ParticleSystemSimulationSnapshot> = Object.freeze({
+            definition: this.definition,
+            parameters: this.parameters,
+            definitionHash: this.definition.hash,
+            compiledPlanHash: this.compiledPlan.hash,
+            seed: this.seed,
+            parameterRevision: this.parameters.revision,
+            eventReadbackCapacity: this.#eventReadbackCapacity,
+            playing: this.#playing,
+            timeScale: this.#timeScale,
+            elapsedSeconds: this.#elapsedSeconds,
+            completed: this.#completed,
+            eventQueue: Object.freeze(this.#eventQueue.map(event => snapshotParticleEvent(event))),
+            eventDroppedCount: this.#eventDroppedCount,
+            emitters: Object.freeze(emitters),
+            storageByteLength
+        });
+        return createParticleSimulationCache(snapshot);
+    }
+
+    /** Restore a compatible checkpoint and make its simulation state current. */
+    restoreSimulation(cache: ParticleSimulationCache): this {
+        const snapshot = readParticleSimulationCache(cache);
+        if (snapshot === undefined) {
+            throw new TypeError('ParticleSystem restore requires a captured simulation cache');
+        }
+        if (snapshot.definition !== this.definition) {
+            throw new TypeError(
+                'Particle simulation cache requires the same immutable definition identity'
+            );
+        }
+        if (
+            snapshot.definitionHash !== this.definition.hash ||
+            snapshot.compiledPlanHash !== this.compiledPlan.hash
+        ) {
+            throw new TypeError('Particle simulation cache compiled plan is incompatible');
+        }
+        if (snapshot.seed !== this.seed) {
+            throw new TypeError('Particle simulation cache seed is incompatible');
+        }
+        if (snapshot.parameters !== this.parameters) {
+            throw new TypeError(
+                'Particle simulation cache requires the same parameter-set identity'
+            );
+        }
+        if (snapshot.parameterRevision !== this.parameters.revision) {
+            throw new TypeError('Particle simulation cache parameter revision is stale');
+        }
+        if (snapshot.eventReadbackCapacity !== this.#eventReadbackCapacity) {
+            throw new TypeError('Particle simulation cache event capacity is incompatible');
+        }
+        if (snapshot.emitters.length !== this.#runtimes.length) {
+            throw new TypeError('Particle simulation cache emitter count is incompatible');
+        }
+        for (let index = 0; index < this.#runtimes.length; index += 1) {
+            const runtime = this.#runtimes[index];
+            if (runtime === undefined) {
+                throw new Error('Particle runtime is unavailable');
+            }
+            const emitter = snapshot.emitters[index];
+            if (
+                emitter?.emitterId !== runtime.plan.emitterId ||
+                emitter.definitionHash !== runtime.plan.definition.hash ||
+                emitter.layoutHash !== runtime.plan.layoutHash
+            ) {
+                throw new TypeError('Particle simulation cache emitter layout is incompatible');
+            }
+            if (
+                (emitter.runtimeKind === 'cpu-stateful' &&
+                    !(runtime.simulator instanceof ParticleCPUSimulator)) ||
+                (emitter.runtimeKind !== 'cpu-stateful' && runtime.plan.kind !== 'stateless') ||
+                (emitter.runtimeKind === 'stateless-gpu' && !runtime.statelessGPUCapable)
+            ) {
+                throw new TypeError('Particle simulation cache execution mode is incompatible');
+            }
+        }
+        for (let index = 0; index < this.#runtimes.length; index += 1) {
+            const runtime = this.#runtimes[index];
+            const emitter = snapshot.emitters[index];
+            if (runtime === undefined || emitter === undefined) {
+                throw new Error('Validated particle simulation cache emitter is unavailable');
+            }
+            runtime.statelessAge = emitter.statelessAge;
+            runtime.budgetEnabled = emitter.budgetEnabled;
+            runtime.budgetParticleLimit = emitter.budgetParticleLimit;
+            runtime.budgetSpawnRateScale = emitter.budgetSpawnRateScale;
+            runtime.budgetSorting = emitter.budgetSorting;
+            runtime.budgetSoftParticles = emitter.budgetSoftParticles;
+            runtime.budgetCollision = emitter.budgetCollision;
+            runtime.budgetRibbons = emitter.budgetRibbons;
+            runtime.culledSeconds = emitter.culledSeconds;
+            runtime.stoppedByCulling = emitter.stoppedByCulling;
+            switch (emitter.runtimeKind) {
+                case 'cpu-stateful': {
+                    const simulator = runtime.simulator;
+                    if (!(simulator instanceof ParticleCPUSimulator)) {
+                        throw new Error('Validated particle CPU runtime is unavailable');
+                    }
+                    runtime.statelessGPUActive = false;
+                    simulator.restore(emitter.simulation);
+                    break;
+                }
+                case 'stateless-cpu': {
+                    runtime.statelessGPUActive = false;
+                    this.materializeStatelessCPU(runtime);
+                    const simulator = runtime.simulator;
+                    if (!(simulator instanceof ParticleStatelessRuntime)) {
+                        throw new Error('Validated particle stateless runtime is unavailable');
+                    }
+                    simulator.restore(emitter.simulation);
+                    break;
+                }
+                case 'stateless-gpu':
+                    runtime.statelessGPUActive = true;
+                    runtime.statelessGPURuntime?.invalidate();
+                    break;
+            }
+            runtime.statelessGPURuntime?.setBudget({
+                systemId: this.budgetId,
+                emitterId: runtime.plan.emitterId,
+                enabled: runtime.budgetEnabled,
+                particleLimit: runtime.budgetParticleLimit,
+                spawnRateScale: runtime.budgetSpawnRateScale,
+                sorting: runtime.budgetSorting,
+                softParticles: runtime.budgetSoftParticles,
+                collision: runtime.budgetCollision,
+                ribbons: runtime.budgetRibbons,
+                reasons: Object.freeze([])
+            });
+        }
+        this.#playing = snapshot.playing;
+        this.#timeScale = snapshot.timeScale;
+        this.#elapsedSeconds = snapshot.elapsedSeconds;
+        this.#completed = snapshot.completed;
+        this.#eventQueue.length = 0;
+        this.#eventQueue.push(...snapshot.eventQueue.map(event => snapshotParticleEvent(event)));
+        this.#eventDroppedCount = snapshot.eventDroppedCount;
+        this.syncWriters();
+        return this;
+    }
+
     override update(deltaTimeMilliseconds: number): void {
+        if (this.#baking) {
+            this.syncWriters();
+            return;
+        }
         if (!this.#playing || this.#completed || this.#timeScale === 0) {
             this.syncWriters();
             return;
@@ -1070,9 +1449,10 @@ class ParticleSystem extends Node {
             }) &&
             this.#runtimes.every(runtime => !runtime.plan.definition.looping)
         ) {
+            const wasCompleted = this.#completed;
             this.#completed = true;
             this.#playing = false;
-            this.fire('complete');
+            if (!wasCompleted && !this.#baking) this.fire('complete');
         }
     }
 

--- a/src/particle/cpu/ParticleCPUEventBuffer.ts
+++ b/src/particle/cpu/ParticleCPUEventBuffer.ts
@@ -18,6 +18,19 @@ export interface ParticleEventAggregate {
     readonly remainingCount: number;
 }
 
+/** @internal */
+export interface ParticleCPUEventBufferSnapshot {
+    readonly names: readonly string[];
+    readonly nameIds: Uint16Array;
+    readonly stableIds: Uint32Array;
+    readonly positions: Float32Array;
+    readonly velocities: Float32Array;
+    readonly start: number;
+    readonly count: number;
+    readonly droppedCount: number;
+    readonly byteLength: number;
+}
+
 /** Compact ring storage; no per-event object is allocated during particle simulation. */
 export class ParticleCPUEventBuffer {
     readonly #definition: ParticleEmitterDefinition;
@@ -51,6 +64,70 @@ export class ParticleCPUEventBuffer {
         this.#start = 0;
         this.#count = 0;
         this.#droppedCount = 0;
+    }
+
+    /** Copy the compact ring without materializing application event objects. @internal */
+    capture(): Readonly<ParticleCPUEventBufferSnapshot> {
+        const nameIds = this.#nameIds.slice();
+        const stableIds = this.#stableIds.slice();
+        const positions = this.#positions.slice();
+        const velocities = this.#velocities.slice();
+        return Object.freeze({
+            names: Object.freeze([...this.#names]),
+            nameIds,
+            stableIds,
+            positions,
+            velocities,
+            start: this.#start,
+            count: this.#count,
+            droppedCount: this.#droppedCount,
+            byteLength:
+                nameIds.byteLength +
+                stableIds.byteLength +
+                positions.byteLength +
+                velocities.byteLength
+        });
+    }
+
+    /** Restore one compatible compact event ring. @internal */
+    restore(snapshot: Readonly<ParticleCPUEventBufferSnapshot>): void {
+        if (
+            snapshot.nameIds.length !== this.#nameIds.length ||
+            snapshot.stableIds.length !== this.#stableIds.length ||
+            snapshot.positions.length !== this.#positions.length ||
+            snapshot.velocities.length !== this.#velocities.length
+        ) {
+            throw new TypeError('Particle event snapshot capacity is incompatible');
+        }
+        const capacity = this.#definition.eventCapacity;
+        if (
+            !Number.isSafeInteger(snapshot.start) ||
+            snapshot.start < 0 ||
+            snapshot.start > Math.max(0, capacity - 1) ||
+            !Number.isSafeInteger(snapshot.count) ||
+            snapshot.count < 0 ||
+            snapshot.count > capacity ||
+            !Number.isSafeInteger(snapshot.droppedCount) ||
+            snapshot.droppedCount < 0
+        ) {
+            throw new RangeError('Particle event snapshot ring metadata is invalid');
+        }
+        this.#names.length = 0;
+        this.#nameToId.clear();
+        for (const name of snapshot.names) {
+            if (this.#nameToId.has(name)) {
+                throw new TypeError('Particle event snapshot name table is invalid');
+            }
+            this.#nameToId.set(name, this.#names.length);
+            this.#names.push(name);
+        }
+        this.#nameIds.set(snapshot.nameIds);
+        this.#stableIds.set(snapshot.stableIds);
+        this.#positions.set(snapshot.positions);
+        this.#velocities.set(snapshot.velocities);
+        this.#start = snapshot.start;
+        this.#count = snapshot.count;
+        this.#droppedCount = snapshot.droppedCount;
     }
 
     push(

--- a/src/particle/cpu/ParticleCPUSimulator.ts
+++ b/src/particle/cpu/ParticleCPUSimulator.ts
@@ -21,8 +21,11 @@ import type {
     ParticleVector3,
     ParticleVector3Source
 } from '../ParticleTypes';
-import { ParticleCPUState } from './ParticleCPUState';
-import { ParticleCPUEventBuffer } from './ParticleCPUEventBuffer';
+import { ParticleCPUState, type ParticleCPUStateSnapshot } from './ParticleCPUState';
+import {
+    ParticleCPUEventBuffer,
+    type ParticleCPUEventBufferSnapshot
+} from './ParticleCPUEventBuffer';
 import { particleCurlNoise, particleVectorNoise } from './ParticleNoise';
 
 const ZERO_VECTOR: ParticleVector3 = Object.freeze([0, 0, 0]);
@@ -191,6 +194,39 @@ export interface ParticleManualEmitCommand {
     readonly count: number;
     readonly position?: ParticleVector3;
     readonly velocity?: ParticleVector3;
+}
+
+/** @internal */
+export interface ParticleCPUSimulatorSnapshot {
+    readonly state: Readonly<ParticleCPUStateSnapshot>;
+    readonly events: Readonly<ParticleCPUEventBufferSnapshot>;
+    readonly pendingCommands: readonly Readonly<ParticleManualEmitCommand>[];
+    readonly emitterAge: number;
+    readonly accumulator: number;
+    readonly rateAccumulator: number;
+    readonly spawnSequence: number;
+    readonly generation: number;
+    readonly particleLimit: number;
+    readonly spawnRateScale: number;
+    readonly collisionEnabled: boolean;
+    readonly lastPosition: Float32Array;
+    readonly emitterVelocity: Float32Array;
+    readonly hasLastPosition: boolean;
+    readonly byteLength: number;
+}
+
+function snapshotManualEmitCommand(
+    command: Readonly<ParticleManualEmitCommand>
+): Readonly<ParticleManualEmitCommand> {
+    return Object.freeze({
+        count: command.count,
+        ...(command.position === undefined
+            ? {}
+            : { position: Object.freeze([...command.position] as ParticleVector3) }),
+        ...(command.velocity === undefined
+            ? {}
+            : { velocity: Object.freeze([...command.velocity] as ParticleVector3) })
+    });
 }
 
 function isRange<T>(value: T | ParticleRange<T>): value is ParticleRange<T> {
@@ -500,6 +536,64 @@ export class ParticleCPUSimulator {
         this.#spawnSequence = 0;
         this.#generation = 0;
         this.#hasLastPosition = false;
+    }
+
+    /** Copy all fixed-step scheduler, dense state, event, and pending-command data. @internal */
+    capture(): Readonly<ParticleCPUSimulatorSnapshot> {
+        const state = this.state.capture();
+        const events = this.events.capture();
+        const lastPosition = this.#lastPosition.slice();
+        const emitterVelocity = this.#emitterVelocity.slice();
+        return Object.freeze({
+            state,
+            events,
+            pendingCommands: Object.freeze(
+                this.#pendingCommands.map(command => snapshotManualEmitCommand(command))
+            ),
+            emitterAge: this.#emitterAge,
+            accumulator: this.#accumulator,
+            rateAccumulator: this.#rateAccumulator,
+            spawnSequence: this.#spawnSequence,
+            generation: this.#generation,
+            particleLimit: this.#particleLimit,
+            spawnRateScale: this.#spawnRateScale,
+            collisionEnabled: this.#collisionEnabled,
+            lastPosition,
+            emitterVelocity,
+            hasLastPosition: this.#hasLastPosition,
+            byteLength:
+                state.byteLength +
+                events.byteLength +
+                lastPosition.byteLength +
+                emitterVelocity.byteLength
+        });
+    }
+
+    /** Restore one compatible fixed-step simulator snapshot. @internal */
+    restore(snapshot: Readonly<ParticleCPUSimulatorSnapshot>): void {
+        if (
+            snapshot.lastPosition.length !== this.#lastPosition.length ||
+            snapshot.emitterVelocity.length !== this.#emitterVelocity.length
+        ) {
+            throw new TypeError('Particle CPU simulator vector snapshot is incompatible');
+        }
+        this.state.restore(snapshot.state);
+        this.events.restore(snapshot.events);
+        this.#pendingCommands.length = 0;
+        for (const command of snapshot.pendingCommands) {
+            this.#pendingCommands.push(snapshotManualEmitCommand(command));
+        }
+        this.#emitterAge = snapshot.emitterAge;
+        this.#accumulator = snapshot.accumulator;
+        this.#rateAccumulator = snapshot.rateAccumulator;
+        this.#spawnSequence = snapshot.spawnSequence;
+        this.#generation = snapshot.generation;
+        this.#particleLimit = snapshot.particleLimit;
+        this.#spawnRateScale = snapshot.spawnRateScale;
+        this.#collisionEnabled = snapshot.collisionEnabled;
+        this.#lastPosition.set(snapshot.lastPosition);
+        this.#emitterVelocity.set(snapshot.emitterVelocity);
+        this.#hasLastPosition = snapshot.hasLastPosition;
     }
 
     /** Advance seconds through a bounded fixed-step accumulator. */

--- a/src/particle/cpu/ParticleCPUState.ts
+++ b/src/particle/cpu/ParticleCPUState.ts
@@ -7,6 +7,22 @@ import type {
 
 type ParticleAttributeArray = Float32Array | Uint32Array;
 
+/** @internal */
+export interface ParticleCPUStateSnapshotAttribute {
+    readonly name: ParticleAttributeName;
+    readonly storage: 'f32' | 'u32';
+    readonly components: 1 | 2 | 3 | 4;
+    readonly values: Float32Array | Uint32Array;
+}
+
+/** @internal */
+export interface ParticleCPUStateSnapshot {
+    readonly capacity: number;
+    readonly aliveCount: number;
+    readonly attributes: readonly Readonly<ParticleCPUStateSnapshotAttribute>[];
+    readonly byteLength: number;
+}
+
 /** Dense alive SoA storage used by the portable CPU execution plan. */
 export class ParticleCPUState {
     readonly capacity: number;
@@ -82,6 +98,72 @@ export class ParticleCPUState {
     }
 
     markChanged(): void {
+        this.revision++;
+    }
+
+    /** Copy all dense storage, including dead slots needed by exact replay. @internal */
+    capture(): Readonly<ParticleCPUStateSnapshot> {
+        let byteLength = 0;
+        const attributes = this.#layout.map(attribute => {
+            const values = this.#arrays.get(attribute.name);
+            if (!values)
+                throw new Error(`Particle attribute ${attribute.name} storage is unavailable`);
+            const snapshot = values.slice();
+            byteLength += snapshot.byteLength;
+            return Object.freeze({
+                name: attribute.name,
+                storage: attribute.storage,
+                components: attribute.components,
+                values: snapshot
+            });
+        });
+        return Object.freeze({
+            capacity: this.capacity,
+            aliveCount: this.aliveCount,
+            attributes: Object.freeze(attributes),
+            byteLength
+        });
+    }
+
+    /** Replace dense storage from one compatible deterministic snapshot. @internal */
+    restore(snapshot: Readonly<ParticleCPUStateSnapshot>): void {
+        if (snapshot.capacity !== this.capacity) {
+            throw new TypeError('Particle CPU state snapshot capacity is incompatible');
+        }
+        if (
+            !Number.isSafeInteger(snapshot.aliveCount) ||
+            snapshot.aliveCount < 0 ||
+            snapshot.aliveCount > this.capacity
+        ) {
+            throw new RangeError('Particle CPU state snapshot alive count is invalid');
+        }
+        if (snapshot.attributes.length !== this.#layout.length) {
+            throw new TypeError('Particle CPU state snapshot layout is incompatible');
+        }
+        for (let index = 0; index < this.#layout.length; index += 1) {
+            const layout = this.#layout[index];
+            if (layout === undefined) {
+                throw new Error('Particle CPU state layout is unavailable');
+            }
+            const attribute = snapshot.attributes[index];
+            if (
+                attribute?.name !== layout.name ||
+                attribute.storage !== layout.storage ||
+                attribute.components !== layout.components
+            ) {
+                throw new TypeError('Particle CPU state snapshot layout is incompatible');
+            }
+            const target = this.#arrays.get(layout.name);
+            const expectedFloat = layout.storage === 'f32';
+            if (
+                target?.length !== attribute.values.length ||
+                attribute.values instanceof Float32Array !== expectedFloat
+            ) {
+                throw new TypeError('Particle CPU state snapshot storage is incompatible');
+            }
+            target.set(attribute.values);
+        }
+        this.aliveCount = snapshot.aliveCount;
         this.revision++;
     }
 

--- a/src/particle/stateless/ParticleStatelessGPURuntime.ts
+++ b/src/particle/stateless/ParticleStatelessGPURuntime.ts
@@ -168,6 +168,11 @@ export class ParticleStatelessGPUEmitterRuntime {
         if (this.#generatedFrame === frameIndex) this.#generatedFrame = -1;
     }
 
+    /** Invalidate renderer data after an absolute-time cache restore. @internal */
+    invalidate(): void {
+        this.#generatedFrame = -1;
+    }
+
     record(
         context: RenderPipelineContext,
         color: RenderGraphTextureHandle,

--- a/src/particle/stateless/ParticleStatelessRuntime.ts
+++ b/src/particle/stateless/ParticleStatelessRuntime.ts
@@ -40,6 +40,45 @@ interface ParticleStatelessManualBatch {
     readonly emitterPosition: ParticleVector3;
 }
 
+/** @internal */
+export interface ParticleStatelessRuntimeSnapshot {
+    readonly manualBatches: readonly Readonly<ParticleStatelessManualBatch>[];
+    readonly pendingCommands: readonly Readonly<ParticleManualEmitCommand>[];
+    readonly emitterPosition: ParticleVector3;
+    readonly emitterAge: number;
+    readonly manualSequence: number;
+    readonly particleLimit: number;
+    readonly spawnRateScale: number;
+    readonly byteLength: number;
+}
+
+function snapshotVector(value: ParticleVector3): ParticleVector3 {
+    return Object.freeze([...value] as ParticleVector3);
+}
+
+function snapshotManualCommand(
+    command: Readonly<ParticleManualEmitCommand>
+): Readonly<ParticleManualEmitCommand> {
+    return Object.freeze({
+        count: command.count,
+        ...(command.position === undefined ? {} : { position: snapshotVector(command.position) }),
+        ...(command.velocity === undefined ? {} : { velocity: snapshotVector(command.velocity) })
+    });
+}
+
+function snapshotManualBatch(
+    batch: Readonly<ParticleStatelessManualBatch>
+): Readonly<ParticleStatelessManualBatch> {
+    return Object.freeze({
+        time: batch.time,
+        firstId: batch.firstId,
+        count: batch.count,
+        ...(batch.position === undefined ? {} : { position: snapshotVector(batch.position) }),
+        ...(batch.velocity === undefined ? {} : { velocity: snapshotVector(batch.velocity) }),
+        emitterPosition: snapshotVector(batch.emitterPosition)
+    });
+}
+
 function maximumScalar(
     value: ParticleScalarSource | undefined,
     fallback: number,
@@ -163,6 +202,44 @@ export class ParticleStatelessRuntime {
         this.clear();
         this.#emitterAge = 0;
         this.#manualSequence = MANUAL_ID_BASE;
+    }
+
+    /** Copy absolute-time reconstruction and queued manual-emission metadata. @internal */
+    capture(): Readonly<ParticleStatelessRuntimeSnapshot> {
+        return Object.freeze({
+            manualBatches: Object.freeze(
+                this.#manualBatches.map(batch => snapshotManualBatch(batch))
+            ),
+            pendingCommands: Object.freeze(
+                this.#pendingCommands.map(command => snapshotManualCommand(command))
+            ),
+            emitterPosition: snapshotVector(this.#emitterPosition),
+            emitterAge: this.#emitterAge,
+            manualSequence: this.#manualSequence,
+            particleLimit: this.#particleLimit,
+            spawnRateScale: this.#spawnRateScale,
+            byteLength: 0
+        });
+    }
+
+    /** Restore and deterministically rematerialize one stateless snapshot. @internal */
+    restore(snapshot: Readonly<ParticleStatelessRuntimeSnapshot>): void {
+        this.#manualBatches.length = 0;
+        for (const batch of snapshot.manualBatches) {
+            this.#manualBatches.push(snapshotManualBatch(batch));
+        }
+        this.#pendingCommands.length = 0;
+        for (const command of snapshot.pendingCommands) {
+            this.#pendingCommands.push(snapshotManualCommand(command));
+        }
+        this.#emitterPosition[0] = snapshot.emitterPosition[0];
+        this.#emitterPosition[1] = snapshot.emitterPosition[1];
+        this.#emitterPosition[2] = snapshot.emitterPosition[2];
+        this.#emitterAge = snapshot.emitterAge;
+        this.#manualSequence = snapshot.manualSequence;
+        this.#particleLimit = snapshot.particleLimit;
+        this.#spawnRateScale = snapshot.spawnRateScale;
+        this.rebuild();
     }
 
     simulate(

--- a/test/spec/particle/ParticleAuthoring.test.ts
+++ b/test/spec/particle/ParticleAuthoring.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+import {
+    compileParticleAuthoringGraph,
+    createParticleAuthoringGraph,
+    PARTICLE_AUTHORING_JSON_SCHEMA,
+    PARTICLE_AUTHORING_SCHEMA,
+    PARTICLE_AUTHORING_VERSION,
+    type ParticleAuthoringGraph
+} from '../../../src/particle/ParticleAuthoring';
+import {
+    PARTICLE_PREVIEW_PROTOCOL_VERSION,
+    ParticleAuthoringPreviewController
+} from '../../../src/particle/ParticleAuthoringPreview';
+import { ParticleParameter } from '../../../src/particle/ParticleParameter';
+import ParticleSystemDefinition from '../../../src/particle/ParticleSystemDefinition';
+
+function definition(): ParticleSystemDefinition {
+    const shared = new ParticleParameter('authoring.shared', 'float', 4);
+    return ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'authoring-main',
+                capacity: 32,
+                execution: 'cpu',
+                duration: 3,
+                looping: true,
+                fixedStep: 1 / 60,
+                bounds: { mode: 'manual', min: [-4, -4, -4], max: [4, 4, 4] },
+                emission: { rateOverTime: shared },
+                initialize: { lifetime: 1, size: shared },
+                modules: [{ type: 'drag', coefficient: 0.2 }],
+                renderers: [{ type: 'sprite' }]
+            }
+        ]
+    });
+}
+
+interface MutableGraphNode {
+    id: string;
+    kind: string;
+    data: Record<string, unknown>;
+}
+
+interface MutableGraphEdge {
+    id: string;
+    from: string;
+    to: string;
+    port: string;
+    order: number;
+}
+
+interface MutableGraph {
+    schema: string;
+    version: number;
+    definitionSchema: string;
+    definitionVersion: number;
+    parameters: unknown[];
+    nodes: MutableGraphNode[];
+    edges: MutableGraphEdge[];
+    metadata?: Record<string, unknown>;
+    extra?: unknown;
+}
+
+function mutableGraph(graph: Readonly<ParticleAuthoringGraph>): MutableGraph {
+    return JSON.parse(JSON.stringify(graph)) as MutableGraph;
+}
+
+describe('particle P6 external authoring and preview', () => {
+    it('round-trips a deterministic fixed-module graph into normalized runtime IR', () => {
+        const source = definition();
+        const graph = createParticleAuthoringGraph(source);
+
+        expect(graph).toMatchObject({
+            schema: PARTICLE_AUTHORING_SCHEMA,
+            version: PARTICLE_AUTHORING_VERSION,
+            definitionSchema: 'hilo3d.particle-system',
+            definitionVersion: 1
+        });
+        expect(graph.nodes.map(node => node.kind)).toEqual([
+            'system',
+            'emitter',
+            'module',
+            'renderer'
+        ]);
+        expect(graph.edges.map(edge => edge.port)).toEqual(['emitters', 'modules', 'renderers']);
+        expect(Object.isFrozen(graph)).toBe(true);
+        expect(Object.isFrozen(PARTICLE_AUTHORING_JSON_SCHEMA)).toBe(true);
+        expect(Object.isFrozen(PARTICLE_AUTHORING_JSON_SCHEMA['properties'])).toBe(true);
+
+        const editable = mutableGraph(graph);
+        editable.nodes.reverse();
+        editable.edges.reverse();
+        editable.metadata = { viewport: { x: 10, y: 20 }, editor: 'external' };
+        const result = compileParticleAuthoringGraph(editable);
+
+        expect(result.success).toBe(true);
+        if (!result.success) throw new Error('Expected authoring compilation success');
+        expect(result.definition.hash).toBe(source.hash);
+        expect(result.compiledPlan.hash).toBe(result.ir.compiledPlanHash);
+        expect(result.ir.definitionHash).toBe(source.hash);
+        expect(result.ir.systemNodeId).toBe('system');
+        expect(result.ir.emitters[0]).toMatchObject({
+            nodeId: 'emitter:0',
+            name: 'authoring-main',
+            planKind: 'cpu-stateful',
+            moduleNodeIds: ['emitter:0:module:0'],
+            rendererNodeIds: ['emitter:0:renderer:0']
+        });
+        expect(result.graph.metadata).toEqual(editable.metadata);
+        const emitter = result.definition.emitters[0];
+        expect(emitter).toBeDefined();
+        if (emitter === undefined) throw new Error('Expected compiled emitter');
+        expect(emitter.emission.rateOverTime).toBe(emitter.initialize.size);
+    });
+
+    it('returns addressable diagnostics for graph topology and definition payload failures', () => {
+        const topology = mutableGraph(createParticleAuthoringGraph(definition()));
+        const moduleEdge = topology.edges.find(edge => edge.port === 'modules');
+        expect(moduleEdge).toBeDefined();
+        if (moduleEdge === undefined) throw new Error('Expected module edge');
+        moduleEdge.order = 2;
+        topology.nodes.push({ ...topology.nodes[1], id: 'emitter:duplicate' } as MutableGraphNode);
+        topology.extra = true;
+        const topologyResult = compileParticleAuthoringGraph(topology);
+        expect(topologyResult.success).toBe(false);
+        expect(topologyResult.diagnostics.map(item => item.code)).toEqual(
+            expect.arrayContaining([
+                'authoring.document.unknown-field',
+                'authoring.node.unowned',
+                'authoring.edge.order-gap'
+            ])
+        );
+
+        const payload = mutableGraph(createParticleAuthoringGraph(definition()));
+        const moduleNode = payload.nodes.find(node => node.kind === 'module');
+        expect(moduleNode).toBeDefined();
+        if (moduleNode === undefined) throw new Error('Expected module node');
+        moduleNode.data = { type: 'drag', coefficient: -1 };
+        const payloadResult = compileParticleAuthoringGraph(payload);
+        expect(payloadResult.success).toBe(false);
+        expect(payloadResult.diagnostics[0]).toMatchObject({
+            code: 'authoring.definition.compile',
+            nodeId: moduleNode.id,
+            path: `/nodes/${moduleNode.id}/data`
+        });
+    });
+
+    it('uses the requested backend when materializing explicit GPU authoring graphs', () => {
+        const gpu = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'authoring-gpu',
+                    capacity: 64,
+                    execution: 'gpu',
+                    bounds: { mode: 'manual', min: [-1, -1, -1], max: [1, 1, 1] },
+                    renderers: [{ type: 'sprite' }]
+                }
+            ]
+        });
+        const graph = createParticleAuthoringGraph(gpu);
+        const webgl2 = compileParticleAuthoringGraph(graph, {
+            compilationEnvironment: { backend: 'webgl2' }
+        });
+        expect(webgl2.success).toBe(false);
+        const webgpu = compileParticleAuthoringGraph(graph, {
+            compilationEnvironment: { backend: 'webgpu' }
+        });
+        expect(webgpu.success).toBe(true);
+        if (!webgpu.success) throw new Error('Expected WebGPU authoring compilation success');
+        expect(webgpu.ir.emitters[0]?.planKind).toBe('gpu-stateful');
+    });
+
+    it('drives deterministic compile, seek, step, inspect, and lifecycle preview commands', () => {
+        const disposed: string[] = [];
+        const controller = new ParticleAuthoringPreviewController({
+            disposeSystem: system => disposed.push(system.definition.hash)
+        });
+        const graph = createParticleAuthoringGraph(definition());
+        const compile = controller.handle({
+            protocolVersion: PARTICLE_PREVIEW_PROTOCOL_VERSION,
+            requestId: 'compile-1',
+            command: 'compile',
+            graph,
+            seed: 42
+        });
+        expect(compile).toMatchObject({
+            success: true,
+            command: 'compile',
+            state: { status: 'ready', seed: 42, timeSeconds: 0 }
+        });
+        expect(compile.ir?.definitionHash).toBe(definition().hash);
+        expect(controller.system).not.toBeNull();
+
+        const firstStep = controller.handle({
+            protocolVersion: 1,
+            requestId: 'step-1',
+            command: 'step',
+            deltaSeconds: 0.5
+        });
+        expect(firstStep.success).toBe(true);
+        expect(firstStep.state.timeSeconds).toBe(0.5);
+        const firstHash = firstStep.state.stateHash;
+
+        const seek = controller.handle({
+            protocolVersion: 1,
+            requestId: 'seek-0',
+            command: 'seek',
+            timeSeconds: 0
+        });
+        expect(seek.state.timeSeconds).toBe(0);
+        const replay = controller.handle({
+            protocolVersion: 1,
+            requestId: 'step-2',
+            command: 'step',
+            deltaSeconds: 0.5
+        });
+        expect(replay.state.stateHash).toBe(firstHash);
+
+        expect(
+            controller.handle({
+                protocolVersion: 1,
+                requestId: 'play',
+                command: 'play'
+            }).state.status
+        ).toBe('playing');
+        expect(
+            controller.handle({
+                protocolVersion: 1,
+                requestId: 'pause',
+                command: 'pause'
+            }).state.status
+        ).toBe('ready');
+        const invalid = controller.handle({
+            protocolVersion: 2,
+            requestId: 'bad-version',
+            command: 'inspect'
+        });
+        expect(invalid).toMatchObject({
+            success: false,
+            diagnostics: [{ code: 'preview.request.version', path: '/protocolVersion' }]
+        });
+
+        const dispose = controller.handle({
+            protocolVersion: 1,
+            requestId: 'dispose',
+            command: 'dispose'
+        });
+        expect(dispose.state.status).toBe('disposed');
+        expect(disposed).toEqual([definition().hash]);
+        expect(controller.system).toBeNull();
+        expect(
+            controller.handle({
+                protocolVersion: 1,
+                requestId: 'after-dispose',
+                command: 'inspect'
+            }).diagnostics[0]?.code
+        ).toBe('preview.disposed');
+    });
+
+    it('keeps the previous preview alive when a replacement graph fails compilation', () => {
+        const controller = new ParticleAuthoringPreviewController();
+        const graph = createParticleAuthoringGraph(definition());
+        const first = controller.handle({
+            protocolVersion: 1,
+            requestId: 'compile-good',
+            command: 'compile',
+            graph
+        });
+        expect(first.success).toBe(true);
+        const previous = controller.system;
+        const invalid = mutableGraph(graph);
+        invalid.edges.length = 0;
+        const failed = controller.handle({
+            protocolVersion: 1,
+            requestId: 'compile-bad',
+            command: 'compile',
+            graph: invalid
+        });
+        expect(failed.success).toBe(false);
+        expect(failed.diagnostics.some(item => item.severity === 'error')).toBe(true);
+        expect(controller.system).toBe(previous);
+    });
+});

--- a/test/spec/particle/ParticleBaking.test.ts
+++ b/test/spec/particle/ParticleBaking.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+import BoxGeometry from '../../../src/geometry/BoxGeometry';
+import { PARTICLE_BAKE_VERSION, type ParticleFlipbook } from '../../../src/particle/ParticleBaking';
+import ParticleSystem from '../../../src/particle/ParticleSystem';
+import ParticleSystemDefinition from '../../../src/particle/ParticleSystemDefinition';
+
+function meshDefinition(): ParticleSystemDefinition {
+    return ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'mesh-cache',
+                capacity: 32,
+                execution: 'cpu',
+                duration: 4,
+                looping: true,
+                fixedStep: 1 / 60,
+                emission: { rateOverTime: 8, bursts: [{ time: 0, count: 2 }] },
+                initialize: {
+                    lifetime: 2,
+                    direction: [1, 0, 0],
+                    speed: { min: 0.5, max: 1.5 },
+                    size: { min: 0.25, max: 0.75 },
+                    rotation: { min: 0, max: 1 }
+                },
+                modules: [{ type: 'gravity', force: [0, -1, 0] }],
+                renderers: [
+                    {
+                        type: 'mesh',
+                        meshes: [{ geometry: new BoxGeometry() }],
+                        orientation: 'velocity'
+                    }
+                ]
+            }
+        ]
+    });
+}
+
+function spriteDefinition(): ParticleSystemDefinition {
+    return ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'flipbook',
+                capacity: 16,
+                execution: 'cpu',
+                duration: 2,
+                looping: true,
+                fixedStep: 1 / 60,
+                emission: { rateOverTime: 4 },
+                initialize: { lifetime: 1 },
+                renderers: [{ type: 'sprite' }]
+            }
+        ]
+    });
+}
+
+describe('particle P6 baking', () => {
+    it('bakes deterministic stable-ID-sorted mesh instance streams and restores pending state', () => {
+        const definition = meshDefinition();
+        const system = new ParticleSystem({ definition, seed: 17, autoPlay: false });
+        const expected = new ParticleSystem({ definition, seed: 17, autoPlay: false });
+        system.simulate(0.37).emit(3);
+        expected.simulate(0.37).emit(3);
+
+        const cache = system.bakeMeshCache({
+            duration: 1,
+            frameRate: 4,
+            startTime: 0.25,
+            includeEnd: true
+        });
+
+        expect(cache.version).toBe(PARTICLE_BAKE_VERSION);
+        expect(cache.definitionHash).toBe(definition.hash);
+        expect(cache.seed).toBe(17);
+        expect(cache.frameCount).toBe(5);
+        expect([...cache.frameTimes]).toEqual([0.25, 0.5, 0.75, 1, 1.25]);
+        expect(cache.emitters).toHaveLength(1);
+        const emitter = cache.emitters[0];
+        expect(emitter).toBeDefined();
+        if (emitter === undefined) throw new Error('Expected one baked mesh emitter');
+        expect(emitter.frameOffsets).toHaveLength(cache.frameCount + 1);
+        expect(emitter.positions).toHaveLength(emitter.stableIds.length * 3);
+        expect(emitter.previousPositions).toHaveLength(emitter.stableIds.length * 3);
+        expect(emitter.velocities).toHaveLength(emitter.stableIds.length * 3);
+        expect(emitter.colors).toHaveLength(emitter.stableIds.length * 4);
+        expect(emitter.sizes).toHaveLength(emitter.stableIds.length);
+        expect(emitter.rotations).toHaveLength(emitter.stableIds.length);
+        expect(emitter.meshIndices).toHaveLength(emitter.stableIds.length);
+        expect(emitter.frameBounds).toHaveLength(cache.frameCount * 6);
+        expect(cache.storageByteLength).toBeGreaterThan(0);
+        for (let frameIndex = 0; frameIndex < cache.frameCount; frameIndex += 1) {
+            const start = emitter.frameOffsets[frameIndex] ?? 0;
+            const end = emitter.frameOffsets[frameIndex + 1] ?? 0;
+            const ids = [...emitter.stableIds.subarray(start, end)];
+            expect(ids).toEqual([...ids].sort((left, right) => left - right));
+        }
+
+        system.simulate(0.2);
+        expected.simulate(0.2);
+        expect(system.stateHash()).toBe(expected.stateHash());
+        expect(system.aliveCount).toBe(expected.aliveCount);
+
+        const repeated = system.bakeMeshCache({
+            duration: 1,
+            frameRate: 4,
+            startTime: 0.25,
+            includeEnd: true
+        });
+        expect(repeated.emitters[0]?.stableIds).toEqual(emitter.stableIds);
+        expect(repeated.emitters[0]?.positions).toEqual(emitter.positions);
+    });
+
+    it('fails bounded mesh baking without losing the caller simulation branch', () => {
+        const definition = meshDefinition();
+        const system = new ParticleSystem({ definition, seed: 3, autoPlay: false });
+        system.simulate(0.4);
+        const before = system.stateHash();
+        expect(() =>
+            system.bakeMeshCache({
+                duration: 1,
+                frameRate: 30,
+                maxSampledParticles: 1
+            })
+        ).toThrow(/sampled particle count exceeds 1/u);
+        expect(system.stateHash()).toBe(before);
+    });
+
+    it('materializes stateless simulation into the same portable mesh-cache contract', () => {
+        const definition = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'stateless-mesh-cache',
+                    capacity: 24,
+                    execution: 'stateless',
+                    duration: 2,
+                    looping: true,
+                    emission: { rateOverTime: 6 },
+                    initialize: { lifetime: 1, speed: 0.5, direction: [0, 1, 0] },
+                    renderers: [{ type: 'mesh', meshes: [{ geometry: new BoxGeometry() }] }]
+                }
+            ]
+        });
+        const system = new ParticleSystem({ definition, seed: 11, autoPlay: false });
+        const cache = system.bakeMeshCache({ duration: 0.5, frameRate: 4, includeEnd: true });
+        expect(cache.frameCount).toBe(3);
+        expect(cache.emitters[0]?.stableIds.length).toBeGreaterThan(0);
+        expect(cache.emitters[0]?.positions.length).toBe(
+            (cache.emitters[0]?.stableIds.length ?? 0) * 3
+        );
+    });
+
+    it('packs copied real-readback frames into a near-square flipbook and restores state', async () => {
+        const definition = spriteDefinition();
+        const system = new ParticleSystem({ definition, seed: 4, autoPlay: false });
+        system.simulate(0.35).emit(2);
+        const before = system.captureSimulation();
+        const reused = new Uint8Array(4);
+        const times: number[] = [];
+
+        const flipbook: ParticleFlipbook = await system.bakeFlipbook({
+            duration: 1,
+            frameRate: 3,
+            captureFrame: context => {
+                times.push(context.timeSeconds);
+                reused.set([context.frameIndex + 1, 10, 20, 255]);
+                return {
+                    data: reused,
+                    format: 'rgba8unorm',
+                    width: 1,
+                    height: 1,
+                    bytesPerPixel: 4,
+                    bytesPerRow: 4
+                };
+            }
+        });
+
+        expect(flipbook.version).toBe(PARTICLE_BAKE_VERSION);
+        expect(flipbook.frameCount).toBe(3);
+        expect(times).toEqual([0, 1 / 3, 2 / 3]);
+        expect(flipbook).toMatchObject({
+            frameWidth: 1,
+            frameHeight: 1,
+            columns: 2,
+            rows: 2,
+            width: 2,
+            height: 2,
+            format: 'rgba8unorm',
+            bytesPerPixel: 4
+        });
+        expect([...flipbook.data]).toEqual([
+            1, 10, 20, 255, 2, 10, 20, 255, 3, 10, 20, 255, 0, 0, 0, 0
+        ]);
+        expect([...flipbook.frameUVs]).toEqual([0, 0, 0.5, 0.5, 0.5, 0, 1, 0.5, 0, 0.5, 0.5, 1]);
+
+        system.simulate(0.2);
+        const branch = system.stateHash();
+        system.restoreSimulation(before).simulate(0.2);
+        expect(system.stateHash()).toBe(branch);
+    });
+
+    it('rejects inconsistent flipbook readbacks and restores after callback failure', async () => {
+        const system = new ParticleSystem({
+            definition: spriteDefinition(),
+            seed: 8,
+            autoPlay: false
+        });
+        system.simulate(0.3);
+        const before = system.stateHash();
+        await expect(
+            system.bakeFlipbook({
+                duration: 1,
+                frameRate: 2,
+                captureFrame: ({ frameIndex }) => ({
+                    data: new Uint8Array(frameIndex === 0 ? 4 : 8),
+                    format: 'rgba8unorm',
+                    width: frameIndex === 0 ? 1 : 2,
+                    height: 1,
+                    bytesPerPixel: 4,
+                    bytesPerRow: frameIndex === 0 ? 4 : 8
+                })
+            })
+        ).rejects.toThrow(/one extent and color format/u);
+        expect(system.stateHash()).toBe(before);
+
+        await expect(
+            system.bakeFlipbook({
+                duration: 1,
+                frameRate: 2,
+                captureFrame: () => Promise.reject(new Error('capture failed'))
+            })
+        ).rejects.toThrow(/capture failed/u);
+        expect(system.stateHash()).toBe(before);
+    });
+
+    it('suppresses Stage advancement and completion side effects during asynchronous baking', async () => {
+        const system = new ParticleSystem({
+            definition: ParticleSystemDefinition.create({
+                emitters: [
+                    {
+                        name: 'bounded-bake',
+                        capacity: 8,
+                        execution: 'cpu',
+                        duration: 0.2,
+                        looping: false,
+                        emission: { rateOverTime: 2 },
+                        initialize: { lifetime: 0.1 },
+                        renderers: [{ type: 'sprite' }]
+                    }
+                ]
+            }),
+            autoPlay: false
+        });
+        let completionCount = 0;
+        system.on('complete', () => completionCount++);
+        await system.bakeFlipbook({
+            duration: 1,
+            frameRate: 2,
+            includeEnd: true,
+            captureFrame: context => {
+                context.system.update(10_000);
+                expect(() => context.system.bakeMeshCache({ duration: 1, frameRate: 1 })).toThrow(
+                    /already has an active bake/u
+                );
+                return {
+                    data: new Uint8Array(4),
+                    format: 'rgba8unorm',
+                    width: 1,
+                    height: 1,
+                    bytesPerPixel: 4,
+                    bytesPerRow: 4
+                };
+            }
+        });
+        expect(completionCount).toBe(0);
+        expect(system.completed).toBe(false);
+        expect(system.elapsedSeconds).toBe(0);
+    });
+
+    it('rejects absent mesh output, unsafe timelines, and stateful GPU baking', async () => {
+        const sprite = new ParticleSystem({
+            definition: spriteDefinition(),
+            autoPlay: false
+        });
+        expect(() => sprite.bakeMeshCache({ duration: 1, frameRate: 30 })).toThrow(
+            /no mesh emitter/u
+        );
+        expect(() => sprite.bakeMeshCache({ duration: 10, frameRate: 60, maxFrames: 10 })).toThrow(
+            /frame count .* exceeds limit/u
+        );
+
+        const gpu = new ParticleSystem({
+            definition: ParticleSystemDefinition.create({
+                emitters: [
+                    {
+                        name: 'gpu-bake',
+                        capacity: 16,
+                        execution: 'gpu',
+                        renderers: [{ type: 'sprite' }]
+                    }
+                ]
+            }),
+            compilationEnvironment: { backend: 'webgpu' },
+            autoPlay: false
+        });
+        await expect(
+            gpu.bakeFlipbook({
+                duration: 1,
+                frameRate: 1,
+                captureFrame: () => ({
+                    data: new Uint8Array(4),
+                    format: 'rgba8unorm',
+                    width: 1,
+                    height: 1,
+                    bytesPerPixel: 4,
+                    bytesPerRow: 4
+                })
+            })
+        ).rejects.toThrow(/does not support stateful GPU emitter gpu-bake/u);
+    });
+});

--- a/test/spec/particle/ParticleDefinitionSerialization.test.ts
+++ b/test/spec/particle/ParticleDefinitionSerialization.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import BoxGeometry from '../../../src/geometry/BoxGeometry';
+import ParticleCurve from '../../../src/particle/ParticleCurve';
+import {
+    deserializeParticleSystemDefinition,
+    parseParticleSystemDefinitionJSON,
+    PARTICLE_DEFINITION_SCHEMA,
+    serializeParticleSystemDefinition,
+    type ParticleDefinitionJSONRecord
+} from '../../../src/particle/ParticleDefinitionSerialization';
+import ParticleGradient from '../../../src/particle/ParticleGradient';
+import { ParticleParameter } from '../../../src/particle/ParticleParameter';
+import ParticleSystemDefinition from '../../../src/particle/ParticleSystemDefinition';
+import Texture from '../../../src/texture/Texture';
+
+function simpleDefinition(): ParticleSystemDefinition {
+    return ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'simple',
+                capacity: 8,
+                execution: 'cpu',
+                renderers: [{ type: 'sprite' }]
+            }
+        ]
+    });
+}
+
+describe('ParticleSystemDefinition JSON serialization', () => {
+    it('round-trips normalized definitions, shared parameter identity, and resource references', () => {
+        const geometry = new BoxGeometry();
+        const texture = new Texture();
+        const sharedScalar = new ParticleParameter('shared.scalar', 'float', 2);
+        const definition = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'round-trip',
+                    capacity: 32,
+                    execution: 'cpu',
+                    bounds: { mode: 'manual', min: [-4, -4, -4], max: [4, 4, 4] },
+                    emission: { rateOverTime: sharedScalar },
+                    initialize: { lifetime: 2, size: sharedScalar, meshIndex: 0 },
+                    modules: [
+                        {
+                            type: 'size-over-lifetime',
+                            curve: new ParticleCurve(
+                                [
+                                    { time: 0, value: 0 },
+                                    { time: 1, value: 1 }
+                                ],
+                                { wrap: 'loop', interpolation: 'smooth' }
+                            )
+                        },
+                        {
+                            type: 'color-over-lifetime',
+                            gradient: new ParticleGradient([
+                                { time: 0, color: [1, 1, 1, 1] },
+                                { time: 1, color: [1, 0, 0, 0] }
+                            ])
+                        }
+                    ],
+                    renderers: [
+                        {
+                            type: 'mesh',
+                            meshes: [{ geometry, texture }],
+                            coverage: 'opaque'
+                        }
+                    ]
+                }
+            ]
+        });
+
+        const serialized = serializeParticleSystemDefinition(definition, {
+            getResourceId: (_resource, kind) =>
+                kind === 'geometry' ? 'geometry/box' : 'texture/particle'
+        });
+        const decoded = parseParticleSystemDefinitionJSON(JSON.stringify(serialized), {
+            resolveResource: (kind, id) => {
+                expect(id).toBe(kind === 'geometry' ? 'geometry/box' : 'texture/particle');
+                return kind === 'geometry' ? geometry : texture;
+            }
+        });
+
+        expect(serialized).toMatchObject({
+            schema: PARTICLE_DEFINITION_SCHEMA,
+            version: 1,
+            parameters: [{ id: 'p0', name: 'shared.scalar', type: 'float' }]
+        });
+        expect(Object.isFrozen(serialized)).toBe(true);
+        expect(Object.isFrozen(serialized.emitters)).toBe(true);
+        expect(decoded.hash).toBe(definition.hash);
+        const emitter = decoded.emitters[0];
+        expect(emitter?.emission.rateOverTime).toBe(emitter?.initialize.size);
+        expect(emitter?.modules[0]?.type).toBe('size-over-lifetime');
+        if (emitter?.modules[0]?.type !== 'size-over-lifetime') {
+            throw new Error('Expected decoded curve module');
+        }
+        expect(emitter.modules[0].curve).toBeInstanceOf(ParticleCurve);
+        if (emitter.renderers[0]?.type !== 'mesh') throw new Error('Expected decoded mesh');
+        expect(emitter.renderers[0].meshes[0]?.geometry).toBe(geometry);
+        expect(emitter.renderers[0].meshes[0]?.texture).toBe(texture);
+    });
+
+    it('requires explicit resource codecs and rejects unknown schema fields and tags', () => {
+        const texture = new Texture();
+        const definition = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'resource',
+                    capacity: 4,
+                    renderers: [{ type: 'sprite', texture }]
+                }
+            ]
+        });
+        expect(() => serializeParticleSystemDefinition(definition)).toThrow(/getResourceId/u);
+
+        const duplicateResourceIds = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'duplicate-resources',
+                    capacity: 4,
+                    renderers: [
+                        { type: 'sprite', texture },
+                        { type: 'sprite', texture: new Texture() }
+                    ]
+                }
+            ]
+        });
+        expect(() =>
+            serializeParticleSystemDefinition(duplicateResourceIds, {
+                getResourceId: () => 'texture/duplicate'
+            })
+        ).toThrow(/refers to multiple objects/u);
+
+        const serialized = serializeParticleSystemDefinition(definition, {
+            getResourceId: () => 'texture/resource'
+        });
+        expect(() => deserializeParticleSystemDefinition(serialized)).toThrow(/resolveResource/u);
+        expect(() =>
+            deserializeParticleSystemDefinition(serialized, {
+                resolveResource: () => new BoxGeometry()
+            })
+        ).toThrow(/wrong object type/u);
+
+        const unknownField = JSON.parse(JSON.stringify(serialized)) as {
+            emitters: Record<string, unknown>[];
+        };
+        const firstEmitter = unknownField.emitters[0];
+        if (!firstEmitter) throw new Error('Expected serialized emitter');
+        firstEmitter['unexpected'] = true;
+        expect(() =>
+            deserializeParticleSystemDefinition(unknownField, {
+                resolveResource: () => texture
+            })
+        ).toThrow(/unexpected is not part of the schema/u);
+
+        const unknownNestedField = JSON.parse(JSON.stringify(serialized)) as {
+            emitters: { emission: Record<string, unknown> }[];
+        };
+        const nestedEmission = unknownNestedField.emitters[0]?.emission;
+        if (!nestedEmission) throw new Error('Expected serialized emission');
+        nestedEmission['unexpected'] = true;
+        expect(() =>
+            deserializeParticleSystemDefinition(unknownNestedField, {
+                resolveResource: () => texture
+            })
+        ).toThrow(/emission.unexpected is not part of the schema/u);
+
+        const unknownTag = JSON.parse(JSON.stringify(serialized)) as {
+            emitters: { renderers: { texture: { $type: string } }[] }[];
+        };
+        const taggedTexture = unknownTag.emitters[0]?.renderers[0]?.texture;
+        if (!taggedTexture) throw new Error('Expected serialized texture tag');
+        taggedTexture.$type = 'native-texture';
+        expect(() => deserializeParticleSystemDefinition(unknownTag)).toThrow(
+            /unknown tagged value/u
+        );
+    });
+
+    it('applies sequential upgrades and rejects missing or invalid version transitions', () => {
+        const current = serializeParticleSystemDefinition(simpleDefinition());
+        const legacy: ParticleDefinitionJSONRecord = Object.freeze({
+            schema: PARTICLE_DEFINITION_SCHEMA,
+            version: 0,
+            emitters: current.emitters
+        });
+        const upgrade = {
+            fromVersion: 0,
+            upgrade: (document: Readonly<ParticleDefinitionJSONRecord>) => ({
+                ...document,
+                version: 1,
+                parameters: []
+            })
+        };
+
+        expect(deserializeParticleSystemDefinition(legacy, { upgrades: [upgrade] }).hash).toBe(
+            simpleDefinition().hash
+        );
+        expect(() => deserializeParticleSystemDefinition(legacy)).toThrow(
+            /no upgrade from version 0/u
+        );
+        expect(() =>
+            deserializeParticleSystemDefinition(legacy, {
+                upgrades: [
+                    {
+                        fromVersion: 0,
+                        upgrade: document => ({ ...document, version: 2 })
+                    }
+                ]
+            })
+        ).toThrow(/must produce version 1/u);
+        expect(() => deserializeParticleSystemDefinition({ ...current, version: 2 })).toThrow(
+            /newer than supported/u
+        );
+    });
+
+    it('rejects malformed JSON and unknown parameter references before compilation', () => {
+        expect(() => parseParticleSystemDefinitionJSON('{')).toThrow(SyntaxError);
+        const serialized = serializeParticleSystemDefinition(simpleDefinition());
+        const malformed = JSON.parse(JSON.stringify(serialized)) as {
+            emitters: { emission: { rateOverTime?: unknown } }[];
+        };
+        const emitter = malformed.emitters[0];
+        if (!emitter) throw new Error('Expected serialized emitter');
+        emitter.emission.rateOverTime = { $type: 'parameter', id: 'missing' };
+        expect(() => deserializeParticleSystemDefinition(malformed)).toThrow(
+            /unknown parameter missing/u
+        );
+    });
+
+    it('validates materialized definitions against the requested backend', () => {
+        const gpu = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'serialized-gpu',
+                    capacity: 16,
+                    execution: 'gpu',
+                    bounds: { mode: 'manual', min: [-1, -1, -1], max: [1, 1, 1] },
+                    renderers: [{ type: 'sprite' }]
+                }
+            ]
+        });
+        const serialized = serializeParticleSystemDefinition(gpu);
+
+        expect(() =>
+            deserializeParticleSystemDefinition(serialized, {
+                compilationEnvironment: { backend: 'webgl2' }
+            })
+        ).toThrow(/requires WebGPU/u);
+        expect(
+            deserializeParticleSystemDefinition(serialized, {
+                compilationEnvironment: { backend: 'webgpu' }
+            }).hash
+        ).toBe(gpu.hash);
+    });
+});

--- a/test/spec/particle/ParticleSimulationCache.test.ts
+++ b/test/spec/particle/ParticleSimulationCache.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import { ParticleParameter, ParticleParameterSet } from '../../../src/particle/ParticleParameter';
+import {
+    PARTICLE_SIMULATION_CACHE_VERSION,
+    type ParticleSimulationCache
+} from '../../../src/particle/ParticleSimulationCache';
+import ParticleSystem from '../../../src/particle/ParticleSystem';
+import ParticleSystemDefinition from '../../../src/particle/ParticleSystemDefinition';
+
+function cpuDefinition(): ParticleSystemDefinition {
+    return ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'cpu-cache',
+                capacity: 64,
+                execution: 'cpu',
+                duration: 4,
+                looping: true,
+                fixedStep: 1 / 60,
+                eventCapacity: 64,
+                emission: { rateOverTime: 7, bursts: [{ time: 0, count: 2 }] },
+                initialize: {
+                    lifetime: { min: 0.4, max: 1.2 },
+                    direction: [0, 1, 0],
+                    speed: { min: 0.5, max: 2 }
+                },
+                modules: [
+                    { type: 'gravity', force: [0, -2, 0] },
+                    { type: 'drag', coefficient: 0.15 }
+                ],
+                renderers: [{ type: 'sprite' }]
+            }
+        ]
+    });
+}
+
+describe('ParticleSimulationCache', () => {
+    it('replays CPU scheduler, dense state, queued commands, and application events exactly', async () => {
+        const definition = cpuDefinition();
+        const parameters = new ParticleParameterSet();
+        const system = new ParticleSystem({
+            definition,
+            parameters,
+            seed: 0x1234,
+            autoPlay: false,
+            eventReadbackCapacity: 128
+        });
+        system.simulate(0.025).emit({ count: 3, position: [2, 3, 4], velocity: [1, 0, -1] });
+        const cache = system.captureSimulation();
+
+        const typedCache: ParticleSimulationCache = cache;
+        expect(typedCache).toBe(cache);
+        expect(cache.version).toBe(PARTICLE_SIMULATION_CACHE_VERSION);
+        expect(cache.definitionHash).toBe(definition.hash);
+        expect(cache.compiledPlanHash).toBe(system.compiledPlan.hash);
+        expect(cache.seed).toBe(0x1234);
+        expect(cache.parameterRevision).toBe(0);
+        expect(cache.emitterCount).toBe(1);
+        expect(cache.storageByteLength).toBeGreaterThan(0);
+        expect(Object.isFrozen(cache)).toBe(true);
+
+        system.timeScale = 2;
+        system.play();
+        system.simulate(0.7);
+        const expectedHash = system.stateHash();
+        const expectedAlive = system.aliveCount;
+        const expectedEvents = await system.readEvents();
+
+        system.restoreSimulation(cache);
+        expect(system.playing).toBe(false);
+        expect(system.timeScale).toBe(1);
+        system.simulate(0.7);
+        expect(system.stateHash()).toBe(expectedHash);
+        expect(system.aliveCount).toBe(expectedAlive);
+        expect(await system.readEvents()).toEqual(expectedEvents);
+
+        system.restoreSimulation(cache).simulate(0.7);
+        expect(system.stateHash()).toBe(expectedHash);
+    });
+
+    it('restores a compatible second CPU system sharing deterministic inputs', () => {
+        const definition = cpuDefinition();
+        const parameters = new ParticleParameterSet();
+        const source = new ParticleSystem({
+            definition,
+            parameters,
+            seed: 9,
+            autoPlay: false
+        });
+        source.simulate(0.5);
+        const cache = source.captureSimulation();
+        source.simulate(0.25);
+        const expected = source.stateHash();
+
+        const target = new ParticleSystem({
+            definition,
+            parameters,
+            seed: 9,
+            autoPlay: false
+        });
+        target.restoreSimulation(cache).simulate(0.25);
+        expect(target.stateHash()).toBe(expected);
+    });
+
+    it('reconstructs stateless CPU manual batches and pending commands', () => {
+        const definition = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'stateless-cache',
+                    capacity: 64,
+                    execution: 'stateless',
+                    duration: 5,
+                    looping: true,
+                    emission: { rateOverTime: 5 },
+                    initialize: { lifetime: 2, direction: [1, 0, 0], speed: 0.5 },
+                    renderers: [{ type: 'sprite' }]
+                }
+            ]
+        });
+        const system = new ParticleSystem({ definition, seed: 7, autoPlay: false });
+        system.emit({ count: 2, position: [1, 2, 3] }).simulate(0.4);
+        system.emit({ count: 3, velocity: [0, 1, 0] });
+        const cache = system.captureSimulation();
+        system.simulate(0.6);
+        const expectedHash = system.stateHash();
+        const expectedAlive = system.aliveCount;
+
+        system.restoreSimulation(cache).simulate(0.6);
+        expect(system.stateHash()).toBe(expectedHash);
+        expect(system.aliveCount).toBe(expectedAlive);
+        expect(cache.storageByteLength).toBe(0);
+    });
+
+    it('restores stateless GPU absolute time after a temporary CPU materialization', () => {
+        const definition = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'gpu-stateless-cache',
+                    capacity: 64,
+                    execution: 'stateless',
+                    duration: 8,
+                    looping: true,
+                    emission: { rateOverTime: 4 },
+                    initialize: { lifetime: 2 },
+                    renderers: [{ type: 'sprite' }]
+                }
+            ]
+        });
+        const system = new ParticleSystem({
+            definition,
+            seed: 5,
+            compilationEnvironment: { backend: 'webgpu' }
+        });
+        system.update(1000);
+        const cache = system.captureSimulation();
+        expect(cache.elapsedSeconds).toBe(1);
+        expect(system.stateHash()).toBe('gpu-stateless');
+
+        system.emit(2).simulate(0.25);
+        expect(system.stateHash()).not.toBe('gpu-stateless');
+        system.restoreSimulation(cache);
+        expect(system.elapsedSeconds).toBe(1);
+        expect(system.stateHash()).toBe('gpu-stateless');
+        system.update(1000);
+        expect(system.elapsedSeconds).toBe(2);
+    });
+
+    it('fails closed for stale parameters and incompatible deterministic inputs', () => {
+        const rate = new ParticleParameter('cache.rate', 'float', 2);
+        const definition = ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name: 'parameter-cache',
+                    capacity: 16,
+                    execution: 'cpu',
+                    emission: { rateOverTime: rate },
+                    renderers: [{ type: 'sprite' }]
+                }
+            ]
+        });
+        const parameters = new ParticleParameterSet();
+        const source = new ParticleSystem({
+            definition,
+            parameters,
+            seed: 3,
+            autoPlay: false
+        });
+        const cache = source.captureSimulation();
+
+        parameters.set(rate, 4);
+        expect(() => source.restoreSimulation(cache)).toThrow(/parameter revision is stale/u);
+        const differentParameters = new ParticleSystem({
+            definition,
+            parameters: new ParticleParameterSet(),
+            seed: 3,
+            autoPlay: false
+        });
+        expect(() => differentParameters.restoreSimulation(cache)).toThrow(
+            /same parameter-set identity/u
+        );
+        const differentSeed = new ParticleSystem({
+            definition,
+            parameters,
+            seed: 4,
+            autoPlay: false
+        });
+        expect(() => differentSeed.restoreSimulation(cache)).toThrow(/seed is incompatible/u);
+        const sameDataDifferentIdentity = new ParticleSystem({
+            definition: ParticleSystemDefinition.create({
+                emitters: [
+                    {
+                        name: 'parameter-cache',
+                        capacity: 16,
+                        execution: 'cpu',
+                        emission: { rateOverTime: rate },
+                        renderers: [{ type: 'sprite' }]
+                    }
+                ]
+            }),
+            parameters,
+            seed: 3,
+            autoPlay: false
+        });
+        expect(() => sameDataDifferentIdentity.restoreSimulation(cache)).toThrow(
+            /same immutable definition identity/u
+        );
+    });
+
+    it('rejects stateful GPU capture instead of performing production-loop readback', () => {
+        const system = new ParticleSystem({
+            definition: ParticleSystemDefinition.create({
+                emitters: [
+                    {
+                        name: 'gpu-stateful-cache',
+                        capacity: 64,
+                        execution: 'gpu',
+                        renderers: [{ type: 'sprite' }]
+                    }
+                ]
+            }),
+            compilationEnvironment: { backend: 'webgpu' },
+            autoPlay: false
+        });
+        expect(() => system.captureSimulation()).toThrow(
+            /does not support stateful GPU emitter gpu-stateful-cache/u
+        );
+    });
+});

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -18,6 +18,7 @@ import {
     MeshPicker,
     Node,
     OrbitControls,
+    ParticleAuthoringPreviewController,
     ParticleBudgetManager,
     ParticleCurve,
     ParticleEventChannel,
@@ -27,6 +28,18 @@ import {
     ParticleSystem,
     ParticleSystemDefinition,
     ParticleSystemPool,
+    compileParticleAuthoringGraph,
+    createParticleAuthoringGraph,
+    deserializeParticleSystemDefinition,
+    parseParticleSystemDefinitionJSON,
+    PARTICLE_DEFINITION_SCHEMA,
+    PARTICLE_AUTHORING_JSON_SCHEMA,
+    PARTICLE_AUTHORING_SCHEMA,
+    PARTICLE_AUTHORING_VERSION,
+    PARTICLE_BAKE_VERSION,
+    PARTICLE_PREVIEW_PROTOCOL_VERSION,
+    PARTICLE_SIMULATION_CACHE_VERSION,
+    serializeParticleSystemDefinition,
     PerspectiveCamera,
     Renderer,
     SCENE_STORAGE_BIND_GROUP,
@@ -55,9 +68,22 @@ import {
     type OrbitControlsOptions,
     type ParticleModule,
     type ParticleAdvancedQualityPlan,
+    type ParticleAuthoringCompileResult,
+    type ParticleAuthoringGraph,
+    type ParticleAuthoringPreviewRequest,
+    type ParticleAuthoringPreviewResponse,
     type ParticleBudgetProfile,
+    type ParticleFlipbook,
+    type ParticleFlipbookOptions,
+    type ParticleMeshCache,
+    type ParticleMeshCacheOptions,
     type ParticleMeshRendererDefinition,
+    type ParticleDefinitionDeserializationOptions,
+    type ParticleDefinitionSerializationOptions,
+    type ParticleDefinitionUpgrade,
+    type ParticleSystemDefinitionJSON,
     type ParticleRibbonRendererDefinition,
+    type ParticleSimulationCache,
     type ParticleStatelessSupport,
     type ParticleSystemDefinitionInput,
     type ParticleSystemParameters,
@@ -184,6 +210,45 @@ const particleDefinitionInput = {
     ]
 } satisfies ParticleSystemDefinitionInput;
 const particleDefinition = ParticleSystemDefinition.create(particleDefinitionInput);
+const particleSerializationOptions = {} satisfies ParticleDefinitionSerializationOptions;
+const particleDefinitionJSON: Readonly<ParticleSystemDefinitionJSON> =
+    serializeParticleSystemDefinition(particleDefinition, particleSerializationOptions);
+const particleUpgrade = {
+    fromVersion: 0,
+    upgrade: document => ({ ...document, version: 1, parameters: [] })
+} satisfies ParticleDefinitionUpgrade;
+const particleDeserializationOptions = {
+    upgrades: [particleUpgrade]
+} satisfies ParticleDefinitionDeserializationOptions;
+const decodedParticleDefinition = deserializeParticleSystemDefinition(particleDefinitionJSON);
+const parsedParticleDefinition = parseParticleSystemDefinitionJSON(
+    JSON.stringify(particleDefinitionJSON)
+);
+const particleAuthoringGraph: Readonly<ParticleAuthoringGraph> =
+    createParticleAuthoringGraph(particleDefinition);
+const particleAuthoringResult: ParticleAuthoringCompileResult =
+    compileParticleAuthoringGraph(particleAuthoringGraph);
+const particlePreviewRequest = {
+    protocolVersion: PARTICLE_PREVIEW_PROTOCOL_VERSION,
+    requestId: 'package-type-preview',
+    command: 'compile',
+    graph: particleAuthoringGraph,
+    seed: 42
+} satisfies ParticleAuthoringPreviewRequest;
+const particlePreview = new ParticleAuthoringPreviewController();
+const particlePreviewResponse: Readonly<ParticleAuthoringPreviewResponse> =
+    particlePreview.handle(particlePreviewRequest);
+void PARTICLE_AUTHORING_JSON_SCHEMA;
+void PARTICLE_AUTHORING_SCHEMA;
+void PARTICLE_AUTHORING_VERSION;
+void particleAuthoringResult;
+void particlePreviewResponse;
+void PARTICLE_DEFINITION_SCHEMA;
+void PARTICLE_BAKE_VERSION;
+void PARTICLE_SIMULATION_CACHE_VERSION;
+void particleDeserializationOptions;
+void decodedParticleDefinition;
+void parsedParticleDefinition;
 const particleMeshRenderer = {
     type: 'mesh',
     meshes: [{ geometry: new BoxGeometry() }],
@@ -213,6 +278,29 @@ const particleSystemParameters = {
     budgetId: 'type-consumer'
 } satisfies ParticleSystemParameters;
 const particleSystem = new ParticleSystem(particleSystemParameters);
+const particleSimulationCache: ParticleSimulationCache = particleSystem.captureSimulation();
+particleSystem.restoreSimulation(particleSimulationCache);
+const particleMeshCacheOptions = {
+    duration: 1,
+    frameRate: 30
+} satisfies ParticleMeshCacheOptions;
+const particleMeshCache: ParticleMeshCache = particleSystem.bakeMeshCache(particleMeshCacheOptions);
+const particleFlipbookOptions = {
+    duration: 1,
+    frameRate: 30,
+    captureFrame: () => ({
+        data: new Uint8Array(4),
+        format: 'rgba8unorm' as const,
+        width: 1,
+        height: 1,
+        bytesPerPixel: 4,
+        bytesPerRow: 4
+    })
+} satisfies ParticleFlipbookOptions;
+const particleFlipbook: Promise<ParticleFlipbook> =
+    particleSystem.bakeFlipbook(particleFlipbookOptions);
+void particleMeshCache;
+void particleFlipbook;
 particleSystem
     .emit(4)
     .simulate(1 / 60)


### PR DESCRIPTION
## Summary

- add versioned particle definition JSON, sequential upgrades, stable resource references, and shared parameter identity
- add deterministic simulation checkpoints plus bounded mesh-cache and flipbook baking
- add the external fixed-module graph JSON Schema, normalized inspector IR, node-addressable diagnostics, and deterministic preview protocol
- export and document the complete P6 API, update the API report, and add unit/package type coverage

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx vitest run test/spec/particle/*.test.ts` — 62 passed
- `npm run test:render:architecture` — 144 passed
- `npm run test:rhi` — 216 passed, 1 skipped
- `npm run api:check`
- `npm run test:types`
- `npm run test:package`
- `npm run docs:check`
- `npm run format:check`
- `npm run check:modernity`

## Known existing failure / coverage boundary

- `npm run test:unit` reaches 1849 passed and 1 skipped, but still has the two pre-existing `ClusteredForwardPlus.test.ts` failures: `Comparison sampler u_shadowAtlas is already represented as a WGSL depth texture`.
- No physical-GPU WebGPU browser lane was run for this authoring/cache/baking change. Stateful GPU capture/baking remains deliberately fail-closed; stateless preview stays on the normal renderer path without particle-state readback.
