### PR TITLE
feat(render): close WebGPU high-end P0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,29 @@
   temporal reactivity for the fused GPU Scene depth/motion pass.
 - Expand the fixed Camera/Model/Skinning/Morph/Instance std140 ABI with current/previous transforms,
   stable and jittered camera projections, render origins, and per-domain history/depth flags. Custom
-  shaders that redeclare built-in blocks must use the updated field order and capacities.
+  shaders that redeclare built-in blocks must use the updated field order and capacities. Add
+  `u_modelLayerParams` to `ModelBlock` so direct and GPU Scene clustered shading share the uint32
+  receiver light-layer contract.
 - Make forward feature color encoding explicit. `replaceColor()` now requires `linear` or `srgb`,
   and the default Forward pipeline always routes surface presentation through the Render Graph so
   the final output transfer is owned by the output stage rather than individual materials.
 - Replace the Forward-specific color-encoding type with the shared `RenderColorEncoding`. Manual
   RenderTarget presentation now accepts an explicit `colorEncoding`; linear inputs receive the final
   sRGB transfer, while display-transformed `srgb` inputs are preserved without a second conversion.
+- Make `ClusteredForwardPlusPipelineFactory.create()` asynchronous so renderer initialization can
+  finish its declared material-variant warmup before the first frame.
 
 ### Changes
+
+- Complete the WebGPU high-end Clustered Forward+ P0 closure. Globally sorted compatible transparent
+  PBR and direct GPU Scene skin, morph, and layered glTF PBR now consume the native storage light
+  list, while mixed Transmission/custom/particle transparent queues fail closed to the shared
+  Forward path. Add transparent/transmission and isolated GPU-particle reactive, depth-agreement,
+  history-resurrection composition; analytic Spot cookie/IES records and uint32 light-layer
+  filtering; a public material-variant manifest with asynchronous warmup, transactional runtime
+  admission, fixed budgets, and diagnostics; and real WebGPU pixel/UI coverage for rollback, device
+  loss, recovery, layered/deformed lighting, particles, and mixed-queue fallback. Fix the stateless
+  particle WGSL hash expression for strict browser parser precedence.
 
 - Resolve the `hilo3d-game` starter dependency from the npm `next` dist-tag, validate its supported
   2.0 release shape, and pin the resolved concrete version for reproducible installs.

--- a/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
+++ b/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
@@ -251,18 +251,18 @@ default 对象而发生串改。
 
 ## 10. 当前完成度与长期路线
 
-| 工作包                       | 状态           | 当前结果 / 下一步                                                                                  |
-| ---------------------------- | -------------- | -------------------------------------------------------------------------------------------------- |
-| Definition / Instance        | 已完成         | 内置与自定义材质都使用不可变结构和实例数据                                                         |
-| Semantic pass                | 已完成基础     | forward/depth/shadow/picking/motion 已接生产路径；attributes 待对应渲染功能实现                    |
-| Texture slot                 | 已完成         | 每槽 UV/transform/encoding/channel，glTF extensions 共用 builder                                   |
-| Typed semantics              | 已完成         | attribute/uniform/texture/slot 常量与联合类型公开                                                  |
-| UBO lowering                 | 已完成         | scalar 与 slot block 分离，双后端固定 ABI                                                          |
-| Shared GPU Material Database | 已完成（PBR）  | 私有 PBR table 已抽取、共享、去重，并具备 dirty upload、提交回滚与 recovery                        |
-| Variant manifest / warmup    | 未完成         | 增加资产收集、异步 warmup、预算与诊断                                                              |
-| Motion vectors               | 已完成生产切片 | opaque/masked、skin/morph/instance history、固定/动态 TAAU 与 authored reactive；透明 history 后续 |
-| Material attributes          | 已完成首版     | oct view normal/roughness/receiver/metallic ABI，SSR opt-in 时按需创建附件                         |
-| Advanced surface families    | 后续           | sheen/specular/dispersion、subsurface、hair 等按真实内容和预算推进                                 |
+| 工作包                       | 状态            | 当前结果 / 下一步                                                                               |
+| ---------------------------- | --------------- | ----------------------------------------------------------------------------------------------- |
+| Definition / Instance        | 已完成          | 内置与自定义材质都使用不可变结构和实例数据                                                      |
+| Semantic pass                | 已完成基础      | forward/depth/shadow/picking/motion 已接生产路径；attributes 待对应渲染功能实现                 |
+| Texture slot                 | 已完成          | 每槽 UV/transform/encoding/channel，glTF extensions 共用 builder                                |
+| Typed semantics              | 已完成          | attribute/uniform/texture/slot 常量与联合类型公开                                               |
+| UBO lowering                 | 已完成          | scalar 与 slot block 分离，双后端固定 ABI                                                       |
+| Shared GPU Material Database | 已完成（PBR）   | 私有 PBR table 已抽取、共享、去重，并具备 dirty upload、提交回滚与 recovery                     |
+| Variant manifest / warmup    | high-end 已完成 | Clustered manifest 异步 warmup、固定预算、事务式运行时准入与诊断                                |
+| Motion vectors               | 已完成生产切片  | opaque/masked、skin/morph/instance history、固定/动态 TAAU，以及透明/粒子 reactive 与短 history |
+| Material attributes          | 已完成首版      | oct view normal/roughness/receiver/metallic ABI，SSR opt-in 时按需创建附件                      |
+| Advanced surface families    | 后续            | sheen/specular/dispersion、subsurface、hair 等按真实内容和预算推进                              |
 
 首个共享 GPU Material Database 已满足：
 
@@ -272,8 +272,8 @@ default 对象而发生串改。
 - GPU Scene 与 indirect bucket 消费同一 material handle；
 - 不宣称或依赖浏览器 API 不具备的无限 bindless。
 
-更多 surface family、variant manifest/warmup，以及统一的 WebGL2 UBO/WebGPU storage family
-schema 属于后续独立工作包；shadow、motion 与首版 material-attributes 已在后续渲染工作中落地。
+更多 surface family 和统一的 WebGL2 UBO/WebGPU storage family schema 属于后续独立工作包；Clustered
+high-end 的 variant manifest/warmup、shadow、motion 与首版 material-attributes 已落地。
 
 ## 11. 架构不变量
 

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -1,6 +1,6 @@
 # Hilo3D 现代 WebGPU 渲染缺口与落地路线
 
-> 代码审计基线：`c2092d9`（`dev`，2026-08-13）；路线状态复核：2026-08-14。F0、F1、D0、MAT0 基础、G0/L0 生产切片、T0、E0、Q0，以及 V0/物理大气天气切片均已有生产代码和自动化证据；未登记的物理 GPU 跨提交性能基线仍不视为完成。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
+> 代码审计基线：`c2092d9`（`dev`，2026-08-13）；路线状态复核：2026-08-24。F0、F1、D0、MAT0、G0/L0、T0、E0、Q0，以及 V0/物理大气天气切片均已有生产代码和自动化证据；未登记的物理 GPU 跨提交性能基线仍不视为完成。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
 > 2 功能对等作为路线目标。
 
 ## 结论先行
@@ -11,22 +11,23 @@ Draw、HDR/PBR、设备丢失恢复、严格帧事务、TAA/TAAU、GTAO、SSR、
 
 1. **材质系统后续层**：`MaterialDefinition`/`MaterialInstance`、forward/depth/shadow/picking/motion/
    material-attributes 语义 Pass、共享 surface/BRDF，以及 renderer-local、按 identity 去重且 submission-aware 的 PBR
