### PR TITLE
fix(rendering): preserve managed texture orientation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,12 @@ with one shared rendering frontend, a Render Graph, a portable RHI, and WebGPU/W
 - Portable non-sampler data belongs in registered std140 uniform blocks. GLSL samplers are the only
   values outside blocks; both backends reject classic numeric uniforms. The constrained
   storage-aware raster contract is the only std430 exception.
+- All engine-managed 2D textures use top-left logical UVs and must cross exactly one normalization
+  boundary. Use `hiloTextureUV()` for managed image textures and `hiloRenderTargetUV()` for scene
+  color, depth, shadow atlases, and other Render Graph/RenderTarget attachments. Do not call
+  `texture()` or `textureLod()` with an unconverted logical UV. Pre-normalizing in a vertex stage or
+  using another backend-native coordinate is an exception only when the shader documents the
+  boundary and a directional, asymmetric WebGL2/WebGPU fixture proves row parity.
 - A shader change is complete only after the relevant WebGL2 compile/link, Naga translation, and
   real WebGPU pipeline or browser coverage passes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
 ### Changes
 
+- Normalize managed particle textures through the shared top-left UV boundary for CPU and WebGPU
+  sprite, mesh, motion-vector, ribbon, and trail shaders. Fix WebGPU 2D Sprite orientation when
+  `Texture.flipY` is false, and extend the asymmetric row-direction fixture across WebGL 2/WebGPU
+  render targets, ordinary materials, 2D Sprites, particles, and cube textures.
 - Add the versioned public `ParticleSystemDefinition`/`ParticleSystem` API through P0-P3. Compile
   immutable fixed modules into liveness-based SoA layouts with deterministic counter RNG and shared
   curve/gradient LUTs; provide portable CPU fixed-step simulation with one interleaved instanced

--- a/documentation/PARTICLE_SYSTEM.md
+++ b/documentation/PARTICLE_SYSTEM.md
@@ -327,6 +327,10 @@ shader, perform their depth comparison in the fragment stage, and omit a depth a
 pass. `softParticle.distance` and optional `contrast` control the fade; `depthWrite: true` is
 rejected before graph compilation.
 
+Sprite, mesh, ribbon, and trail color textures use the renderer-wide top-left logical UV contract
+and sample through `hiloTextureUV()`. This applies equally to portable CPU-generated draws and
+WebGPU storage-raster draws; asymmetric texture rows must not change direction between backends.
+
 ## Mesh, ribbon/trail, and advanced composition
 
 `type: 'mesh'` accepts 1–16 immutable triangle-list `Geometry` assets. CPU/stateless plans create

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -658,7 +658,13 @@ pass，不创建这些原生对象。
 - 普通材质采样通过 `hiloTextureUV()` 把 top-left logical UV 转成 native sampler UV；WebGL 2 在 cube
   face 上传与拷贝边界适配行方向，cube 环境采样因此通过 `hiloTextureCubeDirection()`
   保持连续的原始方向，避免破坏跨 face 的 seamless filtering。base
-  color、normal、metallic/roughness、anisotropy、clearcoat、BRDF LUT 与 LTC lookup 都服从这一规则。
+  color、normal、metallic/roughness、anisotropy、clearcoat、BRDF LUT、LTC
+  lookup、Sprite、粒子、ribbon/trail 与贴图 mesh 都服从这一规则。任何直接接收 logical UV 的
+  `texture()`/`textureLod()`
+  调用都是合同违规；只有明确记录为 backend-native 的坐标可以跳过 helper，并且必须由上下不对称的 WebGL
+  2/WebGPU 方向性 fixture 证明行方向一致。2D Sprite 因共享 PlaneGeometry 与 atlas
+  rect 的正负高度语义，在 vertex 阶段完成且只完成一次 WebGPU native V 归一化；`Texture.flipY`
+  两种策略都必须进入同一个方向性 fixture。
 - fullscreen quad 自身仍以 bottom-left geometry UV 表达，因此 scene/render-target
   sampling 使用不同的
   `hiloRenderTargetUV()`；不能在 vertex、fragment、present 和单个 effect 中重复翻转。

