### PR TITLE
feat(render): add stable shadow atlas content cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 
 ### Changes
 
+- Add the first S0 production shadow-cache slice. Stable atlas tiles now use exact light/caster
+  snapshots, scissored portable depth clears, per-slice invalidation, submission commit/rollback,
+  recovery invalidation, and `RendererDiagnostics.caches.shadowAtlas`; static slices issue no shadow
+  pass, while local-light changes redraw only their affected faces.
 - Complete the WebGPU high-end Clustered Forward+ P0 closure. Globally sorted compatible transparent
   PBR and direct GPU Scene skin, morph, and layered glTF PBR now consume the native storage light
   list, while mixed Transmission/custom/particle transparent queues fail closed to the shared

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ path and compose into the same linear HDR frame.
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | GPU Scene               | Dirty object/material databases, previous-frame Hi-Z occlusion, projected-radius LOD, compact visible ranges, and fixed indirect buckets  |
 | Clustered Forward+      | Depth-driven 3D clusters, bounded deterministic light allocation, storage PBR, shared directional/spot/point shadows, and LTC area lights |
+| Shadow caching          | Stable atlas tiles, exact per-slice invalidation, scissored depth clears, transactional reuse, and recovery-aware diagnostics             |
 | Temporal rendering      | Motion vectors, authored reactive masks, native TAA, 0.5–1.0 TAAU, and timestamp-driven dynamic resolution                                |
 | Screen-space lighting   | Portable GTAO and SSGI on WebGPU/WebGL 2, plus WebGPU Clustered hierarchical SSR                                                          |
 | Volumetrics and weather | Froxel height/local fog, directional/point/spot injection, physical atmosphere LUTs, temporal clouds, and cloud shadows                   |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -123,6 +123,7 @@ Scene 覆盖范围内的兼容 Mesh 会继续走共享 Forward 路径，并合�
 | ------------------ | ----------------------------------------------------------------------------------------------------- |
 | GPU Scene          | 脏对象/材质数据库、previous-frame Hi-Z 遮挡、projected-radius LOD、紧凑可见区间与固定 indirect bucket |
 | Clustered Forward+ | depth-driven 3D cluster、有界且确定性的灯光分配、storage PBR、共享方向光/聚光/点光阴影与 LTC 面光     |
+| 阴影缓存           | 稳定 atlas tile、逐 slice 精确失效、局部深度清理、事务式复用与 recovery-aware 诊断                    |
 | 时域渲染           | Motion Vector、authored reactive mask、原生 TAA、0.5–1.0 TAAU 与 timestamp 驱动的动态分辨率           |
 | 屏幕空间光照       | WebGPU/WebGL 2 可移植 GTAO 与 SSGI，以及 WebGPU Clustered hierarchical SSR                            |
 | 体积与天气         | Froxel 高度雾/局部雾、方向光/点光/聚光注入、物理大气 LUT、时域云与云影                                |

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -1,6 +1,7 @@
 # Hilo3D 现代 WebGPU 渲染缺口与落地路线
 
-> 代码审计基线：`c2092d9`（`dev`，2026-08-13）；路线状态复核：2026-08-24。F0、F1、D0、MAT0、G0/L0、T0、E0、Q0，以及 V0/物理大气天气切片均已有生产代码和自动化证据；未登记的物理 GPU 跨提交性能基线仍不视为完成。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
+> 代码审计基线：`c2092d9`（`dev`，2026-08-13）；路线状态复核：2026-08-29。F0、F1、D0、MAT0、G0/L0、T0、E0、Q0、V0/物理大气天气，以及 S0
+> stable-atlas 内容缓存首版均已有生产代码和自动化证据；未登记的物理 GPU 跨提交性能基线仍不视为完成。本文只讨论面向现代 WebGPU 图形架构的增量，不把恢复旧图形 API、补传统效果清单或维持 WebGL
 > 2 功能对等作为路线目标。
 
 ## 结论先行
@@ -28,9 +29,10 @@ Draw、HDR/PBR、设备丢失恢复、严格帧事务、TAA/TAAU、GTAO、SSR、
    jitter、opaque/masked motion vector、原生分辨率 TAA、固定/动态 0.5–1 比例 TAAU 与 authored
    reactive mask 已落地；透明、transmission 与 GPU particle 已有隔离的 reactive/depth/history
    resurrection 策略。
-5. **阴影缓存与虚拟页**：当前共享 Shadow Atlas、CSM、Spot/Point shadow 和 Clustered surface
-   sampling 已完成，但仍每帧规划/绘制所需 slice；没有 static/dynamic invalidation、GPU caster
-   cull、receiver-driven budget 或 virtual shadow page residency。
+5. **阴影缓存与虚拟页**：共享 Shadow Atlas、CSM、Spot/Point shadow、Clustered surface
+   sampling，以及 submission-aware stable-slice 内容缓存、局部 scissored
+   clear 和刚体 caster/light 精确失效已完成；GPU caster cull、receiver-driven budget 与 virtual
+   shadow page residency 仍未完成。
 6. **现代资源与几何虚拟化**：GPU Scene 已有 projected-radius bucket LOD，但仍没有 meshlet/cluster
    geometry streaming、KTX 2/Basis、mip
    residency、虚拟纹理或虚拟阴影页系统；SSGI 已覆盖屏幕内漫反射传输，off-screen probe/software-BVH
@@ -115,7 +117,7 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 | ------------------------------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Shared Renderer / Render Graph / RHI | 生产可用          | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                                                                        |
 | Raster PBR / HDR                     | 生产可用          | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                                             |
-| Shadow                               | 可用基线          | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow 和 PCF；Clustered opaque surface 已复用同一 atlas，仍缺缓存、GPU caster cull、receiver-driven 分配和虚拟页                      |
+| Shadow                               | 生产缓存首版      | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow、PCF 与 stable-slice 内容缓存；Clustered opaque surface 复用同一 atlas，仍缺 GPU caster cull、receiver-driven 分配和虚拟页      |
 | Compute / Storage / Indirect         | 底座生产可用      | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                                        |
 | Material architecture                | high-end P0 完成  | Definition/Instance、语义 Pass、共享 PBR GPU record，以及 variant manifest、异步 warmup、预算和诊断已落地；更多 family 按需扩展                                                  |
 | GPU-driven ordinary scene            | high-end P0 完成  | opaque/alpha-mask 走固定 bucket indirect；skin/morph/layered PBR 走 GPU Scene direct storage lane；兼容透明保留全局排序并消费 clustered light list                               |
@@ -159,9 +161,9 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
   texture 仍只支持屏幕空间 transmission，不是离屏折射场景表示。
 - RHI 已有 timestamp QuerySet、pass timestamp、debug group/marker 和 Render Graph
   timeline；occlusion query 仍不在当前合同内。
-- 当前 Shadow
-  Atlas 的 allocation/cache 是资源复用，不是内容 residency：静态 slice 没有跨帧“无需重绘”的缓存语义，体积光也只使用 bounded
-  screen-space caster visibility 与 cloud shadow，尚未采样 shared shadow atlas。
+- 当前 Shadow Atlas 已有跨帧 stable-slice 内容缓存，但仍不是 virtual-page residency：GPU caster
+  cull、receiver-driven budget 和 page table 尚未落地；体积光也只使用 bounded screen-space caster
+  visibility 与 cloud shadow，尚未采样 shared shadow atlas。
 - KTX loader 明确只解析 KTX 1.1、单 face 2D；没有 KTX 2、Basis Universal transcode、mip
   residency 或带宽预算。
 - 110k object / 256 light fixture 已验证 GPU-only 规模正确性、CPU record/GPU
@@ -217,22 +219,22 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 
 ## 5. 缺口优先级矩阵
 
-| ID   | 能力                                                                     | 优先级 | 当前状态                                | 工作量 | 前置依赖                                      |
-| ---- | ------------------------------------------------------------------------ | ------ | --------------------------------------- | ------ | --------------------------------------------- |
-| F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                  | L      | 当前 Graph/RHI                                |
-| F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                  | M      | WebGPU compiler/RHI                           |
-| D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                  | L      | Camera/shader ABI                             |
-| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续      | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
-| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                        | XL     | F0、D0；材质/变形扩展使用 MAT0                |
-| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                        | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
-| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                        | XL     | F0、D0、MAT0                                  |
-| E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                  | M      | F0、compute/storage；可独立于 T0 使用         |
-| Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0    | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
-| S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | 未开始；现有 atlas 没有内容 residency   | XL     | MAT0、G0、F0、F1                              |
-| V0   | Froxel volumetric fog/lighting/cloud foundation                          | P1     | 生产切片完成；atlas shadow/透明体积后续 | XL     | L0、F0；T0 可稳定最终边缘但非创建前置         |
-| A0   | KTX 2/Basis、mip residency、texture/geometry streaming budget            | P1     | 未开始                                  | XL     | F0、diagnostics                               |
-| M0   | Offline meshlet build、cluster LOD、GPU material bin、geometry streaming | P2     | 未开始；已有 bucket-level LOD 可复用    | XXL    | MAT0、G0、A0                                  |
-| GI0  | Screen/probe/software-BVH hybrid GI                                      | P2     | 屏幕内 SSGI 已完成；off-screen 层未开始 | XXL    | T0、Q0、G0、A0                                |
+| ID   | 能力                                                                     | 优先级 | 当前状态                                         | 工作量 | 前置依赖                                      |
+| ---- | ------------------------------------------------------------------------ | ------ | ------------------------------------------------ | ------ | --------------------------------------------- |
+| F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                           | L      | 当前 Graph/RHI                                |
+| F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                           | M      | WebGPU compiler/RHI                           |
+| D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                           | L      | Camera/shader ABI                             |
+| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续               | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
+| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                                 | XL     | F0、D0；材质/变形扩展使用 MAT0                |
+| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                                 | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
+| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                                 | XL     | F0、D0、MAT0                                  |
+| E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                           | M      | F0、compute/storage；可独立于 T0 使用         |
+| Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0             | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
+| S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | stable-atlas 缓存首版完成；GPU cull/虚拟页未开始 | XL     | MAT0、G0、F0、F1                              |
+| V0   | Froxel volumetric fog/lighting/cloud foundation                          | P1     | 生产切片完成；atlas shadow/透明体积后续          | XL     | L0、F0；T0 可稳定最终边缘但非创建前置         |
+| A0   | KTX 2/Basis、mip residency、texture/geometry streaming budget            | P1     | 未开始                                           | XL     | F0、diagnostics                               |
+| M0   | Offline meshlet build、cluster LOD、GPU material bin、geometry streaming | P2     | 未开始；已有 bucket-level LOD 可复用             | XXL    | MAT0、G0、A0                                  |
+| GI0  | Screen/probe/software-BVH hybrid GI                                      | P2     | 屏幕内 SSGI 已完成；off-screen 层未开始          | XXL    | T0、Q0、G0、A0                                |
 
 `P0` 是“现代 WebGPU renderer”定义所需能力；`P1` 是高画质生产 profile；`P2`
 是依赖场景规模、内容管线和长期性能投入的虚拟化能力。