-   GPU Material Database 已落地；更多 surface family 与 variant manifest/warmup 仍待完成。详见
+   GPU Material Database 已落地；high-end variant
+   manifest、异步 warmup、预算和诊断已经闭环，更多 surface family 仍待按内容需求扩展。详见
    [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 2. **GPU Scene 与 GPU 可见性**：high-end profile 已让注册的普通不透明 `Mesh` 进入常驻 GPU
    database、previous-frame Hi-Z、GPU cull/LOD/compact 和固定 bucket indirect
    draw；alpha-mask 已覆盖 opacity/base-color
-   coverage、depth/motion/attributes/color 一致性；透明、蒙皮、morph 仍走正确的共享 Forward
-   compatibility path，尚未进入 GPU fast
-   path。110k 对象规模正确性 fixture 已存在，但登记的物理 GPU 跨提交性能基线仍是发布门禁。
+   coverage、depth/motion/attributes/color 一致性；skin/morph/layered PBR 使用 GPU Scene direct
+   storage lane，兼容透明 PBR 保留全局排序并消费 clustered light
+   list。110k 对象规模正确性 fixture 已存在，但登记的物理 GPU 跨提交性能基线仍是发布门禁。
 3. **生产级 Clustered Forward+**：high-end profile 已提供 depth-driven 3D cluster、GPU
    count/prefix/write allocator、有界 overflow 与 storage-aware GGX PBR、共享 shadow-atlas
-   sampling 与精确 LTC area light；完整 layered
-   material、cookie/IES、透明以及变形材质仍通过共享 Forward fallback，尚未成为 clustered-native
-   consumer。
+   sampling 与精确 LTC area light；完整 layered material、透明与变形材质已有 clustered-native
+   consumer，Spot analytic cookie/IES 和 uint32 light-layer ABI 已接入。
 4. **时域渲染框架**：recovery-aware history owner、current/previous transform、projection
    jitter、opaque/masked motion vector、原生分辨率 TAA、固定/动态 0.5–1 比例 TAAU 与 authored
-   reactive mask 已落地；透明 history/resurrection 策略仍未完成。
+   reactive mask 已落地；透明、transmission 与 GPU particle 已有隔离的 reactive/depth/history
+   resurrection 策略。
 5. **阴影缓存与虚拟页**：当前共享 Shadow Atlas、CSM、Spot/Point shadow 和 Clustered surface
    sampling 已完成，但仍每帧规划/绘制所需 slice；没有 static/dynamic invalidation、GPU caster
    cull、receiver-driven budget 或 virtual shadow page residency。
@@ -35,7 +36,7 @@ Draw、HDR/PBR、设备丢失恢复、严格帧事务、TAA/TAAU、GTAO、SSR、
    residency、虚拟纹理或虚拟阴影页系统；SSGI 已覆盖屏幕内漫反射传输，off-screen probe/software-BVH
    fallback 仍属于 GI0。
 
-最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 MAT0、T0、E0、Q0 与 V0 切片上继续完成 G0/L0 的剩余门禁、透明时域策略和物理 GPU 性能证据，再进入 S0/A0：
+最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 P0 功能闭环上登记物理 GPU 性能证据，再进入 S0/A0：
 
 ```mermaid
 flowchart LR
@@ -46,9 +47,10 @@ flowchart LR
   T --> Q
   F --> E["已完成切片：Auto Exposure / Filmic"]
   G --> V["已完成切片：Froxel / Atmosphere / Clouds"]
-  G --> P0["下一步：透明 / 变形 / Layered PBR / 性能基线"]
+  G --> P0["已完成：透明 / 变形 / Layered PBR / 时域策略"]
   T --> P0
-  P0 --> S["S0：Shadow cache / caster cull / pages"]
+  P0 --> PERF["下一步：登记物理 GPU 性能基线"]
+  PERF --> S["S0：Shadow cache / caster cull / pages"]
   P0 --> A["A0：KTX2 / Mip / Geometry streaming"]
   A --> M["M0：Meshlet / Cluster LOD"]
   Q --> GI["GI0：Probe / Software-BVH off-screen fallback"]
@@ -115,10 +117,10 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 | Raster PBR / HDR                     | 生产可用          | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                                             |
 | Shadow                               | 可用基线          | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow 和 PCF；Clustered opaque surface 已复用同一 atlas，仍缺缓存、GPU caster cull、receiver-driven 分配和虚拟页                      |
 | Compute / Storage / Indirect         | 底座生产可用      | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                                        |
-| Material architecture                | 生产基础          | Definition/Instance、shadow/motion/attribute 语义 Pass、authored temporal reactivity 与共享 PBR GPU record 已落地；更多 family/warmup 待补                                       |
-| GPU-driven ordinary scene            | high-end 生产切片 | 注册的 opaque/alpha-mask indexed `Mesh` 走 dirty GPU database、Hi-Z/projected-radius LOD/compact 与固定 bucket indirect；透明/变形保持 Forward fallback                          |
-| Forward+                             | high-end 生产切片 | 3D cluster count/prefix/write、有界预算、storage GGX PBR、共享 shadow atlas 与 LTC AreaLight 已闭环；完整 layered PBR、cookie/IES、透明/变形 clustered-native path 待补          |
-| Temporal rendering                   | 生产 TAAU 切片    | jitter/non-jitter matrix、opaque/masked velocity、depth rejection、output-resolution history、GPU-time dynamic resolution 与 authored reactive mask 已完成；透明 history 待补    |
+| Material architecture                | high-end P0 完成  | Definition/Instance、语义 Pass、共享 PBR GPU record，以及 variant manifest、异步 warmup、预算和诊断已落地；更多 family 按需扩展                                                  |
+| GPU-driven ordinary scene            | high-end P0 完成  | opaque/alpha-mask 走固定 bucket indirect；skin/morph/layered PBR 走 GPU Scene direct storage lane；兼容透明保留全局排序并消费 clustered light list                               |
+| Forward+                             | high-end P0 完成  | 3D cluster、有界预算、storage GGX PBR、共享 shadow/LTC、透明/变形/layered consumer、analytic cookie/IES 与 uint32 light-layer ABI 已闭环                                         |
+| Temporal rendering                   | high-end P0 完成  | opaque TAAU、GPU-time dynamic resolution、authored reactive，以及透明/transmission/GPU-particle 独立 short history 与 resurrection 已完成                                        |
 | Exposure / display transform         | WebGPU 生产切片   | 独立 Forward `AutoExposure` 与 Clustered 集成都具备 GPU histogram、asymmetric eye adaptation、submission-aware history；`ColorUber` 有参数化 filmic，Clustered 有 compact filmic |
 | Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；透明/离屏几何不参与 trace，probe/BVH fallback 待 GI0                                                  |
 | Volumetrics / atmosphere             | high-end 生产切片 | WebGPU Clustered froxel、height/local fog、screen-space caster visibility、physical atmosphere LUT、aerial perspective、temporal clouds，以及 surface/froxel cloud shadow 已落地 |
@@ -135,8 +137,9 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 - 通用 `SceneRenderPass.storageShaderVariant` 仍会替换整个 graphics
   shader，命中 instancing 时还会展开为逐 Mesh direct draw；G0/L0 专用 factory 已消费共享 PBR GPU
   record，并让 depth/motion/reactive/material-attributes/color 共用对象/材质索引。当前 native
-  storage shading 仍只覆盖注册的 opaque/alpha-mask、unskinned PBR bucket；透明、变形与更多 surface
-  family 走共享 Forward fallback。
+  storage shading 的固定 indirect bucket 覆盖注册的 opaque/alpha-mask、unskinned
+  PBR；skin、morph、layered 与全兼容透明队列使用 direct storage lane。未知 surface
+  family 和混合 compatibility transparent queue 继续 fail closed 到共享 Forward。
 - graph texture subresource view 与 persistent history 已落地；当前 history
   recipe 仍限定单 sample、单 mip、单 layer 的 2D color texture，多 subresource
   history 需要持久化 validity 后再开放。
@@ -147,7 +150,8 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
   reuse 或同帧物理 alias。
 - Camera/mesh/instance/skin/morph current/previous transform、history-valid ABI、projection
   jitter、motion-vector material pass、原生分辨率 TAA、固定/动态比例 TAAU 与 authored reactive
-  mask 已完成；仍缺透明 history/resurrection policy。
+  mask 已完成；透明/transmission/GPU-particle 使用隔离的短 history、reactive/depth
+  agreement 与 resurrection policy。
 - Turnkey Forward 已提供 GTAO、SSGI、TemporalAA、Bloom、`AutoExposure` 与
   `ColorUber`；其中 AutoExposure 是 WebGPU compute/storage feature，支持 average/center-weighted
   metering，但没有任意 authored metering mask。SSR、froxel 和 physical atmosphere/weather 仍只集成在
@@ -218,10 +222,10 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 | F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                  | L      | 当前 Graph/RHI                                |
 | F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                  | M      | WebGPU compiler/RHI                           |
 | D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                  | L      | Camera/shader ABI                             |
-| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | 生产基础完成；family/warmup 后续        | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
-| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | opaque/alpha-mask 生产切片完成          | XL     | F0、D0；材质/变形扩展使用 MAT0                |
-| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | opaque/alpha-mask 生产切片完成          | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
-| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | 生产切片完成；透明 history 后续         | XL     | F0、D0、MAT0                                  |
+| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续      | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
+| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                        | XL     | F0、D0；材质/变形扩展使用 MAT0                |
+| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                        | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
+| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                        | XL     | F0、D0、MAT0                                  |
 | E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                  | M      | F0、compute/storage；可独立于 T0 使用         |
 | Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0    | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
 | S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | 未开始；现有 atlas 没有内容 residency   | XL     | MAT0、G0、F0、F1                              |
@@ -237,10 +241,9 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 Material
 Database 已完成；G0/L0、T0、E0、Q0、V0/天气均已形成可运行的生产切片**。后续工作包可直接复用 subresource/history、GPU
 timeline、确定的前后帧坐标 ABI、GPU Scene object/light database、共享 PBR material
-handle/variant、3D cluster
-allocator 与现有时域/屏幕空间 controller。当前 P0 收口是 G0/L0 的透明、变形、完整 layered
-PBR/cookie/IES 接入和物理性能门禁；MAT0 继续扩展 family schema 与 variant
-warmup。S0、A0、M0 和 GI0 的 off-screen 层尚未开始。详见
+handle/variant、3D cluster allocator 与现有时域/屏幕空间 controller。P0 的透明、变形、完整 layered
+PBR、analytic cookie/IES、light-layer、variant
+warmup 和透明/粒子时域策略已收口；尚需在登记物理 GPU 上建立不可覆盖的跨提交性能基线。S0、A0、M0 和 GI0 的 off-screen 层尚未开始。详见
 [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 
 ## 6. 可落地工作包
@@ -388,9 +391,11 @@ Hi-Z 同时保留区块 min/max，culling 对 standard/reversed depth 分别读�
 最远值，SSR 读取完整区间。当前公开切片限定为单相机、single-sample、opaque/alpha-mask、unskinned、indexed
 triangle PBR bucket GPU fast
 path；alpha-mask 在 depth/motion/attributes/color 共用 base-color/opacity
-coverage；未注册 mesh、容量 overflow、skinning/morph、transparent/layered
-material 以及运行时 material/geometry replacement 会进入共享 Forward compatibility path，并通过 mesh
-identity exclusion 避免重复绘制。真实 WebGPU scale fixture 已覆盖 100k static + 10k dynamic、256
+coverage。符合内置 PBR 合同的 skin/morph/layered material 通过 GPU Scene direct storage
+lane；全兼容 transparent queue 保持 CPU 全局 back-to-front 顺序并消费 clustered light
+list。未注册 mesh、容量 overflow、混合 compatibility-transparent queue，以及运行时 material/geometry
+replacement 会进入共享 Forward compatibility path，并通过 mesh identity
+exclusion 避免重复绘制。真实 WebGPU scale fixture 已覆盖 100k static + 10k dynamic、256
 lights、dirty dynamic upload 与 device recovery；物理 GPU 上可比较的长期性能基线仍是 G0 发布门禁。
 
 当前切片采用稳定、后端中立的 GPU Scene 数据库合同：
@@ -402,7 +407,7 @@ lights、dirty dynamic upload 与 device recovery；物理 GPU 上可比较的�
 - compute 生成每 bucket indirect arguments，普通 `Mesh` 通过 GPU-driven
   renderer-list 路径消费，不另建第二套 scene renderer；
 - camera cut/disocclusion 时临时关闭 previous-frame occlusion，避免错误剔除；
-- transparent object 先保留独立排序策略，之后再加入 GPU radix/tile sort。
+- transparent object 保留全局 CPU back-to-front 排序；当前 P0 不要求 GPU radix/tile sort。
 
 WebGPU 没有 multi-draw-indirect-count，因此第一版应控制 bucket 数量：相同 pipeline/material/geometry 聚类后，每个 bucket 发一个固定 indirect
 draw；无可见实例的 bucket 由 GPU 写零 instance count。不要以为“GPU
@@ -452,12 +457,15 @@ scale 通过每对象 inverse-transpose normal basis 正确着色。alpha-mask �
 coverage 在 depth、motion、material-attributes 和 color pass 中一致 discard。directional/spot/point
 shadow light 复用 renderer 唯一 shadow atlas、shadow-first light
 order 与 cascade/bias/matrix 数据；storage PBR 支持 standard/reversed depth 3×3 PCF 和逐物体
-`receiveShadows`。贴图身份或同能力 variant 的运行时变化保留 GPU path；custom compile、layered
-PBR、transparent、transmission、parallax/environment 和变形输入由共享 Forward
+`receiveShadows`。layered PBR、skin/morph 与全兼容 transparent queue 通过 direct storage
+lane 使用相同 cluster light list；Spot analytic cookie/IES 与 uint32 receiver/light
+layer 在同一 light record ABI 中过滤。贴图身份或同能力 variant 的运行时变化保留 GPU path；custom
+compile、transmission、parallax/environment 和混合 compatibility-transparent queue 由共享 Forward
 fallback 保持功能正确；fallback 的 opaque/transparent split、shadow 录制和 transmission opaque scene
 copy 已有真实 WebGPU 覆盖，并与 GPU Scene 一起写 linear HDR 后统一经过 separable
-Bloom/ACES。它们尚未获得 clustered-native light list；cookie/IES、完整 layered
-PBR 与透明的 clustered-native 像素/性能证据仍是 L0 最终画质门禁。
+Bloom/ACES。material variant manifest 在异步创建期 warmup
+Naga/pipeline，运行时 variant 按固定预算和 submission
+transaction 准入，并暴露 warm/active/rejected/time diagnostics。
 
 当前第一版没有继续扩充普通 Forward 的固定 LightBlock，而是：
 
@@ -468,17 +476,18 @@ PBR 与透明的 clustered-native 像素/性能证据仍是 L0 最终画质门�
 - built-in PBR 的 BRDF/material evaluation 已与 light iteration 解耦；storage-aware
   variant 复用同一 surface/BRDF chunk，只注入 clustered light
   provider，而不是要求应用重写整个 shader；
-- opaque 和 alpha-tested material 使用 clustered list；透明先使用独立 coarse cluster 或 CPU-selected
-  light list；
-- shadow index 与 AreaLight 已进入同一 light
-  database/稳定全局前缀；cookie/IES 和更完整的 light-layer 策略仍是后续 ABI；
+- opaque、alpha-tested、兼容透明、skin/morph 与 layered material 使用 clustered
+  list；透明保留 CPU 全局排序；
+- shadow index 与 AreaLight 已进入同一 light database/稳定全局前缀；Spot analytic
+  cookie/IES 与 uint32 light-layer ABI 已进入固定 record；
 - WebGL 2 使用独立传统 forward factory，不在 WebGPU frame 内分支或静默截断。
 
 当前完成证据：数百动态局部光 fixture 不再生成按精确 light count 爆炸的 shader
 variant；opaque/alpha-mask PBR、shared shadow atlas、AreaLight、Forward fallback
 transmission、overflow 与 device recovery 有真实 WebGPU
-pipeline/browser 覆盖。L0 完整收口仍要求 layered/transparent/变形材质获得 clustered-native
-light-list 证据，并补 cookie/IES 与登记物理 GPU 性能基线。
+pipeline/browser 覆盖。P0 收口测试进一步覆盖 layered/transparent/变形 clustered-native
+light-list、cookie/IES/light-layer、variant budget、失败回滚与 device
+recovery；剩余证据门禁是登记的物理 GPU 跨提交性能基线。
 
 ### 6.3 Milestone 1B：时域画质主线
 
@@ -504,7 +513,8 @@ depth 供透明阶段继续组合。普通 Forward 使用独立 motion semantic 
 Scene motion 融入 depth prepass 并记录前一已提交帧 visibility。首次出现、显隐间断、camera/projection
 cut、resize、resolution-scale change、失败帧和 device recovery 均进入提交事务与 history
 invalidation 验收。材质 `temporalReactiveFactor` 写 `r8unorm` MRT，resolve 以 3×3
-dilation 与 luminance heuristic 共同抑制 history。transparent history/resurrection 保留到后续切片。
+dilation 与 luminance heuristic 共同抑制 history。transparent/transmission 与 GPU
+particle 使用独立 reactive/depth short history 和衰减 resurrection，不污染 opaque history。
 
 - opaque/alpha-tested geometry 输出 motion vector；skinning/morph 必须有 previous pose；
 - camera jitter 不污染 CPU picking/frustum；提供 jittered 与 non-jittered matrix；
@@ -512,8 +522,8 @@ dilation 与 luminance heuristic 共同抑制 history。transparent history/resu
   mask 是当帧 transient attachment，不伪装成跨帧资源；
 - disocclusion、relative-depth rejection、YCoCg neighborhood/variance clipping；
 - opaque/masked emissive 可通过 authored/luminance
-  reactivity 抑制 history；transmission、transparent、particle 与 UI 当前只有 resolve 后合成边界，更细 reactive/history
-  policy 仍待补；
+  reactivity 抑制 history；transmission、transparent 与 GPU particle 使用独立 reactive/depth/history
+  policy，UI 保持在全部时域 resolve 之后；
 - camera cut、FOV jump、origin shift、resize 和 resolution-scale change 重置 history。
 
 #### TAA → TAAU → Dynamic Resolution
@@ -524,13 +534,13 @@ dilation 与 luminance heuristic 共同抑制 history。transparent history/resu
 2. ~~内部低分辨率到输出分辨率的 TAAU，加入 reconstruction filter 和 sharpness；~~ 已完成；
 3. ~~基于 GPU timestamp 的动态分辨率控制器，带迟滞、上下限、history invalidation 和 camera/UI
    policy；~~ 已完成；
-4. authored reactive mask 已完成；transparency history composition 和 history
-   resurrection 继续作为质量迭代。
+4. ~~authored reactive mask、transparency/particle history composition 和 decaying resurrection；~~
+   已完成。
 
 当前切片完成标准已经覆盖静态收敛、运动物体、camera cut、alpha-test、动态分辨率与 authored
-reactive；动态分辨率不改变 UI/透明组合的输出分辨率。透明、transmission 和 particle 目前只执行 resolve 后的当帧合成，不进入 opaque
-history；它们的独立 history/resurrection 与更细 reactive
-policy 仍是 T0 后续质量门禁，不能写成已经完成。
+reactive；动态分辨率不改变 UI/透明组合的输出分辨率。透明、transmission 和 GPU particle 不进入 opaque
+history，而是使用各自 output-resolution color/mask/depth short history、depth agreement、reactive
+coverage 和衰减 resurrection；失败提交与 device recovery 遵守同一事务边界。
 
 #### E0：Auto Exposure 与 Filmic Display Transform（已完成）
 
@@ -775,8 +785,8 @@ flowchart TD
 | WebGPU backend    | `src/render/rhi/backends/webgpu/`                                         | 为 streaming/page/meshlet 消费者补精确 feature/limit 映射，不建立 bypass            |
 | Render Graph      | `src/render/graph/`、`src/render/pipeline/ScriptableRenderGraph.ts`       | multi-subresource history validity、compiled graph reuse、证据充分后的同帧 alias    |
 | Shader compiler   | `src/render/shader/`、`src/render/compute/`                               | 新 surface family、meshlet/streaming kernel；继续遵守 GLSL/Naga 与 Direct WGSL 边界 |
-| Shared renderer   | `src/render/renderer/`、`src/render/pipeline/ClusteredForwardPlus.ts`     | transparent/deformed/layered clustered consumer、shadow residency、GPU caster cull  |
-| Pipeline features | `src/render/pipeline/`、`src/render/postprocessing/`                      | transparent temporal policy、volumetric atlas shadow、未来 probe/off-screen GI      |
+| Shared renderer   | `src/render/renderer/`、`src/render/pipeline/ClusteredForwardPlus.ts`     | shadow residency、GPU caster cull 与未来 meshlet/streaming consumer                 |
+| Pipeline features | `src/render/pipeline/`、`src/render/postprocessing/`                      | volumetric atlas shadow、未来 probe/off-screen GI                                   |
 | Camera/frame ABI  | `src/camera/`、`src/render/ubo/BuiltInUniformBlocks.ts`                   | 当前 D0 已完成；新增空间表示必须复用现有 current/previous/origin transaction        |
 | Assets            | `src/loader/`、`src/texture/`、`src/geometry/`                            | KTX 2/Basis、meshopt/meshlet metadata、residency 与 streaming budget                |
 | Diagnostics       | `RendererDiagnostics`、RHI diagnostics、`ClusteredForwardPlusDiagnostics` | resident/in-flight/evicted bytes、shadow page、warmup queue 与登记物理 GPU baseline |
@@ -800,12 +810,12 @@ report、类型消费和 package 验证必须同版本完成。
   recovery 与 CPU record/GPU batch
   completion 分离。**仍缺**：登记物理 GPU 上不可覆盖的跨提交 frame-time/显存阈值；
 - **Clustered Forward+ 已有**：Sponza 数百局部光、deterministic overflow、shared
-  directional/spot/point shadow、LTC AreaLight、alpha-mask、fallback
-  transmission。**仍缺**：transparent/deformed/layered clustered-native 像素与性能场景、cookie/IES；
+  directional/spot/point shadow、LTC AreaLight、alpha-mask、fallback transmission，以及 P0
+  fixture 的 transparent/deformed/layered clustered-native、cookie/IES/ light-layer、variant
+  rollback/recovery 像素证据。**仍缺**：登记物理 GPU 性能基线；
 - **TAAU 已有**：Temporal Observatory 的收敛、camera
-  cut、固定/动态 scale、alpha-mask、emissive 与 authored
-  reactive。**仍缺**：transparent/particle/transmission
-  history/resurrection，而不是只验证 resolve 后合成；
+  cut、固定/动态 scale、alpha-mask、emissive 与 authored reactive，以及 P0
+  fixture 的 transparent/particle/transmission history/resurrection；
 - **E0 已有**：Stormfront Observatory 的大气明暗跨度、auto exposure、filmic、云/风暴交互与 GPU
   health；option/历史测试覆盖 EV 上下限和 camera continuity。任意 authored metering
   mask 只有在新增 API 时才需要新 fixture；
@@ -839,35 +849,25 @@ time、确定的资源预算和失败时的可观察行为。
 
 ## 11. 推荐实施顺序
 
-历史完成链已经包括 F0、F1、D0、MAT0 基础、G0/L0
-opaque/alpha-mask 生产切片、T0、E0、Q0 与 V0/天气。接下来不应重新排期这些能力，建议按以下可独立验收的变更链推进：
+历史完成链已经包括 F0、F1、D0、MAT0、G0/L0、T0、E0、Q0 与 V0/天气。接下来不应重新排期这些能力，建议按以下可独立验收的变更链推进：
 
 1. **登记 G0/L0 物理 GPU baseline**：把现有 110k object / 256 light
    fixture 纳入固定 hardware/browser/driver 的不可覆盖跨提交协议，先锁定 CPU record、GPU
    pass、upload 与显存阈值；
-2. **透明 clustered consumer + T0 透明策略**：保持现有 CPU
-   back-to-front 排序，先让透明 PBR 明确消费 coarse/clustered light list、shared
-   shadow 与 AreaLight，再定义 transparent/particle/transmission 的 reactive、history
-   composition 和 resurrection；不把 GPU radix sort 强塞进首版；
-3. **G0/L0 材质与变形扩展**：按真实内容依次接入 skin/morph previous pose、layered PBR
-   family、cookie/IES 和需要的 light-layer contract；同步增加 variant
-   manifest/warmup、失败回滚、recovery 与像素/性能证据；
-4. **S0 生产缓存层**：先做 stable atlas content cache、static/dynamic invalidation、GPU caster
+2. **S0 生产缓存层**：先做 stable atlas content cache、static/dynamic invalidation、GPU caster
    cull 和 receiver/budget 更新；只有第一层证明收益后再进入 virtual shadow page；
-5. **A0 资源流送**：KTX 2/Basis + capability-driven transcode、Worker decode、mip
+3. **A0 资源流送**：KTX 2/Basis + capability-driven transcode、Worker decode、mip
    residency、上传/内存/in-flight budget；随后再增加 geometry page/meshopt；
-6. **M0 meshlet/cluster geometry**：复用 GPU Scene、bucket LOD 与 A0 residency，先限定 static rigid
+4. **M0 meshlet/cluster geometry**：复用 GPU Scene、bucket LOD 与 A0 residency，先限定 static rigid
    mesh，以真实内容证明 cull/带宽收益；
-7. **GI0 off-screen 层**：在已完成 SSGI 基线上按产品需要评估 probe grid，再决定 software BVH/SDF
+5. **GI0 off-screen 层**：在已完成 SSGI 基线上按产品需要评估 probe grid，再决定 software BVH/SDF
    clipmap；virtual texture 和完整 virtual shadow 同样以真实内容/预算决定，不预先公开空 provider。
 
 ```mermaid
 flowchart LR
-  DONE["已完成：F0 / F1 / D0 / MAT0 基础 / T0 / E0 / Q0 / V0"] --> PERF["物理 GPU baseline"]
-  DONE --> GL["G0/L0 透明、变形、Layered 收口"]
-  PERF --> GL
-  GL --> S0["S0 Cache / GPU caster cull"]
-  GL --> A0["A0 KTX2 / Mip / Geometry streaming"]
+  DONE["已完成：F0 / F1 / D0 / MAT0 / G0 / L0 / T0 / E0 / Q0 / V0"] --> PERF["物理 GPU baseline"]
+  PERF --> S0["S0 Cache / GPU caster cull"]
+  PERF --> A0["A0 KTX2 / Mip / Geometry streaming"]
   S0 --> VSM["条件进入：Virtual shadow pages"]
   A0 --> M0
   M0["M0 Meshlet / Cluster geometry"] --> GI0["GI0 Probe / Software fallback"]
@@ -875,8 +875,8 @@ flowchart LR
   A0 --> GI0
 ```
 
-当前引擎已经覆盖通用材质前端、时域画质和多项 high-end 屏幕/体积效果；剩余 P0 问题是 G0/L0 fast
-path 的适用面和登记性能证据，而不是 motion/attributes、E0、Q0 或 V0 是否存在。S0/A0 是下一阶段 P1 主线，M0/GI0/完整虚拟页必须继续由真实内容、硬件预算和跨提交证据驱动。
+当前引擎已经覆盖通用材质前端、P0 GPU
+Scene/Clustered 适用面、时域画质和多项 high-end 屏幕/体积效果；功能 P0 已收口，尚需登记物理 GPU 性能证据。S0/A0 是下一阶段 P1 主线，M0/GI0/完整虚拟页必须继续由真实内容、硬件预算和跨提交证据驱动。
 
 ## 12. 外部参照
 

--- a/documentation/PARTICLE_SYSTEM_IMPLEMENTATION_PLAN.md
+++ b/documentation/PARTICLE_SYSTEM_IMPLEMENTATION_PLAN.md
@@ -706,8 +706,9 @@ draw。两者共享 particle surface shader chunks、texture/color/soft-depth �
 ### 10.3 透明、TAA 与后处理
 
 - 粒子默认在 opaque TAA/TAAU resolve 后、Bloom/tone mapping 前进入 linear HDR scene color；
-- transparent particle 不写 opaque motion/depth history；
-- 高 emissive/快速闪烁粒子通过显式 composition policy 避免污染 opaque history；
+- transparent particle 不写 opaque motion/depth history；Clustered high-end 把 GPU
+  particle 先写入 output-resolution overlay/mask/depth，再以独立短 history resolve 后合成；
+- 高 emissive/快速闪烁粒子通过 conservative reactive mask 和隔离 history 避免污染 opaque/透明表面；
 - soft particle 读取当前 scene depth，但不能与同一 pass 的 depth write 形成非法 feedback；
 - 首版只在 system/renderer group 粒度与普通 transparent
   queue 排序，不承诺每粒子与任意透明 Mesh 全局交错；

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -155,8 +155,11 @@ recovery 会让下一帧重新初始化，失败帧保留上一份已提交 hist
 
 Camera 同时维护 jittered raster projection 与 non-jittered CPU
 projection；frustum、picking、project/unproject 不读取 jitter。TAA/TAAU
-resolve 只处理 opaque 结果；TAAU 同时重建 full-resolution
-depth，供 transparent/transmission 在输出尺寸继续合成，Bloom 再消费完整线性 HDR 颜色。重建深度使用对应 internal
+resolve 先处理 opaque 结果；TAAU 同时重建 full-resolution
+depth，供 transparent/transmission 在输出尺寸继续合成。Clustered high-end 随后用透明 motion/reactive
+coverage 和 depth agreement resolve 独立的 color/mask/depth 短 history；GPU
+particle 使用隔离的 output-resolution
+overlay 与短 history，最后 Bloom 消费完整线性 HDR 颜色。重建深度使用对应 internal
 texel；带 stencil 的目标会在 TAAU 输出深度上把 stencil 清零，因此依赖 opaque
 stencil 值的透明自定义 pass 应保持 `renderScale=1`。
 
@@ -165,7 +168,7 @@ render/compute pass GPU duration，以 EWMA、迟滞、量化 `scaleStep`、warm
 `minScale`/`maxScale` 内调节；无可用、失败或饱和 sample 时保持当前比例，不回退到 CPU frame
 time。比例变化在下一帧同步更新 scene color/depth/motion/reactive、Hi-Z、cluster
 viewport、GTAO/SSGI/SSR、volumetric 与 atmosphere/cloud extent，并 fail
-closed 地重建尺寸相关 history。TAA color/depth history、transparent/particle/UI
+closed 地重建尺寸相关 history。TAA color/depth history、transparent/particle 短 history、UI
 composition 和 presentation 始终保持 output resolution。使用 dynamic resolution 的 Forward
 feature 可通过 `TemporalAA.readDynamicResolutionDiagnostics()`
 读取单 renderer 的当前比例与平滑 GPU 时间；Clustered 路径在 `readDiagnostics()` 返回相同字段。

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -208,12 +208,15 @@ dilation，并与亮度 heuristic 取最大值抑制不稳定 shading 的 histor
 是原生分辨率 TAA；固定或动态 0.5–1 的 sub-native scale 会同步缩放 opaque
 color/depth/motion、Hi-Z 与 cluster viewport，用 Catmull-Rom 重建当前帧，并写 output-resolution
 color/depth history、resolved color 和供后续 scene pass 使用的 full-resolution depth。resolved
-opaque color 随后才接受 transparent composition，因此透明不写入 TAA/TAAU history。Clustered Forward+
-opt-in TAA 时把 GPU Scene motion 融入 depth prepass，以前一已提交帧的 visibility
-buffer 拒绝重现物体的陈旧 history；fallback opaque/masked 在 resolve 前补写同一 motion
-target，fallback transparent 在 resolve 后合成。`dynamicResolution` 仅在 WebGPU `timestamp-query`
-可用时创建：控制器异步消费逐 Graph pass GPU 时间，使用 EWMA、迟滞、量化步进、warmup 与 settling
-window，在声明的 min/max 内调整 scene
+opaque color 随后接受 transparent/transmission composition；Clustered
+Forward+ 再以透明 motion、reactive coverage 和当前深度驱动独立的 color/mask/depth
+history，使用深度一致性、衰减与 resurrection 抑制拖影。GPU
+particle 在输出分辨率独立合成并使用自己的短 history；opaque/masked particle 还保守写满 reactive
+coverage。UI 始终留在全部时域 resolve 之后。Clustered Forward+ opt-in TAA 时把 GPU Scene
+motion 融入 depth prepass，以前一已提交帧的 visibility buffer 拒绝重现物体的陈旧 history；fallback
+opaque/masked 在 opaque resolve 前补写同一 motion target。`dynamicResolution` 仅在 WebGPU
+`timestamp-query` 可用时创建：控制器异步消费逐 Graph pass
+GPU 时间，使用 EWMA、迟滞、量化步进、warmup 与 settling window，在声明的 min/max 内调整 scene
 scale；比例变化会失效 TAA、Hi-Z、SSR、SSGI/GTAO、volumetric 与 atmosphere/cloud 的尺寸相关 history，但 UI/透明合成和最终 output 保持原生分辨率。之后
 `Bloom` 在 tone mapping 前记录 soft-knee/Karis prefilter、13-tap downsample pyramid、tent
 upsample 与线性 composite；`ColorUber` 最后统一完成 grading、tone
@@ -289,12 +292,17 @@ engine `Texture` 通过 graph import 复用 renderer 的上传、恢复与 submi
 pipeline runtime 的 `frameSubmitted()` / `frameDiscarded()` 是 CPU-side temporal
 state 的事务边界；current/previous object/camera transform 只在 RHI
 submission 已存在后提交，录制或提交前失败则丢弃 staged revision。当前 factory 限定 single-sample
-perspective camera 与 opaque/alpha-mask、unskinned、indexed triangle PBR bucket；GPU fast
-path 接受 scalar factor 以及 base-color/metallic/roughness/combined-MR/occlusion/emission/normal 2D
+perspective camera；固定 indirect bucket 限于 opaque/alpha-mask、unskinned、indexed triangle
+PBR；GPU fast path 接受 scalar
+factor 以及 base-color/metallic/roughness/combined-MR/occlusion/emission/normal 2D
 map，支持每纹理槽独立的 UV0/UV1、UV transform、encoding、channel 与 sampler
 mutation；alpha-mask 的 depth、motion、material-attributes 与 color pass 共用 base-color/opacity
-coverage 语义。未注册 mesh、对象容量 overflow、skinning/morph、transparent/layered
-material，以及注册 bucket 在运行时发生的不兼容 material/geometry/raster-state
+coverage 语义。符合内置 PBR 合同的 skin/morph 与完整 layered glTF opaque 通过 GPU Scene
+object/material record 进入 clustered direct storage
+lane；整个透明队列均兼容时，按全局 back-to-front 顺序进入同一 clustered-native light
+list。Transmission、自定义材质或粒子与透明 Mesh 混排时整条透明队列 fail
+closed，避免跨 native/compatibility
+pass 改写排序。未注册 mesh、对象容量 overflow，以及注册 bucket 在运行时发生的不兼容 material/geometry/raster-state
 replacement 会在同一帧迁移到共享 Forward compatibility path；恢复兼容后可重新进入 GPU
 Scene。fallback 使用显式 mesh identity
 exclusion 避免重复绘制，按 opaque/transparent 分开排序并复用共享 shadow 录制。compatibility
@@ -309,9 +317,12 @@ LUT 和显式 LOD 查询，不按点光近似；directional、spot 与 point sha
 light 继续由共享 renderer 录制唯一 shadow atlas，再把同一 graph texture、shadow-first light
 order、bias/cascade/matrix 数据返回 pipeline。clustered PBR 按物体 `receiveShadows`
 标志使用 standard/reversed-depth comparison sampler 做 3×3 PCF，不复制 atlas、不绕过 Render
-Graph，也不因启用阴影而整相机回退。初始 bucket 声明不合法、非 perspective/multisample
-output 或不支持的 WebGPU 设备仍 fail-closed；cookie/IES 继续走后续 high-end 扩展，不会静默退化到 WebGL
-2。factory 的 required
+Graph，也不因启用阴影而整相机回退。Spot light record 提供解析式 cookie scale/offset/intensity/
+softness 与归一化轴向 IES fit；所有灯光和 receiver 使用 uint32 light-layer mask，在 shader 入口 fail
+closed。该合同不伪装成任意 cookie texture atlas 或原始 `.ies` 文件导入。材质 variant
+manifest 在异步 factory 创建时 warmup Naga/pipeline，运行时新 variant 受固定预算与 submission
+transaction 约束，并通过 diagnostics 暴露 warm、active、rejected 和耗时。初始 bucket 声明不合法、非 perspective/multisample
+output 或不支持的 WebGPU 设备仍 fail-closed，不会静默退化到 WebGL 2。factory 的 required
 limits 覆盖 object/geometry/visible/cluster/light-index 全部 buffer 与最坏 dispatch
 dimension，在 runtime 分配前完成设备准入。
 

--- a/documentation/TEMPORAL_RENDERING_REMEDIATION.md
+++ b/documentation/TEMPORAL_RENDERING_REMEDIATION.md
@@ -82,9 +82,13 @@ shader 保持非 reactive；custom shader 可在 `HILO_TEMPORAL_REACTIVE_MASK` �
    role 补写同一 motion/reactive target；
 6. TAA initialize 或 resolve；TAAU 先以 Catmull-Rom 重建当前颜色，并写 output-resolution color/depth
    history、未进入 history 的 sharpened output 与 full-resolution scene depth；
-7. ordinary Forward fallback transparent/transmission 合成；
-8. Bloom、display transform、present；
-9. 只有 queue 接受 submission 后才轮换 color/depth/visibility history 并提交 previous transforms。
+7. native clustered 或 ordinary Forward transparent/transmission 合成，随后用透明 motion、reactive
+   coverage 与当前深度 resolve 独立的 color/mask/depth history；
+8. GPU particle 在 output
+   resolution 独立记录 overlay/reactive/depth，resolve 自己的短 history，再合成回场景；
+9. Bloom、display transform、present；
+10. 只有 queue 接受 submission 后才轮换 opaque、透明、粒子与 visibility history，并提交 previous
+    transforms 和 GPU particle state。
 
 任何 setup、prepare、execute 或提交失败都会走 discard：jitter 被清除，history index、visibility
 index 和 previous transform 都保持最后成功状态。
@@ -98,9 +102,10 @@ index 和 previous transform 都保持最后成功状态。
   box 对亮度和色度同时过宽。
 - 大 motion 最多只保留 60% history；当前/上一亮度差进一步降低 weight。材质 authored mask 做 3×3
   dilation 后与该 heuristic 取最大抑制量，`1` 会完全拒绝 history。
-- transparent、particle、UI 不写当前 opaque
-  history。它们在 TAAU 后保持 output-resolution 的当前帧 composition；transparent
-  history/resurrection 仍是后续质量切片。
+- transparent、transmission 与 particle 不写 opaque
+  history。它们在 TAAU 后以 output-resolution 独立 history resolve：透明使用 motion/reactive/depth
+  agreement 和衰减 resurrection；particle 使用隔离 overlay/mask/depth
+  history，避免污染表面 history。UI 保持在全部时域 composition 之后。
 - TAAU full-resolution depth 使用对应 internal depth texel；stencil 从零开始。依赖 opaque
   stencil 标记的透明自定义 pass 必须保持原生 `renderScale=1`。
 
@@ -117,6 +122,8 @@ TAA/TAAU 是明确 opt-in。以不含 backend row-pitch/alignment 的格式字�
 | Resolved target     | output-resolution `8 B/pixel` transient                               | 相同                                                                                           |
 | TAAU resolved depth | sub-native 模式额外一张 output-resolution depth transient             | 相同                                                                                           |
 | Visibility history  | 无                                                                    | 双缓冲 `uint`，合计 `8 B/object`；只在启用时存在                                               |
+| Transparent history | 无                                                                    | 双缓冲 `rgba16float` color + `r8unorm` mask + `r32float` depth；按需存在                       |
+| Particle history    | 无                                                                    | 独立双缓冲 color/mask/depth；仅可见 GPU particle 且 TAAU 启用时按需存在                        |
 
 原生 1080p 下，上述 history 加 motion/reactive/resolved 的理论额外峰值约 85 MB；其中约 50
 MB 是跨帧 persistent history。TAAU 的 current scene/motion/depth 成本按 `renderScale²`
@@ -126,6 +133,10 @@ history、一个 motion sample 和最多四个 depth history texel，并输出�
 attachment。它适合 high-end profile，不应在内存受限设备上默认开启。动态控制开启后还会激活 Render
 Graph timestamp query/resolve/readback 三槽 ring；回读不阻塞生产帧，ring 饱和时保持当前比例。history
 packing 或更低质量 tier 必须作为独立设计，不能偷偷改变当前 ABI。
+
+表中约 85 MB 的旧峰值估算只覆盖 opaque
+TAAU 基线；启用透明或粒子短 history 时还需按上述格式计入各自 output-resolution
+persistent 资源，未启用对应内容时不创建。
 
 ## 自动化验收
 

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -801,8 +801,11 @@ export interface CameraParameters extends NodeParameters {
 
 // @public
 export interface ClusteredForwardPlusDiagnostics {
+    readonly activeMaterialVariantCount: number;
     readonly autoExposureEV: number;
     readonly autoExposureTargetEV: number;
+    readonly clusteredDeformedObjectCount: number;
+    readonly clusteredTransparentObjectCount: number;
     readonly clusterLightIndexCount: number;
     readonly clusterOverflowCount: number;
     readonly droppedLightCount: number;
@@ -810,6 +813,9 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly hiZValid: boolean;
     readonly lightCount: number;
     readonly lodObjectCount: number;
+    readonly materialVariantBudget: number;
+    readonly materialVariantBudgetExceededCount: number;
+    readonly materialVariantWarmupTimeMs: number;
     readonly objectCount: number;
     readonly occludedObjectCount: number;
     readonly renderScale: number;
@@ -817,12 +823,13 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly visibleObjectCount: number;
     readonly volumetricFroxelCount: number;
     readonly volumetricHistoryUsed: boolean;
+    readonly warmedMaterialVariantCount: number;
 }
 
 // @public
 export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactory {
     constructor(options: Readonly<ClusteredForwardPlusPipelineOptions>);
-    create(context: RenderPipelineCreateContext): RenderPipeline;
+    create(context: RenderPipelineCreateContext): Promise<RenderPipeline>;
     readonly name = "GPU Scene + Clustered Forward+";
     readDiagnostics(): Promise<Readonly<ClusteredForwardPlusDiagnostics>>;
     readonly requirements: Readonly<RenderPipelineRequirements>;
@@ -848,8 +855,22 @@ export interface ClusteredForwardPlusPipelineOptions {
     readonly temporalAA?: Readonly<TemporalAAOptions> | false;
     readonly tileSize?: number;
     readonly toneMapping?: 'aces' | 'filmic';
+    readonly variantManifest?: Readonly<ClusteredMaterialVariantManifest>;
     readonly volumetricLighting?: Readonly<VolumetricLightingOptions> | false;
     readonly zSlices?: number;
+}
+
+// @public
+export interface ClusteredMaterialVariantManifest {
+    readonly entries: readonly Readonly<ClusteredMaterialVariantManifestEntry>[];
+    readonly maxVariants?: number;
+    readonly warmupBatchSize?: number;
+}
+
+// @public
+export interface ClusteredMaterialVariantManifestEntry {
+    readonly mesh: Mesh;
+    readonly shadowed?: boolean;
 }
 
 // @public (undocumented)
@@ -3683,6 +3704,8 @@ export class Light extends Node_2 {
     isPointLight: boolean;
     // (undocumented)
     isSpotLight: boolean;
+    get lightLayerMask(): number;
+    set lightLayerMask(value: number);
     linearAttenuation: number;
     quadraticAttenuation: number;
     get range(): number;
@@ -3793,6 +3816,7 @@ export interface LightParameters extends NodeParameters {
     enabled?: boolean;
     // (undocumented)
     isDirty?: boolean;
+    lightLayerMask?: number;
     // (undocumented)
     linearAttenuation?: number;
     // (undocumented)
@@ -8145,6 +8169,7 @@ export interface RenderPipelineContext {
 export interface RenderPipelineCreateContext {
     readonly capabilities: RenderPipelineCapabilities;
     createStorageBuffer(descriptor: Readonly<StorageBufferDescriptor>): StorageBuffer;
+    warmupStorageGraphicsShaders(shaders: readonly StorageGraphicsShader[], batchSize?: number): Promise<void>;
 }
 
 // @public
@@ -8585,6 +8610,7 @@ export interface SceneStorageBufferBinding {
 export interface SceneStorageShaderVariant {
     readonly buffers: readonly Readonly<SceneStorageBufferBinding>[];
     readonly shader: StorageGraphicsShader;
+    readonly shaderByMesh?: ReadonlyMap<Mesh, StorageGraphicsShader>;
 }
 
 // @public
@@ -8775,6 +8801,11 @@ export const semantic: {
     };
     OBJECTIDCOLOR: {
         get(mesh: SemanticMesh, _material: SemanticMaterial, _programInfo: ProgramBindingInfo): Float32Array;
+        isDependMesh: boolean;
+        notSupportInstanced: boolean;
+    };
+    MODELLAYERPARAMS: {
+        get(mesh: SemanticMesh, _material: SemanticMaterial, _programInfo: ProgramBindingInfo): Uint32Array;
         isDependMesh: boolean;
         notSupportInstanced: boolean;
     };
@@ -9627,6 +9658,8 @@ export class SpotLight extends Light {
     constructor(params?: SpotLightParameters);
     // (undocumented)
     className: string;
+    get cookie(): Readonly<Required<SpotLightCookie>> | null;
+    set cookie(value: Readonly<SpotLightCookie> | null);
     get cutoff(): number;
     set cutoff(value: number);
     // (undocumented)
@@ -9637,6 +9670,8 @@ export class SpotLight extends Light {
     getViewDirection(camera: Camera): Vector3;
     // (undocumented)
     getWorldDirection(): Vector3;
+    get iesProfile(): Readonly<Required<SpotLightIESProfile>> | null;
+    set iesProfile(value: Readonly<SpotLightIESProfile> | null);
     // (undocumented)
     isSpotLight: boolean;
     get outerCutoff(): number;
@@ -9645,6 +9680,20 @@ export class SpotLight extends Light {
     get outerCutoffCos(): number;
     // (undocumented)
     static readonly typeName = "SpotLight";
+}
+
+// @public
+export interface SpotLightCookie {
+    readonly intensity?: number;
+    readonly offset?: readonly [number, number];
+    readonly scale?: readonly [number, number];
+    readonly softness?: number;
+}
+
+// @public
+export interface SpotLightIESProfile {
+    readonly exponent?: number;
+    readonly intensity?: number;
 }
 
 // @public (undocumented)
@@ -9661,10 +9710,12 @@ export interface SpotLightInfo extends DirectionalLightInfo {
 
 // @public (undocumented)
 export interface SpotLightParameters extends ShadowCastingLightParameters {
+    cookie?: Readonly<SpotLightCookie> | null;
     // (undocumented)
     cutoff?: number;
     // (undocumented)
     direction?: Vector3;
+    iesProfile?: Readonly<SpotLightIESProfile> | null;
     // (undocumented)
     outerCutoff?: number;
 }

--- a/scripts/shader-modernity.ts
+++ b/scripts/shader-modernity.ts
@@ -13,6 +13,10 @@ interface SourceLiteral {
 
 const shaderGuardFixturePath = 'test/spec/shader/ShaderModernityGuardrails.test.ts';
 const shaderGuardImplementationPath = 'scripts/shader-modernity.ts';
+const storageGraphicsBoundaryImplementationPath = 'src/render/compute/StorageGraphicsShader.ts';
+const controlledStorageGraphicsChunkPaths: ReadonlySet<string> = new Set([
+    'src/shader/chunk/clusteredForward.frag'
+]);
 const controlledComputeFixturePaths: ReadonlySet<string> = new Set([
     'test/spec/renderer/ComputeKernel.test.ts',
     'test/spec/renderer/ComputePipelineResourceCache.test.ts',
@@ -277,7 +281,11 @@ function hasExactReadonlyStorageBlocks(source: string): boolean {
 }
 
 function isShaderGuardExempt(path: string): boolean {
-    return path === shaderGuardFixturePath || path === shaderGuardImplementationPath;
+    return (
+        path === shaderGuardFixturePath ||
+        path === shaderGuardImplementationPath ||
+        path === storageGraphicsBoundaryImplementationPath
+    );
 }
 
 /**
@@ -298,6 +306,18 @@ export function collectShaderModernityViolations(
     const isTypeScript = new Set(['.ts', '.tsx', '.mts', '.cts']).has(extension);
     if (!isTypeScript) {
         const violations: ShaderModernityViolation[] = [];
+        if (controlledStorageGraphicsChunkPaths.has(path)) {
+            if (!hasExactReadonlyStorageBlocks(source)) {
+                violations.push({
+                    label: 'StorageGraphicsShader storage block is not readonly std430',
+                    line: 1
+                });
+            }
+            if (glslComputeDialectPattern.test(source)) {
+                violations.push({ label: 'GLSL compute dialect', line: 1 });
+            }
+            return violations;
+        }
         const version = glslVersionPattern.exec(source);
         if (version && (version[1] !== '300' || version[2] !== 'es')) {
             violations.push({ label: 'graphics shader source is not GLSL ES 3.00', line: 1 });

--- a/src/Hilo3d.ts
+++ b/src/Hilo3d.ts
@@ -589,7 +589,12 @@ export {
     type SpotLightInfo
 } from './light/LightManager';
 export { default as PointLight, type PointLightParameters } from './light/PointLight';
-export { default as SpotLight, type SpotLightParameters } from './light/SpotLight';
+export {
+    default as SpotLight,
+    type SpotLightCookie,
+    type SpotLightIESProfile,
+    type SpotLightParameters
+} from './light/SpotLight';
 
 export { default as AxisHelper, type AxisHelperParameters } from './helper/AxisHelper';
 export { default as AxisNetHelper, type AxisNetHelperParameters } from './helper/AxisNetHelper';

--- a/src/light/Light.ts
+++ b/src/light/Light.ts
@@ -45,6 +45,8 @@ export interface LightParameters extends NodeParameters {
     quadraticAttenuation?: number;
     range?: number;
     isDirty?: boolean;
+    /** Receiver-layer mask used by clustered lighting; defaults to every layer. */
+    lightLayerMask?: number;
 }
 
 /** Parameters shared only by light kinds that implement shadows on every rendering backend. */
@@ -68,6 +70,19 @@ class Light extends Node {
      * 光强度
      */
     amount = 1;
+    private lightLayerMaskValue = 0xffffffff;
+
+    /** Receiver-layer mask evaluated independently from camera/node visibility. */
+    get lightLayerMask(): number {
+        return this.lightLayerMaskValue;
+    }
+
+    set lightLayerMask(value: number) {
+        if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+            throw new RangeError('Light.lightLayerMask must be an unsigned 32-bit integer.');
+        }
+        this.lightLayerMaskValue = value >>> 0;
+    }
     /**
      * 是否开启灯光
      */

--- a/src/light/SpotLight.ts
+++ b/src/light/SpotLight.ts
@@ -11,6 +11,30 @@ export interface SpotLightParameters extends ShadowCastingLightParameters {
     direction?: Vector3;
     cutoff?: number;
     outerCutoff?: number;
+    /** Optional analytic projected cookie for native clustered lighting. */
+    cookie?: Readonly<SpotLightCookie> | null;
+    /** Optional normalized axial IES fit for native clustered lighting. */
+    iesProfile?: Readonly<SpotLightIESProfile> | null;
+}
+
+/** Analytic projected cookie carried by the high-end clustered-light ABI. */
+export interface SpotLightCookie {
+    /** Projected half-extent on the light plane. */
+    readonly scale?: readonly [number, number];
+    /** Projected cookie-center offset. */
+    readonly offset?: readonly [number, number];
+    /** Cookie multiplier. Defaults to one. */
+    readonly intensity?: number;
+    /** Edge transition as a fraction of the cookie extent. Defaults to 0.1. */
+    readonly softness?: number;
+}
+
+/** Compact axial fit for an imported IES photometric profile. */
+export interface SpotLightIESProfile {
+    /** Candela multiplier after normalization. Defaults to one. */
+    readonly intensity?: number;
+    /** Axial concentration exponent. Defaults to one. */
+    readonly exponent?: number;
 }
 /**
  * 聚光灯
@@ -20,6 +44,72 @@ class SpotLight extends Light {
     override isSpotLight = true;
     override className = 'SpotLight';
     direction: Vector3;
+    private cookieValue: Readonly<Required<SpotLightCookie>> | null = null;
+    private iesProfileValue: Readonly<Required<SpotLightIESProfile>> | null = null;
+
+    /** Analytic projected cookie used by native clustered Spot lighting. */
+    get cookie(): Readonly<Required<SpotLightCookie>> | null {
+        return this.cookieValue;
+    }
+
+    /** Analytic projected cookie used by native clustered Spot lighting. */
+    set cookie(value: Readonly<SpotLightCookie> | null) {
+        if (value === null) {
+            this.cookieValue = null;
+            return;
+        }
+        const scale = value.scale ?? [1, 1];
+        const offset = value.offset ?? [0, 0];
+        const intensity = value.intensity ?? 1;
+        const softness = value.softness ?? 0.1;
+        if (
+            !Number.isFinite(scale[0]) ||
+            !Number.isFinite(scale[1]) ||
+            scale[0] <= 0 ||
+            scale[1] <= 0
+        ) {
+            throw new RangeError('SpotLight.cookie scale must contain two positive numbers.');
+        }
+        if (!Number.isFinite(offset[0]) || !Number.isFinite(offset[1])) {
+            throw new RangeError('SpotLight.cookie offset must contain two finite numbers.');
+        }
+        if (!Number.isFinite(intensity) || intensity < 0) {
+            throw new RangeError('SpotLight.cookie intensity must be finite and non-negative.');
+        }
+        if (!Number.isFinite(softness) || softness < 0 || softness > 1) {
+            throw new RangeError('SpotLight.cookie softness must be between zero and one.');
+        }
+        const normalizedScale: readonly [number, number] = Object.freeze([scale[0], scale[1]]);
+        const normalizedOffset: readonly [number, number] = Object.freeze([offset[0], offset[1]]);
+        this.cookieValue = Object.freeze({
+            scale: normalizedScale,
+            offset: normalizedOffset,
+            intensity,
+            softness
+        });
+    }
+
+    /** Normalized axial IES fit used by native clustered Spot lighting. */
+    get iesProfile(): Readonly<Required<SpotLightIESProfile>> | null {
+        return this.iesProfileValue;
+    }
+
+    /** Normalized axial IES fit used by native clustered Spot lighting. */
+    set iesProfile(value: Readonly<SpotLightIESProfile> | null) {
+        if (value === null) {
+            this.iesProfileValue = null;
+            return;
+        }
+        const intensity = value.intensity ?? 1;
+        const exponent = value.exponent ?? 1;
+        if (!Number.isFinite(intensity) || intensity < 0) {
+            throw new RangeError('SpotLight.iesProfile intensity must be finite and non-negative.');
+        }
+        if (!Number.isFinite(exponent) || exponent < 0) {
+            throw new RangeError('SpotLight.iesProfile exponent must be finite and non-negative.');
+        }
+        this.iesProfileValue = Object.freeze({ intensity, exponent });
+    }
     private cutoffCosine = Math.cos(math.degToRad(12.5));
     private cutoffDegrees = 12.5;
     /**

--- a/src/material/semantic.ts
+++ b/src/material/semantic.ts
@@ -34,6 +34,7 @@ const tempMatrix3 = new Matrix3();
 const tempMatrix4 = new Matrix4();
 const tempFloat32Array4 = new Float32Array([0.5, 0.5, 0.5, 1]);
 const tempFloat32Array2 = new Float32Array([0, 0]);
+const tempUint32Array4 = new Uint32Array(4);
 const activeViewport = new Float32Array(4);
 const legacyViewport: [number, number, number, number] = [0, 0, 0, 0];
 const materialTextureTransforms = new Float32Array(MATERIAL_TEXTURE_SLOT_COUNT * 9);
@@ -614,6 +615,22 @@ const semantic = {
             _programInfo: ProgramBindingInfo
         ): Float32Array {
             return getMeshPickingIdentity(mesh).color;
+        },
+        isDependMesh: true,
+        notSupportInstanced: true
+    },
+
+    MODELLAYERPARAMS: {
+        get(
+            mesh: SemanticMesh,
+            _material: SemanticMaterial,
+            _programInfo: ProgramBindingInfo
+        ): Uint32Array {
+            tempUint32Array4[0] = mesh.layer >>> 0;
+            tempUint32Array4[1] = 0;
+            tempUint32Array4[2] = 0;
+            tempUint32Array4[3] = 0;
+            return tempUint32Array4;
         },
         isDependMesh: true,
         notSupportInstanced: true

--- a/src/particle/stateless/ParticleStatelessGPUPlan.ts
+++ b/src/particle/stateless/ParticleStatelessGPUPlan.ts
@@ -213,9 +213,9 @@ fn mix32(input: u32) -> u32 {
 
 fn particleRandom(stableId: u32, lane: u32) -> f32 {
     var value = mix32(params.identity.x);
-    value = mix32(value ^ params.identity.y * 0x9e3779b1u);
-    value = mix32(value ^ stableId * 0x85ebca77u);
-    value = mix32(value ^ lane * 0x27d4eb2fu);
+    value = mix32(value ^ (params.identity.y * 0x9e3779b1u));
+    value = mix32(value ^ (stableId * 0x85ebca77u));
+    value = mix32(value ^ (lane * 0x27d4eb2fu));
     return f32(value) / 4294967296.0;
 }
 

--- a/src/render/BuiltInUniformBlockManager.ts
+++ b/src/render/BuiltInUniformBlockManager.ts
@@ -145,6 +145,7 @@ const MATERIAL_TEXTURE_BLOCK_FIELD_NAMES = Object.freeze(
 );
 const MODEL_HISTORY_INVALID = new Float32Array(4);
 const MODEL_HISTORY_VALID = new Float32Array([1, 0, 0, 0]);
+const MODEL_LAYER_PARAMS = new Uint32Array(4);
 
 function fieldNamesOf(layout: Std140Layout): readonly string[] {
     let names = layoutFieldNames.get(layout);
@@ -373,6 +374,8 @@ function updateModelTransformBlock(
         getMeshPickingIdentity(mesh).color,
         std140WriteResult
     );
+    MODEL_LAYER_PARAMS[0] = mesh.layer >>> 0;
+    modelBlockLayout.writeInto(target, 'u_modelLayerParams', MODEL_LAYER_PARAMS, std140WriteResult);
     if (!bytesEqual(bytesOf(buffer), candidate, 0, candidate.byteLength)) {
         buffer.write(0, candidate);
     }

--- a/src/render/compute/StorageGraphicsShader.ts
+++ b/src/render/compute/StorageGraphicsShader.ts
@@ -12,6 +12,16 @@ export interface StorageGraphicsShaderDescriptor {
     readonly bindings: readonly ShaderReadBinding[];
 }
 
+/** Internal adapter for a preprocessed portable shader promoted into the storage-raster dialect. */
+export interface PortableStorageGraphicsShaderDescriptor {
+    readonly label?: string;
+    /** Fully preprocessed GLSL ES 3.00 vertex source. */
+    readonly portableVertexSource: string;
+    /** Fully preprocessed GLSL ES 3.00 fragment source with constrained readonly storage blocks. */
+    readonly portableFragmentSource: string;
+    readonly bindings: readonly ShaderReadBinding[];
+}
+
 const MAX_U32 = 0xffff_ffff;
 const identifierPattern = /^[A-Za-z_]\w*$/u;
 const sampledTextureTypes: ReadonlySet<string> = new Set([
@@ -178,6 +188,14 @@ function requireSource(value: unknown, path: string): string {
     return value;
 }
 
+function promotePortableSource(source: string, stage: 'vertex' | 'fragment'): string {
+    const promoted = source.replace(/^#version 300 es$/mu, '#version 310 es');
+    if (promoted === source) {
+        throw new TypeError(`Portable storage graphics ${stage} source must use GLSL ES 3.00`);
+    }
+    return promoted;
+}
+
 /**
  * Immutable WebGPU-only graphics shader configuration for readonly storage-buffer rendering.
  *
@@ -242,6 +260,24 @@ export class StorageGraphicsShader {
         this.bindings = Object.freeze(bindings);
         Object.freeze(this);
     }
+}
+
+/**
+ * Promote fully preprocessed portable raster source at the single storage-graphics boundary.
+ * This keeps dynamic built-in material variants on the same GLSL/Naga path without admitting a
+ * second handwritten WGSL or raster-material tree.
+ *
+ * @internal
+ */
+export function createStorageGraphicsShaderFromPortable(
+    descriptor: Readonly<PortableStorageGraphicsShaderDescriptor>
+): StorageGraphicsShader {
+    return new StorageGraphicsShader({
+        ...(descriptor.label === undefined ? {} : { label: descriptor.label }),
+        vertexSource: promotePortableSource(descriptor.portableVertexSource, 'vertex'),
+        fragmentSource: promotePortableSource(descriptor.portableFragmentSource, 'fragment'),
+        bindings: descriptor.bindings
+    });
 }
 
 export default StorageGraphicsShader;

--- a/src/render/internal/RenderPipelineHost.ts
+++ b/src/render/internal/RenderPipelineHost.ts
@@ -10,6 +10,7 @@ import type { RHICapabilities } from '../rhi/core';
 import type { RenderTarget } from '../RenderTarget';
 import type { RendererScene } from '../RendererCore';
 import type { StorageBuffer, StorageBufferDescriptor } from '../StorageBuffer';
+import type StorageGraphicsShader from '../compute/StorageGraphicsShader';
 import {
     createRenderPipelineCapabilities,
     validateRenderPipelineCapabilitySuperset,
@@ -33,6 +34,10 @@ export interface RenderPipelineHostLifecycle {
     failFrame(error: unknown): void;
     endFrame(submitted: boolean): void;
     createPipelineStorageBuffer(descriptor: Readonly<StorageBufferDescriptor>): StorageBuffer;
+    warmupStorageGraphicsShaders(
+        shaders: readonly StorageGraphicsShader[],
+        batchSize?: number
+    ): Promise<void>;
     createPipelineContext(
         scene: RendererScene,
         camera: Camera,
@@ -115,7 +120,12 @@ export class RenderPipelineHost {
         const candidate: unknown = await factory.create(
             Object.freeze({
                 capabilities,
-                createStorageBuffer: this.lifecycle.createPipelineStorageBuffer.bind(this.lifecycle)
+                createStorageBuffer: this.lifecycle.createPipelineStorageBuffer.bind(
+                    this.lifecycle
+                ),
+                warmupStorageGraphicsShaders: this.lifecycle.warmupStorageGraphicsShaders.bind(
+                    this.lifecycle
+                )
             })
         );
         if (

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -5,6 +5,7 @@ import type LightManager from '../../light/LightManager';
 import type Material from '../../material/MaterialInstance';
 import type { MaterialPassRole } from '../../material/MaterialDefinition';
 import Texture from '../../texture/Texture';
+import StorageGraphicsShader from '../compute/StorageGraphicsShader';
 import type { RenderGraphFrameBuildScope } from '../frame/RenderGraphFrame';
 import type { RenderGraphFrameContext } from '../frame/RenderGraphFrameContext';
 import type { RGPassBuilder, RenderPassTemplate } from '../graph/RenderGraphBuilder';
@@ -2035,7 +2036,8 @@ class ScriptablePassSlot {
     #activeGPUDrivenDraw = false;
     #sceneStorageVariant: Readonly<SceneStorageShaderVariant> | null = null;
     #sceneStorageBindingCount = 0;
-    #sceneStorageBindGroup: RHIBindGroup | null = null;
+    readonly #sceneStorageBindGroups: RHIBindGroup[] = [];
+    readonly #sceneStorageLayouts: RHIBindGroupLayout[] = [];
     #activeSceneStorage = false;
     #sceneTextureHandle: RGTextureAccessHandle | null = null;
     #sceneTextureBindGroup: RHIBindGroup | null = null;
@@ -2056,15 +2058,15 @@ class ScriptablePassSlot {
     };
     readonly #sceneStoragePlans: MutableSceneStorageBindingPlan[] = [];
     readonly #sceneStoragePreparation: StorageScenePreparationState = {
-        globalBindGroupLayout: null
+        globalBindGroupLayouts: []
     };
     readonly #sceneStorageEntries: MutableFrameBindGroupEntry[] = [];
-    readonly #sceneStorageDescriptor = {
-        label: 'Scene pass-global readonly storage',
-        lifetime: 'frame' as const,
-        layout: null as RHIBindGroupLayout | null,
-        entries: this.#sceneStorageEntries
-    };
+    readonly #sceneStorageDescriptors: {
+        label: string;
+        lifetime: 'frame';
+        layout: RHIBindGroupLayout | null;
+        entries: MutableFrameBindGroupEntry[];
+    }[] = [];
     #capabilities: RenderPipelineCapabilities | null = null;
     #activeSetupLease: ScriptablePassCallbackLease | null = null;
     #activePrepareLease: ScriptablePassCallbackLease | null = null;
@@ -2139,7 +2141,7 @@ class ScriptablePassSlot {
         this.#sceneTextureHandle = null;
         this.#sceneStorageVariant = null;
         this.#sceneStorageBindingCount = 0;
-        this.#sceneStoragePreparation.globalBindGroupLayout = null;
+        this.#sceneStoragePreparation.globalBindGroupLayouts.length = 0;
         this.#sceneTexturePreparation.globalBindGroupLayout = null;
         this.#sceneTexturePreparation.bindingName = null;
         this.#copyDeclarationCount = 0;
@@ -2227,7 +2229,7 @@ class ScriptablePassSlot {
             this.#activeSceneTexture = false;
             this.#sceneTextureHandle = null;
             this.#sceneStorageVariant = null;
-            this.#sceneStoragePreparation.globalBindGroupLayout = null;
+            this.#sceneStoragePreparation.globalBindGroupLayouts.length = 0;
             this.#sceneTexturePreparation.globalBindGroupLayout = null;
             this.#sceneTexturePreparation.bindingName = null;
             this.#computeServices.release();
@@ -2498,6 +2500,44 @@ class ScriptablePassSlot {
         if (!registry.deviceCapabilities.features.has('storage-buffers')) {
             throw new Error('Scene storage shader variants require storage-buffer support');
         }
+        const shaderByMesh = variant.shaderByMesh;
+        if (shaderByMesh !== undefined) {
+            if (!(shaderByMesh instanceof Map)) {
+                throw new TypeError('Scene storage shaderByMesh must be a Map');
+            }
+            const canonicalStorageBindings = variant.shader.bindings.filter(
+                binding => binding.kind === 'read-only-storage-buffer'
+            );
+            for (const [mesh, shader] of shaderByMesh) {
+                if (!(mesh instanceof Mesh)) {
+                    throw new TypeError('Scene storage shaderByMesh keys must be Mesh instances');
+                }
+                if (!(shader instanceof StorageGraphicsShader)) {
+                    throw new TypeError(
+                        'Scene storage shaderByMesh values must be StorageGraphicsShader instances'
+                    );
+                }
+                const storageBindings = shader.bindings.filter(
+                    binding => binding.kind === 'read-only-storage-buffer'
+                );
+                if (
+                    storageBindings.length !== canonicalStorageBindings.length ||
+                    storageBindings.some((binding, index) => {
+                        const canonical = canonicalStorageBindings[index];
+                        if (canonical === undefined) return true;
+                        return (
+                            binding.name !== canonical.name ||
+                            binding.group !== canonical.group ||
+                            binding.binding !== canonical.binding
+                        );
+                    })
+                ) {
+                    throw new TypeError(
+                        `Scene storage shader variant for Mesh ${mesh.id} does not match the canonical readonly-storage ABI`
+                    );
+                }
+            }
+        }
         requireRuntimeArray(variant.buffers, 'Scene storage shader variant buffers');
         let storageCount = 0;
         for (const binding of variant.shader.bindings) {
@@ -2608,15 +2648,16 @@ class ScriptablePassSlot {
 
     private prepareSceneStorage(context: RGPrepareContext): void {
         const owner = this.requireOwner();
-        const layoutHandle = this.#sceneStoragePreparation.globalBindGroupLayout;
-        if (layoutHandle === null) {
+        const layoutHandles = this.#sceneStoragePreparation.globalBindGroupLayouts;
+        if (layoutHandles.length === 0) {
             if (this.draw.drawCount === 0) return;
             throw new Error('Scene storage draw preparation did not produce a global layout');
         }
+        if (layoutHandles.length !== this.draw.drawCount) {
+            throw new Error('Scene storage draw layouts do not match the prepared draw count');
+        }
         this.cleanupSceneStorage(owner.resources);
         const registry = owner.services.getScriptableGPUDrivenPipelineResources().registry;
-        const layout = registry.resolve(layoutHandle);
-        this.#sceneStorageDescriptor.layout = layout;
         for (let index = 0; index < this.#sceneStorageBindingCount; index += 1) {
             const plan = this.#sceneStoragePlans[index];
             if (plan?.handle === null || plan?.handle === undefined) {
@@ -2634,17 +2675,40 @@ class ScriptablePassSlot {
             plan.resource.size = plan.byteLength;
             plan.entry.resource = plan.resource as RHIBindingResource;
         }
-        const bindGroup = registry.createFrameBindGroup(
-            this.#sceneStorageDescriptor as RHIBindGroupDescriptor
-        );
-        this.#sceneStorageBindGroup = bindGroup;
-        owner.resources.trackFrameBindGroup(bindGroup);
-        for (let index = 0; index < this.#rangeCount; index += 1) {
-            const range = this.ranges[index];
-            if (range === undefined) continue;
+        for (let drawIndex = 0; drawIndex < layoutHandles.length; drawIndex += 1) {
+            const layoutHandle = layoutHandles[drawIndex];
+            if (layoutHandle === undefined) {
+                throw new Error(`Scene storage draw ${String(drawIndex)} has no layout`);
+            }
+            const layout = registry.resolve(layoutHandle);
+            let layoutIndex = this.#sceneStorageLayouts.indexOf(layout);
+            if (layoutIndex < 0) {
+                layoutIndex = this.#sceneStorageLayouts.length;
+                this.#sceneStorageLayouts.push(layout);
+                let descriptor = this.#sceneStorageDescriptors[layoutIndex];
+                if (descriptor === undefined) {
+                    descriptor = {
+                        label: 'Scene pass-global readonly storage',
+                        lifetime: 'frame',
+                        layout: null,
+                        entries: this.#sceneStorageEntries
+                    };
+                    this.#sceneStorageDescriptors.push(descriptor);
+                }
+                descriptor.layout = layout;
+                const bindGroup = registry.createFrameBindGroup(
+                    descriptor as RHIBindGroupDescriptor
+                );
+                this.#sceneStorageBindGroups.push(bindGroup);
+                owner.resources.trackFrameBindGroup(bindGroup);
+            }
+            const bindGroup = this.#sceneStorageBindGroups[layoutIndex];
+            if (bindGroup === undefined) {
+                throw new Error(`Scene storage layout ${String(layoutIndex)} has no bind group`);
+            }
             this.draw.setPreparedBindGroupForRange(
-                range.start,
-                range.count,
+                drawIndex,
+                1,
                 SCENE_STORAGE_BIND_GROUP,
                 bindGroup
             );
@@ -2652,10 +2716,12 @@ class ScriptablePassSlot {
     }
 
     private cleanupSceneStorage(resources: ScriptableRenderPipelineResources): void {
-        const bindGroup = this.#sceneStorageBindGroup;
-        this.#sceneStorageBindGroup = null;
-        if (bindGroup !== null) resources.releaseFrameBindGroup(bindGroup);
-        this.#sceneStorageDescriptor.layout = null;
+        for (const bindGroup of this.#sceneStorageBindGroups) {
+            resources.releaseFrameBindGroup(bindGroup);
+        }
+        this.#sceneStorageBindGroups.length = 0;
+        this.#sceneStorageLayouts.length = 0;
+        for (const descriptor of this.#sceneStorageDescriptors) descriptor.layout = null;
         for (let index = 0; index < this.#sceneStorageBindingCount; index += 1) {
             const plan = this.#sceneStoragePlans[index];
             if (plan === undefined) continue;
@@ -5194,6 +5260,12 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                 `Storage scene draws do not support material pass ${list.materialPass}`
             );
         }
+        const storageShader = (mesh: Mesh): StorageGraphicsShader => {
+            if (storageVariant === null) {
+                throw new Error('Scene storage shader variant is unavailable');
+            }
+            return storageVariant.shaderByMesh?.get(mesh) ?? storageVariant.shader;
+        };
         for (const item of plan.opaqueItems) {
             if (item instanceof Mesh) {
                 drawPass.addDrawSnapshot(
@@ -5208,7 +5280,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                         : processor.prepareStorageScene(
                               item,
                               target,
-                              storageVariant.shader,
+                              storageShader(item),
                               storagePipelines,
                               storagePreparation,
                               list.overrideMaterial
@@ -5234,7 +5306,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                     processor.prepareStorageScene(
                         mesh,
                         target,
-                        storageVariant.shader,
+                        storageShader(mesh),
                         storagePipelines,
                         storagePreparation,
                         list.overrideMaterial,
@@ -5257,7 +5329,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                         : processor.prepareStorageScene(
                               item,
                               target,
-                              storageVariant.shader,
+                              storageShader(item),
                               storagePipelines,
                               storagePreparation,
                               list.overrideMaterial
@@ -5283,7 +5355,7 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
                     processor.prepareStorageScene(
                         mesh,
                         target,
-                        storageVariant.shader,
+                        storageShader(mesh),
                         storagePipelines,
                         storagePreparation,
                         list.overrideMaterial,

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -99,6 +99,7 @@ import { StorageBufferResourceCache } from '../renderer/StorageBufferResourceCac
 import { prepareWebGPUMipmapShaderArtifacts } from '../renderer/WebGPUMipmapShader';
 import { WgslComputeShaderCompiler } from '../shader/WgslComputeCompiler';
 import { StorageGraphicsShaderCompiler } from '../shader/StorageGraphicsShaderCompiler';
+import type StorageGraphicsShader from '../compute/StorageGraphicsShader';
 import { RenderPipelineHost, type RenderPipelineHostLifecycle } from './RenderPipelineHost';
 import { cameraCompositionRequiresSingleSample } from './CameraCompositionPolicy';
 import { depthClearValue } from '../renderer/DepthConvention';
@@ -933,6 +934,36 @@ class SharedRendererDriver
         const buffer = new RendererStorageBuffer(this, descriptor);
         this.#storageBuffers.add(buffer);
         return buffer;
+    }
+
+    async warmupStorageGraphicsShaders(
+        shaders: readonly StorageGraphicsShader[],
+        batchSize = 4
+    ): Promise<void> {
+        if (this.#destroyed) throw new Error('Renderer is destroyed');
+        if (this.#pipelineHost.recording) {
+            throw new Error(
+                'Storage graphics warmup is allowed only during pipeline initialization'
+            );
+        }
+        if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+            throw new RangeError('Storage graphics warmup batchSize must be a positive integer');
+        }
+        const features = this.requireDevice().capabilities.features;
+        if (
+            this.backend !== 'webgpu' ||
+            !features.has('storage-buffers') ||
+            !features.has('compute-pipelines')
+        ) {
+            throw new Error('Storage graphics warmup requires a compute-capable WebGPU renderer');
+        }
+        const pipelines = this.requireResources().gpuDrivenPipelines;
+        for (let index = 0; index < shaders.length; index += 1) {
+            const shader = shaders[index];
+            if (shader === undefined) throw new Error('Storage graphics warmup shader is missing');
+            pipelines.resolveCompiledShader(shader);
+            if ((index + 1) % batchSize === 0) await Promise.resolve();
+        }
     }
 
     override createRenderTarget(parameters: RenderTargetParameters): RHIRenderTarget {

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -1,5 +1,6 @@
 import type Camera from '../../camera/Camera';
 import PerspectiveCamera from '../../camera/PerspectiveCamera';
+import type Fog from '../../core/Fog';
 import Mesh from '../../core/Mesh';
 import Node from '../../core/Node';
 import { getTransformHistoryRevision } from '../../core/TransformHistory';
@@ -10,6 +11,7 @@ import AreaLight from '../../light/AreaLight';
 import DirectionalLight from '../../light/DirectionalLight';
 import PointLight from '../../light/PointLight';
 import SpotLight from '../../light/SpotLight';
+import LightManager from '../../light/LightManager';
 import PBRMaterial from '../../material/PBRMaterial';
 import {
     DEFAULT_MATERIAL_PIPELINE_STATE,
@@ -29,6 +31,7 @@ import encodingSource from '../../shader/method/encoding.glsl';
 import getAreaLightSource from '../../shader/method/getAreaLight.glsl';
 import portableCoordinatesSource from '../../shader/method/portableCoordinates.glsl';
 import type Texture from '../../texture/Texture';
+import ParticleSystem from '../../particle/ParticleSystem';
 import {
     CLAMP_TO_EDGE,
     LINEAR,
@@ -52,7 +55,18 @@ import ComputeShader, {
     type ComputeShaderBinding,
     type ShaderReadBinding
 } from '../compute/ComputeShader';
-import StorageGraphicsShader from '../compute/StorageGraphicsShader';
+import StorageGraphicsShader, {
+    createStorageGraphicsShaderFromPortable
+} from '../compute/StorageGraphicsShader';
+import {
+    prepareGLSLForNaga,
+    type GlslSamplerType,
+    type WebGPUSamplerBinding
+} from '../shader/GlslToWgsl';
+import {
+    getWebGPUSceneTextureBinding,
+    getWebGPUUniformBlockBinding
+} from '../shader/WebGPUBindingLayout';
 import {
     GPUDrivenRenderBatchPass,
     type GPUDrivenRenderBatchPassParameters
@@ -99,6 +113,8 @@ import {
     type GPUDrivenRenderPassParameters,
     type GPUDrivenVertexBufferLayout,
     type SceneRenderPassParameters,
+    type SceneStorageBufferBinding,
+    type SceneStorageShaderVariant,
     type TextureCopyPassParameters
 } from './passes';
 import { PORTABLE_FULLSCREEN_VERTEX_SOURCE } from './passes/internal/PortableFullscreenShader';
@@ -123,6 +139,7 @@ import {
     type TemporalAAOptions,
     type TemporalAASettings
 } from '../postprocessing/TemporalAA';
+import { TransparentTemporalController } from '../postprocessing/TransparentTemporal';
 import {
     SCREEN_SPACE_REFLECTION_COLOR_LEVELS,
     SCREEN_SPACE_REFLECTION_TRACE_HIZ_LEVELS,
@@ -171,7 +188,8 @@ const OBJECT_RECORD_BYTES = 208;
 const LIGHT_RECORD_FLOATS = 28;
 const LIGHT_RECORD_BYTES = LIGHT_RECORD_FLOATS * 4;
 const BUCKET_RECORD_BYTES = 48;
-const FRAME_BASE_VEC4_COUNT = 32;
+const FRAME_OUTPUT_MAPPING_VEC4 = 32;
+const FRAME_BASE_VEC4_COUNT = FRAME_OUTPUT_MAPPING_VEC4 + 1;
 const SHADOW_ATLAS_SIZE_VEC4 = FRAME_BASE_VEC4_COUNT;
 const SHADOW_METADATA_VEC4 = SHADOW_ATLAS_SIZE_VEC4 + 1;
 const SHADOW_ATLAS_RECTS_VEC4 = SHADOW_METADATA_VEC4 + 1;
@@ -203,6 +221,8 @@ const OBJECT_HIZ_STABLE_FLAG = 4;
 const OBJECT_MOTION_HISTORY_FLAG = 8;
 const OBJECT_MOTION_CHANGED_FLAG = 16;
 const OBJECT_RECEIVE_SHADOW_FLAG = 32;
+const LIGHT_COOKIE_FLAG = 1;
+const LIGHT_IES_FLAG = 2;
 const CULL_WORKGROUP_SIZE = 64;
 const PREFIX_WORKGROUP_SIZE = 256;
 const DEFAULT_MAX_OBJECTS = 16_384;
@@ -226,6 +246,170 @@ const CLUSTERED_AREA_LIGHT_SOURCE = getAreaLightSource
         'texture(areaLightsLtcTexture2, hiloTextureUV(uv))',
         'textureLod(areaLightsLtcTexture2, hiloTextureUV(uv), 0.0)'
     );
+const CLUSTERED_SCENE_LIGHT_MANAGER = new LightManager();
+const CLUSTERED_TRANSPARENT_SHADER_CACHE = new WeakMap<Shader, StorageGraphicsShader>();
+
+function clusteredTransparentFragmentSource(source: string): string {
+    return source
+        .replace(
+            'texture(areaLightsLtcTexture1, hiloTextureUV(uv))',
+            'textureLod(areaLightsLtcTexture1, hiloTextureUV(uv), 0.0)'
+        )
+        .replace(
+            'texture(areaLightsLtcTexture2, hiloTextureUV(uv))',
+            'textureLod(areaLightsLtcTexture2, hiloTextureUV(uv), 0.0)'
+        );
+}
+
+function sampledTextureViewDimension(type: GlslSamplerType): '2d' | '2d-array' | '3d' | 'cube' {
+    if (type.includes('2DArray')) return '2d-array';
+    if (type.includes('3D')) return '3d';
+    if (type.includes('Cube')) return 'cube';
+    return '2d';
+}
+
+function sampledTextureSampleType(
+    name: string,
+    type: GlslSamplerType
+): 'float' | 'unfilterable-float' | 'depth' | 'sint' | 'uint' {
+    if (type.endsWith('Shadow')) return 'depth';
+    if (type.startsWith('isampler')) return 'sint';
+    if (type.startsWith('usampler')) return 'uint';
+    if (name === 'u_areaLightsLtcTexture1' || name === 'u_areaLightsLtcTexture2') {
+        return 'unfilterable-float';
+    }
+    return 'float';
+}
+
+function appendStorageSamplerBindings(
+    bindings: ShaderReadBinding[],
+    sampler: Readonly<WebGPUSamplerBinding>
+): void {
+    if (sampler.arrayIndex !== 0) {
+        throw new TypeError(
+            `Clustered transparent sampler arrays are unsupported (${sampler.name}[${String(sampler.arrayIndex)}])`
+        );
+    }
+    bindings.push({
+        name: sampler.name,
+        group: sampler.group,
+        binding: sampler.textureBinding,
+        kind: 'sampled-texture',
+        sampleType: sampledTextureSampleType(sampler.name, sampler.type),
+        viewDimension: sampledTextureViewDimension(sampler.type)
+    });
+    bindings.push({
+        name: sampler.name,
+        group: sampler.group,
+        binding: sampler.samplerBinding,
+        kind: sampler.type.endsWith('Shadow') ? 'comparison-sampler' : 'sampler'
+    });
+}
+
+function clusteredTransparentShader(
+    mesh: Mesh,
+    material: PBRMaterial,
+    fog: Fog | null,
+    withShadows: boolean
+): StorageGraphicsShader {
+    let header = Shader.getHeader(
+        mesh,
+        material,
+        CLUSTERED_SCENE_LIGHT_MANAGER,
+        fog,
+        false,
+        'forward'
+    );
+    header += '#define HILO_CLUSTERED_FORWARD 1\n';
+    if (withShadows && mesh.receiveShadows) {
+        header += '#define HILO_CLUSTERED_SHADOWS 1\n';
+    }
+    const baseShader = Shader.getBasicShader(material, false, header, undefined, 'forward');
+    const cached = CLUSTERED_TRANSPARENT_SHADER_CACHE.get(baseShader);
+    if (cached !== undefined) return cached;
+    const prepared = prepareGLSLForNaga(
+        baseShader.vs,
+        baseShader.fs,
+        getWebGPUUniformBlockBinding,
+        { resolveSamplerBinding: getWebGPUSceneTextureBinding }
+    );
+    const bindings: ShaderReadBinding[] = prepared.uniformBlocks.map(block => ({
+        name: block.name,
+        group: block.group,
+        binding: block.binding,
+        kind: 'uniform-buffer'
+    }));
+    for (const sampler of prepared.samplers) appendStorageSamplerBindings(bindings, sampler);
+    bindings.push(
+        {
+            name: 'clusterFrameData',
+            group: 3,
+            binding: 0,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: FRAME_RECORD_BYTES
+        },
+        {
+            name: 'clusterLights',
+            group: 3,
+            binding: 1,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: LIGHT_RECORD_BYTES
+        },
+        {
+            name: 'clusterLightGrid',
+            group: 3,
+            binding: 2,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 8
+        },
+        {
+            name: 'clusterLightIndices',
+            group: 3,
+            binding: 3,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 4
+        }
+    );
+    const result = createStorageGraphicsShaderFromPortable({
+        label: `Clustered transparent PBR (${material.definition.id})`,
+        portableVertexSource: baseShader.vs,
+        portableFragmentSource: clusteredTransparentFragmentSource(baseShader.fs),
+        bindings
+    });
+    CLUSTERED_TRANSPARENT_SHADER_CACHE.set(baseShader, result);
+    return result;
+}
+
+function clusteredTransparentMaterial(mesh: Mesh): PBRMaterial | null {
+    const material = mesh.material;
+    if (
+        !(material instanceof PBRMaterial) ||
+        mesh.geometry === null ||
+        material.lightType !== 'PBR' ||
+        !material.isTransparent ||
+        material.requiresOpaqueSceneTexture ||
+        material.forwardQueue !== 'transparent' ||
+        mesh.useInstanced
+    ) {
+        return null;
+    }
+    return material;
+}
+
+function clusteredOpaqueMaterial(mesh: Mesh): PBRMaterial | null {
+    const material = mesh.material;
+    if (
+        !(material instanceof PBRMaterial) ||
+        mesh.geometry === null ||
+        material.lightType !== 'PBR' ||
+        material.forwardQueue !== 'opaque' ||
+        material.requiresOpaqueSceneTexture ||
+        mesh.useInstanced
+    ) {
+        return null;
+    }
+    return material;
+}
 
 /** One lower-detail geometry selected when its projected bounding radius is small enough. */
 export interface GPUSceneLOD {
@@ -251,6 +435,24 @@ export interface GPUSceneBucket {
     readonly lods?: readonly GPUSceneLOD[];
 }
 
+/** One concrete scene shader topology requested before the first application frame. */
+export interface ClusteredMaterialVariantManifestEntry {
+    /** Exemplar carrying the exact geometry deformation and PBR material topology. */
+    readonly mesh: Mesh;
+    /** Also warm the receive-shadow variant. Defaults to the exemplar's current setting. */
+    readonly shadowed?: boolean;
+}
+
+/** Bounded startup manifest for clustered scene shader translation and diagnostics. */
+export interface ClusteredMaterialVariantManifest {
+    /** Exact mesh/material exemplars whose native clustered variants are required at startup. */
+    readonly entries: readonly Readonly<ClusteredMaterialVariantManifestEntry>[];
+    /** Maximum unique native scene variants, including runtime discoveries. Defaults to 64. */
+    readonly maxVariants?: number;
+    /** Variants translated before yielding back to renderer initialization. Defaults to 4. */
+    readonly warmupBatchSize?: number;
+}
+
 /** Construction options for the WebGPU high-end GPU Scene and Clustered Forward+ pipeline. */
 export interface ClusteredForwardPlusPipelineOptions {
     /**
@@ -258,7 +460,10 @@ export interface ClusteredForwardPlusPipelineOptions {
      * other scene meshes remain renderable through the shared Forward compatibility path.
      */
     readonly buckets: readonly GPUSceneBucket[];
-    /** Stable GPU Scene object capacity. Excess meshes use the Forward fallback. Defaults to 16,384. */
+    /**
+     * Stable fixed-bucket GPU Scene object capacity. Compatible excess PBR uses the direct native
+     * clustered lane; unsupported content uses Forward compatibility. Defaults to 16,384.
+     */
     readonly maxObjects?: number;
     /** GPU light-database capacity. Extra traversal-order lights are deterministically dropped. */
     readonly maxLights?: number;
@@ -311,6 +516,8 @@ export interface ClusteredForwardPlusPipelineOptions {
      * This WebGPU path uses the complete 3D cluster light grid and submission-aware history.
      */
     readonly volumetricLighting?: Readonly<VolumetricLightingOptions> | false;
+    /** Optional bounded material/deformation topology manifest translated during async creation. */
+    readonly variantManifest?: Readonly<ClusteredMaterialVariantManifest>;
 }
 
 /** On-demand GPU counters plus current CPU database occupancy. */
@@ -319,6 +526,10 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly objectCount: number;
     /** Visible-layer meshes routed through the shared Forward compatibility fallback. */
     readonly fallbackObjectCount: number;
+    /** Alpha-blended PBR meshes shaded from the Clustered Forward+ light database. */
+    readonly clusteredTransparentObjectCount: number;
+    /** Non-bucket opaque PBR meshes using native clustered lighting with shared deformation. */
+    readonly clusteredDeformedObjectCount: number;
     /** Enabled supported lights uploaded to the current GPU light database. */
     readonly lightCount: number;
     /** Enabled supported lights rejected by the configured light capacity. */
@@ -347,6 +558,16 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly autoExposureEV: number;
     /** Latest histogram-derived target exposure in EV stops, or zero when disabled. */
     readonly autoExposureTargetEV: number;
+    /** Unique manifest variants translated before renderer creation completed. */
+    readonly warmedMaterialVariantCount: number;
+    /** Unique native variants admitted by the configured runtime budget. */
+    readonly activeMaterialVariantCount: number;
+    /** Runtime candidates rejected after the unique variant budget was exhausted. */
+    readonly materialVariantBudgetExceededCount: number;
+    /** Configured unique clustered scene-variant ceiling. */
+    readonly materialVariantBudget: number;
+    /** CPU translation wall time spent in asynchronous warmup. */
+    readonly materialVariantWarmupTimeMs: number;
 }
 
 interface NormalizedLOD {
@@ -384,6 +605,16 @@ interface NormalizedOptions {
     readonly screenSpaceGlobalIllumination: ScreenSpaceGlobalIlluminationSettings | null;
     readonly screenSpaceReflections: ScreenSpaceReflectionsSettings | null;
     readonly volumetricLighting: VolumetricLightingSettings | null;
+    readonly variantManifest: Readonly<{
+        readonly entries: readonly Readonly<ClusteredMaterialVariantManifestEntry>[];
+        readonly maxVariants: number;
+        readonly warmupBatchSize: number;
+    }>;
+}
+
+interface MaterialVariantWarmupDiagnostics {
+    readonly shaders: ReadonlySet<StorageGraphicsShader>;
+    readonly durationMs: number;
 }
 
 interface ClusterCapacityPlan {
@@ -1095,6 +1326,60 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
             'Clustered Forward+ screen-space global illumination requires temporalAA'
         );
     }
+    const rawManifestInput: unknown = input.variantManifest;
+    if (
+        rawManifestInput !== undefined &&
+        (typeof rawManifestInput !== 'object' ||
+            rawManifestInput === null ||
+            Array.isArray(rawManifestInput))
+    ) {
+        throw new TypeError('Clustered Forward+ variantManifest must be an object');
+    }
+    const rawManifest = rawManifestInput as Readonly<ClusteredMaterialVariantManifest> | undefined;
+    const manifestEntriesInput: unknown = rawManifest?.entries ?? [];
+    if (!Array.isArray(manifestEntriesInput)) {
+        throw new TypeError('Clustered Forward+ variantManifest entries must be an array');
+    }
+    const manifestEntries = manifestEntriesInput.map(
+        (entry: unknown, index): Readonly<ClusteredMaterialVariantManifestEntry> => {
+            if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+                throw new TypeError(
+                    `Material variant manifest entry ${String(index)} must be an object`
+                );
+            }
+            const candidate = entry as Partial<ClusteredMaterialVariantManifestEntry>;
+            if (!(candidate.mesh instanceof Mesh)) {
+                throw new TypeError(
+                    `Material variant manifest entry ${String(index)} requires Mesh`
+                );
+            }
+            if (
+                clusteredOpaqueMaterial(candidate.mesh) === null &&
+                clusteredTransparentMaterial(candidate.mesh) === null
+            ) {
+                throw new TypeError(
+                    `Material variant manifest entry ${String(index)} must use native clustered PBR`
+                );
+            }
+            if (candidate.shadowed !== undefined && typeof candidate.shadowed !== 'boolean') {
+                throw new TypeError(
+                    `Material variant manifest entry ${String(index)} shadowed must be boolean`
+                );
+            }
+            return Object.freeze({
+                mesh: candidate.mesh,
+                shadowed: candidate.shadowed ?? candidate.mesh.receiveShadows
+            });
+        }
+    );
+    const materialVariantBudget = positiveInteger(
+        rawManifest?.maxVariants ?? 64,
+        'Clustered Forward+ variantManifest maxVariants'
+    );
+    const warmupBatchSize = positiveInteger(
+        rawManifest?.warmupBatchSize ?? 4,
+        'Clustered Forward+ variantManifest warmupBatchSize'
+    );
     return Object.freeze({
         buckets: Object.freeze(buckets),
         maxObjects: positiveInteger(
@@ -1133,7 +1418,12 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         groundTruthAmbientOcclusion,
         screenSpaceGlobalIllumination,
         screenSpaceReflections,
-        volumetricLighting
+        volumetricLighting,
+        variantManifest: Object.freeze({
+            entries: Object.freeze(manifestEntries),
+            maxVariants: materialVariantBudget,
+            warmupBatchSize
+        })
     });
 }
 
@@ -2756,6 +3046,7 @@ out vec3 v_viewPosition;
 out vec3 v_viewNormal;
 flat out uint v_materialIndex;
 flat out uint v_objectFlags;
+flat out uint v_objectLayer;
 ${GPU_SCENE_POSITION_TRANSFORM_SOURCE}
 ${GPU_SCENE_VISIBLE_INDEX_SOURCE}
 mat3 readObjectNormalMatrix(uint base) {
@@ -2773,6 +3064,7 @@ void main() {
     v_viewNormal = viewNormal;
     v_materialIndex = floatBitsToUint(objects.values[objectBase + 12u].w);
     v_objectFlags = floatBitsToUint(objects.values[objectBase + 12u].z);
+    v_objectLayer = floatBitsToUint(objects.values[objectBase + 12u].y);
     ${vertexUVWrites}
     gl_Position = gpuSceneClipPosition(objectBase, a_position);
 }`,
@@ -2799,6 +3091,7 @@ in vec3 v_viewNormal;
 ${fragmentUVDeclarations}
 flat in uint v_materialIndex;
 flat in uint v_objectFlags;
+flat in uint v_objectLayer;
 layout(location=0) out vec4 color;
 ${withMaterialAttributes ? 'layout(location=1) out vec4 materialAttributes;' : ''}
 ${encodingSource}
@@ -2832,6 +3125,37 @@ ${pbrSurfaceSource}
 ${pbrBrdfSource}
 ${CLUSTERED_AREA_LIGHT_SOURCE}
 ${withShadows ? gpuSceneShadowSource() : ''}
+float hiloClusteredPhotometricAttenuation(
+    vec3 viewPosition,
+    vec3 lightPosition,
+    vec3 lightAxis,
+    vec4 cookieParameters,
+    vec4 photometricParameters,
+    uint featureFlags
+) {
+    vec3 axis = normalize(lightAxis);
+    vec3 delta = viewPosition - lightPosition;
+    vec3 reference = abs(axis.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+    vec3 right = normalize(cross(reference, axis));
+    vec3 up = cross(axis, right);
+    float axialDistance = max(dot(delta, axis), 1e-5);
+    float attenuation = 1.0;
+    if ((featureFlags & ${String(LIGHT_COOKIE_FLAG)}u) != 0u) {
+        vec2 projected = vec2(dot(delta, right), dot(delta, up)) / axialDistance;
+        vec2 coordinate = (projected - cookieParameters.zw) / cookieParameters.xy;
+        float edge = 1.0 - max(abs(coordinate.x), abs(coordinate.y));
+        attenuation *= photometricParameters.x * smoothstep(
+            0.0,
+            max(photometricParameters.y, 1e-5),
+            edge
+        );
+    }
+    if ((featureFlags & ${String(LIGHT_IES_FLAG)}u) != 0u) {
+        float axialCosine = max(dot(normalize(delta), axis), 0.0);
+        attenuation *= photometricParameters.z * pow(axialCosine, photometricParameters.w);
+    }
+    return attenuation;
+}
 vec3 hiloEvaluateClusteredLight(
     uint lightIndex,
     vec3 viewPosition,
@@ -2846,6 +3170,8 @@ vec3 hiloEvaluateClusteredLight(
     vec4 directionOuter = lights.values[lightBase + 2u];
     vec4 attenuationInner = lights.values[lightBase + 3u];
     vec4 shadowMetadata = lights.values[lightBase + 4u];
+    uint lightLayerMask = floatBitsToUint(shadowMetadata.z);
+    if ((v_objectLayer & lightLayerMask) == 0u) return vec3(0.0);
     vec3 areaWidth = lights.values[lightBase + 5u].xyz;
     vec3 areaHeight = lights.values[lightBase + 6u].xyz;
     uint lightType = uint(colorType.w + 0.5);
@@ -2892,6 +3218,14 @@ vec3 hiloEvaluateClusteredLight(
         if (lightType == 1u) {
             float theta = dot(lightDirection, normalize(-directionOuter.xyz));
             radiance *= smoothstep(directionOuter.w, attenuationInner.w, theta);
+            radiance *= hiloClusteredPhotometricAttenuation(
+                viewPosition,
+                positionRange.xyz,
+                directionOuter.xyz,
+                lights.values[lightBase + 5u],
+                lights.values[lightBase + 6u],
+                floatBitsToUint(shadowMetadata.w)
+            );
         }
     }
     vec3 lightDiffuse;
@@ -3538,6 +3872,7 @@ class MutableFallbackSceneParameters implements SceneRenderPassParameters {
     depthStencilAttachment?: RenderPipelineDepthStencilAttachment;
     opaqueTexture?: RenderGraphTextureHandle;
     ambientOcclusionTexture?: RenderGraphTextureHandle;
+    storageShaderVariant?: Readonly<SceneStorageShaderVariant>;
 
     reset(): void {
         this.rendererList = INVALID_RENDERER_LIST;
@@ -3545,6 +3880,7 @@ class MutableFallbackSceneParameters implements SceneRenderPassParameters {
         delete this.depthStencilAttachment;
         delete this.opaqueTexture;
         delete this.ambientOcclusionTexture;
+        delete this.storageShaderVariant;
     }
 }
 
@@ -3572,6 +3908,16 @@ class MutableFallbackTextureCopyParameters implements TextureCopyPassParameters 
 interface MutableFallbackRendererListDescriptor extends RendererListDescriptor {
     cullingResults: CullingResultsHandle;
     excludeMeshes: readonly Mesh[];
+}
+
+interface MutableSceneStorageBufferBinding extends SceneStorageBufferBinding {
+    buffer: RenderGraphBufferHandle;
+}
+
+interface MutableClusteredSceneShaderVariant extends SceneStorageShaderVariant {
+    shader: StorageGraphicsShader;
+    readonly shaderByMesh: Map<Mesh, StorageGraphicsShader>;
+    readonly buffers: readonly MutableSceneStorageBufferBinding[];
 }
 
 function gpuSceneVertexLayouts(
@@ -3817,11 +4163,28 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #logicalBucketByGeometry = new Map<Geometry, Map<PBRMaterial, number>>();
     readonly #logicalGPUCompatible: Uint8Array;
     readonly #gpuManagedMeshes: Mesh[] = [];
+    readonly #fallbackOpaqueMeshes: Mesh[] = [];
+    readonly #clusteredOpaqueMeshes: Mesh[] = [];
+    readonly #fallbackOpaqueExcludedMeshes: Mesh[] = [];
+    readonly #clusteredOpaqueExcludedMeshes: Mesh[] = [];
+    readonly #clusteredOpaqueShaderByMesh = new Map<Mesh, StorageGraphicsShader>();
+    readonly #fallbackTransparentMeshes: Mesh[] = [];
+    readonly #clusteredTransparentMeshes: Mesh[] = [];
+    readonly #fallbackTransparentExcludedMeshes: Mesh[] = [];
+    readonly #clusteredTransparentExcludedMeshes: Mesh[] = [];
+    readonly #clusteredTransparentShaderByMesh = new Map<Mesh, StorageGraphicsShader>();
+    readonly #clusteredSceneStorageBuffers: readonly MutableSceneStorageBufferBinding[] = [
+        { buffer: INVALID_BUFFER },
+        { buffer: INVALID_BUFFER },
+        { buffer: INVALID_BUFFER },
+        { buffer: INVALID_BUFFER }
+    ];
     readonly #collectedLights: (PointLight | SpotLight | DirectionalLight | AreaLight)[] = [];
     readonly #fallbackWithoutMaterialAttributes: Mesh[] = [];
     readonly #materialAttributeExcludedMeshes: Mesh[] = [];
     readonly #fallbackTemporalParticipation = new WeakMap<Mesh, number>();
     readonly #pendingFallbackTemporalMeshes = new Set<Mesh>();
+    readonly #recordedGPUParticleSystems = new Set<ParticleSystem>();
     readonly #objectByMesh = new Map<Mesh, GPUSceneObjectRecord>();
     readonly #freeObjectSlots: number[] = [];
     readonly #objectData: ArrayBuffer;
@@ -3831,12 +4194,21 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #frameFloats = new Float32Array(this.#frameBytes);
     readonly #frameUInts = new Uint32Array(this.#frameBytes);
     readonly #lightFloats: Float32Array;
+    readonly #lightUInts: Uint32Array;
     readonly #localLightFloats: Float32Array;
+    readonly #localLightUInts: Uint32Array;
     readonly #directionalLightFloats: Float32Array;
+    readonly #directionalLightUInts: Uint32Array;
     readonly #samplerByTexture = new WeakMap<
         Texture<unknown>,
         Readonly<{ key: string; sampler: ComputeSampler }>
     >();
+    readonly #activeMaterialVariants = new Set<StorageGraphicsShader>();
+    readonly #rejectedMaterialVariants = new WeakSet<StorageGraphicsShader>();
+    readonly #pendingMaterialVariants = new Set<StorageGraphicsShader>();
+    readonly #pendingRejectedMaterialVariants = new Set<StorageGraphicsShader>();
+    readonly #warmedMaterialVariantCount: number;
+    readonly #materialVariantWarmupTimeMs: number;
     readonly #stagedCameraMatrix = new Float32Array(16);
     readonly #committedCameraMatrix = new Float32Array(16);
     readonly #stagedRasterCameraMatrix = new Float32Array(16);
@@ -3857,6 +4229,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #hizDescriptors: readonly Readonly<RenderPipelineHistoryTextureDescriptor>[];
     readonly #hizCullPass: ComputeRenderPass | null;
     readonly #temporal: TemporalResolveController | null;
+    readonly #transparentTemporal: TransparentTemporalController | null;
+    readonly #particleTemporal: TransparentTemporalController | null;
     readonly #temporalInputExtent = { relativeTo: 'output' as const, scale: 1 };
     readonly #temporalMotionDescriptor: Readonly<RenderPipelineTextureDescriptor> | null;
     readonly #temporalReactiveMaskDescriptor: Readonly<RenderPipelineTextureDescriptor> | null;
@@ -3987,9 +4361,16 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         'GPU Scene GTAO material attributes'
     );
     readonly #fallbackPass = new SceneRenderPass('Clustered Forward+ compatibility fallback');
+    readonly #clusteredOpaquePass = new SceneRenderPass(
+        'GPU Scene deformed and layered clustered PBR'
+    );
+    readonly #clusteredTransparentPass = new SceneRenderPass('Clustered Forward+ transparent PBR');
     readonly #fallbackDepthPass = new SceneRenderPass('Clustered Forward+ fallback depth prepass');
     readonly #fallbackMotionPass = new SceneRenderPass(
         'Clustered Forward+ fallback temporal motion'
+    );
+    readonly #transparentReactivePass = new SceneRenderPass(
+        'Transparent transmission and particle temporal reactive coverage'
     );
     readonly #fallbackMaterialAttributesPass = new SceneRenderPass(
         'Clustered Forward+ fallback material attributes'
@@ -4001,7 +4382,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         cullingResults: INVALID_CULLING_RESULTS,
         queue: 'opaque',
         sorting: 'material-front-to-back',
-        excludeMeshes: this.#gpuManagedMeshes
+        excludeMeshes: this.#fallbackOpaqueExcludedMeshes
+    };
+    readonly #clusteredOpaqueListDescriptor: MutableFallbackRendererListDescriptor = {
+        cullingResults: INVALID_CULLING_RESULTS,
+        queue: 'opaque',
+        sorting: 'material-front-to-back',
+        excludeMeshes: this.#clusteredOpaqueExcludedMeshes
     };
     readonly #fallbackDepthListDescriptor: MutableFallbackRendererListDescriptor = {
         cullingResults: INVALID_CULLING_RESULTS,