--- a/src/2d/SpriteMaterial.ts
+++ b/src/2d/SpriteMaterial.ts
@@ -39,11 +39,10 @@ void main() {
     v_texcoord = i_uvRect.xy + a_texcoord0 * i_uvRect.zw;
 #ifdef HILO_WEBGPU
     // PlaneGeometry carries WebGL's bottom-left V convention. Texture uploads with flipY=true
-    // retain that convention in WebGL2, while WebGPU samples from a top-left texture origin.
-    // A negative frame height already represents a non-flipped, top-left source.
-    if (i_uvRect.w > 0.0) {
-        v_texcoord.y = 1.0 - v_texcoord.y;
-    }
+    // and SpriteFrame's negative-height rectangles both resolve in that convention on WebGL2.
+    // WebGPU samples from a top-left texture origin, so every Sprite frame crosses this one
+    // backend-native normalization boundary regardless of the texture's authored flipY policy.
+    v_texcoord.y = 1.0 - v_texcoord.y;
 #endif
     v_tint = i_tint;
 }
@@ -101,7 +100,7 @@ class SpriteMaterial extends ShaderMaterial {
         const { texture, ...materialParameters } = params;
         super({
             ...materialParameters,
-            sourceRevision: 'Hilo3d.SpriteMaterial:1',
+            sourceRevision: 'Hilo3d.SpriteMaterial:2',
             compositing: {
                 mode: 'alpha-blend',
                 premultiplied: texture.premultiplyAlpha

--- a/src/particle/cpu/ParticleCPUInstanceWriter.ts
+++ b/src/particle/cpu/ParticleCPUInstanceWriter.ts
@@ -6,6 +6,7 @@ import ShaderMaterial from '../../material/ShaderMaterial';
 import type { MaterialBindingInfo } from '../../material/MaterialInstance';
 import { TRIANGLES } from '../../constants/webgl';
 import type { Renderer } from '../../render/Renderer';
+import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type { ParticleCompiledEmitterPlan } from '../ParticleCompiledPlan';
 import type {
     ParticleSortMode,
@@ -199,7 +200,7 @@ function createFragmentSource(renderer: ParticleSpriteRendererDefinition): strin
     const textureSample =
         renderer.texture === undefined || renderer.texture === null
             ? 'vec4 texel = vec4(1.0);'
-            : 'vec4 texel = texture(u_particleTexture, v_particleUV);';
+            : 'vec4 texel = texture(u_particleTexture, hiloTextureUV(v_particleUV));';
     const premultiply =
         renderer.blend === 'premultiplied-alpha' || renderer.blend === 'additive'
             ? 'color.rgb *= color.a;'
@@ -209,6 +210,7 @@ precision highp float;
 in vec2 v_particleUV;
 in vec4 v_particleColor;
 ${textureDeclaration}
+${renderer.texture === undefined || renderer.texture === null ? '' : portableCoordinatesSource}
 layout(location = 0) out vec4 fragmentColor;
 void main(void) {
     ${textureSample}

--- a/src/particle/cpu/ParticleCPUMeshInstanceWriter.ts
+++ b/src/particle/cpu/ParticleCPUMeshInstanceWriter.ts
@@ -6,6 +6,7 @@ import ShaderMaterial from '../../material/ShaderMaterial';
 import type { MaterialBindingInfo } from '../../material/MaterialInstance';
 import type { MaterialCompositing, MaterialCoverage } from '../../material/MaterialDefinition';
 import type { Renderer } from '../../render/Renderer';
+import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type { ParticleCompiledEmitterPlan } from '../ParticleCompiledPlan';
 import type {
     ParticleMeshRendererDefinition,
@@ -130,7 +131,7 @@ void main(void) {
 function fragmentSource(renderer: ParticleMeshRendererDefinition, hasTexture: boolean): string {
     const textureDeclaration = hasTexture ? 'uniform sampler2D u_particleTexture;' : '';
     const textureSample = hasTexture
-        ? 'vec4 texel = texture(u_particleTexture, v_particleUV);'
+        ? 'vec4 texel = texture(u_particleTexture, hiloTextureUV(v_particleUV));'
         : 'vec4 texel = vec4(1.0);';
     const lighting =
         renderer.lighting === 'lambert'
@@ -163,6 +164,7 @@ in vec4 v_particleColor;
 in vec3 v_particleNormal;
 ${textureDeclaration}
 ${lightBlock}
+${hasTexture ? portableCoordinatesSource : ''}
 layout(location = 0) out vec4 fragmentColor;
 void main(void) {
     ${textureSample}
@@ -228,12 +230,13 @@ flat in float v_motionHistoryValid;
 in vec2 v_motionUV;
 in float v_motionAlpha;
 ${hasTexture ? 'uniform sampler2D u_particleTexture;' : ''}
+${hasTexture ? portableCoordinatesSource : ''}
 layout(location = 0) out vec4 fragmentColor;
 #ifdef HILO_TEMPORAL_REACTIVE_MASK
 layout(location = 1) out float hilo_ReactiveMask;
 #endif
 void main(void) {
-    float coverageAlpha = v_motionAlpha * ${hasTexture ? 'texture(u_particleTexture, v_motionUV).a' : '1.0'};
+    float coverageAlpha = v_motionAlpha * ${hasTexture ? 'texture(u_particleTexture, hiloTextureUV(v_motionUV)).a' : '1.0'};
     ${renderer.coverage === 'masked' ? `if (coverageAlpha <= ${String(renderer.alphaCutoff ?? 0.5)}) discard;` : ''}
     float currentLogDepth = log2(1.0 + max(v_currentViewDepth, 0.0));
     if (v_motionHistoryValid < 0.5 || v_currentClipPosition.w <= 0.000001 || v_previousClipPosition.w <= 0.000001) {

--- a/src/particle/cpu/ParticleCPURibbonWriter.ts
+++ b/src/particle/cpu/ParticleCPURibbonWriter.ts
@@ -7,6 +7,7 @@ import type { MaterialBindingInfo } from '../../material/MaterialInstance';
 import type { MaterialCompositing } from '../../material/MaterialDefinition';
 import { TRIANGLES } from '../../constants/webgl';
 import type { Renderer } from '../../render/Renderer';
+import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type { ParticleCompiledEmitterPlan } from '../ParticleCompiledPlan';
 import type { ParticleRibbonRendererDefinition, ParticleVector3 } from '../ParticleTypes';
 import type { ParticleCPUState } from './ParticleCPUState';
@@ -138,9 +139,10 @@ in vec4 v_particleColor;
 in vec3 v_particleNormal;
 ${textured ? 'uniform sampler2D u_particleTexture;' : ''}
 ${lightBlock}
+${textured ? portableCoordinatesSource : ''}
 layout(location = 0) out vec4 fragmentColor;
 void main(void) {
-    vec4 color = ${textured ? 'texture(u_particleTexture, v_particleUV)' : 'vec4(1.0)'} * v_particleColor;
+    vec4 color = ${textured ? 'texture(u_particleTexture, hiloTextureUV(v_particleUV))' : 'vec4(1.0)'} * v_particleColor;
     if (color.a <= 0.00001) discard;
     ${lighting}
     ${premultiply}

--- a/src/particle/gpu/ParticleGPUAdvancedPlan.ts
+++ b/src/particle/gpu/ParticleGPUAdvancedPlan.ts
@@ -1,5 +1,6 @@
 import ComputeShader from '../../render/compute/ComputeShader';
 import StorageGraphicsShader from '../../render/compute/StorageGraphicsShader';
+import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type GeometryData from '../../geometry/GeometryData';
 import type { ParticleCompiledEmitterPlan } from '../ParticleCompiledPlan';
 import type {
@@ -192,9 +193,10 @@ in vec2 particleUV;
 in vec4 particleColor;
 in vec3 particleNormal;
 ${textured ? 'uniform sampler2D u_particleTexture;' : ''}
+${textured ? portableCoordinatesSource : ''}
 layout(location = 0) out vec4 fragmentColor;
 void main() {
-    vec4 color = ${textured ? 'texture(u_particleTexture, particleUV)' : 'vec4(1.0)'} * particleColor;
+    vec4 color = ${textured ? 'texture(u_particleTexture, hiloTextureUV(particleUV))' : 'vec4(1.0)'} * particleColor;
     if (color.a <= ${f32(masked ? (renderer.alphaCutoff ?? 0.5) : 0.00001)}) discard;
     ${lightingSource(renderer.lighting === 'lambert')}
     ${premultiply}
@@ -522,9 +524,10 @@ in vec3 particleNormal;
 ${soft === undefined ? '' : 'in float particleDepthMode;'}
 ${textured ? 'uniform sampler2D u_particleTexture;' : ''}
 ${soft === undefined ? '' : 'uniform sampler2D u_particleSceneDepth;'}
+${textured ? portableCoordinatesSource : ''}
 layout(location = 0) out vec4 fragmentColor;
 void main() {
-    vec4 color = ${textured ? 'texture(u_particleTexture, particleUV)' : 'vec4(1.0)'} * particleColor;
+    vec4 color = ${textured ? 'texture(u_particleTexture, hiloTextureUV(particleUV))' : 'vec4(1.0)'} * particleColor;
     ${
         soft === undefined
             ? ''

--- a/src/particle/gpu/ParticleGPUPlan.ts
+++ b/src/particle/gpu/ParticleGPUPlan.ts
@@ -1,5 +1,6 @@
 import ComputeShader from '../../render/compute/ComputeShader';
 import StorageGraphicsShader from '../../render/compute/StorageGraphicsShader';
+import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type { ParticleCompiledEmitterPlan } from '../ParticleCompiledPlan';
 import type {
     ParticleModule,
@@ -1273,7 +1274,7 @@ export function compileParticleGPUStorageRenderer(
     const columns = sheet?.type === 'texture-sheet' ? sheet.columns : 1;
     const textureSource = renderer.texture ? 'uniform sampler2D u_particleTexture;' : '';
     const textureSample = renderer.texture
-        ? 'vec4 texel = texture(u_particleTexture, particleUV);'
+        ? 'vec4 texel = texture(u_particleTexture, hiloTextureUV(particleUV));'
         : 'vec4 texel = vec4(1.0);';
     const textureBinding = 1;
     const depthBinding = renderer.texture ? textureBinding + 2 : textureBinding;
@@ -1444,6 +1445,7 @@ layout(std140) uniform ParticleViewBlock {
 in vec2 particleUV; in vec4 particleColor; ${softFragmentInput}
 ${textureSource}
 ${softParticleSource}
+${renderer.texture ? portableCoordinatesSource : ''}
 layout(location = 0) out vec4 fragmentColor;
 void main() { ${textureSample} vec4 color = texel * particleColor; ${softParticleFade} ${renderer.blend === 'alpha' || renderer.blend === undefined ? '' : 'color.rgb *= color.a;'} if (color.a <= 0.00001) discard; fragmentColor = color; }`
         })

--- a/test/spec/particle/ParticleAdvancedRendering.test.ts
+++ b/test/spec/particle/ParticleAdvancedRendering.test.ts
@@ -11,6 +11,7 @@ import { compileParticleGPUPlan } from '../../../src/particle/gpu/ParticleGPUPla
 import { WgslComputeShaderCompiler } from '../../../src/render/shader/WgslComputeCompiler';
 import { StorageGraphicsShaderCompiler } from '../../../src/render/shader/StorageGraphicsShaderCompiler';
 import Renderer from '../../../src/render/Renderer';
+import Texture from '../../../src/texture/Texture';
 
 declare const __HILO3D_GITHUB_ACTIONS_COVERAGE__: boolean;
 
@@ -22,6 +23,7 @@ const bounds = {
 
 describe('ParticleSystem P5 portable topology', () => {
     it('buckets CPU mesh particles into one instanced draw per mesh', () => {
+        const texture = new Texture();
         const system = new ParticleSystem({
             definition: ParticleSystemDefinition.create({
                 emitters: [
@@ -37,6 +39,7 @@ describe('ParticleSystem P5 portable topology', () => {
                                     { geometry: new BoxGeometry() },
                                     { geometry: new SphereGeometry() }
                                 ],
+                                texture,
                                 coverage: 'opaque',
                                 lighting: 'lambert',
                                 motionVectors: true
@@ -59,9 +62,26 @@ describe('ParticleSystem P5 portable topology', () => {
         expect(system.children.every(child => child instanceof Mesh && !child.useInstanced)).toBe(
             true
         );
+        for (const child of system.children) {
+            if (!(child instanceof Mesh)) throw new Error('Expected a CPU particle mesh bridge');
+            const forward = child.material?.definition.getPass('forward')?.shader;
+            const motion = child.material?.definition.getPass('motion-vector')?.shader;
+            expect(forward?.kind).toBe('glsl');
+            expect(motion?.kind).toBe('glsl');
+            if (forward?.kind !== 'glsl' || motion?.kind !== 'glsl') {
+                throw new Error('Expected textured particle mesh GLSL passes');
+            }
+            expect(forward.fragmentSource).toContain(
+                'texture(u_particleTexture, hiloTextureUV(v_particleUV))'
+            );
+            expect(motion.fragmentSource).toContain(
+                'texture(u_particleTexture, hiloTextureUV(v_motionUV)).a'
+            );
+        }
     });
 
     it('compacts CPU ribbon members into one segment-instanced draw', () => {
+        const texture = new Texture();
         const system = new ParticleSystem({
             definition: ParticleSystemDefinition.create({
                 emitters: [
@@ -71,7 +91,7 @@ describe('ParticleSystem P5 portable topology', () => {
                         execution: 'cpu',
                         bounds,
                         initialize: { ribbonId: 0 },
-                        renderers: [{ type: 'trail', widthScale: 0.5 }]
+                        renderers: [{ type: 'trail', texture, widthScale: 0.5 }]
                     }
                 ]
             }),
@@ -84,6 +104,12 @@ describe('ParticleSystem P5 portable topology', () => {
         if (!(output instanceof Mesh)) throw new Error('Expected a ribbon mesh bridge');
         expect(output.instanceCount).toBe(4);
         expect(system.children).toHaveLength(1);
+        const shader = output.material?.definition.getPass('forward')?.shader;
+        expect(shader?.kind).toBe('glsl');
+        if (shader?.kind !== 'glsl') throw new Error('Expected a textured CPU trail GLSL pass');
+        expect(shader.fragmentSource).toContain(
+            'texture(u_particleTexture, hiloTextureUV(v_particleUV))'
+        );
     });
 
     it('fails unsupported ordering and motion-vector combinations before a frame', () => {
@@ -255,6 +281,7 @@ describe('ParticleSystem P5 WebGPU plans', () => {
     });
 
     it('compiles mesh buckets and ribbon compact/indirect stages to validated GPU artifacts', () => {
+        const texture = new Texture();
         const definition = ParticleSystemDefinition.create({
             emitters: [
                 {
@@ -270,11 +297,13 @@ describe('ParticleSystem P5 WebGPU plans', () => {
                                 { geometry: new BoxGeometry() },
                                 { geometry: new SphereGeometry() }
                             ],
+                            texture,
                             coverage: 'opaque',
                             lighting: 'lambert'
                         },
                         {
                             type: 'ribbon',
+                            texture,
                             lighting: 'lambert',
                             softParticle: { distance: 0.1 }
                         }
@@ -295,11 +324,17 @@ describe('ParticleSystem P5 WebGPU plans', () => {
                     expect(() => computeCompiler.compile(shader)).not.toThrow();
                 }
                 for (const asset of renderer.assets) {
+                    expect(asset.shader.fragmentSource).toContain(
+                        'texture(u_particleTexture, hiloTextureUV(particleUV))'
+                    );
                     expect(() => graphicsCompiler.compile(asset.shader, 'webgpu')).not.toThrow();
                 }
             } else {
                 expect(renderer.topologyCapacity).toBe(32);
                 expect(renderer.shader.fragmentSource).toContain('bool hasSceneDepth');
+                expect(renderer.shader.fragmentSource).toContain(
+                    'texture(u_particleTexture, hiloTextureUV(particleUV))'
+                );
                 for (const shader of [
                     renderer.reset,
                     renderer.initializeTopology,

--- a/test/spec/particle/ParticleGPUPlan.test.ts
+++ b/test/spec/particle/ParticleGPUPlan.test.ts
@@ -127,6 +127,7 @@ describe('ParticleSystem P2 GPU artifacts', () => {
                     renderers: [
                         {
                             type: 'sprite',
+                            texture: new Texture(),
                             pivot: [0.25, 0.75],
                             alignment: 'stretched',
                             stretchScale: 2
@@ -153,6 +154,10 @@ describe('ParticleSystem P2 GPU artifacts', () => {
             'particleSize = particlePixelSize / particleWorldToPixels;'
         );
         expect(renderer.shader.vertexSource).not.toContain('length(viewVelocity) / particleSize');
+        expect(renderer.shader.fragmentSource).toContain('vec2 hiloTextureUV(vec2 uv)');
+        expect(renderer.shader.fragmentSource).toContain(
+            'texture(u_particleTexture, hiloTextureUV(particleUV))'
+        );
 
         const parent = new Node({ visible: false });
         const system = new ParticleSystem({

--- a/test/spec/particle/ParticleSystem.test.ts
+++ b/test/spec/particle/ParticleSystem.test.ts
@@ -6,6 +6,7 @@ import { ParticleParameter, ParticleParameterSet } from '../../../src/particle/P
 import ParticleSystem from '../../../src/particle/ParticleSystem';
 import ParticleSystemDefinition from '../../../src/particle/ParticleSystemDefinition';
 import { compileParticleSystemDefinition } from '../../../src/particle/ParticleCompiler';
+import Texture from '../../../src/texture/Texture';
 
 function definition(): ParticleSystemDefinition {
     return ParticleSystemDefinition.create({
@@ -217,7 +218,7 @@ describe('ParticleSystem P0/P1 contracts', () => {
         expect((mesh as Mesh).useInstanced).toBe(false);
     });
 
-    it('keeps CPU sprite stretch relative and screen-size constraints in pixel space', () => {
+    it('keeps CPU sprite sizing and managed-texture UVs portable', () => {
         const system = new ParticleSystem({
             definition: ParticleSystemDefinition.create({
                 emitters: [
@@ -227,7 +228,14 @@ describe('ParticleSystem P0/P1 contracts', () => {
                         execution: 'cpu',
                         initialize: { size: 0.03 },
                         modules: [{ type: 'screen-space-size', scale: 1.5, range: [2, 24] }],
-                        renderers: [{ type: 'sprite', alignment: 'stretched', stretchScale: 2 }]
+                        renderers: [
+                            {
+                                type: 'sprite',
+                                texture: new Texture(),
+                                alignment: 'stretched',
+                                stretchScale: 2
+                            }
+                        ]
                     }
                 ]
             }),
@@ -248,6 +256,10 @@ describe('ParticleSystem P0/P1 contracts', () => {
             'particleSize = particlePixelSize / particleWorldToPixels;'
         );
         expect(shader.vertexSource).not.toContain('length(a_particleVelocity) / particleSize');
+        expect(shader.fragmentSource).toContain('vec2 hiloTextureUV(vec2 uv)');
+        expect(shader.fragmentSource).toContain(
+            'texture(u_particleTexture, hiloTextureUV(v_particleUV))'
+        );
     });
 
     it('initializes new CPU particles after the current simulation step', () => {

--- a/test/spec/shader/ShaderModernity.test.ts
+++ b/test/spec/shader/ShaderModernity.test.ts
@@ -101,6 +101,8 @@ const legacySyntaxRules: readonly (readonly [string, RegExp])[] = [
 
 const classicUniformDeclaration =
     /\buniform\s+(?:(?:lowp|mediump|highp)\s+)?([A-Za-z_]\w*)\s+([A-Za-z_]\w*)(?:\s*\[[^\]]+\])?\s*;/g;
+const unnormalizedParticleTextureSample =
+    /\btexture(?:Lod)?\s*\(\s*u_particleTexture\s*,(?!\s*hiloTextureUV\s*\()/gu;
 
 function sourceLine(source: string, offset: number): { line: number; source: string } {
     const line = source.slice(0, offset).split('\n').length;
@@ -178,6 +180,19 @@ describe('WebGL 2 shader contract', () => {
 
     it('keeps hand-authored history uniform blocks on canonical ABI prefixes', () => {
         expect(collectBuiltInBlockViolations()).toEqual([]);
+    });
+
+    it('normalizes every managed particle texture sample through the portable UV boundary', () => {
+        const violations = Object.entries(engineShaderContainerSources).flatMap(
+            ([path, source]) => {
+                unnormalizedParticleTextureSample.lastIndex = 0;
+                return [...source.matchAll(unnormalizedParticleTextureSample)].map(match => ({
+                    path,
+                    ...sourceLine(source, match.index)
+                }));
+            }
+        );
+        expect(violations).toEqual([]);
     });
 
     it('uses the canonical CameraBlock source for viewport ABI diagnostics', () => {

--- a/test/ui/fixtures/fullscreen-orientation.ts
+++ b/test/ui/fixtures/fullscreen-orientation.ts
@@ -112,6 +112,20 @@ const managedCube = renderer.createRenderTarget({
     ...targetParameters,
     label: 'orientation.managed-cube'
 });
+const particleTarget = renderer.createRenderTarget({
+    width: 8,
+    height: 8,
+    sampleCount: 1,
+    depthStencilAttachment: false,
+    label: 'orientation.particle'
+});
+const spriteTarget = renderer.createRenderTarget({
+    width: 8,
+    height: 8,
+    sampleCount: 1,
+    depthStencilAttachment: false,
+    label: 'orientation.sprite'
+});
 const portableCoordinateShader = Hilo3d.Shader.shaders['method/portableCoordinates.glsl'];
 if (!portableCoordinateShader) {
     throw new Error('Portable coordinate shader helpers are unavailable');
@@ -191,24 +205,93 @@ const renderManagedCube = createManagedMaterialPass(
     }),
     new Float32Array([-1, 1, 1, 1, 1, 1, -1, -1, 1, 1, -1, 1])
 );
+const particleTexture = new Hilo3d.Texture({
+    image: new Uint8Array([255, 0, 0, 255, 255, 0, 0, 255, 0, 0, 255, 255, 0, 0, 255, 255]),
+    width: 2,
+    height: 2,
+    internalFormat: Hilo3d.constants.RGBA8,
+    format: Hilo3d.constants.RGBA,
+    type: Hilo3d.constants.UNSIGNED_BYTE,
+    minFilter: Hilo3d.constants.webgl.NEAREST,
+    magFilter: Hilo3d.constants.webgl.NEAREST,
+    wrapS: Hilo3d.constants.webgl.CLAMP_TO_EDGE,
+    wrapT: Hilo3d.constants.webgl.CLAMP_TO_EDGE
+});
+const particleScene = new Hilo3d.Node();
+const particleCamera = new Hilo3d.OrthographicCamera({
+    left: -1,
+    right: 1,
+    bottom: -1,
+    top: 1,
+    near: 0.1,
+    far: 10,
+    z: 3
+});
+particleCamera.lookAt(new Hilo3d.Vector3(0, 0, 0));
+const particleSystem = new Hilo3d.ParticleSystem({
+    definition: Hilo3d.ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'orientation-sprite',
+                capacity: 1,
+                execution: 'cpu',
+                bounds: { mode: 'manual', min: [-1, -1, -1], max: [1, 1, 1] },
+                initialize: { lifetime: 10, speed: 0, size: 1.5 },
+                renderers: [
+                    {
+                        type: 'sprite',
+                        texture: particleTexture,
+                        depthTest: false,
+                        depthWrite: false
+                    }
+                ]
+            }
+        ]
+    }),
+    autoPlay: false,
+    compilationEnvironment: { backend }
+}).addTo(particleScene);
+particleSystem.emit(1).simulate(1 / 60);
+const spriteScene = new Hilo3d.Node();
+const spriteCamera = new Hilo3d.Camera2D({ width: 8, height: 8 });
+new Hilo3d.Sprite({
+    texture: particleTexture,
+    x: 4,
+    y: 4,
+    width: 6,
+    height: 6
+}).addTo(spriteScene);
 
 renderSource(source);
 renderCopy(copied);
 renderManaged2D(managed2D);
 renderManagedCube(managedCube);
+renderer.renderToTarget(particleTarget, particleScene, particleCamera, false);
+renderer.renderToTarget(spriteTarget, spriteScene, spriteCamera, false);
 renderer.present(copied);
-const [sourceReadback, copiedReadback, managed2DReadback, managedCubeReadback] = await Promise.all([
+const [
+    sourceReadback,
+    copiedReadback,
+    managed2DReadback,
+    managedCubeReadback,
+    particleReadback,
+    spriteReadback
+] = await Promise.all([
     source.readColorAttachment(),
     copied.readColorAttachment(),
     managed2D.readColorAttachment(),
-    managedCube.readColorAttachment()
+    managedCube.readColorAttachment(),
+    particleTarget.readColorAttachment(),
+    spriteTarget.readColorAttachment()
 ]);
 window.__HILO3D_FULLSCREEN_ORIENTATION_RESULT__ = {
     backend,
     source: [...sourceReadback.data],
     copied: [...copiedReadback.data],
     managed2D: [...managed2DReadback.data],
-    managedCube: [...managedCubeReadback.data]
+    managedCube: [...managedCubeReadback.data],
+    particle: [...particleReadback.data],
+    sprite: [...spriteReadback.data]
 };
 document.body.dataset['fullscreenOrientationComplete'] = 'true';
 
@@ -220,6 +303,8 @@ declare global {
             readonly copied: readonly number[];
             readonly managed2D: readonly number[];
             readonly managedCube: readonly number[];
+            readonly particle: readonly number[];
+            readonly sprite: readonly number[];
         };
     }
 }

--- a/test/ui/post-processing.spec.ts
+++ b/test/ui/post-processing.spec.ts
@@ -212,7 +212,7 @@ for (const backend of backends) {
         }
     });
 
-    test(`fullscreen render-target copy preserves row orientation on ${backend} @${backend}`, async ({
+    test(`managed textures preserve row orientation on ${backend} @${backend}`, async ({
         page
     }) => {
         await installRenderHealthProbe(page);
@@ -248,6 +248,44 @@ for (const backend of backends) {
             expect(result?.managedCube.slice(-16)).toEqual([
                 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255
             ]);
+            const particle = result?.particle ?? [];
+            let upperRed = 0;
+            let upperBlue = 0;
+            let lowerRed = 0;
+            let lowerBlue = 0;
+            for (let y = 0; y < 8; y += 1) {
+                for (let x = 0; x < 8; x += 1) {
+                    const offset = (y * 8 + x) * 4;
+                    if (y < 4) {
+                        upperRed += particle[offset] ?? 0;
+                        upperBlue += particle[offset + 2] ?? 0;
+                    } else {
+                        lowerRed += particle[offset] ?? 0;
+                        lowerBlue += particle[offset + 2] ?? 0;
+                    }
+                }
+            }
+            expect(upperRed).toBeGreaterThan(upperBlue + 1_000);
+            expect(lowerBlue).toBeGreaterThan(lowerRed + 1_000);
+            const sprite = result?.sprite ?? [];
+            let spriteUpperRed = 0;
+            let spriteUpperBlue = 0;
+            let spriteLowerRed = 0;
+            let spriteLowerBlue = 0;
+            for (let y = 0; y < 8; y += 1) {
+                for (let x = 0; x < 8; x += 1) {
+                    const offset = (y * 8 + x) * 4;
+                    if (y < 4) {
+                        spriteUpperRed += sprite[offset] ?? 0;
+                        spriteUpperBlue += sprite[offset + 2] ?? 0;
+                    } else {
+                        spriteLowerRed += sprite[offset] ?? 0;
+                        spriteLowerBlue += sprite[offset + 2] ?? 0;
+                    }
+                }
+            }
+            expect(spriteUpperRed).toBeGreaterThan(spriteUpperBlue + 1_000);
+            expect(spriteLowerBlue).toBeGreaterThan(spriteLowerRed + 1_000);
             await assertFinalGraphicsHealth(
                 page,
                 backend,
@@ -426,6 +464,8 @@ declare global {
             readonly copied: readonly number[];
             readonly managed2D: readonly number[];
             readonly managedCube: readonly number[];
+            readonly particle: readonly number[];
+            readonly sprite: readonly number[];
         };
     }
 }


### PR DESCRIPTION
## Summary

- normalize CPU and WebGPU particle sprite, mesh, motion-vector, ribbon, and trail texture sampling through the shared top-left UV boundary
- fix WebGPU 2D Sprite orientation when Texture.flipY is false
- document the repository-wide single-normalization rule and add static plus asymmetric dual-backend regression coverage

## Validation

- npm run format:check
- npm run typecheck
- npm run lint
- targeted Vitest: 40 tests passed
- targeted Playwright orientation fixture: WebGL2 and WebGPU passed

## Not run

- full npm run validate
- physical native-GPU lane