@@ -243,7 +245,8 @@ Database 已完成；G0/L0、T0、E0、Q0、V0/天气均已形成可运行的生
 timeline、确定的前后帧坐标 ABI、GPU Scene object/light database、共享 PBR material
 handle/variant、3D cluster allocator 与现有时域/屏幕空间 controller。P0 的透明、变形、完整 layered
 PBR、analytic cookie/IES、light-layer、variant
-warmup 和透明/粒子时域策略已收口；尚需在登记物理 GPU 上建立不可覆盖的跨提交性能基线。S0、A0、M0 和 GI0 的 off-screen 层尚未开始。详见
+warmup 和透明/粒子时域策略已收口；尚需在登记物理 GPU 上建立不可覆盖的跨提交性能基线。S0 已完成 stable-atlas 内容缓存首版，但 GPU
+caster cull、receiver budget 与虚拟页仍未开始；A0、M0 和 GI0 的 off-screen 层也尚未开始。详见
 [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 
 ## 6. 可落地工作包
@@ -610,7 +613,7 @@ off-screen GI 补偿属于 GI0，而不是未完成的 Q0。实现与上线证�
 这里推荐 GTAO/temporal AO，而不是补传统 SSAO；推荐 hierarchical SSR/temporal
 SSGI，而不是单帧固定步长 ray march。
 
-#### S0：现代阴影（未开始）
+#### S0：现代阴影（生产缓存首版已完成；GPU cull / 虚拟页未开始）
 
 ![S0：阴影缓存、脏页更新与虚拟阴影 Atlas](./images/modern-webgpu-roadmap/virtual-shadow-cache.jpg)
 
@@ -624,6 +627,14 @@ SSGI，而不是单帧固定步长 ray march。
    tile、按灯光预算更新、receiver-driven resolution、远近级更新频率；
 2. **虚拟阴影层**：directional clipmap/local-light virtual page table、depth/receiver 分析产生 page
    request、physical page allocation、per-page draw list、submission 后提交 residency。
+
+当前已交付第一层中的 stable atlas content cache、static/dynamic exact invalidation、slice-local
+scissored depth clear、submission commit/rollback、recovery invalidation 和
+`RendererDiagnostics.caches.shadowAtlas`。静态 slice 不再记录 Shadow Pass；移动 local
+light 只重绘对应 face，刚体 caster 用 shadow-camera bounds 把失效限制到相交 slice。geometry
+bounds 变化、skin/morph 目前保守失效相关全部 slice。GPU caster culling、receiver-driven
+resolution/update budget 和远近级更新频率仍是第一层剩余工作，不能由当前 CPU-side exact
+invalidation 冒充。
 
 这里的 virtual shadow
 page 不等同于 SVT/RVT。SVT 是从磁盘按 tile 流送纹理，RVT 是运行时生成并缓存材质或地形 shading 数据；两者可以承载 lightmap 或 shadow
@@ -763,7 +774,7 @@ flowchart TD
   X --> L["Filmic / Color Uber / Display transform"]
   Y --> L
   L --> M["Present"]
-  G -.-> S["S0 future：Cache / caster cull / virtual pages"]
+  G -.-> S["S0 next：caster cull / virtual pages"]
 ```
 
 关键约束：
@@ -826,8 +837,9 @@ report、类型消费和 package 验证必须同版本完成。
   atmosphere/cloud/cloud-shadow 场景。**仍缺**：shared shadow-atlas volumetric
   sampling、透明介质参与和对应性能证据；
 - **Streaming 未有**：后续场景需覆盖低带宽冷启动、快速 teleport、取消、内存压力与 device loss；
-- **Virtual shadow 未有**：后续场景需覆盖静态缓存、局部动态 caster、快速 camera 与 page budget
-  overflow。
+- **Shadow cache 已有首版**：单元/生产接线覆盖静态 hit、local-light face 局部失效、失败回滚、atlas
+  detach 与 recovery；**仍缺** GPU caster cull、receiver/update
+  budget、快速 camera 压力场景与 virtual page overflow。
 
 不能把验收 example 的“算法跑通”当成 production baseline，也不能通过 CPU readback visible
 count 来驱动下一步 draw。功能完成必须同时回答：更少的 CPU work、更稳定的 GPU
@@ -854,8 +866,9 @@ time、确定的资源预算和失败时的可观察行为。
 1. **登记 G0/L0 物理 GPU baseline**：把现有 110k object / 256 light
    fixture 纳入固定 hardware/browser/driver 的不可覆盖跨提交协议，先锁定 CPU record、GPU
    pass、upload 与显存阈值；
-2. **S0 生产缓存层**：先做 stable atlas content cache、static/dynamic invalidation、GPU caster
-   cull 和 receiver/budget 更新；只有第一层证明收益后再进入 virtual shadow page；
+2. **S0 生产缓存层**：stable atlas content cache、static/dynamic exact
+   invalidation 和局部 clear 已完成；继续补 GPU caster
+   cull 与 receiver/budget 更新，只有第一层证明收益后再进入 virtual shadow page；
 3. **A0 资源流送**：KTX 2/Basis + capability-driven transcode、Worker decode、mip
    residency、上传/内存/in-flight budget；随后再增加 geometry page/meshopt；
 4. **M0 meshlet/cluster geometry**：复用 GPU Scene、bucket LOD 与 A0 residency，先限定 static rigid

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -78,6 +78,21 @@ base 不随当前 cascade 数变化；物理 atlas 只创建实际启用的 slic
 bytes，仍低于 WebGL 2 保证的 16,384-byte minimum uniform-block
 capacity；WebGPU 使用相同 std140 布局和 GLSL→Naga→WGSL 产物。
 
+Shadow Atlas 现在还包含首版 S0 内容缓存。共享层按 atlas allocation、slice placement、light
+view-projection，以及 caster identity、transform、geometry stream、material/texture
+revision 和 skin/morph
+deformation 做精确快照；不使用可能碰撞的 hash。静态 slice 在后续有效帧中不再记录 Shadow
+Pass，刚体 caster/light 的变化只失效相交的 light slice；geometry
+bounds 变化、skin 和 morph 则保守失效全部相关 slice。脏 slice 通过同一 GLSL→Naga→WGSL/RHI 路径的 depth-only
+fullscreen triangle 在 viewport/scissor 内局部清理，Render Pass 使用 `load`
+保留其他 tile，避免整张 atlas clear 破坏缓存。内容 revision 只在有效 submission 后提交，graph
+build/prepare/execute 失败会回滚并在下一帧重试；atlas resize、detach、资源释放和 device/context
+recovery 都会明确失效。注册 `RendererDiagnostics` 后，`caches.shadowAtlas`
+提供累计 hit/miss/replacement/live-slice 观测。
+
+这一切仍是稳定 tile 的生产缓存层，不宣称已经实现 GPU caster culling、receiver-driven
+budget 或 virtual shadow page table/residency。
+
 Sprite 仍是 Mesh：共享单位 quad、按 atlas Texture 共享 SpriteMaterial，先按 Node 级
 `sortingLayer / zIndex / stable scene traversal` 确定显示顺序，再仅对相邻兼容项合批，并把 UV
 rect、size/anchor、tint 与 transform 编译成 portable instance batch。WebGL 2 使用 instance vertex

--- a/src/render/RendererDiagnostics.ts
+++ b/src/render/RendererDiagnostics.ts
@@ -31,7 +31,8 @@ export type RendererCacheKind =
     | 'pipelineLayout'
     | 'bindGroup'
     | 'framebuffer'
-    | 'vertexArray';
+    | 'vertexArray'
+    | 'shadowAtlas';
 
 export interface RendererNativeObjectCountersSnapshot {
     readonly created: number;
@@ -77,6 +78,8 @@ export interface RendererCacheDiagnosticsSnapshot {
     readonly bindGroup: RendererCacheCountersSnapshot;
     readonly framebuffer: RendererCacheCountersSnapshot;
     readonly vertexArray: RendererCacheCountersSnapshot;
+    /** Stable shadow-atlas content slices reused without issuing caster draws. */
+    readonly shadowAtlas: RendererCacheCountersSnapshot;
 }
 
 export interface RendererFrameDiagnosticsSnapshot {
@@ -168,8 +171,9 @@ const CACHE_PIPELINE_LAYOUT = CACHE_BIND_GROUP_LAYOUT + CACHE_STRIDE;
 const CACHE_BIND_GROUP = CACHE_PIPELINE_LAYOUT + CACHE_STRIDE;
 const CACHE_FRAMEBUFFER = CACHE_BIND_GROUP + CACHE_STRIDE;
 const CACHE_VERTEX_ARRAY = CACHE_FRAMEBUFFER + CACHE_STRIDE;
+const CACHE_SHADOW_ATLAS = CACHE_VERTEX_ARRAY + CACHE_STRIDE;
 
-const FRAME_START = CACHE_VERTEX_ARRAY + CACHE_STRIDE;
+const FRAME_START = CACHE_SHADOW_ATLAS + CACHE_STRIDE;
 const FRAME_DRAWS = FRAME_START;
 const FRAME_INDIRECT_DRAWS = FRAME_DRAWS + 1;
 const FRAME_DISPATCHES = FRAME_INDIRECT_DRAWS + 1;
@@ -242,6 +246,8 @@ function cacheBase(kind: RendererCacheKind): number {
             return CACHE_FRAMEBUFFER;
         case 'vertexArray':
             return CACHE_VERTEX_ARRAY;
+        case 'shadowAtlas':
+            return CACHE_SHADOW_ATLAS;
     }
 }
 
@@ -505,7 +511,8 @@ export class RendererDiagnostics implements RenderGraphTimelineSink {
                 pipelineLayout: this.cacheSnapshot(CACHE_PIPELINE_LAYOUT),
                 bindGroup: this.cacheSnapshot(CACHE_BIND_GROUP),
                 framebuffer: this.cacheSnapshot(CACHE_FRAMEBUFFER),
-                vertexArray: this.cacheSnapshot(CACHE_VERTEX_ARRAY)
+                vertexArray: this.cacheSnapshot(CACHE_VERTEX_ARRAY),
+                shadowAtlas: this.cacheSnapshot(CACHE_SHADOW_ATLAS)
             }),
             frame: Object.freeze({
                 draws: this.value(FRAME_DRAWS),

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -5,6 +5,10 @@ import { LINES, LINE_STRIP, TRIANGLES, TRIANGLE_STRIP } from '../../constants/we
 import type Texture from '../../texture/Texture';
 import Shader from '../../shader/Shader';
 import {
+    DEFAULT_MATERIAL_PIPELINE_STATE,
+    type MaterialPipelineState
+} from '../../material/MaterialDefinition';
+import {
     createRendererFrame,
     invokeRendererFrameCallback,
     default as RendererCore,
@@ -69,6 +73,8 @@ import {
 import { externalTextureBindingRegistry } from '../renderer/ExternalTextureBindingRegistry';
 import type { FullscreenDrawProcessor } from '../renderer/FullscreenDrawProcessor';
 import { MeshDrawProcessor } from '../renderer/MeshDrawProcessor';
+import type { PreparedDraw } from '../renderer/PreparedDraw';
+import type { RHIMeshDrawTargetDescriptor } from '../renderer/RHIDescriptorMapping';
 import { OffscreenRenderTargetRenderer } from '../renderer/OffscreenRenderTargetRenderer';
 import { PostProcessRenderer } from '../renderer/PostProcessRenderer';
 import {
@@ -86,6 +92,7 @@ import { RenderTargetTextureBindingProvider } from '../renderer/RenderTargetText
 import { RendererRecoveringError, type ResourceRegistryHandle } from '../renderer/ResourceRegistry';
 import { ShaderArtifactCompiler } from '../renderer/ShaderArtifactCompiler';
 import { ShadowAtlasMeshPreparer } from '../renderer/ShadowAtlasMeshPreparer';
+import { ShadowAtlasContentCache } from '../renderer/ShadowAtlasContentCache';
 import { ShadowAtlasRenderer } from '../renderer/ShadowAtlasRenderer';
 import { ShadowAtlasResourceCache } from '../renderer/ShadowAtlasResourceCache';
 import { ShadowAtlasSceneAdapter } from '../renderer/ShadowAtlasSceneAdapter';
@@ -127,16 +134,26 @@ interface RenderingResources {
     readonly gpuDrivenPipelines: GPUDrivenPipelineResourceCache;
     readonly scriptableBindGroups: ScriptableBindGroupResourceCache;
     readonly shadowScene: ShadowAtlasSceneAdapter;
+    readonly shadowContent: ShadowAtlasContentCache;
     readonly shadowResources: ShadowAtlasResourceCache;
     readonly shadowRenderer: ShadowAtlasRenderer;
     readonly shadowPreparer: ShadowAtlasMeshPreparer;
     readonly shadowBinding: ShadowAtlasTextureBinding;
+    readonly shadowClearShaders: Readonly<Record<'standard' | 'reversed', Shader>>;
+    readonly shadowClearOwners: Readonly<Record<'standard' | 'reversed', object>>;
+    readonly shadowClearTarget: {
+        readonly colorFormats: RHIMeshDrawTargetDescriptor['colorFormats'];
+        depthStencilFormat: NonNullable<RHIMeshDrawTargetDescriptor['depthStencilFormat']>;
+        readonly sampleCount: 1;
+    };
     readonly shadowOwner: object;
     readonly shadowPrepareOptions: { width: number; height: number };
     readonly shadowRenderOptions: {
         label: string;
         preparer: ShadowAtlasMeshPreparer;
         depthClearValue: number;
+        dirtySlices: readonly boolean[] | undefined;
+        sliceClearDraw: PreparedDraw | undefined;
     };
     readonly shadowViewport: {
         x: number;
@@ -163,6 +180,29 @@ const OPTIONAL_WEBGPU_FEATURES: readonly RHIRequestableWebGPUFeature[] = Object.
     'texture-compression-etc2',
     'texture-compression-astc'
 ]);
+
+const SHADOW_ATLAS_CLEAR_FRAGMENT_SOURCE = `#version 300 es
+precision highp float;
+void main() {}
+`;
+const EMPTY_SHADOW_COLOR_FORMATS = Object.freeze([]);
+
+function shadowAtlasClearVertexSource(depthMode: Camera['depthMode']): string {
+    const clipDepth = depthMode === 'reversed' ? '-1.0' : '1.0';
+    return `#version 300 es
+void main() {
+    vec2 positions[3] = vec2[3](vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+    gl_Position = vec4(positions[gl_VertexID], ${clipDepth}, 1.0);
+}`;
+}
+
+const SHADOW_ATLAS_CLEAR_PIPELINE_STATE: Readonly<MaterialPipelineState> = Object.freeze({
+    ...DEFAULT_MATERIAL_PIPELINE_STATE,
+    cullMode: 'none',
+    depthTest: true,
+    depthWrite: true,
+    depthCompare: 'always'
+});
 
 const REQUESTABLE_WEBGPU_FEATURES = new Set<string>([
     ...OPTIONAL_WEBGPU_FEATURES,
@@ -308,6 +348,7 @@ class SharedRendererDriver
     #selectedTargetColorEncoding: RenderColorEncoding = 'linear';
     #pipelineCacheMetrics: RHICacheCounterContinuation | null = null;
     #bindGroupCacheMetrics: RHICacheCounterContinuation | null = null;
+    #shadowAtlasCacheMetrics: RHICacheCounterContinuation | null = null;
     #vertexInputCacheMetrics: RHICacheCounterContinuation | null = null;
     #framebufferCacheMetrics: RHICacheCounterContinuation | null = null;
     #scriptablePipelineContextCursor = 0;
@@ -1448,6 +1489,7 @@ class SharedRendererDriver
         );
         const scriptableBindGroups = new ScriptableBindGroupResourceCache(processor.registry);
         const shadowScene = new ShadowAtlasSceneAdapter();
+        const shadowContent = new ShadowAtlasContentCache();
         const shadowResources = new ShadowAtlasResourceCache(processor.registry);
         const shadowRenderer = new ShadowAtlasRenderer(
             processor.registry,
@@ -1458,12 +1500,33 @@ class SharedRendererDriver
         );
         const shadowPreparer = new ShadowAtlasMeshPreparer(processor);
         const shadowBinding = new ShadowAtlasTextureBinding();
+        const shadowClearShaders = Object.freeze({
+            standard: new Shader({
+                vs: shadowAtlasClearVertexSource('standard'),
+                fs: SHADOW_ATLAS_CLEAR_FRAGMENT_SOURCE
+            }),
+            reversed: new Shader({
+                vs: shadowAtlasClearVertexSource('reversed'),
+                fs: SHADOW_ATLAS_CLEAR_FRAGMENT_SOURCE
+            })
+        });
+        const shadowClearOwners = Object.freeze({
+            standard: Object.freeze({ depthMode: 'standard' }),
+            reversed: Object.freeze({ depthMode: 'reversed' })
+        });
+        const shadowClearTarget = {
+            colorFormats: EMPTY_SHADOW_COLOR_FORMATS,
+            depthStencilFormat: 'depth24plus' as const,
+            sampleCount: 1 as const
+        };
         const shadowOwner = Object.freeze({ renderer: this });
         const shadowPrepareOptions = { width: 1, height: 1 };
         const shadowRenderOptions = {
             label: 'Shadow atlas',
             preparer: shadowPreparer,
-            depthClearValue: 1
+            depthClearValue: 1,
+            dirtySlices: undefined,
+            sliceClearDraw: undefined
         };
         const shadowViewport = {
             x: 0,
@@ -1486,6 +1549,11 @@ class SharedRendererDriver
         recovery.registerSynchronizer(processor.uniformBlocks);
         recovery.registerSynchronizer(postProcess.fullscreen);
         recovery.registerSynchronizer(storageBuffers);
+        recovery.registerSynchronizer({
+            synchronizeAfterRecovery: () => {
+                shadowContent.invalidateAll();
+            }
+        });
         recovery.registerSynchronizer({
             synchronizeAfterRecovery: () => {
                 // Render-target pass contents are not recoverable from isolated public patches.
@@ -1516,10 +1584,14 @@ class SharedRendererDriver
             gpuDrivenPipelines,
             scriptableBindGroups,
             shadowScene,
+            shadowContent,
             shadowResources,
             shadowRenderer,
             shadowPreparer,
             shadowBinding,
+            shadowClearShaders,
+            shadowClearOwners,
+            shadowClearTarget,
             shadowOwner,
             shadowPrepareOptions,
             shadowRenderOptions,
@@ -1549,6 +1621,11 @@ class SharedRendererDriver
         if (this.#bindGroupCacheMetrics === null) {
             this.#bindGroupCacheMetrics = new RHICacheCounterContinuation(bindGroupMetrics);
         } else this.#bindGroupCacheMetrics.rebind(bindGroupMetrics);
+        if (this.#shadowAtlasCacheMetrics === null) {
+            this.#shadowAtlasCacheMetrics = new RHICacheCounterContinuation(
+                resources.shadowContent.metrics
+            );
+        } else this.#shadowAtlasCacheMetrics.rebind(resources.shadowContent.metrics);
         this.bindDeviceCacheDiagnostics(device, resources.processor);
     }
 
@@ -1620,6 +1697,9 @@ class SharedRendererDriver
             resources.shadowBinding.destroy();
         });
         attempt(() => {
+            resources.shadowContent.destroy();
+        });
+        attempt(() => {
             resources.shadowPreparer.destroy();
         });
         attempt(() => {
@@ -1627,6 +1707,10 @@ class SharedRendererDriver
         });
         attempt(() => {
             resources.shadowScene.destroy();
+        });
+        attempt(() => {
+            resources.shadowClearShaders.standard.destroy();
+            resources.shadowClearShaders.reversed.destroy();
         });
         const cleanup = (async (): Promise<void> => {
             await Promise.allSettled([
@@ -1831,7 +1915,9 @@ class SharedRendererDriver
             prepareOptions
         );
         if (plan.atlas.sliceCount === 0) {
-            resources.shadowPreparer.retireAll(this.#pipelineHost.requireActiveScope().uploads);
+            const uploads = this.#pipelineHost.requireActiveScope().uploads;
+            resources.shadowContent.stageEmpty(uploads);
+            resources.shadowPreparer.retireAll(uploads);
             resources.shadowResources.detach(resources.shadowOwner);
             return null;
         }
@@ -1841,13 +1927,31 @@ class SharedRendererDriver
             plan.atlas,
             context.camera.depthMode
         );
+        const scope = this.#pipelineHost.requireActiveScope();
+        const content = resources.shadowContent.stage(atlas, plan, meshes, scope.uploads);
         resources.shadowRenderOptions.depthClearValue = depthClearValue(context.camera.depthMode);
+        resources.shadowRenderOptions.dirtySlices = content.dirtySlices;
+        if (content.dirtySliceCount > 0) {
+            this.beginScriptableFullscreenPass(context);
+            const depthMode = context.camera.depthMode;
+            resources.shadowClearTarget.depthStencilFormat = plan.atlas.format;
+            resources.shadowRenderOptions.sliceClearDraw = resources.postProcess.fullscreen.prepare(
+                {
+                    owner: resources.shadowClearOwners[depthMode],
+                    shader: resources.shadowClearShaders[depthMode],
+                    pipelineState: SHADOW_ATLAS_CLEAR_PIPELINE_STATE,
+                    target: resources.shadowClearTarget,
+                    fragmentOutputMode: 'depth-only',
+                    depthMode
+                }
+            );
+        } else resources.shadowRenderOptions.sliceClearDraw = undefined;
         resources.shadowPreparer.configure(plan, meshes);
         const viewport = resources.shadowViewport;
         viewport.width = atlas.width;
         viewport.height = atlas.height;
         const build = resources.shadowRenderer.build(
-            this.#pipelineHost.requireActiveScope(),
+            scope,
             context,
             atlas,
             plan.atlas,
@@ -2067,11 +2171,13 @@ class SharedRendererDriver
         const bindGroup = this.#bindGroupCacheMetrics;
         const vertexInput = this.#vertexInputCacheMetrics;
         const framebuffer = this.#framebufferCacheMetrics;
+        const shadowAtlas = this.#shadowAtlasCacheMetrics;
         if (
             pipeline === null ||
             bindGroup === null ||
             vertexInput === null ||
-            framebuffer === null
+            framebuffer === null ||
+            shadowAtlas === null
         ) {
             throw new Error('Renderer cache diagnostics are not initialized');
         }
@@ -2079,6 +2185,7 @@ class SharedRendererDriver
         sink.synchronizeCache('bindGroup', bindGroup);
         sink.synchronizeCache('vertexArray', vertexInput);
         sink.synchronizeCache('framebuffer', framebuffer);
+        sink.synchronizeCache('shadowAtlas', shadowAtlas);
     }
 
     private createContext(

--- a/src/render/renderer/FullscreenDrawProcessor.ts
+++ b/src/render/renderer/FullscreenDrawProcessor.ts
@@ -1,4 +1,5 @@
 import type { MaterialPipelineState } from '../../material/MaterialDefinition';
+import type { CameraDepthMode } from '../../camera/Camera';
 import type Shader from '../../shader/Shader';
 import type { RHIUploadBatch } from '../frame/RHIUploadBatch';
 import type { RenderGraphFrameContext } from '../frame/RenderGraphFrameContext';
@@ -13,7 +14,7 @@ import {
     type ShaderBindGroupHandleSet,
     type ShaderSampledBindingResources
 } from './ShaderBindGroupResourceCache';
-import { ShaderArtifactCompiler } from './ShaderArtifactCompiler';
+import { ShaderArtifactCompiler, type ShaderFragmentOutputMode } from './ShaderArtifactCompiler';
 import { ShaderResourceCache } from './ShaderResourceCache';
 import { SubmissionResourceTracker } from './SubmissionResourceTracker';
 
@@ -36,6 +37,10 @@ export interface FullscreenDrawPrepareOptions {
     readonly uniformBuffers?: readonly ResourceRegistryHandle<RHIBuffer>[];
     /** Resources follow `pipeline.bindingPlan.sampledBindings` order exactly. */
     readonly sampledResources?: readonly Readonly<ShaderSampledBindingResources>[];
+    /** Depth-only fullscreen work, such as a scissored atlas clear, has no color outputs. */
+    readonly fragmentOutputMode?: ShaderFragmentOutputMode;
+    /** Depth convention used when a depth-only target is prepared. */
+    readonly depthMode?: CameraDepthMode;
 }
 
 /**
@@ -152,7 +157,10 @@ export class FullscreenDrawProcessor {
         const pipeline = this.prepareGraphPipeline(
             options.shader,
             options.pipelineState,
-            options.target
+            options.target,
+            0,
+            options.fragmentOutputMode,
+            options.depthMode
         );
         const uniformBuffers = options.uniformBuffers ?? EMPTY_UNIFORM_BUFFERS;
         const sampledResources = options.sampledResources ?? EMPTY_SAMPLED_RESOURCES;
@@ -196,13 +204,16 @@ export class FullscreenDrawProcessor {
         shader: Shader,
         pipelineState: Readonly<MaterialPipelineState>,
         target: RHIMeshDrawTargetDescriptor,
-        numericDepthSamplerMask = 0
+        numericDepthSamplerMask = 0,
+        fragmentOutputMode: ShaderFragmentOutputMode = 'color',
+        depthMode: CameraDepthMode = 'standard'
     ): Readonly<PipelineResourceRecord> {
         this.assertAlive();
         if (!this.active) {
             throw new Error('Fullscreen draw processor requires beginFrame before preparation');
         }
         const compiled = this.compiler.compile(shader, this.registry.deviceBackend, {
+            fragmentOutputs: fragmentOutputMode,
             numericDepthSamplerMask
         });
         if (compiled.metadata.vertexInputs.length !== 0) {
@@ -214,10 +225,11 @@ export class FullscreenDrawProcessor {
             EMPTY_VERTEX_LAYOUTS,
             pipelineState,
             target,
-            'color',
+            fragmentOutputMode,
             undefined,
             undefined,
-            numericDepthSamplerMask
+            numericDepthSamplerMask,
+            depthMode
         );
         this.resourceUses.use(pipeline.pipeline);
         return pipeline;

--- a/src/render/renderer/ShadowAtlasContentCache.ts
+++ b/src/render/renderer/ShadowAtlasContentCache.ts
@@ -1,0 +1,663 @@
+import Mesh from '../../core/Mesh';
+import SkinnedMesh from '../../core/SkinnedMesh';
+import type Geometry from '../../geometry/Geometry';
+import type GeometryData from '../../geometry/GeometryData';
+import MorphGeometry from '../../geometry/MorphGeometry';
+import type Material from '../../material/MaterialInstance';
+import type Texture from '../../texture/Texture';
+import type { RHIUploadBatch, RHIUploadBatchParticipant } from '../frame/RHIUploadBatch';
+import { RHICacheCounter, type RHISubmission } from '../rhi/core';
+import type { ShadowAtlasResourceRecord } from './ShadowAtlasResourceCache';
+import type { ShadowAtlasScenePlan, ShadowAtlasSceneSlice } from './ShadowAtlasSceneAdapter';
+
+export type ShadowAtlasInvalidationReason =
+    | 'allocation'
+    | 'layout'
+    | 'light'
+    | 'caster-set'
+    | 'caster-transform'
+    | 'caster-geometry'
+    | 'caster-material'
+    | 'caster-texture'
+    | 'caster-deformation';
+
+export interface ShadowAtlasContentDecision {
+    /** Reused physical-index mask. It remains valid only until the next `stage` call. */
+    readonly dirtySlices: readonly boolean[];
+    /** First exact invalidation cause for each physical slice, or `null` on a cache hit. */
+    readonly reasons: readonly (ShadowAtlasInvalidationReason | null)[];
+    readonly sliceCount: number;
+    readonly dirtySliceCount: number;
+    readonly cachedSliceCount: number;
+}
+
+interface CasterSnapshot {
+    mesh: Mesh | null;
+    geometry: Geometry | null;
+    geometryMode: number;
+    material: Material | null;
+    materialRevision: number;
+    instanceCount: number;
+    skeleton: object | null;
+    readonly geometrySources: (GeometryData | null)[];
+    readonly geometrySourceRevisions: number[];
+    geometrySourceCount: number;
+    readonly textures: (Texture<unknown> | null)[];
+    readonly textureRevisions: number[];
+    textureCount: number;
+    readonly numericState: number[];
+    numericStateCount: number;
+}
+
+interface CasterRecord {
+    readonly mesh: Mesh;
+    committed: CasterSnapshot;
+    pending: CasterSnapshot;
+    committedValid: boolean;
+    committedRevision: number;
+    pendingRevision: number;
+    pendingEpoch: number;
+    pendingChanged: boolean;
+    pendingReason: ShadowAtlasInvalidationReason;
+}
+
+interface SliceSnapshot {
+    atlasToken: number;
+    owner: object | null;
+    kind: ShadowAtlasSceneSlice['kind'];
+    face: number | null;
+    cascade: number | null;
+    sliceIndex: number;
+    physicalIndex: number;
+    readonly viewport: number[];
+    readonly viewProjection: number[];
+    readonly casters: (CasterRecord | null)[];
+    readonly casterRevisions: number[];
+    casterCount: number;
+}
+
+interface SliceRecord {
+    committed: SliceSnapshot;
+    pending: SliceSnapshot;
+    committedValid: boolean;
+    pendingEpoch: number;
+}
+
+function createCasterSnapshot(): CasterSnapshot {
+    return {
+        mesh: null,
+        geometry: null,
+        geometryMode: -1,
+        material: null,
+        materialRevision: -1,
+        instanceCount: 0,
+        skeleton: null,
+        geometrySources: [],
+        geometrySourceRevisions: [],
+        geometrySourceCount: 0,
+        textures: [],
+        textureRevisions: [],
+        textureCount: 0,
+        numericState: [],
+        numericStateCount: 0
+    };
+}
+
+function createSliceSnapshot(): SliceSnapshot {
+    return {
+        atlasToken: 0,
+        owner: null,
+        kind: 'directional',
+        face: null,
+        cascade: null,
+        sliceIndex: -1,
+        physicalIndex: -1,
+        viewport: new Array<number>(6).fill(0),
+        viewProjection: new Array<number>(16).fill(0),
+        casters: [],
+        casterRevisions: [],
+        casterCount: 0
+    };
+}
+
+function sameNumbers(
+    previous: ArrayLike<number>,
+    current: ArrayLike<number>,
+    count: number,
+    offset = 0
+): boolean {
+    if (previous.length < offset + count || current.length < offset + count) return false;
+    for (let index = offset; index < offset + count; index += 1) {
+        if (!Object.is(previous[index], current[index])) return false;
+    }
+    return true;
+}
+
+function copyNumbers(target: number[], source: readonly number[], count: number): void {
+    target.length = count;
+    for (let index = 0; index < count; index += 1) target[index] = source[index] ?? 0;
+}
+
+function appendNumbers(target: number[], values: ArrayLike<number> | null): void {
+    if (values === null) {
+        target.push(-1);
+        return;
+    }
+    target.push(values.length);
+    let index = 0;
+    while (index < values.length) {
+        target.push(values[index] ?? 0);
+        index++;
+    }
+}
+
+function appendGeometrySource(target: GeometryData[], source: GeometryData | null): void {
+    if (source !== null) target.push(source);
+}
+
+function collectGeometrySources(target: GeometryData[], geometry: Geometry | null): void {
+    target.length = 0;
+    if (geometry === null) return;
+    appendGeometrySource(target, geometry.vertices);
+    appendGeometrySource(target, geometry.uvs);
+    appendGeometrySource(target, geometry.uvs1);
+    appendGeometrySource(target, geometry.colors);
+    appendGeometrySource(target, geometry.indices);
+    appendGeometrySource(target, geometry.skinIndices);
+    appendGeometrySource(target, geometry.skinWeights);
+    if (!(geometry instanceof MorphGeometry) || geometry.targets === null) return;
+    for (const name in geometry.targets) {
+        if (!Object.hasOwn(geometry.targets, name)) continue;
+        const sources = geometry.targets[name];
+        if (sources === undefined) continue;
+        for (const source of sources) appendGeometrySource(target, source);
+    }
+}
+
+function collectTextures(target: Texture<unknown>[], material: Material | null): void {
+    target.length = 0;
+    if (material === null) return;
+    for (const slot of material.definition.textureSlots) {
+        const binding = material.getTextureSlotByIndex(slot.index);
+        if (binding !== null) target.push(binding.texture);
+    }
+}
+
+function collectNumericState(target: number[], mesh: Mesh): void {
+    target.length = 0;
+    appendNumbers(target, mesh.worldMatrix.elements);
+    const geometry = mesh.geometry;
+    appendNumbers(target, geometry?.positionDecodeMat ?? null);
+    if (geometry instanceof MorphGeometry) appendNumbers(target, geometry.weights);
+    else appendNumbers(target, null);
+    if (mesh instanceof SkinnedMesh && mesh.skeleton !== null) {
+        appendNumbers(target, mesh.getJointMat());
+    } else appendNumbers(target, null);
+}
+
+function sameIdentities<T extends object>(
+    previous: readonly (T | null)[],
+    current: readonly T[],
+    count: number
+): boolean {
+    if (current.length !== count) return false;
+    for (let index = 0; index < count; index += 1) {
+        if (previous[index] !== current[index]) return false;
+    }
+    return true;
+}
+
+/**
+ * Submission-aware S0 content cache for stable shadow-atlas slices.
+ *
+ * The cache compares exact light/caster state, never a collision-prone hash. Rigid casters use the
+ * shadow camera frustum to localize invalidation to intersecting slices; deformation and geometry
+ * changes conservatively invalidate every slice until GPU caster culling owns those bounds.
+ */
+export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
+    readonly metrics = new RHICacheCounter();
+    readonly #casters = new WeakMap<Mesh, CasterRecord>();
+    readonly #activeCasterRecords = new Set<CasterRecord>();
+    readonly #currentCasters: CasterRecord[] = [];
+    readonly #geometryScratch: GeometryData[] = [];
+    readonly #textureScratch: Texture<unknown>[] = [];
+    readonly #numericScratch: number[] = [];
+    readonly #slices: SliceRecord[] = [];
+    readonly #dirtySlices: boolean[] = [];
+    readonly #reasons: (ShadowAtlasInvalidationReason | null)[] = [];
+    #transactionEpoch = 0;
+    #transactionActive = false;
+    #pendingSliceCount = 0;
+    #pendingInsertions = 0;
+    #pendingReplacements = 0;
+    #pendingRemovals = 0;
+    #nextCasterRevision = 1;
+    #destroyed = false;
+
+    stage(
+        atlas: Readonly<ShadowAtlasResourceRecord>,
+        plan: Readonly<ShadowAtlasScenePlan>,
+        meshes: readonly Mesh[],
+        uploads: RHIUploadBatch
+    ): Readonly<ShadowAtlasContentDecision> {
+        this.assertAlive();
+        if (plan.atlas.sliceCount !== plan.slices.length) {
+            throw new TypeError('Shadow content cache requires a complete scene plan');
+        }
+        this.beginTransaction(uploads);
+        this.captureCasters(meshes);
+        const sliceCount = plan.slices.length;
+        this.#dirtySlices.length = sliceCount;
+        this.#reasons.length = sliceCount;
+        this.#pendingSliceCount = sliceCount;
+        this.#pendingInsertions = 0;
+        this.#pendingReplacements = 0;
+        this.#pendingRemovals = 0;
+        let dirtySliceCount = 0;
+
+        for (let physicalIndex = 0; physicalIndex < sliceCount; physicalIndex += 1) {
+            const slice = plan.slices[physicalIndex];
+            if (slice?.physicalIndex !== physicalIndex) {
+                throw new TypeError('Shadow scene plan must be dense in physical atlas order');
+            }
+            const record = this.sliceAt(physicalIndex);
+            const previous =
+                record.pendingEpoch === this.#transactionEpoch
+                    ? record.pending
+                    : record.committedValid
+                      ? record.committed
+                      : null;
+            const reason = this.sliceInvalidationReason(previous, atlas.token, slice);
+            const committedReason = this.sliceInvalidationReason(
+                record.committedValid ? record.committed : null,
+                atlas.token,
+                slice
+            );
+            const dirty = reason !== null;
+            this.copySlice(record.pending, atlas.token, slice);
+            record.pendingEpoch = this.#transactionEpoch;
+            this.#dirtySlices[physicalIndex] = dirty;
+            this.#reasons[physicalIndex] = reason;
+            if (dirty) {
+                dirtySliceCount++;
+                this.metrics.recordMiss();
+            } else this.metrics.recordHit();
+            if (!record.committedValid) this.#pendingInsertions++;
+            else if (committedReason !== null) this.#pendingReplacements++;
+        }
+        for (let index = sliceCount; index < this.#slices.length; index += 1) {
+            const record = this.#slices[index];
+            if (record?.committedValid === true) this.#pendingRemovals++;
+        }
+
+        return Object.freeze({
+            dirtySlices: this.#dirtySlices,
+            reasons: this.#reasons,
+            sliceCount,
+            dirtySliceCount,
+            cachedSliceCount: sliceCount - dirtySliceCount
+        });
+    }
+
+    /** Stage an empty final atlas state without breaking an already-enlisted frame transaction. */
+    stageEmpty(uploads: RHIUploadBatch): void {
+        this.assertAlive();
+        this.beginTransaction(uploads);
+        this.#pendingSliceCount = 0;
+        this.#pendingInsertions = 0;
+        this.#pendingReplacements = 0;
+        this.#pendingRemovals = 0;
+        for (const record of this.#slices) {
+            if (record.committedValid) this.#pendingRemovals++;
+        }
+    }
+
+    /** Drop all content validity after atlas detach, resize, or device recovery. */
+    invalidateAll(): void {
+        this.assertAlive();
+        this.rollback();
+        for (const record of this.#slices) record.committedValid = false;
+        this.metrics.clear();
+    }
+
+    prepareCommit(_submission: RHISubmission): void {
+        this.assertAlive();
+        if (!this.#transactionActive) {
+            throw new Error('Shadow content cache has no staged transaction to commit');
+        }
+    }
+
+    commit(_submission: RHISubmission): void {
+        this.assertAlive();
+        if (!this.#transactionActive) return;
+        for (const record of this.#activeCasterRecords) {
+            if (record.pendingEpoch !== this.#transactionEpoch) continue;
+            if (record.pendingChanged) {
+                const previous = record.committed;
+                record.committed = record.pending;
+                record.pending = previous;
+                record.committedValid = true;
+            }
+            record.committedRevision = record.pendingRevision;
+        }
+        for (let index = 0; index < this.#pendingSliceCount; index += 1) {
+            const record = this.#slices[index];
+            if (record?.pendingEpoch !== this.#transactionEpoch) continue;
+            const previous = record.committed;
+            record.committed = record.pending;
+            record.pending = previous;
+            record.committedValid = true;
+        }
+        for (let index = this.#pendingSliceCount; index < this.#slices.length; index += 1) {
+            const record = this.#slices[index];
+            if (record !== undefined) record.committedValid = false;
+        }
+        if (this.#pendingReplacements > 0) {
+            this.metrics.recordReplacement(this.#pendingReplacements);
+        }
+        if (this.#pendingRemovals > 0) this.metrics.recordRemoval(this.#pendingRemovals);
+        if (this.#pendingInsertions > 0) this.metrics.recordInsertion(this.#pendingInsertions);
+        this.finishTransaction();
+    }
+
+    rollback(): void {
+        if (!this.#transactionActive) return;
+        this.finishTransaction();
+    }
+
+    destroy(): void {
+        if (this.#destroyed) return;
+        this.rollback();
+        this.metrics.clear();
+        this.#activeCasterRecords.clear();
+        this.#currentCasters.length = 0;
+        this.#slices.length = 0;
+        this.#dirtySlices.length = 0;
+        this.#reasons.length = 0;
+        this.#destroyed = true;
+    }
+
+    private beginTransaction(uploads: RHIUploadBatch): void {
+        if (!this.#transactionActive) {
+            if (!Number.isSafeInteger(this.#transactionEpoch + 1)) {
+                throw new RangeError('Shadow content-cache transaction space is exhausted');
+            }
+            this.#transactionEpoch++;
+            this.#transactionActive = true;
+            this.#activeCasterRecords.clear();
+        }
+        uploads.enlist(this);
+    }
+
+    private captureCasters(meshes: readonly Mesh[]): void {
+        this.#currentCasters.length = 0;
+        for (const mesh of meshes) {
+            if (!(mesh instanceof Mesh) || !mesh.castShadows || mesh.material === null) continue;
+            let record = this.#casters.get(mesh);
+            if (record === undefined) {
+                record = {
+                    mesh,
+                    committed: createCasterSnapshot(),
+                    pending: createCasterSnapshot(),
+                    committedValid: false,
+                    committedRevision: 0,
+                    pendingRevision: 0,
+                    pendingEpoch: 0,
+                    pendingChanged: false,
+                    pendingReason: 'caster-set'
+                };
+                this.#casters.set(mesh, record);
+            }
+            this.captureCaster(record);
+            this.#activeCasterRecords.add(record);
+            this.#currentCasters.push(record);
+        }
+    }
+
+    private captureCaster(record: CasterRecord): void {
+        const mesh = record.mesh;
+        const geometry = mesh.geometry;
+        const material = mesh.material;
+        collectGeometrySources(this.#geometryScratch, geometry);
+        collectTextures(this.#textureScratch, material);
+        collectNumericState(this.#numericScratch, mesh);
+        const comparingPending =
+            record.pendingEpoch === this.#transactionEpoch && record.pendingChanged;
+        const previous = comparingPending
+            ? record.pending
+            : record.committedValid
+              ? record.committed
+              : null;
+        const reason = this.casterInvalidationReason(previous, mesh);
+        record.pendingEpoch = this.#transactionEpoch;
+        record.pendingReason = reason ?? record.pendingReason;
+        if (reason === null) {
+            if (comparingPending) return;
+            record.pendingChanged = false;
+            record.pendingRevision = record.committedRevision;
+            return;
+        }
+        this.copyCaster(record.pending, mesh);
+        if (reason === 'caster-geometry' && mesh.geometry?.vertices !== null) {
+            mesh.geometry?.getLocalSphereBounds(true);
+        }
+        record.pendingChanged = true;
+        record.pendingRevision = this.allocateCasterRevision();
+        record.pendingReason = reason;
+    }
+
+    private casterInvalidationReason(
+        previous: Readonly<CasterSnapshot> | null,
+        mesh: Mesh
+    ): ShadowAtlasInvalidationReason | null {
+        if (previous?.mesh !== mesh) return 'caster-set';
+        if (!sameNumbers(previous.numericState, this.#numericScratch, 17, 0)) {
+            return 'caster-transform';
+        }
+        const geometry = mesh.geometry;
+        if (
+            previous.geometry !== geometry ||
+            previous.geometryMode !== (geometry?.mode ?? -1) ||
+            !sameIdentities(
+                previous.geometrySources,
+                this.#geometryScratch,
+                previous.geometrySourceCount
+            )
+        ) {
+            return 'caster-geometry';
+        }
+        for (let index = 0; index < this.#geometryScratch.length; index += 1) {
+            if (
+                previous.geometrySourceRevisions[index] !== this.#geometryScratch[index]?.revision
+            ) {
+                return 'caster-geometry';
+            }
+        }
+        const material = mesh.material;
+        if (
+            previous.material !== material ||
+            previous.materialRevision !== (material?.revision ?? -1) ||
+            previous.instanceCount !== mesh.instanceCount ||
+            previous.skeleton !== (mesh instanceof SkinnedMesh ? mesh.skeleton : null)
+        ) {
+            return 'caster-material';
+        }
+        if (!sameIdentities(previous.textures, this.#textureScratch, previous.textureCount)) {
+            return 'caster-texture';
+        }
+        for (let index = 0; index < this.#textureScratch.length; index += 1) {
+            const texture = this.#textureScratch[index];
+            if (
+                texture?.autoUpdate === true ||
+                previous.textureRevisions[index] !== texture?.updateRevision
+            ) {
+                return 'caster-texture';
+            }
+        }
+        if (
+            previous.numericStateCount !== this.#numericScratch.length ||
+            !sameNumbers(previous.numericState, this.#numericScratch, this.#numericScratch.length)
+        ) {
+            return 'caster-deformation';
+        }
+        return null;
+    }
+
+    private copyCaster(target: CasterSnapshot, mesh: Mesh): void {
+        const geometry = mesh.geometry;
+        const material = mesh.material;
+        target.mesh = mesh;
+        target.geometry = geometry;
+        target.geometryMode = geometry?.mode ?? -1;
+        target.material = material;
+        target.materialRevision = material?.revision ?? -1;
+        target.instanceCount = mesh.instanceCount;
+        target.skeleton = mesh instanceof SkinnedMesh ? mesh.skeleton : null;
+        target.geometrySourceCount = this.#geometryScratch.length;
+        target.geometrySources.length = this.#geometryScratch.length;
+        target.geometrySourceRevisions.length = this.#geometryScratch.length;
+        for (let index = 0; index < this.#geometryScratch.length; index += 1) {
+            const source = this.#geometryScratch[index] ?? null;
+            target.geometrySources[index] = source;
+            target.geometrySourceRevisions[index] = source?.revision ?? -1;
+        }
+        target.textureCount = this.#textureScratch.length;
+        target.textures.length = this.#textureScratch.length;
+        target.textureRevisions.length = this.#textureScratch.length;
+        for (let index = 0; index < this.#textureScratch.length; index += 1) {
+            const texture = this.#textureScratch[index] ?? null;
+            target.textures[index] = texture;
+            target.textureRevisions[index] = texture?.updateRevision ?? -1;
+        }
+        target.numericStateCount = this.#numericScratch.length;
+        copyNumbers(target.numericState, this.#numericScratch, this.#numericScratch.length);
+    }
+
+    private sliceInvalidationReason(
+        previous: Readonly<SliceSnapshot> | null,
+        atlasToken: number,
+        slice: Readonly<ShadowAtlasSceneSlice>
+    ): ShadowAtlasInvalidationReason | null {
+        if (previous?.atlasToken !== atlasToken) return 'allocation';
+        if (
+            previous.owner !== slice.light ||
+            previous.kind !== slice.kind ||
+            previous.face !== slice.face ||
+            previous.cascade !== slice.cascade ||
+            previous.sliceIndex !== slice.sliceIndex ||
+            previous.physicalIndex !== slice.physicalIndex ||
+            previous.viewport[0] !== slice.viewport.x ||
+            previous.viewport[1] !== slice.viewport.y ||
+            previous.viewport[2] !== slice.viewport.width ||
+            previous.viewport[3] !== slice.viewport.height ||
+            previous.viewport[4] !== slice.viewport.minDepth ||
+            previous.viewport[5] !== slice.viewport.maxDepth
+        ) {
+            return 'layout';
+        }
+        const matrix = slice.viewProjectionMatrix.elements;
+        if (!sameNumbers(previous.viewProjection, matrix, 16)) return 'light';
+
+        let casterIndex = 0;
+        for (const record of this.#currentCasters) {
+            if (!this.casterAffectsSlice(record, slice)) continue;
+            if (previous.casters[casterIndex] !== record) return 'caster-set';
+            if (previous.casterRevisions[casterIndex] !== record.pendingRevision) {
+                return record.pendingReason;
+            }
+            casterIndex++;
+        }
+        return previous.casterCount === casterIndex ? null : 'caster-set';
+    }
+
+    private copySlice(
+        target: SliceSnapshot,
+        atlasToken: number,
+        slice: Readonly<ShadowAtlasSceneSlice>
+    ): void {
+        target.atlasToken = atlasToken;
+        target.owner = slice.light;
+        target.kind = slice.kind;
+        target.face = slice.face;
+        target.cascade = slice.cascade;
+        target.sliceIndex = slice.sliceIndex;
+        target.physicalIndex = slice.physicalIndex;
+        target.viewport[0] = slice.viewport.x;
+        target.viewport[1] = slice.viewport.y;
+        target.viewport[2] = slice.viewport.width;
+        target.viewport[3] = slice.viewport.height;
+        target.viewport[4] = slice.viewport.minDepth;
+        target.viewport[5] = slice.viewport.maxDepth;
+        const matrix = slice.viewProjectionMatrix.elements;
+        for (let index = 0; index < 16; index += 1) {
+            target.viewProjection[index] = matrix[index] ?? 0;
+        }
+        let casterIndex = 0;
+        for (const record of this.#currentCasters) {
+            if (!this.casterAffectsSlice(record, slice)) continue;
+            target.casters[casterIndex] = record;
+            target.casterRevisions[casterIndex] = record.pendingRevision;
+            casterIndex++;
+        }
+        for (let index = casterIndex; index < target.casterCount; index += 1) {
+            target.casters[index] = null;
+            target.casterRevisions[index] = 0;
+        }
+        target.casterCount = casterIndex;
+    }
+
+    private casterAffectsSlice(
+        record: Readonly<CasterRecord>,
+        slice: Readonly<ShadowAtlasSceneSlice>
+    ): boolean {
+        const mesh = record.mesh;
+        const geometry = mesh.geometry;
+        if (
+            geometry === null ||
+            !mesh.frustumTest ||
+            mesh instanceof SkinnedMesh ||
+            geometry instanceof MorphGeometry ||
+            (record.pendingChanged && record.pendingReason === 'caster-geometry')
+        ) {
+            return true;
+        }
+        return slice.camera.isMeshVisible(mesh);
+    }
+
+    private sliceAt(index: number): SliceRecord {
+        let record = this.#slices[index];
+        if (record === undefined) {
+            record = {
+                committed: createSliceSnapshot(),
+                pending: createSliceSnapshot(),
+                committedValid: false,
+                pendingEpoch: 0
+            };
+            this.#slices[index] = record;
+        }
+        return record;
+    }
+
+    private allocateCasterRevision(): number {
+        const revision = this.#nextCasterRevision;
+        if (!Number.isSafeInteger(revision)) {
+            throw new RangeError('Shadow caster revision space is exhausted');
+        }
+        this.#nextCasterRevision++;
+        return revision;
+    }
+
+    private finishTransaction(): void {
+        this.#transactionActive = false;
+        this.#activeCasterRecords.clear();
+        this.#currentCasters.length = 0;
+        this.#pendingSliceCount = 0;
+        this.#pendingInsertions = 0;
+        this.#pendingReplacements = 0;
+        this.#pendingRemovals = 0;
+    }
+
+    private assertAlive(): void {
+        if (this.#destroyed) throw new Error('ShadowAtlasContentCache is destroyed');
+    }
+}

--- a/src/render/renderer/ShadowAtlasMeshPreparer.ts
+++ b/src/render/renderer/ShadowAtlasMeshPreparer.ts
@@ -29,6 +29,8 @@ export class ShadowAtlasMeshPreparer
     readonly #ownerRecords = new Map<object, ShadowOwnerRecord>();
     readonly #usedOwners = new Set<object>();
     readonly #pendingDetachOwners = new Set<object>();
+    readonly #configuredCameras = new Set<Camera>();
+    readonly #configuredMeshes = new Set<Mesh>();
     #plan: Readonly<ShadowAtlasScenePlan> | null = null;
     #meshes: readonly Mesh[] = Object.freeze([]);
     #target: RHIMeshDrawTargetDescriptor | null = null;
@@ -50,11 +52,17 @@ export class ShadowAtlasMeshPreparer
         // Truncating first clears entries when the reusable plan keeps the same slice count.
         this.#sceneSlicesByPhysicalIndex.length = 0;
         this.#sceneSlicesByPhysicalIndex.length = plan.atlas.sliceCount;
+        this.#configuredCameras.clear();
         for (const slice of plan.slices) {
             if (this.#sceneSlicesByPhysicalIndex[slice.physicalIndex] !== undefined) {
                 throw new TypeError('Shadow scene plan contains a duplicate physical slice');
             }
             this.#sceneSlicesByPhysicalIndex[slice.physicalIndex] = slice;
+            this.#configuredCameras.add(slice.camera);
+        }
+        this.#configuredMeshes.clear();
+        for (const mesh of meshes) {
+            if (mesh.castShadows && mesh.material !== null) this.#configuredMeshes.add(mesh);
         }
         this.#plan = plan;
         this.#meshes = meshes;
@@ -105,6 +113,14 @@ export class ShadowAtlasMeshPreparer
         this.#active = false;
         for (const owner of this.#ownerRecords.keys()) {
             if (this.#usedOwners.has(owner)) continue;
+            const record = this.#ownerRecords.get(owner);
+            if (
+                record !== undefined &&
+                this.#configuredCameras.has(record.camera) &&
+                this.#configuredMeshes.has(record.mesh)
+            ) {
+                continue;
+            }
             this.#pendingDetachOwners.add(owner);
         }
         this.#usedOwners.clear();
@@ -143,6 +159,8 @@ export class ShadowAtlasMeshPreparer
         this.#ownersByCamera.clear();
         this.#usedOwners.clear();
         this.#pendingDetachOwners.clear();
+        this.#configuredCameras.clear();
+        this.#configuredMeshes.clear();
         this.#sceneSlicesByPhysicalIndex.length = 0;
         this.#draws.length = 0;
         this.#plan = null;

--- a/src/render/renderer/ShadowAtlasRenderer.ts
+++ b/src/render/renderer/ShadowAtlasRenderer.ts
@@ -33,6 +33,10 @@ export interface ShadowAtlasRenderOptions<Owner extends object = object> {
     readonly preparer?: ShadowAtlasSlicePreparer<Owner>;
     /** Clear value matching the shadow cameras' depth convention. */
     readonly depthClearValue?: number;
+    /** Physical-index update mask supplied by the submission-aware S0 content cache. */
+    readonly dirtySlices?: readonly boolean[] | undefined;
+    /** Portable depth-only fullscreen draw used to clear one scissored dirty slice. */
+    readonly sliceClearDraw?: PreparedDraw | undefined;
 }
 
 /** @internal Exact graph resource produced by one shadow-atlas build. */
@@ -44,9 +48,10 @@ export interface ShadowAtlasBuildResult {
 /**
  * Executes one shared depth-atlas graph for directional, spot, and point-light slices.
  *
- * The first pass clears the complete atlas; following slice passes load it and restrict writes
- * with a viewport/scissor. This avoids backend framebuffer managers and gives WebGL immediate and
- * WebGPU deferred execution the same observable pass ordering.
+ * Legacy callers clear the complete atlas in the first pass. S0 callers instead provide an exact
+ * dirty-slice mask and a portable depth-only clear draw; every dirty pass loads the persistent
+ * atlas, clears only its viewport/scissor, and preserves all cached slices. This keeps WebGL
+ * immediate and WebGPU deferred execution on the same Render Graph/RHI path.
  */
 export class ShadowAtlasRenderer<Owner extends object = object> {
     readonly frame: RenderGraphFrame;
@@ -139,17 +144,22 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
             );
 
             let previousPass: RGPassHandle | null = null;
+            let builtPassCount = 0;
             for (let index = 0; index < plan.slices.length; index += 1) {
                 const slice = plan.slices[index];
                 if (slice === undefined)
                     throw new Error('Shadow atlas plan contains a sparse slice');
+                if (options.dirtySlices?.[index] === false) continue;
                 const pass = this.passAt(this.#passCursor++);
                 pass.reset();
                 pass.label = `${options.label ?? 'Shadow atlas'} ${slice.kind} ${String(slice.sliceIndex)}`;
+                const usesSliceClear = options.sliceClearDraw !== undefined;
                 pass.setDepthStencilAttachment({
                     texture: atlasTexture,
-                    ...(index === 0 ? { depthClearValue: options.depthClearValue ?? 1 } : {}),
-                    depthLoadOp: index === 0 ? 'clear' : 'load',
+                    ...(!usesSliceClear && builtPassCount === 0
+                        ? { depthClearValue: options.depthClearValue ?? 1 }
+                        : {}),
+                    depthLoadOp: !usesSliceClear && builtPassCount === 0 ? 'clear' : 'load',
                     depthStoreOp: 'store'
                 });
                 pass.setViewport(slice.viewport);
@@ -160,6 +170,10 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
                     height: Math.floor(slice.viewport.height)
                 });
                 if (previousPass !== null) pass.dependsOn(previousPass);
+                if (options.sliceClearDraw !== undefined) {
+                    if (meshFrameStarted) pass.addDrawSnapshot(options.sliceClearDraw);
+                    else pass.addDraw(options.sliceClearDraw);
+                }
                 const draws =
                     options.preparer?.prepare(slice) ?? options.sliceDraws?.[index] ?? EMPTY_DRAWS;
                 for (const draw of draws) {
@@ -177,9 +191,10 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
                     bridge.addSampledTextureReads(scope.graph, pass, sampledDependencies);
                 }
                 previousPass = scope.graph.addPass(ShadowPassTemplate, pass);
+                builtPassCount++;
             }
             scope.graph.markOutput(atlasTexture);
-            return Object.freeze({ passCount: plan.sliceCount, texture: atlasTexture });
+            return Object.freeze({ passCount: builtPassCount, texture: atlasTexture });
         } finally {
             options.preparer?.end?.();
         }
@@ -242,6 +257,20 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
         }
         if (options.sliceDraws !== undefined && options.sliceDraws.length !== plan.slices.length) {
             throw new RangeError('Shadow sliceDraws must match plan.slices order and count');
+        }
+        if (
+            options.dirtySlices !== undefined &&
+            options.dirtySlices.length !== plan.slices.length
+        ) {
+            throw new RangeError('Shadow dirtySlices must match plan.slices order and count');
+        }
+        if (
+            options.dirtySlices !== undefined &&
+            options.sliceClearDraw === undefined &&
+            options.dirtySlices.some(dirty => dirty) &&
+            options.dirtySlices.some(dirty => !dirty)
+        ) {
+            throw new TypeError('Partial shadow-atlas updates require a sliceClearDraw');
         }
     }
 

--- a/test/spec/renderer/ShadowAtlasContentCache.test.ts
+++ b/test/spec/renderer/ShadowAtlasContentCache.test.ts
@@ -1,0 +1,125 @@
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import Mesh from '../../../src/core/Mesh';
+import { FrameArena } from '../../../src/render/frame/FrameArena';
+import { RHIUploadBatch } from '../../../src/render/frame/RHIUploadBatch';
+import BoxGeometry from '../../../src/geometry/BoxGeometry';
+import DirectionalLight from '../../../src/light/DirectionalLight';
+import LightManager from '../../../src/light/LightManager';
+import BasicMaterial from '../../../src/material/BasicMaterial';
+import Vector3 from '../../../src/math/Vector3';
+import { ResourceRegistry } from '../../../src/render/renderer/ResourceRegistry';
+import { ShadowAtlasContentCache } from '../../../src/render/renderer/ShadowAtlasContentCache';
+import { ShadowAtlasResourceCache } from '../../../src/render/renderer/ShadowAtlasResourceCache';
+import { ShadowAtlasSceneAdapter } from '../../../src/render/renderer/ShadowAtlasSceneAdapter';
+import type { RHISubmission } from '../../../src/render/rhi/core';
+import { describe, expect, it } from 'vitest';
+import { FakeWebGLRHIBackend } from '../rhi/portable/FakeRHIBackend';
+
+function submit(device: ReturnType<FakeWebGLRHIBackend['createDevice']>, batch: RHIUploadBatch) {
+    const commands = device.graphicsQueue.beginFrame();
+    batch.flush(commands);
+    const submission = device.graphicsQueue.endFrame(commands);
+    batch.commit(submission);
+    return submission;
+}
+
+describe('ShadowAtlasContentCache', () => {
+    it('commits exact slice state only after submission and retries rolled-back caster changes', async () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+        const registry = new ResourceRegistry(device);
+        const resources = new ShadowAtlasResourceCache(registry);
+        const adapter = new ShadowAtlasSceneAdapter();
+        const content = new ShadowAtlasContentCache();
+        const manager = new LightManager();
+        const light = new DirectionalLight({ shadow: { width: 32, height: 32 } });
+        light.setPosition(2, 4, 3).lookAt(new Vector3());
+        manager.addLight(light);
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.setPosition(0, 1, 5).lookAt(new Vector3());
+        camera.updateViewProjectionMatrix();
+        const mesh = new Mesh({
+            geometry: new BoxGeometry(),
+            material: new BasicMaterial(),
+            frustumTest: false
+        });
+        mesh.updateMatrixWorld();
+        const plan = adapter.prepare(manager, camera, device.capabilities, {
+            width: 32,
+            height: 32
+        });
+        const atlasOwner = {};
+        const atlas = resources.prepare(atlasOwner, plan.atlas);
+
+        const firstBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], firstBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            cachedSliceCount: 0,
+            reasons: ['allocation']
+        });
+        const firstSubmission: RHISubmission = submit(device, firstBatch);
+        await firstSubmission.done;
+        expect(content.metrics).toMatchObject({ size: 1, misses: 1, hits: 0 });
+
+        const stableBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], stableBatch)).toMatchObject({
+            dirtySliceCount: 0,
+            cachedSliceCount: 1,
+            reasons: [null]
+        });
+        stableBatch.rollback();
+
+        mesh.x = 1;
+        mesh.updateMatrixWorld();
+        const failedBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], failedBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            reasons: ['caster-transform']
+        });
+        failedBatch.rollback();
+
+        const retryBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], retryBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            reasons: ['caster-transform']
+        });
+        const retrySubmission = submit(device, retryBatch);
+        await retrySubmission.done;
+
+        const committedBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], committedBatch)).toMatchObject({
+            dirtySliceCount: 0,
+            cachedSliceCount: 1
+        });
+        const committedSubmission = submit(device, committedBatch);
+        await committedSubmission.done;
+        expect(content.metrics).toMatchObject({ size: 1, highWater: 1 });
+
+        mesh.x = 10_000;
+        mesh.updateMatrixWorld();
+        const distantBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], distantBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            reasons: ['caster-transform']
+        });
+        const distantSubmission = submit(device, distantBatch);
+        await distantSubmission.done;
+
+        mesh.x = 10_001;
+        mesh.updateMatrixWorld();
+        const uncullableBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], uncullableBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            reasons: ['caster-transform']
+        });
+        const uncullableSubmission = submit(device, uncullableBatch);
+        await uncullableSubmission.done;
+
+        content.destroy();
+        resources.destroy();
+        registry.collect(1);
+        adapter.destroy();
+        registry.destroy();
+        backend.destroy();
+    });
+});

--- a/test/spec/renderer/ShadowAtlasRenderer.test.ts
+++ b/test/spec/renderer/ShadowAtlasRenderer.test.ts
@@ -142,9 +142,29 @@ describe.each([
             'less-equal'
         );
 
+        const drawCountBeforePartial = backend.executionLog.filter(command =>
+            command.startsWith('draw:')
+        ).length;
+        const partial = renderer.render(context(device, 2), atlas, plan, {
+            sliceDraws: [[draw], [draw]],
+            dirtySlices: [false, true],
+            sliceClearDraw: draw
+        });
+        await complete(backend);
+        await partial.submission.done;
+        expect(descriptors).toHaveLength(3);
+        expect(descriptors.at(-1)?.depthStencilAttachment).toMatchObject({
+            depthLoadOp: 'load',
+            depthStoreOp: 'store'
+        });
+        expect(
+            backend.executionLog.filter(command => command.startsWith('draw:')).length -
+                drawCountBeforePartial
+        ).toBe(2);
+
         renderer.destroy();
         resources.destroy();
-        expect(registry.collect(1)).toBe(3);
+        expect(registry.collect(2)).toBe(3);
         pipeline.destroy();
         planner.destroy();
         registry.destroy();

--- a/test/spec/renderer/SharedRendererShadow.test.ts
+++ b/test/spec/renderer/SharedRendererShadow.test.ts
@@ -134,7 +134,7 @@ describe('SharedRendererDriver shadow production wiring', () => {
         if (atlasTexture === null) throw new Error('Directional shadow atlas was not attached');
         expect(renderer.lightManager.shadowAtlasSize).toEqualishValues(16, 8, 1 / 16, 1 / 8);
         expect(diagnostics.snapshot().frame).toMatchObject({
-            draws: 3,
+            draws: 4,
             passes: 3,
             submissions: 1
         });
@@ -143,7 +143,8 @@ describe('SharedRendererDriver shadow production wiring', () => {
             firstDiagnostics.caches.pipeline,
             firstDiagnostics.caches.bindGroup,
             firstDiagnostics.caches.vertexArray,
-            firstDiagnostics.caches.framebuffer
+            firstDiagnostics.caches.framebuffer,
+            firstDiagnostics.caches.shadowAtlas
         ]) {
             expect(cache.misses).not.toBeNull();
             expect(cache.size).not.toBeNull();
@@ -167,6 +168,23 @@ describe('SharedRendererDriver shadow production wiring', () => {
         }
         firstPasses.restore();
 
+        const cachedPasses = observePassLabels(rhiExtension(renderer).device);
+        renderer.render(scene, camera);
+        await renderer.waitForIdle();
+        expect(cachedPasses.labels).toEqual([
+            'Forward scene',
+            'Forward linear-to-sRGB output transfer'
+        ]);
+        expect(diagnostics.snapshot().frame).toMatchObject({
+            draws: 2,
+            passes: 2,
+            submissions: 1
+        });
+        expect(diagnostics.snapshot().caches.shadowAtlas.hits).toBeGreaterThan(
+            firstDiagnostics.caches.shadowAtlas.hits ?? 0
+        );
+        cachedPasses.restore();
+
         scene.addChild(spot).addChild(point);
         const allPasses = observePassLabels(rhiExtension(renderer).device);
         renderer.render(scene, camera);
@@ -187,7 +205,7 @@ describe('SharedRendererDriver shadow production wiring', () => {
         expect(renderer.lightManager.shadowAtlas).toBe(atlasTexture);
         expect(renderer.lightManager.shadowAtlasSize).toEqualishValues(96, 48, 1 / 96, 1 / 48);
         expect(diagnostics.snapshot().frame).toMatchObject({
-            draws: 10,
+            draws: 18,
             passes: 10,
             submissions: 1
         });
@@ -206,6 +224,22 @@ describe('SharedRendererDriver shadow production wiring', () => {
         );
         allPasses.restore();
 
+        point.x += 0.25;
+        const pointPasses = observePassLabels(rhiExtension(renderer).device);
+        renderer.render(scene, camera);
+        await renderer.waitForIdle();
+        const pointShadowLabels = pointPasses.labels.filter(label =>
+            label.startsWith('Shadow atlas')
+        );
+        expect(pointShadowLabels).toHaveLength(6);
+        expect(pointShadowLabels.every(label => label.split(' ')[2] === 'point')).toBe(true);
+        expect(diagnostics.snapshot().frame).toMatchObject({
+            draws: 14,
+            passes: 8,
+            submissions: 1
+        });
+        pointPasses.restore();
+
         const renderTarget = renderer.createRenderTarget({
             label: 'Shadow integration target',
             width: 12,
@@ -217,13 +251,13 @@ describe('SharedRendererDriver shadow production wiring', () => {
         renderer.renderToTarget(renderTarget, scene, camera);
         await renderer.waitForIdle();
         expect(targetPasses.labels.filter(label => label.startsWith('Shadow atlas'))).toHaveLength(
-            8
+            0
         );
         expect(targetPasses.labels.at(-1)).toBe('Forward scene');
         expect(renderer.lightManager.shadowAtlas).toBe(atlasTexture);
         expect(diagnostics.snapshot().frame).toMatchObject({
-            draws: 9,
-            passes: 9,
+            draws: 1,
+            passes: 1,
             submissions: 1
         });
         targetPasses.restore();
@@ -294,7 +328,7 @@ describe('SharedRendererDriver shadow production wiring', () => {
         expect(bindingAfterRecovery?.textureView).toBe(viewHandle);
         expect(bindingAfterRecovery?.sampler).toBe(samplerHandle);
         expect(diagnostics.snapshot().frame).toMatchObject({
-            draws: 10,
+            draws: 18,
             passes: 10,
             submissions: 1
         });
@@ -315,7 +349,7 @@ describe('SharedRendererDriver shadow production wiring', () => {
         expect(renderer.lightManager.shadowAtlas).not.toBeNull();
         expect(renderer.lightManager.shadowAtlas).not.toBe(atlasTexture);
         expect(diagnostics.snapshot().frame).toMatchObject({
-            draws: 10,
+            draws: 18,
             passes: 10,
             submissions: 1
         });

--- a/test/ui/webgpu.spec.ts
+++ b/test/ui/webgpu.spec.ts
@@ -26,8 +26,8 @@ test('renders a real frame through WebGPU and Naga', async ({ page }) => {
         backend: 'webgpu',
         rhiExtensionBackend: 'webgpu',
         rhiSurfaceState: 'configured',
-        // Production RenderInfo includes the main pass plus directional, spot, and cube-shadow draws.
-        drawCount: 52,
+        // Static shadow slices are cached, so this frame contains only the main-scene draws.
+        drawCount: 4,
         faceCount: 60,
         hasShadowAtlas: true,
         shadowLightKinds: { directional: 1, point: 1, spot: 1 },


### PR DESCRIPTION
## Summary

- add a submission-aware stable shadow-atlas content cache with exact per-slice light and caster invalidation
- preserve clean atlas tiles and clear only dirty slices through portable depth-only scissored draws
- invalidate on allocation, recovery, caster transforms, geometry, material, texture, and deformation changes
- expose shadow-atlas cache diagnostics and update architecture, roadmap, README, and changelog documentation

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run docs:check`
- `npm run api:check`
- `npm run test:render:architecture` — 144 passed
- `npm run test:rhi` — portable 213 passed; native 3 passed, 1 skipped
- targeted shadow Vitest coverage
- `npm run test:webgpu` — 18 passed
- `npm run test:ui:webgl2` — contract 12 passed; browser 91 passed

## Scope boundary

This completes the first production S0 stable-atlas cache slice. GPU caster culling, receiver-driven update budgets, virtual shadow pages, and registered physical-GPU cross-commit performance evidence remain follow-up work. Full `npm run validate` and physical-GPU `npm run test:webgpu:native` were not run.