@@ -4014,12 +4401,25 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         cullingResults: INVALID_CULLING_RESULTS,
         queue: 'transparent',
         sorting: 'back-to-front',
-        excludeMeshes: this.#gpuManagedMeshes
+        excludeMeshes: this.#fallbackTransparentExcludedMeshes
+    };
+    readonly #clusteredTransparentListDescriptor: MutableFallbackRendererListDescriptor = {
+        cullingResults: INVALID_CULLING_RESULTS,
+        queue: 'transparent',
+        sorting: 'back-to-front',
+        excludeMeshes: this.#clusteredTransparentExcludedMeshes
     };
     readonly #fallbackMotionListDescriptor: MutableFallbackRendererListDescriptor = {
         cullingResults: INVALID_CULLING_RESULTS,
         queue: 'opaque',
         sorting: 'material-front-to-back',
+        materialPass: 'motion-vector',
+        excludeMeshes: this.#gpuManagedMeshes
+    };
+    readonly #transparentReactiveListDescriptor: MutableFallbackRendererListDescriptor = {
+        cullingResults: INVALID_CULLING_RESULTS,
+        queue: 'transparent',
+        sorting: 'back-to-front',
         materialPass: 'motion-vector',
         excludeMeshes: this.#gpuManagedMeshes
     };
@@ -4041,6 +4441,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     #fallbackObjectCount = 0;
     #fallbackHasOpaque = false;
     #fallbackHasTransparent = false;
+    #fallbackHasCompatibilityTransparent = false;
+    #clusteredDeformedObjectCount = 0;
+    #clusteredTransparentObjectCount = 0;
+    #materialVariantBudgetExceededCount = 0;
+    #clusteredOpaqueShaderVariant: MutableClusteredSceneShaderVariant | null = null;
+    #clusteredTransparentShaderVariant: MutableClusteredSceneShaderVariant | null = null;
     #lightCount = 0;
     #localLightCount = 0;
     #directionalLightCount = 0;
@@ -4060,15 +4466,23 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     constructor(
         options: Readonly<NormalizedOptions>,
         context: RenderPipelineCreateContext,
+        warmup: Readonly<MaterialVariantWarmupDiagnostics>,
         onDestroy: (runtime: ClusteredForwardPlusPipeline) => void
     ) {
         this.#options = options;
         this.#onDestroy = onDestroy;
+        for (const shader of warmup.shaders) this.#activeMaterialVariants.add(shader);
+        this.#warmedMaterialVariantCount = warmup.shaders.size;
+        this.#materialVariantWarmupTimeMs = warmup.durationMs;
         this.usesRenderGraphTimeline =
             options.temporalAA !== null && options.temporalAA.dynamicResolution !== null;
         AreaLight.initializeLtcTexture();
         this.#temporal =
             options.temporalAA === null ? null : new TemporalResolveController(options.temporalAA);
+        this.#transparentTemporal =
+            options.temporalAA === null ? null : new TransparentTemporalController();
+        this.#particleTemporal =
+            options.temporalAA === null ? null : new TransparentTemporalController();
         this.#temporalMotionDescriptor =
             options.temporalAA === null
                 ? null
@@ -4176,8 +4590,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             packRecord: packPBRGPUMaterialRecord
         });
         this.#lightFloats = new Float32Array(options.maxLights * LIGHT_RECORD_FLOATS);
+        this.#lightUInts = new Uint32Array(this.#lightFloats.buffer);
         this.#localLightFloats = new Float32Array(options.maxLights * LIGHT_RECORD_FLOATS);
+        this.#localLightUInts = new Uint32Array(this.#localLightFloats.buffer);
         this.#directionalLightFloats = new Float32Array(options.maxLights * LIGHT_RECORD_FLOATS);
+        this.#directionalLightUInts = new Uint32Array(this.#directionalLightFloats.buffer);
         this.#lights = create({
             label: 'Clustered Forward+ light database',
             byteLength: this.#lightFloats.byteLength,
@@ -4383,6 +4800,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         this.packLights(context, shadowResources);
         this.packShadowFrame(shadowResources);
+        this.prepareClusteredOpaqueMeshes(context, shadowResources !== null);
+        this.prepareClusteredTransparentMeshes(context, shadowResources !== null);
+        this.#fallbackObjectCount = Math.max(
+            0,
+            this.#fallbackObjectCount -
+                this.#clusteredDeformedObjectCount -
+                this.#clusteredTransparentObjectCount
+        );
         this.refreshShadowCompatibility(shadowResources !== null);
         this.#materialDatabase.stage(context);
         this.syncGeometryDatabases(context);
@@ -4423,6 +4848,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                       'Clustered Forward+ authored reactive mask',
                       reactiveMaskDescriptor
                   );
+        const transparentTemporalMask =
+            temporalFrame === null || this.#transparentTemporal === null
+                ? null
+                : this.#transparentTemporal.createCurrentMask(context, sceneScale);
         const materialAttributes =
             this.#screenSpaceReflections === null &&
             this.#screenSpaceGlobalIllumination === null &&
@@ -4611,17 +5040,45 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             temporalFrame !== null &&
             temporalMotion !== null &&
             temporalReactiveMask !== null &&
-            fallbackCulling !== null &&
-            this.#fallbackHasOpaque
+            fallbackCulling !== null
         ) {
-            this.recordFallbackMotion(
-                context,
-                fallbackCulling,
-                temporalMotion,
-                temporalReactiveMask,
-                sceneDepth
-            );
+            if (this.#fallbackHasOpaque) {
+                this.recordFallbackMotion(
+                    context,
+                    fallbackCulling,
+                    temporalMotion,
+                    temporalReactiveMask,
+                    sceneDepth
+                );
+            }
+            if (this.#fallbackHasTransparent) {
+                if (transparentTemporalMask === null) {
+                    throw new Error('Transparent temporal coverage mask is unavailable');
+                }
+                this.recordTransparentReactiveCoverage(
+                    context,
+                    fallbackCulling,
+                    temporalMotion,
+                    transparentTemporalMask,
+                    sceneDepth
+                );
+            }
         }
+        const combinedTemporalReactiveMask =
+            temporalReactiveMask === null || transparentTemporalMask === null
+                ? temporalReactiveMask
+                : (() => {
+                      if (this.hasVisibleGPUOpaqueParticles(context)) {
+                          this.#transparentTemporal?.forceReactive(context, temporalReactiveMask);
+                      }
+                      return (
+                          this.#transparentTemporal?.combineReactive(
+                              context,
+                              temporalReactiveMask,
+                              transparentTemporalMask
+                          ) ?? temporalReactiveMask
+                      );
+                  })();
         const ambientOcclusion =
             groundTruthAmbientOcclusion === null ||
             materialAttributes === null ||
@@ -4660,6 +5117,18 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             cloudShadow: atmospherePrerequisites?.cloudShadow ?? null,
             shadowResources
         });
+        if (fallbackCulling !== null && this.#clusteredDeformedObjectCount !== 0) {
+            this.recordClusteredOpaque(
+                context,
+                fallbackCulling,
+                sceneColor,
+                sceneDepth,
+                frameBuffer,
+                lights,
+                clusterGrid,
+                clusterIndices
+            );
+        }
         if (fallbackCulling !== null && this.#fallbackHasOpaque) {
             this.recordFallbackOpaque(
                 context,
@@ -4669,6 +5138,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 ambientOcclusion
             );
         }
+        this.recordGPUParticles(context, sceneColor, sceneDepth, 'opaque');
         if (
             groundTruthAmbientOcclusion === null &&
             materialAttributes !== null &&
@@ -4742,13 +5212,17 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         let resolvedSceneColor = volumetricSceneColor;
         let resolvedSceneDepth = sceneDepth;
-        if (temporalFrame !== null && temporalMotion !== null && temporalReactiveMask !== null) {
+        if (
+            temporalFrame !== null &&
+            temporalMotion !== null &&
+            combinedTemporalReactiveMask !== null
+        ) {
             const resolved = this.#temporal?.resolve(
                 context,
                 temporalFrame,
                 volumetricSceneColor,
                 temporalMotion,
-                temporalReactiveMask,
+                combinedTemporalReactiveMask,
                 sceneDepth,
                 'depth32float'
             );
@@ -4760,8 +5234,62 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 context,
                 fallbackCulling,
                 resolvedSceneColor,
-                resolvedSceneDepth
+                resolvedSceneDepth,
+                frameBuffer,
+                lights,
+                clusterGrid,
+                clusterIndices
             );
+        }
+        if (
+            temporalFrame !== null &&
+            transparentTemporalMask !== null &&
+            this.#transparentTemporal !== null
+        ) {
+            resolvedSceneColor = this.#transparentTemporal.resolve(
+                context,
+                resolvedSceneColor,
+                resolvedSceneDepth,
+                transparentTemporalMask,
+                temporalFrame.historyValid && this.#committedCamera === context.camera
+            );
+        }
+        if (this.hasGPUParticleSystems(context)) {
+            if (
+                temporalFrame === null ||
+                this.#transparentTemporal === null ||
+                this.#particleTemporal === null
+            ) {
+                this.recordGPUParticles(
+                    context,
+                    resolvedSceneColor,
+                    resolvedSceneDepth,
+                    'transparent'
+                );
+            } else {
+                const particleOverlay = this.#transparentTemporal.createParticleOverlay(context);
+                const particleDepth = this.#transparentTemporal.createParticleDepth(
+                    context,
+                    resolvedSceneDepth
+                );
+                this.recordGPUParticles(context, particleOverlay, particleDepth, 'transparent');
+                const particleMask = this.#transparentTemporal.createParticleMask(
+                    context,
+                    particleOverlay
+                );
+                const resolvedParticles = this.#particleTemporal.resolve(
+                    context,
+                    particleOverlay,
+                    resolvedSceneDepth,
+                    particleMask,
+                    temporalFrame.historyValid && this.#committedCamera === context.camera
+                );
+                resolvedSceneColor = this.#transparentTemporal.compositeParticles(
+                    context,
+                    resolvedSceneColor,
+                    resolvedParticles
+                );
+            }
         }
         const exposureTexture =
             this.#autoExposure?.record(context, resolvedSceneColor, frame.historyValid) ?? null;
@@ -4783,7 +5311,20 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     frameSubmitted(frameIndex: number): void {
         if (frameIndex !== this.#lastRecordedFrame) return;
         const committedSubmission = this.#submissionIndex + 1;
+        for (const shader of this.#pendingMaterialVariants) {
+            this.#activeMaterialVariants.add(shader);
+        }
+        this.#pendingMaterialVariants.clear();
+        for (const shader of this.#pendingRejectedMaterialVariants) {
+            this.#rejectedMaterialVariants.add(shader);
+            this.#materialVariantBudgetExceededCount++;
+        }
+        this.#pendingRejectedMaterialVariants.clear();
         this.#materialDatabase.frameSubmitted(frameIndex);
+        for (const system of this.#recordedGPUParticleSystems) {
+            system.gpuFrameSubmitted(frameIndex);
+        }
+        this.#recordedGPUParticleSystems.clear();
         for (const mesh of this.#pendingFallbackTemporalMeshes) {
             this.#fallbackTemporalParticipation.set(mesh, committedSubmission);
         }
@@ -4827,7 +5368,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
 
     frameDiscarded(frameIndex: number): void {
         if (frameIndex !== this.#lastRecordedFrame) return;
+        this.#pendingMaterialVariants.clear();
+        this.#pendingRejectedMaterialVariants.clear();
         this.#materialDatabase.frameDiscarded(frameIndex);
+        for (const system of this.#recordedGPUParticleSystems) {
+            system.gpuFrameDiscarded(frameIndex);
+        }
+        this.#recordedGPUParticleSystems.clear();
         this.#pendingFallbackTemporalMeshes.clear();
         for (const record of this.#objectByMesh.values()) {
             record.pendingWorldVersion = -1;
@@ -4871,6 +5418,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         return Object.freeze({
             objectCount: this.#objectCount,
             fallbackObjectCount: this.#fallbackObjectCount,
+            clusteredTransparentObjectCount: this.#clusteredTransparentObjectCount,
+            clusteredDeformedObjectCount: this.#clusteredDeformedObjectCount,
             lightCount: this.#lightCount,
             droppedLightCount: this.#droppedLightCount,
             visibleObjectCount: cullValues[0] ?? 0,
@@ -4885,13 +5434,21 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             volumetricFroxelCount: this.#volumetricLighting?.froxelCount ?? 0,
             volumetricHistoryUsed: this.#volumetricLighting?.historyUsed ?? false,
             autoExposureEV: exposure.actualEV,
-            autoExposureTargetEV: exposure.targetEV
+            autoExposureTargetEV: exposure.targetEV,
+            warmedMaterialVariantCount: this.#warmedMaterialVariantCount,
+            activeMaterialVariantCount: this.#activeMaterialVariants.size,
+            materialVariantBudgetExceededCount: this.#materialVariantBudgetExceededCount,
+            materialVariantBudget: this.#options.variantManifest.maxVariants,
+            materialVariantWarmupTimeMs: this.#materialVariantWarmupTimeMs
         });
     }
 
     destroy(): void {
         if (this.#destroyed) return;
         this.#destroyed = true;
+        this.#recordedGPUParticleSystems.clear();
+        this.#pendingMaterialVariants.clear();
+        this.#pendingRejectedMaterialVariants.clear();
         const buffers: StorageBuffer[] = [
             this.#frameData,
             this.#objects,
@@ -4921,6 +5478,16 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const failures: unknown[] = [];
         try {
             this.#temporal?.destroy();
+        } catch (error) {
+            failures.push(error);
+        }
+        try {
+            this.#transparentTemporal?.destroy();
+        } catch (error) {
+            failures.push(error);
+        }
+        try {
+            this.#particleTemporal?.destroy();
         } catch (error) {
             failures.push(error);
         }
@@ -5289,12 +5856,25 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const cameraVisibility = context.camera.visibility >>> 0;
         const ambient = this.#frameFloats;
         this.#gpuManagedMeshes.length = 0;
+        this.#fallbackOpaqueMeshes.length = 0;
+        this.#clusteredOpaqueMeshes.length = 0;
+        this.#fallbackOpaqueExcludedMeshes.length = 0;
+        this.#clusteredOpaqueExcludedMeshes.length = 0;
+        this.#clusteredOpaqueShaderByMesh.clear();
+        this.#fallbackTransparentMeshes.length = 0;
+        this.#clusteredTransparentMeshes.length = 0;
+        this.#fallbackTransparentExcludedMeshes.length = 0;
+        this.#clusteredTransparentExcludedMeshes.length = 0;
+        this.#clusteredTransparentShaderByMesh.clear();
         this.#collectedLights.length = 0;
         this.#fallbackWithoutMaterialAttributes.length = 0;
         this.#materialAttributeExcludedMeshes.length = 0;
         this.#fallbackObjectCount = 0;
         this.#fallbackHasOpaque = false;
         this.#fallbackHasTransparent = false;
+        this.#fallbackHasCompatibilityTransparent = false;
+        this.#clusteredDeformedObjectCount = 0;
+        this.#clusteredTransparentObjectCount = 0;
         ambient[124] = 0;
         ambient[125] = 0;
         ambient[126] = 0;
@@ -5473,8 +6053,172 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         if (material.definition.getPass('material-attributes') === null) {
             this.#fallbackWithoutMaterialAttributes.push(mesh);
         }
-        if (material.forwardQueue === 'transparent') this.#fallbackHasTransparent = true;
-        else this.#fallbackHasOpaque = true;
+        if (material.forwardQueue === 'transparent') {
+            this.#fallbackHasTransparent = true;
+            this.#fallbackTransparentMeshes.push(mesh);
+        } else {
+            this.#fallbackHasOpaque = true;
+            this.#fallbackOpaqueMeshes.push(mesh);
+        }
+    }
+
+    private prepareClusteredOpaqueMeshes(
+        context: RenderPipelineContext,
+        withShadows: boolean
+    ): void {
+        // The built-in shader keeps skinning, morphing, UV transforms, and layered glTF PBR on
+        // their canonical shared implementation while group three replaces the fixed light UBO
+        // with the GPU Scene clustered databases. GTAO currently owns that same pass-global group,
+        // so those frames retain the compatibility path until the two resources share one ABI.
+        if (this.#groundTruthAmbientOcclusion === null && this.#atmosphere === null) {
+            const fog = context.scene.fog ?? null;
+            for (const mesh of this.#fallbackOpaqueMeshes) {
+                const material = clusteredOpaqueMaterial(mesh);
+                if (material === null) continue;
+                const shader = clusteredTransparentShader(mesh, material, fog, withShadows);
+                if (!this.admitMaterialVariant(shader)) continue;
+                this.#clusteredOpaqueMeshes.push(mesh);
+                this.#clusteredOpaqueShaderByMesh.set(mesh, shader);
+            }
+        }
+        this.#clusteredDeformedObjectCount = this.#clusteredOpaqueMeshes.length;
+        this.#fallbackOpaqueExcludedMeshes.push(
+            ...this.#gpuManagedMeshes,
+            ...this.#clusteredOpaqueMeshes
+        );
+        this.#clusteredOpaqueExcludedMeshes.push(...this.#gpuManagedMeshes);
+        for (const mesh of this.#fallbackOpaqueMeshes) {
+            if (!this.#clusteredOpaqueShaderByMesh.has(mesh)) {
+                this.#clusteredOpaqueExcludedMeshes.push(mesh);
+            }
+        }
+        const firstMesh = this.#clusteredOpaqueMeshes[0];
+        const firstShader =
+            firstMesh === undefined ? undefined : this.#clusteredOpaqueShaderByMesh.get(firstMesh);
+        if (firstShader === undefined) return;
+        if (this.#clusteredOpaqueShaderVariant === null) {
+            this.#clusteredOpaqueShaderVariant = {
+                shader: firstShader,
+                shaderByMesh: this.#clusteredOpaqueShaderByMesh,
+                buffers: this.#clusteredSceneStorageBuffers
+            };
+        } else {
+            this.#clusteredOpaqueShaderVariant.shader = firstShader;
+        }
+    }
+
+    private prepareClusteredTransparentMeshes(
+        context: RenderPipelineContext,
+        withShadows: boolean
+    ): void {
+        const fog = context.scene.fog ?? null;
+        for (const mesh of this.#fallbackTransparentMeshes) {
+            const material = clusteredTransparentMaterial(mesh);
+            if (material === null) continue;
+            const shader = clusteredTransparentShader(mesh, material, fog, withShadows);
+            if (!this.admitMaterialVariant(shader)) continue;
+            this.#clusteredTransparentMeshes.push(mesh);
+            this.#clusteredTransparentShaderByMesh.set(mesh, shader);
+        }
+        // A renderer list owns the only globally correct back-to-front ordering. Splitting one
+        // transparent queue between native clustered and compatibility passes would reorder draws
+        // at the pass boundary. Until every member is storage-compatible, fail closed to the
+        // ordinary renderer-list path so transmission, particles, and custom materials preserve
+        // their authored ordering with PBR meshes.
+        if (
+            this.#clusteredTransparentMeshes.length !== 0 &&
+            this.#clusteredTransparentMeshes.length !== this.#fallbackTransparentMeshes.length
+        ) {
+            this.#clusteredTransparentMeshes.length = 0;
+            this.#clusteredTransparentShaderByMesh.clear();
+        }
+        this.#clusteredTransparentObjectCount = this.#clusteredTransparentMeshes.length;
+        this.#fallbackHasCompatibilityTransparent =
+            this.#fallbackTransparentMeshes.length !== this.#clusteredTransparentObjectCount;
+        this.#fallbackTransparentExcludedMeshes.push(
+            ...this.#gpuManagedMeshes,
+            ...this.#clusteredTransparentMeshes
+        );
+        this.#clusteredTransparentExcludedMeshes.push(...this.#gpuManagedMeshes);
+        for (const mesh of this.#fallbackTransparentMeshes) {
+            if (!this.#clusteredTransparentShaderByMesh.has(mesh)) {
+                this.#clusteredTransparentExcludedMeshes.push(mesh);
+            }
+        }
+        const firstMesh = this.#clusteredTransparentMeshes[0];
+        const firstShader =
+            firstMesh === undefined
+                ? undefined
+                : this.#clusteredTransparentShaderByMesh.get(firstMesh);
+        if (firstShader === undefined) return;
+        if (this.#clusteredTransparentShaderVariant === null) {
+            this.#clusteredTransparentShaderVariant = {
+                shader: firstShader,
+                shaderByMesh: this.#clusteredTransparentShaderByMesh,
+                buffers: this.#clusteredSceneStorageBuffers
+            };
+        } else {
+            this.#clusteredTransparentShaderVariant.shader = firstShader;
+        }
+    }
+
+    private hasGPUParticleSystems(context: RenderPipelineContext): boolean {
+        let result = false;
+        context.scene.traverse(node => {
+            if (node instanceof ParticleSystem && node.hasGPUEmitters) result = true;
+        });
+        return result;
+    }
+
+    private hasVisibleGPUOpaqueParticles(context: RenderPipelineContext): boolean {
+        let result = false;
+        context.scene.traverse(node => {
+            if (
+                node instanceof ParticleSystem &&
+                node.hasGPUEmitters &&
+                node.hasGPUOpaqueRenderers &&
+                node.isGPUVisible(context.camera)
+            ) {
+                result = true;
+            }
+        });
+        return result;
+    }
+
+    private recordGPUParticles(
+        context: RenderPipelineContext,
+        color: RenderGraphTextureHandle,
+        depth: RenderGraphTextureHandle | null,
+        phase: 'opaque' | 'transparent'
+    ): void {
+        context.scene.traverse(node => {
+            if (!(node instanceof ParticleSystem) || !node.hasGPUEmitters) return;
+            if (phase === 'opaque' && !node.hasGPUOpaqueRenderers) return;
+            // Register before recording so a partial emitter update is rolled back when recording
+            // throws before the Render Graph can be submitted.
+            this.#recordedGPUParticleSystems.add(node);
+            node.recordGPU(context, color, depth, node.isGPUVisible(context.camera), phase);
+        });
+    }
+
+    private admitMaterialVariant(shader: StorageGraphicsShader): boolean {
+        if (this.#activeMaterialVariants.has(shader) || this.#pendingMaterialVariants.has(shader)) {
+            return true;
+        }
+        if (
+            this.#activeMaterialVariants.size + this.#pendingMaterialVariants.size <
+            this.#options.variantManifest.maxVariants
+        ) {
+            this.#pendingMaterialVariants.add(shader);
+            return true;
+        }
+        if (
+            !this.#rejectedMaterialVariants.has(shader) &&
+            !this.#pendingRejectedMaterialVariants.has(shader)
+        ) {
+            this.#pendingRejectedMaterialVariants.add(shader);
+        }
+        return false;
     }
 
     private findLogicalBucket(mesh: Mesh): number | null {
@@ -5635,9 +6379,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         const directionalFloatCount = this.#directionalLightCount * LIGHT_RECORD_FLOATS;
         const localFloatCount = this.#localLightCount * LIGHT_RECORD_FLOATS;
-        this.#lightFloats.set(this.#directionalLightFloats.subarray(0, directionalFloatCount), 0);
-        this.#lightFloats.set(
-            this.#localLightFloats.subarray(0, localFloatCount),
+        this.#lightUInts.set(this.#directionalLightUInts.subarray(0, directionalFloatCount), 0);
+        this.#lightUInts.set(
+            this.#localLightUInts.subarray(0, localFloatCount),
             directionalFloatCount
         );
         const lightBytes = Math.max(1, this.#lightCount) * LIGHT_RECORD_BYTES;
@@ -5705,6 +6449,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         const global = light instanceof DirectionalLight || light instanceof AreaLight;
         const target = global ? this.#directionalLightFloats : this.#localLightFloats;
+        const targetUInts = global ? this.#directionalLightUInts : this.#localLightUInts;
         const lightIndex = global ? this.#directionalLightCount : this.#localLightCount;
         const base = lightIndex * LIGHT_RECORD_FLOATS;
         let type = 0;
@@ -5771,8 +6516,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         target[base + 16] = shadowKind;
         target[base + 17] = shadowKind === 0 ? 0 : shadowIndex;
-        target[base + 18] = 0;
-        target[base + 19] = 0;
+        targetUInts[base + 18] = light.lightLayerMask;
+        const cookie = light instanceof SpotLight ? light.cookie : null;
+        const iesProfile = light instanceof SpotLight ? light.iesProfile : null;
+        targetUInts[base + 19] =
+            (cookie === null ? 0 : LIGHT_COOKIE_FLAG) | (iesProfile === null ? 0 : LIGHT_IES_FLAG);
         if (light instanceof AreaLight) {
             this.#tempMatrix.getRotation(this.#tempQuaternion);
             this.#tempMatrix.fromQuat(this.#tempQuaternion);
@@ -5786,6 +6534,15 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             target[base + 25] = this.#tempVector.y;
             target[base + 26] = this.#tempVector.z;
             target[base + 27] = 0;
+        } else if (light instanceof SpotLight) {
+            target[base + 20] = cookie?.scale[0] ?? 1;
+            target[base + 21] = cookie?.scale[1] ?? 1;
+            target[base + 22] = cookie?.offset[0] ?? 0;
+            target[base + 23] = cookie?.offset[1] ?? 0;
+            target[base + 24] = cookie?.intensity ?? 1;
+            target[base + 25] = cookie?.softness ?? 0.1;
+            target[base + 26] = iesProfile?.intensity ?? 1;
+            target[base + 27] = iesProfile?.exponent ?? 1;
         } else {
             target.fill(0, base + 20, base + LIGHT_RECORD_FLOATS);
         }
@@ -5953,6 +6710,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#frameFloats[125] = Math.min(this.#frameFloats[125] ?? 0, 4);
         this.#frameFloats[126] = Math.min(this.#frameFloats[126] ?? 0, 4);
         this.#frameFloats[127] = 0;
+        const outputMapping = FRAME_OUTPUT_MAPPING_VEC4 * 4;
+        this.#frameFloats[outputMapping] = context.output.width;
+        this.#frameFloats[outputMapping + 1] = context.output.height;
+        this.#frameFloats[outputMapping + 2] = renderWidth / context.output.width;
+        this.#frameFloats[outputMapping + 3] = renderHeight / context.output.height;
         matrixElements(camera.viewProjectionMatrix, this.#stagedCameraMatrix, 0);
         matrixElements(camera.jitteredViewProjectionMatrix, this.#stagedRasterCameraMatrix, 0);
         matrixElements(camera.viewMatrix, this.#stagedViewMatrix, 0);
@@ -6559,6 +7321,37 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         );
     }
 
+    private recordClusteredOpaque(
+        context: RenderPipelineContext,
+        cullingResults: CullingResultsHandle,
+        outputColor: RenderGraphTextureHandle,
+        sceneDepth: RenderGraphTextureHandle,
+        frameBuffer: RenderGraphBufferHandle,
+        lights: RenderGraphBufferHandle,
+        clusterGrid: RenderGraphBufferHandle,
+        clusterIndices: RenderGraphBufferHandle
+    ): void {
+        const variant = this.#clusteredOpaqueShaderVariant;
+        if (variant === null) throw new Error('Clustered opaque shader variant is unavailable');
+        this.bindClusteredSceneStorage(variant, frameBuffer, lights, clusterGrid, clusterIndices);
+        this.#clusteredOpaqueListDescriptor.cullingResults = cullingResults;
+        const rendererList = context.createRendererList(this.#clusteredOpaqueListDescriptor);
+        const parameters = context.acquirePassParameters(this.#fallbackPool);
+        parameters.rendererList = rendererList;
+        const color = parameters.colorAttachments[0];
+        if (color === undefined)
+            throw new Error('Clustered opaque color attachment is unavailable');
+        color.texture = outputColor;
+        parameters.depthStencilAttachment = {
+            texture: sceneDepth,
+            depthLoadOp: 'load',
+            depthStoreOp: 'store',
+            depthClearValue: depthClearValue(context.camera.depthMode)
+        };
+        parameters.storageShaderVariant = variant;
+        context.graph.addPass(this.#clusteredOpaquePass, parameters);
+    }
+
     private recordFallbackDepthPrepass(
         context: RenderPipelineContext,
         cullingResults: CullingResultsHandle,
@@ -6581,26 +7374,102 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         context: RenderPipelineContext,
         cullingResults: CullingResultsHandle,
         outputColor: RenderGraphTextureHandle,
-        sceneDepth: RenderGraphTextureHandle
+        sceneDepth: RenderGraphTextureHandle,
+        frameBuffer: RenderGraphBufferHandle,
+        lights: RenderGraphBufferHandle,
+        clusterGrid: RenderGraphBufferHandle,
+        clusterIndices: RenderGraphBufferHandle
     ): void {
-        const opaqueTexture = context.graph.createTexture('Forward fallback opaque scene color', {
-            format: 'rgba16float',
-            extent: { relativeTo: 'output', scale: 1 },
-            sampleCount: 1
-        });
-        const copy = context.acquirePassParameters(this.#fallbackCopyPool);
-        copy.source = outputColor;
-        copy.destination = opaqueTexture;
-        context.graph.addPass(this.#fallbackCopyPass, copy);
-        this.recordFallbackList(
-            context,
-            cullingResults,
-            this.#fallbackTransparentListDescriptor,
-            outputColor,
-            sceneDepth,
-            opaqueTexture,
-            null
-        );
+        let opaqueTexture: RenderGraphTextureHandle | null = null;
+        if (this.#fallbackHasCompatibilityTransparent) {
+            opaqueTexture = context.graph.createTexture('Forward fallback opaque scene color', {
+                format: 'rgba16float',
+                extent: { relativeTo: 'output', scale: 1 },
+                sampleCount: 1
+            });
+            const copy = context.acquirePassParameters(this.#fallbackCopyPool);
+            copy.source = outputColor;
+            copy.destination = opaqueTexture;
+            context.graph.addPass(this.#fallbackCopyPass, copy);
+        }
+        if (this.#clusteredTransparentObjectCount !== 0) {
+            this.recordClusteredTransparent(
+                context,
+                cullingResults,
+                outputColor,
+                sceneDepth,
+                frameBuffer,
+                lights,
+                clusterGrid,
+                clusterIndices
+            );
+        }
+        if (this.#fallbackHasCompatibilityTransparent) {
+            if (opaqueTexture === null) {
+                throw new Error('Forward fallback transparent opaque copy is unavailable');
+            }
+            this.recordFallbackList(
+                context,
+                cullingResults,
+                this.#fallbackTransparentListDescriptor,
+                outputColor,
+                sceneDepth,
+                opaqueTexture,
+                null
+            );
+        }
+    }
+
+    private recordClusteredTransparent(
+        context: RenderPipelineContext,
+        cullingResults: CullingResultsHandle,
+        outputColor: RenderGraphTextureHandle,
+        sceneDepth: RenderGraphTextureHandle,
+        frameBuffer: RenderGraphBufferHandle,
+        lights: RenderGraphBufferHandle,
+        clusterGrid: RenderGraphBufferHandle,
+        clusterIndices: RenderGraphBufferHandle
+    ): void {
+        const variant = this.#clusteredTransparentShaderVariant;
+        if (variant === null) {
+            throw new Error('Clustered transparent shader variant is unavailable');
+        }
+        this.bindClusteredSceneStorage(variant, frameBuffer, lights, clusterGrid, clusterIndices);
+        this.#clusteredTransparentListDescriptor.cullingResults = cullingResults;
+        const rendererList = context.createRendererList(this.#clusteredTransparentListDescriptor);
+        const parameters = context.acquirePassParameters(this.#fallbackPool);
+        parameters.rendererList = rendererList;
+        const color = parameters.colorAttachments[0];
+        if (color === undefined) {
+            throw new Error('Clustered transparent color attachment is unavailable');
+        }
+        color.texture = outputColor;
+        parameters.depthStencilAttachment = {
+            texture: sceneDepth,
+            depthLoadOp: 'load',
+            depthStoreOp: 'store',
+            depthClearValue: depthClearValue(context.camera.depthMode)
+        };
+        parameters.storageShaderVariant = variant;
+        context.graph.addPass(this.#clusteredTransparentPass, parameters);
+    }
+
+    private bindClusteredSceneStorage(
+        variant: MutableClusteredSceneShaderVariant,
+        frameBuffer: RenderGraphBufferHandle,
+        lights: RenderGraphBufferHandle,
+        clusterGrid: RenderGraphBufferHandle,
+        clusterIndices: RenderGraphBufferHandle
+    ): void {
+        const handles = [frameBuffer, lights, clusterGrid, clusterIndices] as const;
+        for (let index = 0; index < handles.length; index += 1) {
+            const binding = variant.buffers[index];
+            const handle = handles[index];
+            if (binding === undefined || handle === undefined) {
+                throw new Error('Clustered scene storage ABI is incomplete');
+            }
+            binding.buffer = handle;
+        }
     }
 
     private recordFallbackMotion(
@@ -6629,6 +7498,34 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             depthReadOnly: true
         };
         context.graph.addPass(this.#fallbackMotionPass, parameters);
+    }
+
+    private recordTransparentReactiveCoverage(
+        context: RenderPipelineContext,
+        cullingResults: CullingResultsHandle,
+        temporalMotion: RenderGraphTextureHandle,
+        temporalReactiveMask: RenderGraphTextureHandle,
+        sceneDepth: RenderGraphTextureHandle
+    ): void {
+        this.#transparentReactiveListDescriptor.cullingResults = cullingResults;
+        const rendererList = context.createRendererList(this.#transparentReactiveListDescriptor);
+        const parameters = context.acquirePassParameters(this.#fallbackPool);
+        parameters.rendererList = rendererList;
+        const color = parameters.colorAttachments[0];
+        if (color === undefined) {
+            throw new Error('Transparent temporal motion attachment is unavailable');
+        }
+        color.texture = temporalMotion;
+        parameters.colorAttachments[1] = {
+            texture: temporalReactiveMask,
+            loadOp: 'load',
+            storeOp: 'store'
+        };
+        parameters.depthStencilAttachment = {
+            texture: sceneDepth,
+            depthReadOnly: true
+        };
+        context.graph.addPass(this.#transparentReactivePass, parameters);
     }
 
     private recordFallbackMaterialAttributes(
@@ -6690,11 +7587,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
  * WebGPU-only high-end factory combining G0 GPU Scene/Hi-Z and L0 Clustered Forward+.
  *
  * Compatible registered bucket meshes bypass CPU frustum sorting and ordinary PreparedDraw
- * creation. The GPU-driven path intentionally accepts opaque, unskinned, indexed triangle PBR
- * buckets with scalar factors or common opaque PBR maps. Material surface evaluation and the BRDF
- * are shared with ordinary Forward PBR; the clustered variant replaces only light-list selection
- * and iteration. Unregistered meshes, runtime-incompatible bucket state, deformation,
- * transparency, and object-capacity overflow use the shared Forward path in the same frame.
+ * creation. Fixed indirect buckets accept opaque, unskinned, indexed triangle PBR geometry;
+ * eligible deformed, layered, and globally sorted transparent PBR meshes use the native direct
+ * storage-lighting lane. Material surface evaluation and the BRDF are shared with ordinary Forward
+ * PBR; clustered variants replace only light-list selection and iteration. Unregistered meshes,
+ * runtime-incompatible state, mixed compatibility-transparent queues, and object-capacity overflow
+ * use the shared Forward path in the same frame.
  * Invalid initial bucket declarations and unsupported devices still fail closed.
  */
 export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactory {
@@ -6838,16 +7736,41 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     : {}),
                 maxComputeInvocationsPerWorkgroup: PREFIX_WORKGROUP_SIZE,
                 maxComputeWorkgroupsPerDimension: requirements.maxComputeWorkgroupsPerDimension,
-                ...(this.#options.temporalAA === null ? {} : { maxColorAttachments: 3 })
+                ...(this.#options.temporalAA === null ? {} : { maxColorAttachments: 4 })
             })
         });
     }
 
     /** Create one independent renderer-local GPU Scene and clustered-lighting runtime. */
-    create(context: RenderPipelineCreateContext): RenderPipeline {
-        const runtime = new ClusteredForwardPlusPipeline(this.#options, context, destroyed => {
-            this.#runtimes.delete(destroyed);
-        });
+    async create(context: RenderPipelineCreateContext): Promise<RenderPipeline> {
+        const start = globalThis.performance.now();
+        const shaders = new Set<StorageGraphicsShader>();
+        for (const entry of this.#options.variantManifest.entries) {
+            const material = entry.mesh.material;
+            if (!(material instanceof PBRMaterial)) {
+                throw new TypeError('Material variant manifest PBR material became unavailable');
+            }
+            shaders.add(clusteredTransparentShader(entry.mesh, material, null, false));
+            if (entry.shadowed === true) {
+                shaders.add(clusteredTransparentShader(entry.mesh, material, null, true));
+            }
+        }
+        if (shaders.size > this.#options.variantManifest.maxVariants) {
+            throw new RangeError('Material variant manifest unique shaders exceed maxVariants');
+        }
+        await context.warmupStorageGraphicsShaders(
+            [...shaders],
+            this.#options.variantManifest.warmupBatchSize
+        );
+        const durationMs = Math.max(0, globalThis.performance.now() - start);
+        const runtime = new ClusteredForwardPlusPipeline(
+            this.#options,
+            context,
+            Object.freeze({ shaders, durationMs }),
+            destroyed => {
+                this.#runtimes.delete(destroyed);
+            }
+        );
         this.#runtimes.add(runtime);
         return runtime;
     }

--- a/src/render/pipeline/RenderPipeline.ts
+++ b/src/render/pipeline/RenderPipeline.ts
@@ -24,6 +24,7 @@ import type {
 import type { RenderGraphTextureHandle, ScriptableRenderGraph } from './ScriptableRenderGraph';
 import type { RenderPipelineTextureFormat } from './RenderPipelineTexture';
 import type { RenderGraphTimelineSnapshot } from '../graph/RenderGraphTimeline';
+import type StorageGraphicsShader from '../compute/StorageGraphicsShader';
 
 /** Optional renderer capabilities exposed only after their complete SRP/RHI path is available. */
 export type RenderPipelineCapabilityName =
@@ -133,6 +134,11 @@ export interface RenderPipelineCreateContext {
      * recording while avoiding native backend access.
      */
     createStorageBuffer(descriptor: Readonly<StorageBufferDescriptor>): StorageBuffer;
+    /** Translate and validate storage-aware raster variants before the first application frame. */
+    warmupStorageGraphicsShaders(
+        shaders: readonly StorageGraphicsShader[],
+        batchSize?: number
+    ): Promise<void>;
 }
 
 /** Attachment operations selected for one physical output color attachment. */

--- a/src/render/pipeline/index.ts
+++ b/src/render/pipeline/index.ts
@@ -2,6 +2,8 @@ export {
     ClusteredForwardPlusPipelineFactory,
     type ClusteredForwardPlusDiagnostics,
     type ClusteredForwardPlusPipelineOptions,
+    type ClusteredMaterialVariantManifest,
+    type ClusteredMaterialVariantManifestEntry,
     type GPUSceneBucket,
     type GPUSceneLOD
 } from './ClusteredForwardPlus';

--- a/src/render/pipeline/passes/SceneRenderPass.ts
+++ b/src/render/pipeline/passes/SceneRenderPass.ts
@@ -1,5 +1,6 @@
 import type { RendererViewport } from '../../RendererCore';
 import type StorageGraphicsShader from '../../compute/StorageGraphicsShader';
+import type Mesh from '../../../core/Mesh';
 import type { RendererListHandle } from '../RendererList';
 import type {
     RenderGraphBufferHandle,
@@ -37,8 +38,15 @@ export interface SceneStorageBufferBinding {
  * explicit: it does not automatically rewrite built-in Basic/PBR shader source.
  */
 export interface SceneStorageShaderVariant {
-    /** Storage-aware shader used by every direct mesh in this renderer list. */
+    /** Default storage-aware shader and the canonical pass-global storage ABI. */
     readonly shader: StorageGraphicsShader;
+    /**
+     * Optional exact per-mesh variants applied without splitting the renderer list. This preserves
+     * global transparent sorting while allowing geometry/material topology to select its compiled
+     * shader. Every mapped shader must expose the same group-three readonly-storage ABI as
+     * the default shader.
+     */
+    readonly shaderByMesh?: ReadonlyMap<Mesh, StorageGraphicsShader>;
     /** Positional ranges matching the shader's sorted readonly-storage binding order. */
     readonly buffers: readonly Readonly<SceneStorageBufferBinding>[];
 }

--- a/src/render/postprocessing/TransparentTemporal.ts
+++ b/src/render/postprocessing/TransparentTemporal.ts
@@ -1,0 +1,492 @@
+import { DEFAULT_MATERIAL_PIPELINE_STATE } from '../../material/MaterialDefinition';
+import Shader from '../../shader/Shader';
+import type { RenderPipelineContext } from '../pipeline/RenderPipeline';
+import { RenderPassParameterPool } from '../pipeline/RenderPassParameterPool';
+import { FullscreenRenderPass, type FullscreenRenderPassParameters } from '../pipeline/passes';
+import { PORTABLE_FULLSCREEN_VERTEX_SOURCE } from '../pipeline/passes/internal/PortableFullscreenShader';
+import { depthClearValue } from '../renderer/DepthConvention';
+import type {
+    RenderGraphTextureAccessHandle,
+    RenderGraphTextureHandle,
+    RenderPipelineColorAttachment,
+    RenderPipelineDepthStencilAttachment,
+    RenderPipelineExtent,
+    RenderPipelineTextureDescriptor
+} from '../pipeline/ScriptableRenderGraph';
+
+const OUTPUT_EXTENT: RenderPipelineExtent = Object.freeze({
+    relativeTo: 'output',
+    scale: 1
+});
+const ZERO = Object.freeze({ r: 0, g: 0, b: 0, a: 0 });
+
+const CLEAR_MASK_FRAGMENT = `#version 300 es
+precision highp float;
+layout(location = 0) out float mask;
+void main() { mask = 0.0; }`;
+
+const FORCE_REACTIVE_FRAGMENT = `#version 300 es
+precision highp float;
+layout(location = 0) out float mask;
+void main() { mask = 1.0; }`;
+
+const CLEAR_COLOR_FRAGMENT = `#version 300 es
+precision highp float;
+layout(location = 0) out vec4 color;
+void main() { color = vec4(0.0); }`;
+
+const UPSAMPLE_DEPTH_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_sceneDepth;
+layout(location = 0) out float scratch;
+void main() {
+    scratch = 0.0;
+    gl_FragDepth = texture(u_sceneDepth, v_uv).r;
+}`;
+
+const COMBINE_REACTIVE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_authoredReactive;
+uniform sampler2D u_transparentReactive;
+layout(location = 0) out float combinedReactive;
+void main() {
+    combinedReactive = max(
+        texture(u_authoredReactive, v_uv).r,
+        texture(u_transparentReactive, v_uv).r
+    );
+}`;
+
+const COMPOSITE_PARTICLE_COLOR_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_particles;
+layout(location = 0) out vec4 compositedScene;
+void main() {
+    vec4 scene = texture(u_scene, v_uv);
+    vec4 particles = texture(u_particles, v_uv);
+    float particleAlpha = clamp(particles.a, 0.0, 1.0);
+    compositedScene = vec4(
+        particles.rgb + scene.rgb * (1.0 - particleAlpha),
+        particleAlpha + scene.a * (1.0 - particleAlpha)
+    );
+}`;
+
+const COMPOSITE_PARTICLE_MASK_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_particles;
+layout(location = 0) out float compositedMask;
+void main() {
+    vec4 particles = texture(u_particles, v_uv);
+    float particleCoverage = max(particles.a, max(particles.r, max(particles.g, particles.b)));
+    compositedMask = step(1.0 / 255.0, particleCoverage);
+}`;
+
+const INITIALIZE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_sceneDepth;
+uniform sampler2D u_currentMask;
+layout(location = 0) out vec4 historyColor;
+layout(location = 1) out vec4 resolvedColor;
+layout(location = 2) out float historyMask;
+layout(location = 3) out float historyDepth;
+void main() {
+    vec4 current = texture(u_scene, v_uv);
+    historyColor = current;
+    resolvedColor = current;
+    historyMask = texture(u_currentMask, v_uv).r;
+    historyDepth = texture(u_sceneDepth, v_uv).r;
+}`;
+
+const RESOLVE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_scene;
+uniform sampler2D u_sceneDepth;
+uniform sampler2D u_currentMask;
+uniform sampler2D u_historyColor;
+uniform sampler2D u_historyDepth;
+uniform sampler2D u_historyMask;
+layout(location = 0) out vec4 nextHistoryColor;
+layout(location = 1) out vec4 resolvedColor;
+layout(location = 2) out float nextHistoryMask;
+layout(location = 3) out float nextHistoryDepth;
+
+float dilatedCurrentMask(vec2 uv) {
+    ivec2 dimensions = textureSize(u_currentMask, 0);
+    ivec2 pixel = clamp(ivec2(uv * vec2(dimensions)), ivec2(0), dimensions - ivec2(1));
+    float value = 0.0;
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            ivec2 coordinate = clamp(pixel + ivec2(x, y), ivec2(0), dimensions - ivec2(1));
+            value = max(value, texelFetch(u_currentMask, coordinate, 0).r);
+        }
+    }
+    return value;
+}
+
+void main() {
+    vec4 current = texture(u_scene, v_uv);
+    float currentDepth = texture(u_sceneDepth, v_uv).r;
+    float currentMask = dilatedCurrentMask(v_uv);
+    float previousMask = textureLod(u_historyMask, v_uv, 0.0).r;
+    float previousDepth = textureLod(u_historyDepth, v_uv, 0.0).r;
+    float depthAgreement = abs(previousDepth - currentDepth) <= 0.0025 ? 1.0 : 0.0;
+    float resurrectedMask = previousMask * (1.0 - currentMask) * depthAgreement * 0.45;
+    float resurrectionWeight = resurrectedMask * 0.35;
+    vec4 previous = textureLod(u_historyColor, v_uv, 0.0);
+    vec4 resolved = mix(current, previous, resurrectionWeight);
+    nextHistoryColor = resolved;
+    resolvedColor = resolved;
+    nextHistoryMask = max(currentMask, resurrectedMask);
+    nextHistoryDepth = currentDepth;
+}`;
+
+interface MutableColorAttachment extends RenderPipelineColorAttachment {
+    texture: RenderGraphTextureHandle;
+}
+
+class FullscreenParameters implements FullscreenRenderPassParameters {
+    readonly inputTextures: RenderGraphTextureAccessHandle[] = [];
+    readonly colorAttachments: MutableColorAttachment[] = [];
+    depthStencilAttachment?: Readonly<RenderPipelineDepthStencilAttachment>;
+
+    reset(): void {
+        this.inputTextures.length = 0;
+        this.colorAttachments.length = 0;
+        delete this.depthStencilAttachment;
+    }
+}
+
+function fullscreenPass(
+    name: string,
+    fragmentSource: string,
+    depthWrite = false
+): FullscreenRenderPass {
+    return new FullscreenRenderPass({
+        name,
+        shader: new Shader({
+            vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE,
+            fs: fragmentSource
+        }),
+        pipelineState: Object.freeze({
+            ...DEFAULT_MATERIAL_PIPELINE_STATE,
+            depthTest: false,
+            depthWrite,
+            cullMode: 'none' as const
+        })
+    });
+}
+
+/** @internal Output-resolution, submission-owned short history for transparent resurrection. */
+export class TransparentTemporalController {
+    readonly #maskExtent = { relativeTo: 'output' as const, scale: 1 };
+    readonly #maskDescriptor: Readonly<RenderPipelineTextureDescriptor> = {
+        format: 'r8unorm',
+        extent: this.#maskExtent
+    };
+    readonly #resolvedDescriptor: Readonly<RenderPipelineTextureDescriptor> = {
+        format: 'rgba16float',
+        extent: OUTPUT_EXTENT
+    };
+    readonly #outputMaskDescriptor: Readonly<RenderPipelineTextureDescriptor> = {
+        format: 'r8unorm',
+        extent: OUTPUT_EXTENT
+    };
+    readonly #outputDepthDescriptor: Readonly<RenderPipelineTextureDescriptor> = {
+        format: 'depth32float',
+        extent: OUTPUT_EXTENT
+    };
+    readonly #colorHistoryDescriptor = Object.freeze({
+        label: 'Transparent resurrection color history',
+        format: 'rgba16float' as const,
+        extent: OUTPUT_EXTENT,
+        usage: Object.freeze(['sampled' as const, 'attachment' as const]),
+        bufferCount: 2 as const
+    });
+    readonly #maskHistoryDescriptor = Object.freeze({
+        label: 'Transparent resurrection coverage history',
+        format: 'r8unorm' as const,
+        extent: OUTPUT_EXTENT,
+        usage: Object.freeze(['sampled' as const, 'attachment' as const]),
+        bufferCount: 2 as const
+    });
+    readonly #depthHistoryDescriptor = Object.freeze({
+        label: 'Transparent resurrection depth history',
+        format: 'r32float' as const,
+        extent: OUTPUT_EXTENT,
+        usage: Object.freeze(['sampled' as const, 'attachment' as const]),
+        bufferCount: 2 as const
+    });
+    readonly #colorHistoryKey = Object.freeze({});
+    readonly #maskHistoryKey = Object.freeze({});
+    readonly #depthHistoryKey = Object.freeze({});
+    readonly #clearMaskPass = fullscreenPass(
+        'Transparent temporal coverage clear',
+        CLEAR_MASK_FRAGMENT
+    );
+    readonly #forceReactivePass = fullscreenPass(
+        'Opaque particle conservative temporal reactive coverage',
+        FORCE_REACTIVE_FRAGMENT
+    );
+    readonly #clearParticleOverlayPass = fullscreenPass(
+        'Transparent GPU particle overlay clear',
+        CLEAR_COLOR_FRAGMENT
+    );
+    readonly #upsampleParticleDepthPass = fullscreenPass(
+        'Transparent GPU particle output-depth reconstruction',
+        UPSAMPLE_DEPTH_FRAGMENT,
+        true
+    );
+    readonly #combineReactivePass = fullscreenPass(
+        'Transparent reactive coverage merge',
+        COMBINE_REACTIVE_FRAGMENT
+    );
+    readonly #initializePass = fullscreenPass(
+        'Transparent temporal history initialize',
+        INITIALIZE_FRAGMENT
+    );
+    readonly #resolvePass = fullscreenPass(
+        'Transparent transmission and particle resurrection',
+        RESOLVE_FRAGMENT
+    );
+    readonly #compositeParticleColorPass = fullscreenPass(
+        'Transparent GPU particle temporal composition',
+        COMPOSITE_PARTICLE_COLOR_FRAGMENT
+    );
+    readonly #compositeParticleMaskPass = fullscreenPass(
+        'Transparent GPU particle resurrection coverage',
+        COMPOSITE_PARTICLE_MASK_FRAGMENT
+    );
+    readonly #parameters = new RenderPassParameterPool(
+        () => new FullscreenParameters(),
+        parameters => {
+            parameters.reset();
+        }
+    );
+    #destroyed = false;
+
+    createCurrentMask(
+        context: RenderPipelineContext,
+        renderScale: number
+    ): RenderGraphTextureHandle {
+        if (this.#destroyed) throw new Error('Transparent temporal controller is destroyed');
+        this.#maskExtent.scale = renderScale;
+        const mask = context.graph.createTexture(
+            'Transparent transmission and particle current coverage',
+            this.#maskDescriptor
+        );
+        const clear = context.acquirePassParameters(this.#parameters);
+        clear.colorAttachments[0] = {
+            texture: mask,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: ZERO
+        };
+        context.graph.addPass(this.#clearMaskPass, clear);
+        return mask;
+    }
+
+    combineReactive(
+        context: RenderPipelineContext,
+        authoredReactive: RenderGraphTextureHandle,
+        transparentReactive: RenderGraphTextureHandle
+    ): RenderGraphTextureHandle {
+        const combined = context.graph.createTexture(
+            'Combined opaque and transparent temporal reactive mask',
+            this.#maskDescriptor
+        );
+        const parameters = context.acquirePassParameters(this.#parameters);
+        parameters.inputTextures.push(authoredReactive, transparentReactive);
+        parameters.colorAttachments[0] = {
+            texture: combined,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: ZERO
+        };
+        context.graph.addPass(this.#combineReactivePass, parameters);
+        return combined;
+    }
+
+    forceReactive(context: RenderPipelineContext, reactiveMask: RenderGraphTextureHandle): void {
+        const parameters = context.acquirePassParameters(this.#parameters);
+        parameters.colorAttachments[0] = {
+            texture: reactiveMask,
+            loadOp: 'load',
+            storeOp: 'store'
+        };
+        context.graph.addPass(this.#forceReactivePass, parameters);
+    }
+
+    createParticleOverlay(context: RenderPipelineContext): RenderGraphTextureHandle {
+        const overlay = context.graph.createTexture(
+            'Transparent GPU particle output-resolution overlay',
+            this.#resolvedDescriptor
+        );
+        const parameters = context.acquirePassParameters(this.#parameters);
+        parameters.colorAttachments[0] = {
+            texture: overlay,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: ZERO
+        };
+        context.graph.addPass(this.#clearParticleOverlayPass, parameters);
+        return overlay;
+    }
+
+    createParticleDepth(
+        context: RenderPipelineContext,
+        resolvedDepth: RenderGraphTextureHandle
+    ): RenderGraphTextureHandle {
+        const scratch = context.graph.createTexture(
+            'Transparent GPU particle depth reconstruction scratch',
+            this.#outputMaskDescriptor
+        );
+        const depth = context.graph.createTexture(
+            'Transparent GPU particle output-resolution depth',
+            this.#outputDepthDescriptor
+        );
+        const parameters = context.acquirePassParameters(this.#parameters);
+        parameters.inputTextures.push(resolvedDepth);
+        parameters.colorAttachments.push({
+            texture: scratch,
+            loadOp: 'clear',
+            storeOp: 'discard',
+            clearValue: ZERO
+        });
+        parameters.depthStencilAttachment = {
+            texture: depth,
+            depthLoadOp: 'clear',
+            depthStoreOp: 'store',
+            depthClearValue: depthClearValue(context.camera.depthMode)
+        };
+        context.graph.addPass(this.#upsampleParticleDepthPass, parameters);
+        return depth;
+    }
+
+    createParticleMask(
+        context: RenderPipelineContext,
+        particles: RenderGraphTextureHandle
+    ): RenderGraphTextureHandle {
+        const mask = context.graph.createTexture(
+            'Transparent GPU particle resurrection coverage',
+            this.#outputMaskDescriptor
+        );
+        const maskParameters = context.acquirePassParameters(this.#parameters);
+        maskParameters.inputTextures.push(particles);
+        maskParameters.colorAttachments.push({
+            texture: mask,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: ZERO
+        });
+        context.graph.addPass(this.#compositeParticleMaskPass, maskParameters);
+        return mask;
+    }
+
+    compositeParticles(
+        context: RenderPipelineContext,
+        scene: RenderGraphTextureHandle,
+        particles: RenderGraphTextureHandle
+    ): RenderGraphTextureHandle {
+        const color = context.graph.createTexture(
+            'Transparent GPU particle composited HDR scene',
+            this.#resolvedDescriptor
+        );
+        const parameters = context.acquirePassParameters(this.#parameters);
+        parameters.inputTextures.push(scene, particles);
+        parameters.colorAttachments.push({
+            texture: color,
+            loadOp: 'clear',
+            storeOp: 'store',
+            clearValue: ZERO
+        });
+        context.graph.addPass(this.#compositeParticleColorPass, parameters);
+        return color;
+    }
+
+    resolve(
+        context: RenderPipelineContext,
+        scene: RenderGraphTextureHandle,
+        sceneDepth: RenderGraphTextureHandle,
+        currentMask: RenderGraphTextureHandle,
+        historyValid: boolean
+    ): RenderGraphTextureHandle {
+        if (!historyValid) {
+            context.graph.invalidateHistoryTexture(this.#colorHistoryKey);
+            context.graph.invalidateHistoryTexture(this.#maskHistoryKey);
+            context.graph.invalidateHistoryTexture(this.#depthHistoryKey);
+        }
+        const colorHistory = context.graph.acquireHistoryTexture(
+            this.#colorHistoryKey,
+            this.#colorHistoryDescriptor
+        );
+        const maskHistory = context.graph.acquireHistoryTexture(
+            this.#maskHistoryKey,
+            this.#maskHistoryDescriptor
+        );
+        const depthHistory = context.graph.acquireHistoryTexture(
+            this.#depthHistoryKey,
+            this.#depthHistoryDescriptor
+        );
+        if (
+            colorHistory.generation !== maskHistory.generation ||
+            colorHistory.generation !== depthHistory.generation ||
+            colorHistory.valid !== maskHistory.valid ||
+            colorHistory.valid !== depthHistory.valid
+        ) {
+            throw new Error('Transparent temporal history generations diverged');
+        }
+        const resolved = context.graph.createTexture(
+            'Transparent temporally resurrected HDR scene',
+            this.#resolvedDescriptor
+        );
+        const valid = historyValid && colorHistory.valid;
+        const parameters = context.acquirePassParameters(this.#parameters);
+        parameters.inputTextures.push(scene, sceneDepth, currentMask);
+        if (valid) {
+            parameters.inputTextures.push(
+                colorHistory.history(),
+                depthHistory.history(),
+                maskHistory.history()
+            );
+        }
+        parameters.colorAttachments.push(
+            {
+                texture: colorHistory.current,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: ZERO
+            },
+            {
+                texture: resolved,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: ZERO
+            },
+            {
+                texture: maskHistory.current,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: ZERO
+            },
+            {
+                texture: depthHistory.current,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: ZERO
+            }
+        );
+        context.graph.addPass(valid ? this.#resolvePass : this.#initializePass, parameters);
+        return resolved;
+    }
+
+    destroy(): void {
+        this.#destroyed = true;
+    }
+}

--- a/src/render/renderer/MeshDrawListPlanner.ts
+++ b/src/render/renderer/MeshDrawListPlanner.ts
@@ -195,7 +195,7 @@ export class MeshDrawListPlanner {
         ) {
             const depthA = this.transparentDepth(a);
             const depthB = this.transparentDepth(b);
-            if (depthA !== depthB) return depthB - depthA;
+            if (depthA !== depthB) return depthA - depthB;
         }
         return 0;
     };
@@ -472,9 +472,7 @@ export class MeshDrawListPlanner {
         record.transparentDepth = 0;
         if (record.transparent && this.#transparentSortCamera !== null) {
             mesh.worldMatrix.getTranslation(this.#transparentPosition);
-            this.#transparentPosition.transformMat4(
-                this.#transparentSortCamera.viewProjectionMatrix
-            );
+            this.#transparentPosition.transformMat4(this.#transparentSortCamera.viewMatrix);
             record.transparentDepth = this.#transparentPosition.z;
         }
 
@@ -819,8 +817,7 @@ export class MeshDrawListPlanner {
     private transparentDepth(mesh: Mesh): number {
         mesh.worldMatrix.getTranslation(this.#transparentPosition);
         this.#transparentPosition.transformMat4(
-            requireRecordValue(this.#transparentSortCamera, 'transparent sort camera')
-                .viewProjectionMatrix
+            requireRecordValue(this.#transparentSortCamera, 'transparent sort camera').viewMatrix
         );
         return this.#transparentPosition.z;
     }

--- a/src/render/renderer/MeshDrawProcessor.ts
+++ b/src/render/renderer/MeshDrawProcessor.ts
@@ -88,7 +88,7 @@ const PASS_GLOBAL_SCENE_TEXTURE_NAMES = new Set(['u_opaqueTexture', 'u_gtaoTextu
 
 /** @internal Reusable pass-owned output populated while scene storage draws are prepared. */
 export interface StorageScenePreparationState {
-    globalBindGroupLayout: ResourceRegistryHandle<RHIBindGroupLayout> | null;
+    readonly globalBindGroupLayouts: ResourceRegistryHandle<RHIBindGroupLayout>[];
 }
 
 /** @internal Reusable pass-owned output for the graph-resolved opaque scene texture. */
@@ -892,7 +892,13 @@ export class MeshDrawProcessor {
             throw new Error(`Mesh ${mesh.id} requires geometry and material`);
         }
         const materialState = requireMaterialPassState(material, 'forward');
-        this.validateLighting(mesh, material, context);
+        if (
+            shader.bindings.some(
+                binding => binding.kind === 'uniform-buffer' && binding.name === 'LightBlock'
+            )
+        ) {
+            this.validateLighting(mesh, material, context);
+        }
         this.validateSceneStorageShader(shader);
         this.validateDeformation(mesh, geometry);
         geometry.normalizePrimitiveTopology();
@@ -1004,13 +1010,7 @@ export class MeshDrawProcessor {
         this.trackGeometrySources(geometry, vertexPlan.streams);
         this.trackMeshTextures(mesh, this.requireSampledScratchSources(mesh, sampledResources));
         this.#preparedMeshes.add(mesh);
-        if (
-            preparationState.globalBindGroupLayout !== null &&
-            preparationState.globalBindGroupLayout !== globalLayout
-        ) {
-            throw new Error('Scene storage meshes produced incompatible pass-global layouts');
-        }
-        preparationState.globalBindGroupLayout = globalLayout;
+        preparationState.globalBindGroupLayouts.push(globalLayout);
         return prepared;
     }
 

--- a/src/render/ubo/BuiltInUniformBlocks.ts
+++ b/src/render/ubo/BuiltInUniformBlocks.ts
@@ -136,7 +136,8 @@ export const modelBlockLayout = createStd140Layout({
     u_previousModelMatrix: 'mat4',
     u_normalWorldMatrix: 'mat3',
     u_objectIdColor: 'vec4',
-    u_modelHistoryParams: 'vec4'
+    u_modelHistoryParams: 'vec4',
+    u_modelLayerParams: 'uvec4'
 });
 
 export const geometryBlockLayout = createStd140Layout({

--- a/src/shader/Shader.ts
+++ b/src/shader/Shader.ts
@@ -697,6 +697,9 @@ function getShaderVariant(
     if (groundTruthAmbientOcclusion) header += '#define HILO_GTAO 1\n';
     if (role === 'motion-vector' && temporalReactiveMask) {
         header += '#define HILO_TEMPORAL_REACTIVE_MASK 1\n';
+        if (material.forwardQueue === 'transparent') {
+            header += '#define HILO_TEMPORAL_FORCE_REACTIVE 1\n';
+        }
     }
     const pass = resolveMaterialPassDefinition(material, role);
     if (pass === null) return null;

--- a/src/shader/basic.vert
+++ b/src/shader/basic.vert
@@ -23,6 +23,9 @@ out float v_currentViewDepth;
 out float v_previousViewDepth;
 flat out float v_motionHistoryValid;
 #endif
+#ifdef HILO_CLUSTERED_FORWARD
+flat out uint v_clusterReceiverLayer;
+#endif
 void main(void) {
     vec4 pos = vec4(a_position, 1.0);
     #ifdef HILO_HAS_TEXCOORD0
@@ -52,6 +55,9 @@ void main(void) {
 
     vec4 currentClipPosition = u_viewProjectionMatrix * u_modelMatrix * pos;
     gl_Position = currentClipPosition;
+    #ifdef HILO_CLUSTERED_FORWARD
+        v_clusterReceiverLayer = u_modelLayerParams.x;
+    #endif
 
     #ifdef HILO_MOTION_VECTOR_PASS
         #if defined(HILO_MORPH_TARGET_COUNT) && defined(HILO_MORPH_HAS_POSITION)

--- a/src/shader/chunk/clusteredForward.frag
+++ b/src/shader/chunk/clusteredForward.frag
@@ -1,0 +1,387 @@
+#ifdef HILO_CLUSTERED_FORWARD
+flat in uint v_clusterReceiverLayer;
+layout(std430) readonly buffer ClusterFrameDataBlock {
+    vec4 values[];
+} clusterFrameData;
+layout(std430) readonly buffer ClusterLightDataBlock {
+    vec4 values[];
+} clusterLights;
+layout(std430) readonly buffer ClusterLightGridBlock {
+    uvec2 values[];
+} clusterLightGrid;
+layout(std430) readonly buffer ClusterLightIndexBlock {
+    uint values[];
+} clusterLightIndices;
+
+// Keep these offsets synchronized with ClusteredForwardPlus.ts. Vec4 32 maps output-resolution
+// fragment coordinates back to the internal cluster viewport; the shadow payload follows it.
+#define HILO_CLUSTER_OUTPUT_MAPPING_VEC4 32u
+#define HILO_CLUSTER_SHADOW_ATLAS_SIZE_VEC4 33u
+#define HILO_CLUSTER_SHADOW_METADATA_VEC4 34u
+#define HILO_CLUSTER_SHADOW_ATLAS_RECTS_VEC4 35u
+#define HILO_CLUSTER_SHADOW_DIRECTIONAL_BIASES_VEC4 171u
+#define HILO_CLUSTER_SHADOW_DIRECTIONAL_SPLITS_VEC4 179u
+#define HILO_CLUSTER_SHADOW_DIRECTIONAL_PARAMS_VEC4 187u
+#define HILO_CLUSTER_SHADOW_DIRECTIONAL_MATRICES_VEC4 195u
+#define HILO_CLUSTER_SHADOW_SPOT_BIASES_VEC4 323u
+#define HILO_CLUSTER_SHADOW_SPOT_MATRICES_VEC4 331u
+#define HILO_CLUSTER_SHADOW_POINT_BIASES_VEC4 363u
+#define HILO_CLUSTER_SHADOW_POINT_MATRICES_VEC4 379u
+
+uvec2 hiloClusteredAllocation(vec3 viewPosition) {
+    float depth = max(-viewPosition.z, clusterFrameData.values[25u].x);
+    uvec4 cluster = floatBitsToUint(clusterFrameData.values[27u]);
+    vec2 clusterPosition = gl_FragCoord.xy *
+        clusterFrameData.values[HILO_CLUSTER_OUTPUT_MAPPING_VEC4].zw;
+    uint tileX = min(uint(clusterPosition.x) / cluster.w, cluster.x - 1u);
+    uint tileY = min(uint(clusterPosition.y) / cluster.w, cluster.y - 1u);
+    float logScale = clusterFrameData.values[25u].z;
+    uint slice = min(
+        uint(
+            clamp(
+                log(depth / clusterFrameData.values[25u].x) / logScale,
+                0.0,
+                0.999999
+            ) * float(cluster.z)
+        ),
+        cluster.z - 1u
+    );
+    uint clusterIndex = slice * cluster.x * cluster.y + tileY * cluster.x + tileX;
+    return clusterLightGrid.values[clusterIndex];
+}
+
+#ifdef HILO_CLUSTERED_SHADOWS
+mat4 hiloClusteredShadowMatrix(uint base) {
+    return mat4(
+        clusterFrameData.values[base],
+        clusterFrameData.values[base + 1u],
+        clusterFrameData.values[base + 2u],
+        clusterFrameData.values[base + 3u]
+    );
+}
+
+float hiloClusteredShadowAtlasVisibility(
+    int sliceIndex,
+    float bias,
+    vec3 viewPosition,
+    mat4 lightMatrix
+) {
+    vec4 clipPosition = lightMatrix * vec4(viewPosition, 1.0);
+    if (clipPosition.w <= 0.0) return 1.0;
+    vec3 projection = clipPosition.xyz / clipPosition.w;
+    projection = projection * 0.5 + 0.5;
+    if (
+        any(lessThan(projection, vec3(0.0))) ||
+        any(greaterThan(projection, vec3(1.0)))
+    ) return 1.0;
+    vec4 atlasRect = clusterFrameData.values[
+        HILO_CLUSTER_SHADOW_ATLAS_RECTS_VEC4 + uint(sliceIndex)
+    ];
+    vec2 atlasUV = atlasRect.zw + hiloRenderTargetUV(projection.xy) * atlasRect.xy;
+    vec2 texel = clusterFrameData.values[HILO_CLUSTER_SHADOW_ATLAS_SIZE_VEC4].zw;
+    vec2 rectEnd = atlasRect.zw + atlasRect.xy;
+    vec2 rectMin = min(atlasRect.zw, rectEnd) + texel * 0.5;
+    vec2 rectMax = max(atlasRect.zw, rectEnd) - texel * 0.5;
+    float depthBias = clusterFrameData.values[HILO_CLUSTER_SHADOW_METADATA_VEC4].w > 0.5
+        ? bias
+        : -bias;
+    float visibility = 0.0;
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            vec2 sampleUV = clamp(
+                atlasUV + vec2(float(x), float(y)) * texel,
+                rectMin,
+                rectMax
+            );
+            visibility += textureLod(
+                u_shadowAtlas,
+                vec3(sampleUV, projection.z + depthBias),
+                0.0
+            );
+        }
+    }
+    return visibility / 9.0;
+}
+
+float hiloClusteredDirectionalShadow(int index, float bias, vec3 viewPosition) {
+    vec4 splits = clusterFrameData.values[
+        HILO_CLUSTER_SHADOW_DIRECTIONAL_SPLITS_VEC4 + uint(index)
+    ];
+    vec4 parameters = clusterFrameData.values[
+        HILO_CLUSTER_SHADOW_DIRECTIONAL_PARAMS_VEC4 + uint(index)
+    ];
+    int cascadeCount = clamp(int(parameters.x + 0.5), 1, HILO_MAX_DIRECTIONAL_SHADOW_CASCADES);
+    float viewDepth = max(-viewPosition.z, 0.0);
+    int cascade = 0;
+    if (cascadeCount > 1 && viewDepth > splits.x) cascade = 1;
+    if (cascadeCount > 2 && viewDepth > splits.y) cascade = 2;
+    if (cascadeCount > 3 && viewDepth > splits.z) cascade = 3;
+    if (viewDepth > splits[cascadeCount - 1]) return 1.0;
+    int matrixIndex = index * HILO_MAX_DIRECTIONAL_SHADOW_CASCADES + cascade;
+    uint matrixBase = HILO_CLUSTER_SHADOW_DIRECTIONAL_MATRICES_VEC4 +
+        uint(matrixIndex) * 4u;
+    float visibility = hiloClusteredShadowAtlasVisibility(
+        matrixIndex,
+        bias,
+        viewPosition,
+        hiloClusteredShadowMatrix(matrixBase)
+    );
+    float blend = parameters.y;
+    if (cascade < cascadeCount - 1 && blend > 0.0) {
+        float previousSplit = cascade == 0
+            ? clusterFrameData.values[25u].x
+            : splits[cascade - 1];
+        float interval = max(splits[cascade] - previousSplit, 0.00001);
+        float blendStart = splits[cascade] - interval * blend;
+        if (viewDepth > blendStart) {
+            int nextMatrixIndex = matrixIndex + 1;
+            float nextVisibility = hiloClusteredShadowAtlasVisibility(
+                nextMatrixIndex,
+                bias,
+                viewPosition,
+                hiloClusteredShadowMatrix(
+                    HILO_CLUSTER_SHADOW_DIRECTIONAL_MATRICES_VEC4 +
+                        uint(nextMatrixIndex) * 4u
+                )
+            );
+            visibility = mix(
+                visibility,
+                nextVisibility,
+                smoothstep(blendStart, splits[cascade], viewDepth)
+            );
+        }
+    }
+    float strength = clamp(parameters.z, 0.0, 4.0);
+    return clamp(1.0 - (1.0 - visibility) * strength, 0.0, 1.0);
+}
+
+float hiloClusteredSpotShadow(int index, float bias, vec3 viewPosition) {
+    int sliceIndex = HILO_MAX_DIRECTIONAL_LIGHTS * HILO_MAX_DIRECTIONAL_SHADOW_CASCADES +
+        index;
+    uint matrixBase = HILO_CLUSTER_SHADOW_SPOT_MATRICES_VEC4 + uint(index) * 4u;
+    return hiloClusteredShadowAtlasVisibility(
+        sliceIndex,
+        bias,
+        viewPosition,
+        hiloClusteredShadowMatrix(matrixBase)
+    );
+}
+
+float hiloClusteredPointShadow(int index, float bias, vec3 viewPosition) {
+    int matrixOffset = index * 6;
+    for (int face = 0; face < 6; face++) {
+        int matrixIndex = matrixOffset + face;
+        uint matrixBase = HILO_CLUSTER_SHADOW_POINT_MATRICES_VEC4 + uint(matrixIndex) * 4u;
+        mat4 lightMatrix = hiloClusteredShadowMatrix(matrixBase);
+        vec4 clipPosition = lightMatrix * vec4(viewPosition, 1.0);
+        if (clipPosition.w <= 0.0) continue;
+        vec3 projection = clipPosition.xyz / clipPosition.w;
+        if (abs(projection.x) <= 1.0001 && abs(projection.y) <= 1.0001) {
+            int sliceIndex = HILO_MAX_DIRECTIONAL_LIGHTS *
+                HILO_MAX_DIRECTIONAL_SHADOW_CASCADES + HILO_MAX_SPOT_LIGHTS + matrixIndex;
+            return hiloClusteredShadowAtlasVisibility(
+                sliceIndex,
+                bias,
+                viewPosition,
+                lightMatrix
+            );
+        }
+    }
+    return 1.0;
+}
+
+float hiloClusteredShadow(
+    vec4 metadata,
+    vec3 viewPosition,
+    vec3 normal,
+    vec3 lightDirection
+) {
+    int kind = int(metadata.x + 0.5);
+    int index = int(metadata.y + 0.5);
+    if (kind == 0) return 1.0;
+    uint biasBase = kind == 1
+        ? HILO_CLUSTER_SHADOW_DIRECTIONAL_BIASES_VEC4
+        : (kind == 2
+            ? HILO_CLUSTER_SHADOW_SPOT_BIASES_VEC4
+            : HILO_CLUSTER_SHADOW_POINT_BIASES_VEC4);
+    vec2 biasParameters = clusterFrameData.values[biasBase + uint(index)].xy;
+    float bias = max(
+        biasParameters.y * (1.0 - dot(normal, lightDirection)),
+        biasParameters.x
+    );
+    if (kind == 1) return hiloClusteredDirectionalShadow(index, bias, viewPosition);
+    if (kind == 2) return hiloClusteredSpotShadow(index, bias, viewPosition);
+    return hiloClusteredPointShadow(index, bias, viewPosition);
+}
+#endif
+
+float hiloClusteredPhotometricAttenuation(
+    vec3 viewPosition,
+    vec3 lightPosition,
+    vec3 lightAxis,
+    vec4 cookieParameters,
+    vec4 photometricParameters,
+    uint featureFlags
+) {
+    vec3 axis = normalize(lightAxis);
+    vec3 delta = viewPosition - lightPosition;
+    vec3 reference = abs(axis.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+    vec3 right = normalize(cross(reference, axis));
+    vec3 up = cross(axis, right);
+    float axialDistance = max(dot(delta, axis), 1e-5);
+    float attenuation = 1.0;
+    if ((featureFlags & 1u) != 0u) {
+        vec2 projected = vec2(dot(delta, right), dot(delta, up)) / axialDistance;
+        vec2 coordinate = (projected - cookieParameters.zw) / cookieParameters.xy;
+        float edge = 1.0 - max(abs(coordinate.x), abs(coordinate.y));
+        float softness = max(photometricParameters.y, 1e-5);
+        attenuation *= photometricParameters.x * smoothstep(0.0, softness, edge);
+    }
+    if ((featureFlags & 2u) != 0u) {
+        float axialCosine = max(dot(normalize(delta), axis), 0.0);
+        attenuation *= photometricParameters.z * pow(axialCosine, photometricParameters.w);
+    }
+    return attenuation;
+}
+
+void hiloEvaluateClusteredPBRLight(
+    uint lightIndex,
+    vec3 viewPosition,
+    vec3 normal,
+    vec3 viewDirection,
+    vec3 clearcoatLayerNormal,
+    vec3 anisotropyT,
+    vec3 anisotropyB,
+    vec3 specularColor,
+    vec3 diffuseColor,
+    vec3 areaSpecularColor,
+    vec3 areaDiffuseColor,
+    float roughness,
+    float anisotropyStrength,
+    float iridescenceFactor,
+    float iridescenceIor,
+    float iridescenceThickness,
+    float clearcoatFactor,
+    float clearcoatRoughness,
+    out vec3 lightDiffuse,
+    out vec3 lightSpecular,
+    out vec3 clearcoatLighting
+) {
+    uint lightBase = lightIndex * 7u;
+    vec4 positionRange = clusterLights.values[lightBase];
+    vec4 colorType = clusterLights.values[lightBase + 1u];
+    vec4 directionOuter = clusterLights.values[lightBase + 2u];
+    vec4 attenuationInner = clusterLights.values[lightBase + 3u];
+    vec4 shadowMetadata = clusterLights.values[lightBase + 4u];
+    uint lightType = uint(colorType.w + 0.5);
+    lightDiffuse = vec3(0.0);
+    lightSpecular = vec3(0.0);
+    clearcoatLighting = vec3(0.0);
+    uint lightLayerMask = floatBitsToUint(shadowMetadata.z);
+    if ((v_clusterReceiverLayer & lightLayerMask) == 0u) return;
+    if (lightType == 3u) {
+        getAreaLightComponents(
+            areaDiffuseColor,
+            areaSpecularColor,
+            roughness,
+            normal,
+            viewDirection,
+            viewPosition,
+            positionRange.xyz,
+            colorType.rgb,
+            clusterLights.values[lightBase + 5u].xyz,
+            clusterLights.values[lightBase + 6u].xyz,
+            u_areaLightsLtcTexture1,
+            u_areaLightsLtcTexture2,
+            lightDiffuse,
+            lightSpecular
+        );
+#ifdef HILO_HAS_CLEARCOAT
+        if (clearcoatFactor > 0.0) {
+            vec3 unusedDiffuse;
+            getAreaLightComponents(
+                vec3(0.0),
+                vec3(0.04),
+                clearcoatRoughness,
+                clearcoatLayerNormal,
+                viewDirection,
+                viewPosition,
+                positionRange.xyz,
+                colorType.rgb,
+                clusterLights.values[lightBase + 5u].xyz,
+                clusterLights.values[lightBase + 6u].xyz,
+                u_areaLightsLtcTexture1,
+                u_areaLightsLtcTexture2,
+                unusedDiffuse,
+                clearcoatLighting
+            );
+        }
+#endif
+        return;
+    }
+    vec3 lightDirection;
+    vec3 radiance = colorType.rgb;
+    if (lightType == 2u) {
+        lightDirection = normalize(-directionOuter.xyz);
+    } else {
+        vec3 distanceVector = positionRange.xyz - viewPosition;
+        lightDirection = normalize(distanceVector);
+        radiance *= getLightAttenuation(
+            distanceVector,
+            attenuationInner.xyz,
+            positionRange.w
+        );
+        if (lightType == 1u) {
+            float theta = dot(lightDirection, normalize(-directionOuter.xyz));
+            float epsilon = max(attenuationInner.w - directionOuter.w, 1e-5);
+            float cone = clamp((theta - directionOuter.w) / epsilon, 0.0, 1.0);
+            radiance *= cone * cone * (3.0 - 2.0 * cone);
+            radiance *= hiloClusteredPhotometricAttenuation(
+                viewPosition,
+                positionRange.xyz,
+                directionOuter.xyz,
+                clusterLights.values[lightBase + 5u],
+                clusterLights.values[lightBase + 6u],
+                floatBitsToUint(shadowMetadata.w)
+            );
+        }
+    }
+    hiloEvaluateBaseBRDF(
+        normal,
+        viewDirection,
+        lightDirection,
+        anisotropyT,
+        anisotropyB,
+        specularColor,
+        diffuseColor,
+        roughness,
+        anisotropyStrength,
+        iridescenceFactor,
+        iridescenceIor,
+        iridescenceThickness,
+        lightDiffuse,
+        lightSpecular
+    );
+    float visibility = 1.0;
+#if defined(HILO_CLUSTERED_SHADOWS) && defined(HILO_RECEIVE_SHADOWS)
+    visibility = hiloClusteredShadow(
+        shadowMetadata,
+        viewPosition,
+        normal,
+        lightDirection
+    );
+#endif
+    lightDiffuse *= visibility * radiance;
+    lightSpecular *= visibility * radiance;
+#ifdef HILO_HAS_CLEARCOAT
+    if (clearcoatFactor > 0.0) {
+        clearcoatLighting = visibility * radiance * hiloEvaluateClearcoatBRDF(
+            clearcoatLayerNormal,
+            viewDirection,
+            lightDirection,
+            clearcoatRoughness
+        );
+    }
+#endif
+}
+#endif

--- a/src/shader/chunk/light.frag
+++ b/src/shader/chunk/light.frag
@@ -1,4 +1,6 @@
-#ifdef HILO_SHADOW_ATLAS
+#ifdef HILO_CLUSTERED_SHADOWS
+    uniform highp sampler2DShadow u_shadowAtlas;
+#elif defined(HILO_SHADOW_ATLAS)
     #if defined(HILO_DIRECTIONAL_LIGHTS_SMC) || defined(HILO_SPOT_LIGHTS_SMC) || defined(HILO_POINT_LIGHTS_SMC)
         uniform highp sampler2DShadow u_shadowAtlas;
     #endif
@@ -22,7 +24,7 @@
     #endif
 #endif
 
-#ifdef HILO_AREA_LIGHTS
+#if defined(HILO_AREA_LIGHTS) || defined(HILO_CLUSTERED_FORWARD)
     uniform sampler2D u_areaLightsLtcTexture1;
     uniform sampler2D u_areaLightsLtcTexture2;
 

--- a/src/shader/chunk/motionVector.frag
+++ b/src/shader/chunk/motionVector.frag
@@ -35,7 +35,11 @@
 
     void hiloWriteTemporalReactiveMask() {
         #ifdef HILO_TEMPORAL_REACTIVE_MASK
-            hilo_ReactiveMask = clamp(u_temporalReactiveFactor, 0.0, 1.0);
+            #ifdef HILO_TEMPORAL_FORCE_REACTIVE
+                hilo_ReactiveMask = 1.0;
+            #else
+                hilo_ReactiveMask = clamp(u_temporalReactiveFactor, 0.0, 1.0);
+            #endif
         #endif
     }
 #endif

--- a/src/shader/chunk/pbr_main.frag
+++ b/src/shader/chunk/pbr_main.frag
@@ -194,6 +194,7 @@ vec3 directSpecular = vec3(0.0);
 vec3 lightDiffuse;
 vec3 lightSpecular;
 
+#ifndef HILO_CLUSTERED_FORWARD
 #ifdef HILO_DIRECTIONAL_LIGHTS
 for (int i = 0; i < HILO_DIRECTIONAL_LIGHTS; i++) {
     vec3 lightDir = normalize(-u_directionalLightsInfo[i]);
@@ -388,6 +389,74 @@ for (int i = 0; i < HILO_AREA_LIGHTS; i++) {
     #endif
 }
 #endif
+#else
+uvec2 clusteredAllocation = hiloClusteredAllocation(v_fragPos);
+uint clusteredGlobalLightCount = floatBitsToUint(clusterFrameData.values[30u]).x;
+uint clusteredLocalLightCount = clusteredAllocation.y;
+vec3 clusteredClearcoatNormal = N;
+#ifdef HILO_HAS_CLEARCOAT
+clusteredClearcoatNormal = clearcoatNormal;
+#endif
+for (uint lightIndex = 0u; lightIndex < clusteredGlobalLightCount; lightIndex += 1u) {
+    vec3 clusteredClearcoat;
+    hiloEvaluateClusteredPBRLight(
+        lightIndex,
+        v_fragPos,
+        N,
+        V,
+        clusteredClearcoatNormal,
+        anisotropyT,
+        anisotropyB,
+        specularColor,
+        diffuseColor,
+        areaSpecularColor,
+        areaDiffuseColor,
+        roughness,
+        anisotropyStrength,
+        iridescenceFactor,
+        iridescenceIor,
+        iridescenceThickness,
+        clearcoatFactor,
+        clearcoatRoughness,
+        lightDiffuse,
+        lightSpecular,
+        clusteredClearcoat
+    );
+    directDiffuse += lightDiffuse;
+    directSpecular += lightSpecular;
+    clearcoatDirect += clusteredClearcoat;
+}
+for (uint clusteredIndex = 0u; clusteredIndex < clusteredLocalLightCount; clusteredIndex += 1u) {
+    uint lightIndex = clusterLightIndices.values[clusteredAllocation.x + clusteredIndex];
+    vec3 clusteredClearcoat;
+    hiloEvaluateClusteredPBRLight(
+        lightIndex,
+        v_fragPos,
+        N,
+        V,
+        clusteredClearcoatNormal,
+        anisotropyT,
+        anisotropyB,
+        specularColor,
+        diffuseColor,
+        areaSpecularColor,
+        areaDiffuseColor,
+        roughness,
+        anisotropyStrength,
+        iridescenceFactor,
+        iridescenceIor,
+        iridescenceThickness,
+        clearcoatFactor,
+        clearcoatRoughness,
+        lightDiffuse,
+        lightSpecular,
+        clusteredClearcoat
+    );
+    directDiffuse += lightDiffuse;
+    directSpecular += lightSpecular;
+    clearcoatDirect += clusteredClearcoat;
+}
+#endif
 
 vec3 indirectDiffuse = hiloGetIBLDiffuse(indirectDiffuseNormal, iblDiffuseColor, ao);
 vec3 indirectSpecular = hiloGetIBLSpecular(
@@ -403,7 +472,9 @@ vec3 indirectSpecular = hiloGetIBLSpecular(
     ao
 );
 
-#if defined(HILO_AMBIENT_LIGHTS) && (defined(HILO_IS_DIFFUSE_ENV_AND_AMBIENT_LIGHT_WORK_TOGETHER) || (!defined(HILO_DIFFUSE_ENV_MAP) && !defined(HILO_DIFFUSE_ENV_SPHERE_HARMONICS3)))
+#if defined(HILO_CLUSTERED_FORWARD) && (defined(HILO_IS_DIFFUSE_ENV_AND_AMBIENT_LIGHT_WORK_TOGETHER) || (!defined(HILO_DIFFUSE_ENV_MAP) && !defined(HILO_DIFFUSE_ENV_SPHERE_HARMONICS3)))
+indirectDiffuse += clusterFrameData.values[31u].rgb * iblDiffuseColor * ao * HILO_INVERSE_PI;
+#elif defined(HILO_AMBIENT_LIGHTS) && (defined(HILO_IS_DIFFUSE_ENV_AND_AMBIENT_LIGHT_WORK_TOGETHER) || (!defined(HILO_DIFFUSE_ENV_MAP) && !defined(HILO_DIFFUSE_ENV_SPHERE_HARMONICS3)))
 indirectDiffuse += u_ambientLightsColor * iblDiffuseColor * ao * HILO_INVERSE_PI;
 #endif
 

--- a/src/shader/chunk/transparency_main.frag
+++ b/src/shader/chunk/transparency_main.frag
@@ -5,6 +5,9 @@ float transparency = 1.0;
     transparency = u_transparencyFactor;
 #endif
 color.a *= transparency;
+#if defined(HILO_MOTION_VECTOR_PASS) && defined(HILO_TEMPORAL_FORCE_REACTIVE)
+    if (color.a <= 0.00392156862745098) discard;
+#endif
 #ifdef HILO_ALPHA_CUTOFF
     if (color.a < u_alphaCutoff) {
         discard;

--- a/src/shader/chunk/uniformBlocks.glsl
+++ b/src/shader/chunk/uniformBlocks.glsl
@@ -20,6 +20,7 @@ layout(std140) uniform SceneBlock {
     vec4 u_fogInfo;
 };
 
+#ifndef HILO_CLUSTERED_FORWARD
 layout(std140) uniform LightBlock {
     vec3 u_ambientLightsColor;
     vec3 u_directionalLightsColor[HILO_MAX_DIRECTIONAL_LIGHTS];
@@ -56,6 +57,7 @@ layout(std140) uniform LightBlock {
     vec3 u_areaLightsWidth[HILO_MAX_AREA_LIGHTS];
     vec3 u_areaLightsHeight[HILO_MAX_AREA_LIGHTS];
 };
+#endif
 
 layout(std140) uniform MaterialBlock {
     vec4 u_diffuseColor;
@@ -134,6 +136,7 @@ layout(std140) uniform MaterialTextureBlock {
         mat3 u_normalWorldMatrix;
         vec4 u_objectIdColor;
         vec4 u_modelHistoryParams;
+        uvec4 u_modelLayerParams;
     };
     #define u_modelHistoryValid u_modelHistoryParams.x
 #endif

--- a/src/shader/pbr.frag
+++ b/src/shader/pbr.frag
@@ -9,6 +9,7 @@
 #include "./chunk/lightFog.frag"
 #include "./chunk/pbr.frag"
 #include "./chunk/light.frag"
+#include "./chunk/clusteredForward.frag"
 #include "./chunk/transparency.frag"
 #include "./chunk/fog.frag"
 #include "./chunk/logDepth.frag"

--- a/test/spec/light/Light.test.ts
+++ b/test/spec/light/Light.test.ts
@@ -30,6 +30,18 @@ describe('Light', () => {
         expect(light.quadraticAttenuation).toBe(0);
     });
 
+    it('keeps clustered receiver layers independent from node visibility layers', () => {
+        const light = new Light({ layer: 0x2, lightLayerMask: 0x80000001 });
+        expect(light.layer).toBe(0x2);
+        expect(light.lightLayerMask).toBe(0x80000001);
+        expect(() => {
+            light.lightLayerMask = -1;
+        }).toThrow(RangeError);
+        expect(() => {
+            light.lightLayerMask = 0x1_0000_0000;
+        }).toThrow(RangeError);
+    });
+
     it.each([-1, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN])(
         'rejects an invalid range: %s',
         range => {

--- a/test/spec/light/SpotLight.test.ts
+++ b/test/spec/light/SpotLight.test.ts
@@ -19,6 +19,31 @@ describe('SpotLight', () => {
         expect(light.outerCutoff).toBe(180);
     });
 
+    it('normalizes analytic cookie and IES profile parameters', () => {
+        const light = new SpotLight({
+            cookie: {
+                scale: [0.75, 0.5],
+                offset: [0.1, -0.2],
+                intensity: 0.8,
+                softness: 0.25
+            },
+            iesProfile: { intensity: 1.4, exponent: 3 }
+        });
+        expect(light.cookie).toEqual({
+            scale: [0.75, 0.5],
+            offset: [0.1, -0.2],
+            intensity: 0.8,
+            softness: 0.25
+        });
+        expect(light.iesProfile).toEqual({ intensity: 1.4, exponent: 3 });
+        expect(Object.isFrozen(light.cookie)).toBe(true);
+        expect(Object.isFrozen(light.iesProfile)).toBe(true);
+
+        expect(() => new SpotLight({ cookie: { scale: [0, 1] } })).toThrow(RangeError);
+        expect(() => new SpotLight({ cookie: { softness: 2 } })).toThrow(RangeError);
+        expect(() => new SpotLight({ iesProfile: { exponent: -1 } })).toThrow(RangeError);
+    });
+
     it.each([-1, 181, Number.POSITIVE_INFINITY, Number.NaN])(
         'rejects an invalid cone angle: %s',
         angle => {

--- a/test/spec/renderer/BuiltInUniformBlocks.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlocks.test.ts
@@ -35,7 +35,7 @@ describe('built-in std140 ABI', () => {
             LightBlock: 16288,
             MaterialBlock: 448,
             MaterialTextureBlock: 1920,
-            ModelBlock: 208,
+            ModelBlock: 224,
             GeometryBlock: 224,
             SkinningBlock: 16400,
             MorphBlock: 80,
@@ -86,6 +86,7 @@ describe('built-in std140 ABI', () => {
         expect(modelBlockLayout.fields.u_normalWorldMatrix.offset).toBe(128);
         expect(modelBlockLayout.fields.u_objectIdColor.offset).toBe(176);
         expect(modelBlockLayout.fields.u_modelHistoryParams.offset).toBe(192);
+        expect(modelBlockLayout.fields.u_modelLayerParams.offset).toBe(208);
         expect(geometryBlockLayout.fields.u_positionDecodeMat.offset).toBe(0);
         expect(geometryBlockLayout.fields.u_uvDecodeMat.offset).toBe(128);
         expect(geometryBlockLayout.fields.u_uv1DecodeMat.offset).toBe(176);

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
 import Mesh from '../../../src/core/Mesh';
 import Node from '../../../src/core/Node';
+import Skeleton from '../../../src/core/Skeleton';
+import SkinnedMesh from '../../../src/core/SkinnedMesh';
 import BoxGeometry from '../../../src/geometry/BoxGeometry';
 import Geometry from '../../../src/geometry/Geometry';
 import GeometryData from '../../../src/geometry/GeometryData';
@@ -10,17 +12,23 @@ import AmbientLight from '../../../src/light/AmbientLight';
 import AreaLight from '../../../src/light/AreaLight';
 import DirectionalLight from '../../../src/light/DirectionalLight';
 import PointLight from '../../../src/light/PointLight';
+import SpotLight from '../../../src/light/SpotLight';
 import BasicMaterial from '../../../src/material/BasicMaterial';
 import PBRMaterial from '../../../src/material/PBRMaterial';
 import Color from '../../../src/math/Color';
 import Matrix3 from '../../../src/math/Matrix3';
+import Matrix4 from '../../../src/math/Matrix4';
 import Vector3 from '../../../src/math/Vector3';
+import ParticleSystem from '../../../src/particle/ParticleSystem';
+import ParticleSystemDefinition from '../../../src/particle/ParticleSystemDefinition';
 import Renderer from '../../../src/render/Renderer';
 import {
     registerRendererDiagnostics,
     unregisterRendererDiagnostics
 } from '../../../src/render/diagnostics/RendererDiagnosticsRegistry';
 import { ClusteredForwardPlusPipelineFactory } from '../../../src/render/pipeline/ClusteredForwardPlus';
+import { FullscreenRenderPass } from '../../../src/render/pipeline/passes';
+import { MeshDrawProcessor } from '../../../src/render/renderer/MeshDrawProcessor';
 import type { RHIDevice } from '../../../src/render/rhi/core';
 import Texture from '../../../src/texture/Texture';
 import { RGBA, TEXTURE_2D, UNSIGNED_BYTE } from '../../../src/constants/webgl';
@@ -82,7 +90,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             temporalAA: {}
         });
         expect(withTemporalAA.requirements.requiredLimits).toMatchObject({
-            maxColorAttachments: 3
+            maxColorAttachments: 4
         });
         expect(withTemporalAA.requirements.requiredTextureFormats).toContainEqual({
             format: 'r32float',
@@ -134,7 +142,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         expect(withReflections.requirements.requiredLimits).toMatchObject({
             maxStorageTexturesPerShaderStage: 2,
             maxSampledTexturesPerShaderStage: 14,
-            maxColorAttachments: 3
+            maxColorAttachments: 4
         });
         expect(withReflections.requirements.requiredTextureFormats).toEqual(
             expect.arrayContaining([
@@ -161,7 +169,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         });
         expect(withSSGI.requirements.requiredLimits).toMatchObject({
             maxSampledTexturesPerShaderStage: 12,
-            maxColorAttachments: 3
+            maxColorAttachments: 4
         });
         expect(withSSGI.requirements.requiredTextureFormats).toEqual(
             expect.arrayContaining([
@@ -215,6 +223,10 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         const material = new PBRMaterial();
         const transparent = new PBRMaterial({
             compositing: { mode: 'alpha-blend', premultiplied: true }
+        });
+        const manifestMesh = new Mesh({
+            geometry: new BoxGeometry({ widthSegments: 2 }),
+            material: new PBRMaterial({ clearcoatFactor: 0.5 })
         });
 
         expect(() => new ClusteredForwardPlusPipelineFactory({ buckets: [] })).toThrow(
@@ -368,6 +380,31 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             () =>
                 new ClusteredForwardPlusPipelineFactory({
                     buckets: [{ geometry, material }],
+                    variantManifest: {
+                        entries: [{ mesh: manifestMesh }, { mesh: manifestMesh }],
+                        maxVariants: 1,
+                        warmupBatchSize: 1
+                    }
+                })
+        ).not.toThrow();
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    variantManifest: { entries: [{ mesh: new Mesh() }] }
+                })
+        ).toThrow(/native clustered PBR/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    variantManifest: { entries: [], maxVariants: 0 }
+                })
+        ).toThrow(/positive safe integer/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
                     volumetricLighting: {
                         localVolumes: [
                             {
@@ -447,6 +484,404 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             maxBufferSize: geometryBufferBytes
         });
     });
+
+    it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
+        'shades globally sorted layered, morph, and skinned transparent PBR from clustered lights',
+        async () => {
+            const bucketGeometry = new BoxGeometry();
+            const bucketMaterial = new PBRMaterial();
+            const layeredMesh = new Mesh({
+                geometry: new BoxGeometry({ widthSegments: 2 }),
+                material: new PBRMaterial({
+                    baseColor: new Color(0.35, 0.9, 0.25),
+                    clearcoatFactor: 0.75,
+                    clearcoatRoughnessFactor: 0.18,
+                    anisotropyStrength: 0.45,
+                    iridescenceFactor: 0.55,
+                    iridescenceThicknessMinimum: 160,
+                    iridescenceThicknessMaximum: 360
+                }),
+                y: 1.05,
+                scaleX: 0.55,
+                scaleY: 0.55,
+                scaleZ: 0.55,
+                frustumTest: false
+            });
+            const factory = new ClusteredForwardPlusPipelineFactory({
+                buckets: [{ geometry: bucketGeometry, material: bucketMaterial }],
+                maxObjects: 1,
+                maxLights: 4,
+                maxLightIndices: 4_096,
+                maxLightsPerCluster: 4,
+                maxViewportWidth: 64,
+                maxViewportHeight: 32,
+                hiZ: false,
+                bloomStrength: 0,
+                temporalAA: { renderScale: 0.5 },
+                variantManifest: {
+                    entries: [{ mesh: layeredMesh, shadowed: false }],
+                    maxVariants: 4,
+                    warmupBatchSize: 1
+                }
+            });
+            const canvas = document.createElement('canvas');
+            const rendererDiagnostics = registerRendererDiagnostics(canvas);
+            const renderer = await Renderer.create({
+                backend: 'webgpu',
+                domElement: canvas,
+                width: 64,
+                height: 32,
+                antialias: false,
+                renderingProfile: 'high-end',
+                renderPipeline: factory
+            });
+            renderer.clearColor = new Color(0, 0, 0);
+            const target = renderer.createRenderTarget({
+                width: 64,
+                height: 32,
+                colorAttachments: [{ format: 'rgba8unorm' }],
+                depthStencilAttachment: { format: 'depth32float', depthMode: 'reversed' }
+            });
+            const particleSystem = new ParticleSystem({
+                definition: ParticleSystemDefinition.create({
+                    emitters: [
+                        {
+                            name: 'clustered-temporal-stateless',
+                            capacity: 64,
+                            execution: 'stateless',
+                            duration: 4,
+                            emission: { rateOverTime: 16 },
+                            initialize: {
+                                lifetime: 2,
+                                direction: [0, 1, 0],
+                                speed: 0.35,
+                                size: 0.35,
+                                color: [1, 0.55, 0.12, 0.8]
+                            },
+                            renderers: [{ type: 'sprite', blend: 'additive', depthTest: false }]
+                        }
+                    ]
+                }),
+                seed: 31,
+                autoPlay: false,
+                compilationEnvironment: { backend: 'webgpu' }
+            });
+            particleSystem.simulate(0.5);
+            try {
+                const scene = new Node();
+                particleSystem.addTo(scene);
+                const morphSource = new BoxGeometry({ widthSegments: 2 });
+                const morphVertices = morphSource.vertices;
+                if (morphVertices === null) throw new Error('Expected morph source vertices');
+                const morphTarget = new Float32Array(morphVertices.data.length);
+                for (let index = 0; index < morphTarget.length; index += 3) {
+                    morphTarget[index] = 0.08;
+                }
+                const morphGeometry = new MorphGeometry({
+                    vertices: morphSource.vertices,
+                    normals: morphSource.normals,
+                    uvs: morphSource.uvs,
+                    indices: morphSource.indices,
+                    weights: new Float32Array([0.5]),
+                    targets: {
+                        vertices: [new GeometryData(morphTarget, 3)]
+                    }
+                });
+                const morphMaterial = new PBRMaterial({
+                    compositing: { mode: 'alpha-blend', premultiplied: true },
+                    cullMode: 'none',
+                    opacity: 0.72,
+                    baseColor: new Color(0.95, 0.18, 0.08),
+                    metallic: 0.05,
+                    roughness: 0.32,
+                    clearcoatFactor: 0.85,
+                    clearcoatRoughnessFactor: 0.16
+                });
+                const morphMesh = new Mesh({
+                    geometry: morphGeometry,
+                    material: morphMaterial,
+                    x: -0.75,
+                    z: -0.6,
+                    frustumTest: false
+                });
+
+                const skinGeometry = new BoxGeometry({ widthSegments: 2 });
+                const skinVertices = skinGeometry.vertices;
+                if (skinVertices === null) throw new Error('Expected skin source vertices');
+                const skinIndices = new Uint8Array(skinVertices.count * 4);
+                const skinWeights = new Uint8Array(skinVertices.count * 4);
+                for (let index = 0; index < skinVertices.count; index += 1) {
+                    skinWeights[index * 4] = 255;
+                }
+                skinGeometry.skinIndices = new GeometryData(skinIndices, 4);
+                skinGeometry.skinWeights = new GeometryData(skinWeights, 4, {
+                    normalized: true
+                });
+                const joint = new Node();
+                joint.updateMatrixWorld(true);
+                const skinMaterial = new PBRMaterial({
+                    compositing: { mode: 'alpha-blend', premultiplied: true },
+                    cullMode: 'none',
+                    opacity: 0.68,
+                    baseColor: new Color(0.05, 0.3, 1),
+                    metallic: 0.2,
+                    roughness: 0.38,
+                    anisotropyStrength: 0.65,
+                    anisotropyRotation: 0.4,
+                    iridescenceFactor: 0.7,
+                    iridescenceThicknessMinimum: 180,
+                    iridescenceThicknessMaximum: 420
+                });
+                const skinned = new SkinnedMesh({
+                    geometry: skinGeometry,
+                    material: skinMaterial,
+                    skeleton: new Skeleton({
+                        jointNodeList: [joint],
+                        jointNames: ['root'],
+                        inverseBindMatrices: [new Matrix4()]
+                    }),
+                    x: 0.75,
+                    z: 0.6,
+                    frustumTest: false
+                });
+                skinned.updateMatrixWorld(true);
+                skinned.addTo(scene);
+                morphMesh.addTo(scene);
+                layeredMesh.addTo(scene);
+                new AmbientLight({ amount: 0.01 }).addTo(scene);
+                const layeredPoint = new PointLight({
+                    amount: 100,
+                    range: 8,
+                    z: 3,
+                    lightLayerMask: 1
+                });
+                layeredPoint.addTo(scene);
+                const photometricLight = new SpotLight({
+                    amount: 10,
+                    range: 8,
+                    z: 3,
+                    direction: new Vector3(0, 0, -1),
+                    lightLayerMask: 1,
+                    cookie: {
+                        scale: [0.9, 0.7],
+                        intensity: 0.9,
+                        softness: 0.2
+                    },
+                    iesProfile: { intensity: 1.1, exponent: 1.5 }
+                });
+                photometricLight.addTo(scene);
+                const camera = new PerspectiveCamera({
+                    aspect: 2,
+                    near: 0.1,
+                    far: 20,
+                    depthMode: 'reversed'
+                });
+                camera.setPosition(0, 0, 6).lookAt(new Vector3(0, 0, 0));
+
+                const prepareStorageScene = vi.spyOn(
+                    MeshDrawProcessor.prototype,
+                    'prepareStorageScene'
+                );
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                const readback = await target.readColorAttachment();
+                let colorEnergy = 0;
+                for (let offset = 0; offset < readback.data.length; offset += 4) {
+                    colorEnergy +=
+                        (readback.data[offset] ?? 0) +
+                        (readback.data[offset + 1] ?? 0) +
+                        (readback.data[offset + 2] ?? 0);
+                }
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    objectCount: 0,
+                    fallbackObjectCount: 0,
+                    clusteredDeformedObjectCount: 1,
+                    clusteredTransparentObjectCount: 2,
+                    lightCount: 2,
+                    warmedMaterialVariantCount: 1,
+                    activeMaterialVariantCount: 3,
+                    materialVariantBudgetExceededCount: 0,
+                    materialVariantBudget: 4
+                });
+                const nativePasses = rendererDiagnostics
+                    .snapshot()
+                    .renderGraph?.passes.map(pass => pass.name);
+                expect(nativePasses).toContain('GPU Scene deformed and layered clustered PBR');
+                expect(nativePasses).toContain('Clustered Forward+ transparent PBR');
+                expect(nativePasses).toContain(
+                    'Transparent transmission and particle temporal reactive coverage'
+                );
+                expect(nativePasses).toContain(
+                    'Transparent transmission and particle resurrection'
+                );
+                expect(nativePasses).toContain('Transparent GPU particle temporal composition');
+                expect(prepareStorageScene.mock.calls.slice(-2).map(call => call[0])).toEqual([
+                    morphMesh,
+                    skinned
+                ]);
+                expect(colorEnergy).toBeGreaterThan(1_000);
+                prepareStorageScene.mockRestore();
+
+                layeredPoint.lightLayerMask = 2;
+                photometricLight.lightLayerMask = 2;
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                const layerExcluded = await target.readColorAttachment();
+                let excludedEnergy = 0;
+                for (let offset = 0; offset < layerExcluded.data.length; offset += 4) {
+                    excludedEnergy +=
+                        (layerExcluded.data[offset] ?? 0) +
+                        (layerExcluded.data[offset + 1] ?? 0) +
+                        (layerExcluded.data[offset + 2] ?? 0);
+                }
+                expect(excludedEnergy).toBeLessThan(colorEnergy * 0.75);
+                layeredPoint.lightLayerMask = 1;
+                photometricLight.lightLayerMask = 1;
+
+                const runtimeVariant = new Mesh({
+                    geometry: new BoxGeometry(),
+                    material: new PBRMaterial({ baseColor: new Color(0.8, 0.8, 0.2) }),
+                    y: -1.25,
+                    x: -2,
+                    frustumTest: false
+                });
+                runtimeVariant.addTo(scene);
+                const originalFullscreenExecute = Object.getOwnPropertyDescriptor(
+                    FullscreenRenderPass.prototype,
+                    'execute'
+                )?.value as (
+                    this: FullscreenRenderPass,
+                    ...parameters: Parameters<FullscreenRenderPass['execute']>
+                ) => void;
+                let injectedFailure = false;
+                let resurrectionPassCount = 0;
+                const executeFailure = vi
+                    .spyOn(FullscreenRenderPass.prototype, 'execute')
+                    .mockImplementation(function (
+                        this: FullscreenRenderPass,
+                        ...parameters: Parameters<typeof originalFullscreenExecute>
+                    ): void {
+                        if (this.name === 'Transparent transmission and particle resurrection') {
+                            resurrectionPassCount++;
+                        }
+                        if (!injectedFailure && resurrectionPassCount === 2) {
+                            injectedFailure = true;
+                            throw new Error('injected clustered temporal submission failure');
+                        }
+                        originalFullscreenExecute.apply(this, parameters);
+                    });
+                try {
+                    expect(() => {
+                        renderer.renderToTarget(target, scene, camera);
+                    }).toThrow(/injected clustered temporal submission failure/u);
+                } finally {
+                    executeFailure.mockRestore();
+                }
+                expect(injectedFailure).toBe(true);
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    activeMaterialVariantCount: 3,
+                    materialVariantBudgetExceededCount: 0
+                });
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    fallbackObjectCount: 0,
+                    clusteredDeformedObjectCount: 2,
+                    activeMaterialVariantCount: 4,
+                    materialVariantBudgetExceededCount: 0
+                });
+
+                new Mesh({
+                    geometry: new BoxGeometry(),
+                    material: new PBRMaterial({
+                        clearcoatFactor: 0.45,
+                        clearcoatRoughnessFactor: 0.3
+                    }),
+                    y: -1.25,
+                    x: 2,
+                    frustumTest: false
+                }).addTo(scene);
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    fallbackObjectCount: 1,
+                    clusteredDeformedObjectCount: 2,
+                    activeMaterialVariantCount: 4,
+                    materialVariantBudgetExceededCount: 1
+                });
+
+                const extension = renderer.getExtension('rhi') as {
+                    readonly device: RHIDevice;
+                } | null;
+                if (extension === null) throw new Error('Expected the public RHI extension');
+                const deviceLost = new Promise<void>(resolve => {
+                    renderer.on(
+                        'webgpuDeviceLost',
+                        () => {
+                            resolve();
+                        },
+                        true
+                    );
+                });
+                const deviceRestored = new Promise<void>(resolve => {
+                    renderer.on(
+                        'webgpuDeviceRestored',
+                        () => {
+                            resolve();
+                        },
+                        true
+                    );
+                });
+                extension.device.destroy();
+                await deviceLost;
+                await Promise.all([renderer.waitForIdle(), deviceRestored]);
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                expect(
+                    rendererDiagnostics.snapshot().renderGraph?.passes.map(pass => pass.name)
+                ).toContain('Transparent temporal history initialize');
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    activeMaterialVariantCount: 4,
+                    materialVariantBudgetExceededCount: 1
+                });
+
+                new Mesh({
+                    geometry: new BoxGeometry(),
+                    material: new PBRMaterial({ transmissionFactor: 0.45 }),
+                    y: -1.2,
+                    frustumTest: false
+                }).addTo(scene);
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                expect(await factory.readDiagnostics()).toMatchObject({
+                    fallbackObjectCount: 4,
+                    clusteredDeformedObjectCount: 2,
+                    clusteredTransparentObjectCount: 0,
+                    materialVariantBudgetExceededCount: 1
+                });
+                const mixedPasses = rendererDiagnostics
+                    .snapshot()
+                    .renderGraph?.passes.map(pass => pass.name);
+                expect(mixedPasses).toContain('Clustered Forward+ compatibility opaque copy');
+                expect(mixedPasses).toContain('Clustered Forward+ compatibility fallback');
+                expect(mixedPasses).not.toContain('Clustered Forward+ transparent PBR');
+            } finally {
+                particleSystem.destroy(renderer);
+                target.destroy();
+                renderer.destroy();
+                unregisterRendererDiagnostics(canvas, rendererDiagnostics);
+            }
+        },
+        20_000
+    );
 
     it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
         'renders every compacted material bucket without indirect-first-instance',
@@ -728,7 +1163,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 const diagnostics = await factory.readDiagnostics();
 
                 expect(diagnostics.objectCount).toBe(8);
-                expect(diagnostics.fallbackObjectCount).toBe(4);
+                expect(diagnostics.fallbackObjectCount).toBe(0);
                 expect(diagnostics.lightCount).toBe(5);
                 expect(diagnostics.visibleObjectCount).toBeGreaterThan(0);
                 expect(diagnostics.clusterLightIndexCount).toBeGreaterThan(0);
@@ -774,7 +1209,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 8,
-                    fallbackObjectCount: 4
+                    fallbackObjectCount: 0
                 });
 
                 camera.invalidateTransformHistory();
@@ -824,7 +1259,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 8,
-                    fallbackObjectCount: 4,
+                    fallbackObjectCount: 0,
                     hiZValid: true
                 });
 
@@ -844,14 +1279,14 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 0,
-                    fallbackObjectCount: 12
+                    fallbackObjectCount: 0
                 });
                 for (const mesh of meshes) mesh.material = material;
                 renderer.render(scene, camera);
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 8,
-                    fallbackObjectCount: 4
+                    fallbackObjectCount: 0
                 });
 
                 const removedMesh = meshes[0];
@@ -861,13 +1296,13 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 7,
-                    fallbackObjectCount: 4
+                    fallbackObjectCount: 0
                 });
                 renderer.render(scene, camera);
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 8,
-                    fallbackObjectCount: 3
+                    fallbackObjectCount: 0
                 });
                 removedMesh.addTo(scene);
 
@@ -886,14 +1321,14 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 0,
-                    fallbackObjectCount: 12
+                    fallbackObjectCount: 0
                 });
                 geometry.vertices = originalVertices;
                 renderer.render(scene, camera);
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 8,
-                    fallbackObjectCount: 4
+                    fallbackObjectCount: 0
                 });
 
                 new Mesh({
@@ -910,7 +1345,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 await renderer.waitForIdle();
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 8,
-                    fallbackObjectCount: 6
+                    fallbackObjectCount: 2
                 });
             } finally {
                 renderer.destroy();

--- a/test/spec/renderer/MeshDrawListPlanner.test.ts
+++ b/test/spec/renderer/MeshDrawListPlanner.test.ts
@@ -427,6 +427,24 @@ describe('MeshDrawListPlanner', () => {
         expect(plan.transparentMeshes).toEqual([far, near]);
     });
 
+    it('keeps transparent sorting back-to-front with reversed camera depth', () => {
+        const planner = new MeshDrawListPlanner();
+        const transparent = material('transparent', 0, true);
+        const sharedGeometry = geometry('reversed-depth');
+        const near = mesh('near-reversed', transparent, sharedGeometry);
+        const far = mesh('far-reversed', transparent, sharedGeometry);
+        near.setPosition(0, 0, -2).updateMatrixWorld(true);
+        far.setPosition(0, 0, -10).updateMatrixWorld(true);
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.depthMode = 'reversed';
+        camera.setPosition(0, 0, 0).lookAt(new Vector3(0, 0, -1));
+        camera.updateViewProjectionMatrix();
+
+        const plan = planner.build([near, far], null, true, camera);
+
+        expect(plan.transparentMeshes).toEqual([far, near]);
+    });
+
     it('detaches owners, prunes omitted meshes, and resets without replacing the result', () => {
         const planner = new MeshDrawListPlanner();
         const direct = mesh('direct', material('direct'), geometry('direct'));

--- a/test/spec/renderer/MeshDrawProcessor.test.ts
+++ b/test/spec/renderer/MeshDrawProcessor.test.ts
@@ -639,7 +639,7 @@ function executeStorageMeshPreparationFrame(
         scope => {
             fixture.processor.beginFrame(scope.context, scope.uploads);
             const preparation: StorageScenePreparationState = {
-                globalBindGroupLayout: null
+                globalBindGroupLayouts: []
             };
             prepared = fixture.processor.prepareStorageScene(
                 mesh,
@@ -650,7 +650,7 @@ function executeStorageMeshPreparationFrame(
                 null,
                 plannerInstancedFallback
             );
-            expect(preparation.globalBindGroupLayout).not.toBeNull();
+            expect(preparation.globalBindGroupLayouts).toHaveLength(1);
         }
     );
     void fixture.processor.trackSubmission(frameIndex, result.submission);
@@ -1944,6 +1944,12 @@ describe('MeshDrawProcessor cache and failure boundaries', () => {
             vertexSource: STORAGE_VERTEX_SOURCE,
             fragmentSource: STORAGE_FRAGMENT_SOURCE,
             bindings: [
+                {
+                    name: 'LightBlock',
+                    group: 0,
+                    binding: 3,
+                    kind: 'uniform-buffer'
+                },
                 {
                     name: 'lightGrid',
                     group: 3,

--- a/test/spec/renderer/RenderPipelineCapabilities.test.ts
+++ b/test/spec/renderer/RenderPipelineCapabilities.test.ts
@@ -282,6 +282,9 @@ describe('RenderPipelineCapabilities', () => {
         const host = new RenderPipelineHost({
             createPipelineStorageBuffer() {
                 throw new Error('Capability replacement test does not create storage buffers');
+            },
+            warmupStorageGraphicsShaders() {
+                return Promise.resolve();
             }
         } as unknown as RenderPipelineHostLifecycle);
         await host.initialize(runtimeFactory(), source);

--- a/test/spec/renderer/ScriptableRenderPipeline.test.ts
+++ b/test/spec/renderer/ScriptableRenderPipeline.test.ts
@@ -1453,6 +1453,11 @@ describe('Scriptable render pipeline', () => {
                 renderPipeline: new FixedRuntimeFactory(runtime)
             });
             activeRenderers.push(renderer);
+            const target = renderer.createRenderTarget({
+                width: 16,
+                height: 8,
+                colorAttachments: [{ format: 'rgba8unorm' }]
+            });
             runtime.buffer = renderer.createStorageBuffer({
                 label: 'instanced storage scene values',
                 byteLength: 16,
@@ -1496,9 +1501,16 @@ describe('Scriptable render pipeline', () => {
                 'prepareStorageScene'
             );
 
-            renderer.render(scene, new PerspectiveCamera());
-            renderer.render(scene, new PerspectiveCamera());
+            renderer.renderToTarget(target, scene, new PerspectiveCamera());
+            renderer.renderToTarget(target, scene, new PerspectiveCamera());
             await renderer.waitForIdle();
+            const readback = await target.readColorAttachment();
+            let redPixels = 0;
+            for (let offset = 0; offset < readback.data.length; offset += 4) {
+                if ((readback.data[offset] ?? 0) > 128 && (readback.data[offset + 1] ?? 0) > 16) {
+                    redPixels++;
+                }
+            }
 
             expect(prepareStorageScene).toHaveBeenCalledTimes(8);
             expect(prepareStorageScene.mock.calls.slice(4).map(call => call[0])).toEqual([
@@ -1510,7 +1522,9 @@ describe('Scriptable render pipeline', () => {
             expect(prepareStorageScene.mock.calls.every(call => call[6] === true)).toBe(true);
             expect(renderer.renderInfo.drawCount).toBe(4);
             expect(renderer.renderInfo.faceCount).toBeGreaterThan(0);
+            expect(redPixels).toBeGreaterThan(8);
             prepareStorageScene.mockRestore();
+            target.destroy();
         }
     );
 

--- a/test/spec/renderer/StorageGraphicsShader.test.ts
+++ b/test/spec/renderer/StorageGraphicsShader.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { ShaderReadBinding } from '../../../src/render/compute/ComputeShader';
-import StorageGraphicsShader from '../../../src/render/compute/StorageGraphicsShader';
+import StorageGraphicsShader, {
+    createStorageGraphicsShaderFromPortable
+} from '../../../src/render/compute/StorageGraphicsShader';
 
 const vertexSource = `#version 310 es
 precision highp float;
@@ -82,6 +84,31 @@ describe('StorageGraphicsShader', () => {
         });
 
         expect(shader.bindings.filter(binding => binding.name === 'albedo')).toHaveLength(2);
+    });
+
+    it('promotes preprocessed portable source at the storage-graphics boundary', () => {
+        const shader = createStorageGraphicsShaderFromPortable({
+            portableVertexSource: vertexSource.replace('#version 310 es', '#version 300 es'),
+            portableFragmentSource: fragmentSource.replace('#version 310 es', '#version 300 es'),
+            bindings: [
+                {
+                    name: 'particles',
+                    group: 2,
+                    binding: 3,
+                    kind: 'read-only-storage-buffer'
+                }
+            ]
+        });
+
+        expect(shader.vertexSource).toMatch(/^#version 310 es/u);
+        expect(shader.fragmentSource).toMatch(/^#version 310 es/u);
+        expect(() =>
+            createStorageGraphicsShaderFromPortable({
+                portableVertexSource: vertexSource,
+                portableFragmentSource: fragmentSource,
+                bindings: shader.bindings
+            })
+        ).toThrow(/must use GLSL ES 3\.00/u);
     });
 
     it('rejects writable bindings, duplicate locations, and shaders without storage', () => {

--- a/test/spec/shader/ShaderModernityGuardrails.test.ts
+++ b/test/spec/shader/ShaderModernityGuardrails.test.ts
@@ -158,4 +158,14 @@ describe('shader source modernity guardrails', () => {
             )
         ).toContain('StorageGraphicsShader storage block is not readonly std430');
     });
+
+    it('allows the reviewed clustered storage chunk but keeps ordinary chunks closed', () => {
+        const source = `#ifdef HILO_CLUSTERED_FORWARD
+            layout(std430) readonly buffer Lights { vec4 values[]; } lights;
+            #endif`;
+        expect(labels('src/shader/chunk/clusteredForward.frag', source)).toEqual([]);
+        expect(labels('src/shader/chunk/ordinary.frag', source)).toContain(
+            'ordinary graphics shader declares storage buffer'
+        );
+    });
 });

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -2,6 +2,7 @@ import {
     BasicLoader,
     BasicMaterial,
     BoxGeometry,
+    ClusteredForwardPlusPipelineFactory,
     ComputeKernel,
     ComputeRenderPass,
     ComputeSampler,
@@ -28,6 +29,7 @@ import {
     ParticleSystem,
     ParticleSystemDefinition,
     ParticleSystemPool,
+    PBRMaterial,
     compileParticleAuthoringGraph,
     createParticleAuthoringGraph,
     deserializeParticleSystemDefinition,
@@ -45,6 +47,7 @@ import {
     SCENE_STORAGE_BIND_GROUP,
     SceneRenderPass,
     Stage,
+    SpotLight,
     StorageGraphicsShader,
     TemporalAA,
     Texture,
@@ -90,6 +93,7 @@ import {
     type CullingResultsHandle,
     type ComputeTextureSampleType,
     type ComputeTextureViewDimension,
+    type ClusteredMaterialVariantManifest,
     type RendererBackend,
     type RendererResourceDiagnostics,
     type RendererRenderingProfile,
@@ -114,6 +118,8 @@ import {
     type RendererListHandle,
     type StorageBuffer,
     type StorageBufferReadback,
+    type SpotLightCookie,
+    type SpotLightIESProfile,
     type TemporalAAOptions,
     type DynamicResolutionOptions,
     type ShaderTextureSampleType,
@@ -129,6 +135,36 @@ import {
     type TextureParameters,
     type TweenParameters
 } from 'hilo3d';
+
+const clusteredGeometry = new BoxGeometry();
+const clusteredMaterial = new PBRMaterial({ clearcoatFactor: 0.5 });
+const clusteredExemplar = new Mesh({
+    geometry: clusteredGeometry,
+    material: clusteredMaterial
+});
+const clusteredManifest = {
+    entries: [{ mesh: clusteredExemplar, shadowed: true }],
+    maxVariants: 8,
+    warmupBatchSize: 2
+} satisfies ClusteredMaterialVariantManifest;
+const clusteredFactory = new ClusteredForwardPlusPipelineFactory({
+    buckets: [{ geometry: new BoxGeometry(), material: new PBRMaterial() }],
+    variantManifest: clusteredManifest
+});
+const spotCookie = {
+    scale: [0.8, 0.6],
+    offset: [0.1, -0.1],
+    intensity: 0.9,
+    softness: 0.2
+} as const satisfies SpotLightCookie;
+const spotIES = { intensity: 1.1, exponent: 1.5 } satisfies SpotLightIESProfile;
+const clusteredSpot = new SpotLight({
+    lightLayerMask: 3,
+    cookie: spotCookie,
+    iesProfile: spotIES
+});
+void clusteredFactory;
+void clusteredSpot;
 
 const orderedNodeParameters = {
     sortingLayer: 100,

--- a/test/ui/fixtures/clustered-forward-plus-p0.html
+++ b/test/ui/fixtures/clustered-forward-plus-p0.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clustered Forward+ P0 acceptance</title>
+        <style>
+            html,
+            body,
+            canvas {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+    <body>
+        <script type="module" src="./clustered-forward-plus-p0.ts"></script>
+    </body>
+</html>

--- a/test/ui/fixtures/clustered-forward-plus-p0.ts
+++ b/test/ui/fixtures/clustered-forward-plus-p0.ts
@@ -1,0 +1,307 @@
+import {
+    AmbientLight,
+    BoxGeometry,
+    ClusteredForwardPlusPipelineFactory,
+    Color,
+    GeometryData,
+    Matrix4,
+    Mesh,
+    MorphGeometry,
+    Node,
+    ParticleSystem,
+    ParticleSystemDefinition,
+    PBRMaterial,
+    PerspectiveCamera,
+    PointLight,
+    Renderer,
+    Skeleton,
+    SkinnedMesh,
+    SpotLight,
+    Vector3
+} from '../../../src/Hilo3d';
+import {
+    registerRendererDiagnostics,
+    unregisterRendererDiagnostics
+} from '../../../src/render/diagnostics/RendererDiagnosticsRegistry';
+import type { RHIDevice } from '../../../src/render/rhi/core';
+
+interface ClusteredForwardPlusP0Result {
+    readonly litEnergy: number;
+    readonly excludedEnergy: number;
+    readonly recoveredEnergy: number;
+    readonly nativeTransparent: boolean;
+    readonly nativeDeformedLayered: boolean;
+    readonly particleTemporalComposition: boolean;
+    readonly transparentResurrection: boolean;
+    readonly recoveryHistoryInitialized: boolean;
+    readonly recoveryDeviceChanged: boolean;
+    readonly warmedMaterialVariantCount: number;
+    readonly activeMaterialVariantCount: number;
+    readonly materialVariantBudgetExceededCount: number;
+    readonly clusteredTransparentObjectCount: number;
+    readonly clusteredDeformedObjectCount: number;
+    readonly fallbackObjectCount: number;
+    readonly mixedTransparencyFallback: boolean;
+}
+
+declare global {
+    interface Window {
+        __HILO3D_CLUSTERED_FORWARD_PLUS_P0_RESULT__?: ClusteredForwardPlusP0Result;
+    }
+}
+
+function energy(data: Uint8Array): number {
+    let result = 0;
+    for (let offset = 0; offset < data.length; offset += 4) {
+        result += (data[offset] ?? 0) + (data[offset + 1] ?? 0) + (data[offset + 2] ?? 0);
+    }
+    return result;
+}
+
+const bucketGeometry = new BoxGeometry();
+const bucketMaterial = new PBRMaterial();
+const layeredMesh = new Mesh({
+    geometry: new BoxGeometry({ widthSegments: 2 }),
+    material: new PBRMaterial({
+        baseColor: new Color(0.3, 0.9, 0.25),
+        clearcoatFactor: 0.75,
+        clearcoatRoughnessFactor: 0.18,
+        anisotropyStrength: 0.45,
+        iridescenceFactor: 0.55,
+        iridescenceThicknessMinimum: 160,
+        iridescenceThicknessMaximum: 360
+    }),
+    y: 1.05,
+    scaleX: 0.55,
+    scaleY: 0.55,
+    scaleZ: 0.55,
+    frustumTest: false
+});
+const factory = new ClusteredForwardPlusPipelineFactory({
+    buckets: [{ geometry: bucketGeometry, material: bucketMaterial }],
+    maxObjects: 1,
+    maxLights: 4,
+    maxLightIndices: 4_096,
+    maxLightsPerCluster: 4,
+    maxViewportWidth: 64,
+    maxViewportHeight: 32,
+    hiZ: false,
+    bloomStrength: 0,
+    temporalAA: { renderScale: 0.5 },
+    variantManifest: {
+        entries: [{ mesh: layeredMesh, shadowed: false }],
+        maxVariants: 4,
+        warmupBatchSize: 1
+    }
+});
+const canvas = document.createElement('canvas');
+document.body.appendChild(canvas);
+const rendererDiagnostics = registerRendererDiagnostics(canvas);
+const renderer = await Renderer.create({
+    backend: 'webgpu',
+    domElement: canvas,
+    width: 64,
+    height: 32,
+    antialias: false,
+    renderingProfile: 'high-end',
+    renderPipeline: factory
+});
+renderer.clearColor = new Color(0, 0, 0);
+const target = renderer.createRenderTarget({
+    width: 64,
+    height: 32,
+    colorAttachments: [{ format: 'rgba8unorm' }],
+    depthStencilAttachment: { format: 'depth32float', depthMode: 'reversed' }
+});
+const scene = new Node();
+layeredMesh.addTo(scene);
+
+const morphSource = new BoxGeometry({ widthSegments: 2 });
+const morphVertices = morphSource.vertices;
+if (morphVertices === null) throw new Error('Expected morph source vertices');
+const morphDelta = new Float32Array(morphVertices.data.length);
+for (let index = 0; index < morphDelta.length; index += 3) morphDelta[index] = 0.08;
+const morphMesh = new Mesh({
+    geometry: new MorphGeometry({
+        vertices: morphSource.vertices,
+        normals: morphSource.normals,
+        uvs: morphSource.uvs,
+        indices: morphSource.indices,
+        weights: new Float32Array([0.5]),
+        targets: { vertices: [new GeometryData(morphDelta, 3)] }
+    }),
+    material: new PBRMaterial({
+        compositing: { mode: 'alpha-blend', premultiplied: true },
+        cullMode: 'none',
+        opacity: 0.72,
+        baseColor: new Color(0.95, 0.18, 0.08),
+        clearcoatFactor: 0.8
+    }),
+    x: -0.75,
+    z: -0.6,
+    frustumTest: false
+});
+morphMesh.addTo(scene);
+
+const skinGeometry = new BoxGeometry({ widthSegments: 2 });
+const skinVertices = skinGeometry.vertices;
+if (skinVertices === null) throw new Error('Expected skin source vertices');
+const skinIndices = new Uint8Array(skinVertices.count * 4);
+const skinWeights = new Uint8Array(skinVertices.count * 4);
+for (let index = 0; index < skinVertices.count; index += 1) skinWeights[index * 4] = 255;
+skinGeometry.skinIndices = new GeometryData(skinIndices, 4);
+skinGeometry.skinWeights = new GeometryData(skinWeights, 4, { normalized: true });
+const joint = new Node();
+joint.updateMatrixWorld(true);
+const skinned = new SkinnedMesh({
+    geometry: skinGeometry,
+    material: new PBRMaterial({
+        compositing: { mode: 'alpha-blend', premultiplied: true },
+        cullMode: 'none',
+        opacity: 0.68,
+        baseColor: new Color(0.05, 0.3, 1),
+        anisotropyStrength: 0.65,
+        iridescenceFactor: 0.7
+    }),
+    skeleton: new Skeleton({
+        jointNodeList: [joint],
+        jointNames: ['root'],
+        inverseBindMatrices: [new Matrix4()]
+    }),
+    x: 0.75,
+    z: 0.6,
+    frustumTest: false
+});
+skinned.updateMatrixWorld(true);
+skinned.addTo(scene);
+
+const particles = new ParticleSystem({
+    definition: ParticleSystemDefinition.create({
+        emitters: [
+            {
+                name: 'clustered-p0-particles',
+                capacity: 64,
+                execution: 'stateless',
+                duration: 4,
+                emission: { rateOverTime: 16 },
+                initialize: {
+                    lifetime: 2,
+                    direction: [0, 1, 0],
+                    speed: 0.35,
+                    size: 0.35,
+                    color: [1, 0.55, 0.12, 0.8]
+                },
+                renderers: [{ type: 'sprite', blend: 'additive', depthTest: false }]
+            }
+        ]
+    }),
+    seed: 31,
+    autoPlay: false,
+    compilationEnvironment: { backend: 'webgpu' }
+});
+particles.simulate(0.5).addTo(scene);
+new AmbientLight({ amount: 0.01 }).addTo(scene);
+const point = new PointLight({ amount: 100, range: 8, z: 3, lightLayerMask: 1 }).addTo(scene);
+const spot = new SpotLight({
+    amount: 10,
+    range: 8,
+    z: 3,
+    direction: new Vector3(0, 0, -1),
+    lightLayerMask: 1,
+    cookie: { scale: [0.9, 0.7], intensity: 0.9, softness: 0.2 },
+    iesProfile: { intensity: 1.1, exponent: 1.5 }
+}).addTo(scene);
+const camera = new PerspectiveCamera({
+    aspect: 2,
+    near: 0.1,
+    far: 20,
+    depthMode: 'reversed'
+});
+camera.setPosition(0, 0, 6).lookAt(new Vector3(0, 0, 0));
+
+renderer.renderToTarget(target, scene, camera);
+renderer.renderToTarget(target, scene, camera);
+await renderer.waitForIdle();
+const litEnergy = energy((await target.readColorAttachment()).data);
+const nativePasses =
+    rendererDiagnostics.snapshot().renderGraph?.passes.map(pass => pass.name) ?? [];
+const nativeDiagnostics = await factory.readDiagnostics();
+
+point.lightLayerMask = 2;
+spot.lightLayerMask = 2;
+renderer.renderToTarget(target, scene, camera);
+renderer.renderToTarget(target, scene, camera);
+await renderer.waitForIdle();
+const excludedEnergy = energy((await target.readColorAttachment()).data);
+point.lightLayerMask = 1;
+spot.lightLayerMask = 1;
+
+const extension = renderer.getExtension('rhi') as { readonly device: RHIDevice } | null;
+if (extension === null) throw new Error('Expected the public RHI extension');
+const deviceBeforeRecovery = extension.device;
+const deviceLost = new Promise<void>(resolve => {
+    renderer.on(
+        'webgpuDeviceLost',
+        () => {
+            resolve();
+        },
+        true
+    );
+});
+const deviceRestored = new Promise<void>(resolve => {
+    renderer.on(
+        'webgpuDeviceRestored',
+        () => {
+            resolve();
+        },
+        true
+    );
+});
+deviceBeforeRecovery.destroy();
+await deviceLost;
+await Promise.all([renderer.waitForIdle(), deviceRestored]);
+renderer.renderToTarget(target, scene, camera);
+await renderer.waitForIdle();
+const recoveryPasses =
+    rendererDiagnostics.snapshot().renderGraph?.passes.map(pass => pass.name) ?? [];
+renderer.renderToTarget(target, scene, camera);
+await renderer.waitForIdle();
+const recoveredEnergy = energy((await target.readColorAttachment()).data);
+
+new Mesh({
+    geometry: new BoxGeometry(),
+    material: new PBRMaterial({ transmissionFactor: 0.45 }),
+    y: -1.2,
+    frustumTest: false
+}).addTo(scene);
+renderer.renderToTarget(target, scene, camera);
+await renderer.waitForIdle();
+const mixedPasses = rendererDiagnostics.snapshot().renderGraph?.passes.map(pass => pass.name) ?? [];
+const mixedDiagnostics = await factory.readDiagnostics();
+
+window.__HILO3D_CLUSTERED_FORWARD_PLUS_P0_RESULT__ = {
+    litEnergy,
+    excludedEnergy,
+    recoveredEnergy,
+    nativeTransparent: nativePasses.includes('Clustered Forward+ transparent PBR'),
+    nativeDeformedLayered: nativePasses.includes('GPU Scene deformed and layered clustered PBR'),
+    particleTemporalComposition: nativePasses.includes(
+        'Transparent GPU particle temporal composition'
+    ),
+    transparentResurrection: nativePasses.includes(
+        'Transparent transmission and particle resurrection'
+    ),
+    recoveryHistoryInitialized: recoveryPasses.includes('Transparent temporal history initialize'),
+    recoveryDeviceChanged: extension.device !== deviceBeforeRecovery,
+    warmedMaterialVariantCount: nativeDiagnostics.warmedMaterialVariantCount,
+    activeMaterialVariantCount: nativeDiagnostics.activeMaterialVariantCount,
+    materialVariantBudgetExceededCount: nativeDiagnostics.materialVariantBudgetExceededCount,
+    clusteredTransparentObjectCount: nativeDiagnostics.clusteredTransparentObjectCount,
+    clusteredDeformedObjectCount: nativeDiagnostics.clusteredDeformedObjectCount,
+    fallbackObjectCount: nativeDiagnostics.fallbackObjectCount,
+    mixedTransparencyFallback:
+        mixedDiagnostics.clusteredTransparentObjectCount === 0 &&
+        mixedPasses.includes('Clustered Forward+ compatibility fallback')
+};
+
+unregisterRendererDiagnostics(canvas, rendererDiagnostics);

--- a/test/ui/webgpu.spec.ts
+++ b/test/ui/webgpu.spec.ts
@@ -74,6 +74,59 @@ test('renders a real frame through WebGPU and Naga', async ({ page }) => {
     });
 });
 
+test('closes the high-end clustered transparent, particle, and recovery P0 gate', async ({
+    page
+}) => {
+    test.setTimeout(30_000);
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    const gpuValidationErrors: string[] = [];
+    const devtools = await page.context().newCDPSession(page);
+    await devtools.send('Log.enable');
+    devtools.on('Log.entryAdded', ({ entry }) => {
+        if (entry.level === 'error' && entry.source === 'rendering') {
+            gpuValidationErrors.push(entry.text);
+        }
+    });
+    page.on('console', message => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    await page.goto('/test/ui/fixtures/clustered-forward-plus-p0.html', {
+        waitUntil: 'load'
+    });
+    await page.waitForFunction(
+        () => window.__HILO3D_CLUSTERED_FORWARD_PLUS_P0_RESULT__ !== undefined,
+        undefined,
+        { timeout: 25_000 }
+    );
+    const result = await page.evaluate(() => window.__HILO3D_CLUSTERED_FORWARD_PLUS_P0_RESULT__);
+    await devtools.detach();
+
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+    expect(gpuValidationErrors).toEqual([]);
+    expect(result).toMatchObject({
+        nativeTransparent: true,
+        nativeDeformedLayered: true,
+        particleTemporalComposition: true,
+        transparentResurrection: true,
+        recoveryHistoryInitialized: true,
+        recoveryDeviceChanged: true,
+        warmedMaterialVariantCount: 1,
+        activeMaterialVariantCount: 3,
+        materialVariantBudgetExceededCount: 0,
+        clusteredTransparentObjectCount: 2,
+        clusteredDeformedObjectCount: 1,
+        fallbackObjectCount: 0,
+        mixedTransparencyFallback: true
+    });
+    expect(result?.litEnergy).toBeGreaterThan(1_000);
+    expect(result?.excludedEnergy).toBeLessThan((result?.litEnergy ?? 0) * 0.75);
+    expect(result?.recoveredEnergy).toBeGreaterThan(1_000);
+});
+
 for (const backend of ['webgl2', 'webgpu'] as const) {
     test(`runs the same scriptable forward feature through ${backend}`, async ({ page }) => {
         const consoleErrors: string[] = [];
@@ -181,6 +234,24 @@ declare global {
             readonly supportedSources: readonly string[];
             readonly renderedSources: readonly string[];
             readonly skipped: readonly string[];
+        };
+        __HILO3D_CLUSTERED_FORWARD_PLUS_P0_RESULT__?: {
+            readonly litEnergy: number;
+            readonly excludedEnergy: number;
+            readonly recoveredEnergy: number;
+            readonly nativeTransparent: boolean;
+            readonly nativeDeformedLayered: boolean;
+            readonly particleTemporalComposition: boolean;
+            readonly transparentResurrection: boolean;
+            readonly recoveryHistoryInitialized: boolean;
+            readonly recoveryDeviceChanged: boolean;
+            readonly warmedMaterialVariantCount: number;
+            readonly activeMaterialVariantCount: number;
+            readonly materialVariantBudgetExceededCount: number;
+            readonly clusteredTransparentObjectCount: number;
+            readonly clusteredDeformedObjectCount: number;
+            readonly fallbackObjectCount: number;
+            readonly mixedTransparencyFallback: boolean;
         };
     }
 }


### PR DESCRIPTION
## Summary

- route globally sorted compatible transparent PBR plus skin, morph, and layered glTF PBR through native Clustered Forward+ storage lighting
- add isolated transparent, transmission, and GPU-particle TAAU reactive/depth/history resurrection
- add analytic Spot cookie and IES records, uint32 light-layer filtering, and the ModelBlock receiver-layer ABI
- add material variant manifests, asynchronous warmup, transactional runtime budgets, and diagnostics
- cover rollback, device loss/recovery, real WebGPU pixels, UI behavior, and mixed transparent fail-closed ordering
- update the API report, changelog, architecture documents, and shader modernity guardrails

## Validation

- full coverage: 190 files, 1856 tests passed
- WebGPU browser suite: 18/18 passed
- browser UI/parity suite: 197/197 passed
- visual baselines: 3/3 passed
- render architecture, portable/native RHI, benchmark contract, typecheck, lint, modernity, TypeDoc, API, examples build, package checks, and pack dry-run passed

## Boundaries

- deformed and layered PBR use the GPU Scene pipeline direct storage lane rather than fixed-bucket indirect draws
- cookie/IES is the analytic ABI slice; arbitrary cookie textures and raw IES asset import are not included
- mixed Transmission/custom/particle transparent queues fail closed to shared Forward to preserve global ordering
- the monolithic validate run hit one transient Vitest browser WebSocket disconnect after all assertions passed; the full coverage stage and every remaining validate stage passed on retry