### PR TITLE
feat(render): add shadow atlas page residency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
   snapshots, scissored portable depth clears, per-slice invalidation, submission commit/rollback,
   recovery invalidation, and `RendererDiagnostics.caches.shadowAtlas`; static slices issue no shadow
   pass, while local-light changes redraw only their affected faces.
+- Extend S0 shadows with clustered GPU Scene caster culling and fixed-bucket indirect depth draws;
+  receiver-driven local/cascade resolution; deterministic slice budgets and 1/2/4/8-frame CSM
+  cadence; and submission-aware 128-pixel page residency with page-scissored updates. Expose page
+  request/update/defer/residency and budget-overflow counts in frame diagnostics. Arbitrary physical
+  page remapping, GPU receiver/depth requests, and directional clipmaps remain future work.
 - Complete the WebGPU high-end Clustered Forward+ P0 closure. Globally sorted compatible transparent
   PBR and direct GPU Scene skin, morph, and layered glTF PBR now consume the native storage light
   list, while mixed Transmission/custom/particle transparent queues fail closed to the shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@
   pass, while local-light changes redraw only their affected faces.
 - Extend S0 shadows with clustered GPU Scene caster culling and fixed-bucket indirect depth draws;
   receiver-driven local/cascade resolution; deterministic slice budgets and 1/2/4/8-frame CSM
-  cadence; and submission-aware 128-pixel page residency with page-scissored updates. Expose page
+  cadence; and submission-aware 128-pixel page residency with coalesced page-scissored updates that
+  avoid replaying the caster queue once per adjacent page. Expose page
   request/update/defer/residency and budget-overflow counts in frame diagnostics. Arbitrary physical
   page remapping, GPU receiver/depth requests, and directional clipmaps remain future work.
 - Complete the WebGPU high-end Clustered Forward+ P0 closure. Globally sorted compatible transparent

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -30,9 +30,10 @@ Draw、HDR/PBR、设备丢失恢复、严格帧事务、TAA/TAAU、GTAO、SSR、
    reactive mask 已落地；透明、transmission 与 GPU particle 已有隔离的 reactive/depth/history
    resurrection 策略。
 5. **阴影缓存与虚拟页**：共享 Shadow Atlas、CSM、Spot/Point shadow、Clustered surface
-   sampling，以及 submission-aware stable-slice 内容缓存、局部 scissored
-   clear 和刚体 caster/light 精确失效已完成；GPU caster cull、receiver-driven budget 与 virtual
-   shadow page residency 仍未完成。
+   sampling、submission-aware stable-slice 内容缓存、GPU Scene caster cull、receiver-driven
+   resolution/update budget、CSM cadence，以及固定 atlas 内的 submission-aware page
+   residency 已完成；GPU receiver/depth request、任意 physical-page remap/page table 与 directional
+   clipmap 仍未完成。
 6. **现代资源与几何虚拟化**：GPU Scene 已有 projected-radius bucket LOD，但仍没有 meshlet/cluster
    geometry streaming、KTX 2/Basis、mip
    residency、虚拟纹理或虚拟阴影页系统；SSGI 已覆盖屏幕内漫反射传输，off-screen probe/software-BVH
@@ -113,21 +114,21 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 
 ## 2. 当前渲染能力基线
 
-| 领域                                 | 当前状态          | 证据与边界                                                                                                                                                                       |
-| ------------------------------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Shared Renderer / Render Graph / RHI | 生产可用          | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                                                                        |
-| Raster PBR / HDR                     | 生产可用          | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                                             |
-| Shadow                               | 生产缓存首版      | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow、PCF 与 stable-slice 内容缓存；Clustered opaque surface 复用同一 atlas，仍缺 GPU caster cull、receiver-driven 分配和虚拟页      |
-| Compute / Storage / Indirect         | 底座生产可用      | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                                        |
-| Material architecture                | high-end P0 完成  | Definition/Instance、语义 Pass、共享 PBR GPU record，以及 variant manifest、异步 warmup、预算和诊断已落地；更多 family 按需扩展                                                  |
-| GPU-driven ordinary scene            | high-end P0 完成  | opaque/alpha-mask 走固定 bucket indirect；skin/morph/layered PBR 走 GPU Scene direct storage lane；兼容透明保留全局排序并消费 clustered light list                               |
-| Forward+                             | high-end P0 完成  | 3D cluster、有界预算、storage GGX PBR、共享 shadow/LTC、透明/变形/layered consumer、analytic cookie/IES 与 uint32 light-layer ABI 已闭环                                         |
-| Temporal rendering                   | high-end P0 完成  | opaque TAAU、GPU-time dynamic resolution、authored reactive，以及透明/transmission/GPU-particle 独立 short history 与 resurrection 已完成                                        |
-| Exposure / display transform         | WebGPU 生产切片   | 独立 Forward `AutoExposure` 与 Clustered 集成都具备 GPU histogram、asymmetric eye adaptation、submission-aware history；`ColorUber` 有参数化 filmic，Clustered 有 compact filmic |
-| Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；透明/离屏几何不参与 trace，probe/BVH fallback 待 GI0                                                  |
-| Volumetrics / atmosphere             | high-end 生产切片 | WebGPU Clustered froxel、height/local fog、screen-space caster visibility、physical atmosphere LUT、aerial perspective、temporal clouds，以及 surface/froxel cloud shadow 已落地 |
-| Geometry / texture streaming         | 仅 bucket LOD     | GPU Scene 已有 projected-radius geometry bucket LOD；没有 meshlet/cluster streaming、KTX 2/Basis 或 mip residency，KTX loader 仅支持 KTX 1.1 单面 2D 容器                        |
-| GPU profiling / graph debugging      | 生产基线          | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 且无内部 timing consumer 时不创建 query                                                 |
+| 领域                                 | 当前状态          | 证据与边界                                                                                                                                                                                                    |
+| ------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared Renderer / Render Graph / RHI | 生产可用          | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                                                                                                     |
+| Raster PBR / HDR                     | 生产可用          | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                                                                          |
+| Shadow                               | 生产缓存与固定页  | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow、PCF、stable-slice cache、Clustered GPU caster cull、receiver/budget/cadence 与固定物理页 residency；仍缺 GPU page request、任意 page-table remap 和 clipmap |
+| Compute / Storage / Indirect         | 底座生产可用      | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                                                                     |
+| Material architecture                | high-end P0 完成  | Definition/Instance、语义 Pass、共享 PBR GPU record，以及 variant manifest、异步 warmup、预算和诊断已落地；更多 family 按需扩展                                                                               |
+| GPU-driven ordinary scene            | high-end P0 完成  | opaque/alpha-mask 走固定 bucket indirect；skin/morph/layered PBR 走 GPU Scene direct storage lane；兼容透明保留全局排序并消费 clustered light list                                                            |
+| Forward+                             | high-end P0 完成  | 3D cluster、有界预算、storage GGX PBR、共享 shadow/LTC、透明/变形/layered consumer、analytic cookie/IES 与 uint32 light-layer ABI 已闭环                                                                      |
+| Temporal rendering                   | high-end P0 完成  | opaque TAAU、GPU-time dynamic resolution、authored reactive，以及透明/transmission/GPU-particle 独立 short history 与 resurrection 已完成                                                                     |
+| Exposure / display transform         | WebGPU 生产切片   | 独立 Forward `AutoExposure` 与 Clustered 集成都具备 GPU histogram、asymmetric eye adaptation、submission-aware history；`ColorUber` 有参数化 filmic，Clustered 有 compact filmic                              |
+| Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；透明/离屏几何不参与 trace，probe/BVH fallback 待 GI0                                                                               |
+| Volumetrics / atmosphere             | high-end 生产切片 | WebGPU Clustered froxel、height/local fog、screen-space caster visibility、physical atmosphere LUT、aerial perspective、temporal clouds，以及 surface/froxel cloud shadow 已落地                              |
+| Geometry / texture streaming         | 仅 bucket LOD     | GPU Scene 已有 projected-radius geometry bucket LOD；没有 meshlet/cluster streaming、KTX 2/Basis 或 mip residency，KTX loader 仅支持 KTX 1.1 单面 2D 容器                                                     |
+| GPU profiling / graph debugging      | 生产基线          | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 且无内部 timing consumer 时不创建 query                                                                              |
 
 ### 2.1 现有实现中最关键的限制
 
@@ -161,9 +162,11 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
   texture 仍只支持屏幕空间 transmission，不是离屏折射场景表示。
 - RHI 已有 timestamp QuerySet、pass timestamp、debug group/marker 和 Render Graph
   timeline；occlusion query 仍不在当前合同内。
-- 当前 Shadow Atlas 已有跨帧 stable-slice 内容缓存，但仍不是 virtual-page residency：GPU caster
-  cull、receiver-driven budget 和 page table 尚未落地；体积光也只使用 bounded screen-space caster
-  visibility 与 cloud shadow，尚未采样 shared shadow atlas。
+- 当前 Shadow Atlas 已有跨帧 stable-slice cache、Clustered GPU caster cull、receiver-driven
+  budget/cadence 和固定物理页 residency；但仍不是完整 Virtual Shadow Maps，因为 GPU receiver/depth
+  request、任意 physical-page remap/page table 与 directional
+  clipmap 尚未落地。体积光也只使用 bounded screen-space caster visibility 与 cloud
+  shadow，尚未采样 shared shadow atlas。
 - KTX loader 明确只解析 KTX 1.1、单 face 2D；没有 KTX 2、Basis Universal transcode、mip
   residency 或带宽预算。
 - 110k object / 256 light fixture 已验证 GPU-only 规模正确性、CPU record/GPU
@@ -219,22 +222,22 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 
 ## 5. 缺口优先级矩阵
 
-| ID   | 能力                                                                     | 优先级 | 当前状态                                         | 工作量 | 前置依赖                                      |
-| ---- | ------------------------------------------------------------------------ | ------ | ------------------------------------------------ | ------ | --------------------------------------------- |
-| F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                           | L      | 当前 Graph/RHI                                |
-| F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                           | M      | WebGPU compiler/RHI                           |
-| D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                           | L      | Camera/shader ABI                             |
-| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续               | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
-| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                                 | XL     | F0、D0；材质/变形扩展使用 MAT0                |
-| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                                 | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
-| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                                 | XL     | F0、D0、MAT0                                  |
-| E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                           | M      | F0、compute/storage；可独立于 T0 使用         |
-| Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0             | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
-| S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | stable-atlas 缓存首版完成；GPU cull/虚拟页未开始 | XL     | MAT0、G0、F0、F1                              |
-| V0   | Froxel volumetric fog/lighting/cloud foundation                          | P1     | 生产切片完成；atlas shadow/透明体积后续          | XL     | L0、F0；T0 可稳定最终边缘但非创建前置         |
-| A0   | KTX 2/Basis、mip residency、texture/geometry streaming budget            | P1     | 未开始                                           | XL     | F0、diagnostics                               |
-| M0   | Offline meshlet build、cluster LOD、GPU material bin、geometry streaming | P2     | 未开始；已有 bucket-level LOD 可复用             | XXL    | MAT0、G0、A0                                  |
-| GI0  | Screen/probe/software-BVH hybrid GI                                      | P2     | 屏幕内 SSGI 已完成；off-screen 层未开始          | XXL    | T0、Q0、G0、A0                                |
+| ID   | 能力                                                                     | 优先级 | 当前状态                                                | 工作量 | 前置依赖                                      |
+| ---- | ------------------------------------------------------------------------ | ------ | ------------------------------------------------------- | ------ | --------------------------------------------- |
+| F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                                  | L      | 当前 Graph/RHI                                |
+| F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                                  | M      | WebGPU compiler/RHI                           |
+| D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                                  | L      | Camera/shader ABI                             |
+| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续                      | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
+| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                                        | XL     | F0、D0；材质/变形扩展使用 MAT0                |
+| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                                        | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
+| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                                        | XL     | F0、D0、MAT0                                  |
+| E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                                  | M      | F0、compute/storage；可独立于 T0 使用         |
+| Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0                    | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
+| S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | 生产缓存与固定物理页首版完成；page-table/clipmap 未开始 | XL     | MAT0、G0、F0、F1                              |
+| V0   | Froxel volumetric fog/lighting/cloud foundation                          | P1     | 生产切片完成；atlas shadow/透明体积后续                 | XL     | L0、F0；T0 可稳定最终边缘但非创建前置         |
+| A0   | KTX 2/Basis、mip residency、texture/geometry streaming budget            | P1     | 未开始                                                  | XL     | F0、diagnostics                               |
+| M0   | Offline meshlet build、cluster LOD、GPU material bin、geometry streaming | P2     | 未开始；已有 bucket-level LOD 可复用                    | XXL    | MAT0、G0、A0                                  |
+| GI0  | Screen/probe/software-BVH hybrid GI                                      | P2     | 屏幕内 SSGI 已完成；off-screen 层未开始                 | XXL    | T0、Q0、G0、A0                                |
 
 `P0` 是“现代 WebGPU renderer”定义所需能力；`P1` 是高画质生产 profile；`P2`
 是依赖场景规模、内容管线和长期性能投入的虚拟化能力。
@@ -245,8 +248,9 @@ Database 已完成；G0/L0、T0、E0、Q0、V0/天气均已形成可运行的生
 timeline、确定的前后帧坐标 ABI、GPU Scene object/light database、共享 PBR material
 handle/variant、3D cluster allocator 与现有时域/屏幕空间 controller。P0 的透明、变形、完整 layered
 PBR、analytic cookie/IES、light-layer、variant
-warmup 和透明/粒子时域策略已收口；尚需在登记物理 GPU 上建立不可覆盖的跨提交性能基线。S0 已完成 stable-atlas 内容缓存首版，但 GPU
-caster cull、receiver budget 与虚拟页仍未开始；A0、M0 和 GI0 的 off-screen 层也尚未开始。详见
+warmup 和透明/粒子时域策略已收口；尚需在登记物理 GPU 上建立不可覆盖的跨提交性能基线。S0 已完成 stable-atlas
+cache、GPU caster cull、receiver budget/cadence 与固定物理页 residency；任意 page-table remap、GPU
+page request 和 clipmap 仍未开始。A0、M0 和 GI0 的 off-screen 层也尚未开始。详见
 [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 
 ## 6. 可落地工作包
@@ -613,7 +617,7 @@ off-screen GI 补偿属于 GI0，而不是未完成的 Q0。实现与上线证�
 这里推荐 GTAO/temporal AO，而不是补传统 SSAO；推荐 hierarchical SSR/temporal
 SSGI，而不是单帧固定步长 ray march。
 
-#### S0：现代阴影（生产缓存首版已完成；GPU cull / 虚拟页未开始）
+#### S0：现代阴影（生产缓存完成；固定物理页首版完成）
 
 ![S0：阴影缓存、脏页更新与虚拟阴影 Atlas](./images/modern-webgpu-roadmap/virtual-shadow-cache.jpg)
 
@@ -628,13 +632,19 @@ SSGI，而不是单帧固定步长 ray march。
 2. **虚拟阴影层**：directional clipmap/local-light virtual page table、depth/receiver 分析产生 page
    request、physical page allocation、per-page draw list、submission 后提交 residency。
 
-当前已交付第一层中的 stable atlas content cache、static/dynamic exact invalidation、slice-local
-scissored depth clear、submission commit/rollback、recovery invalidation 和
-`RendererDiagnostics.caches.shadowAtlas`。静态 slice 不再记录 Shadow Pass；移动 local
-light 只重绘对应 face，刚体 caster 用 shadow-camera bounds 把失效限制到相交 slice。geometry
-bounds 变化、skin/morph 目前保守失效相关全部 slice。GPU caster culling、receiver-driven
-resolution/update budget 和远近级更新频率仍是第一层剩余工作，不能由当前 CPU-side exact
-invalidation 冒充。
+第一层现已交付 stable atlas content cache、static/dynamic exact invalidation、slice-local scissored
+depth clear、submission commit/rollback、recovery invalidation、Clustered GPU Scene caster
+cull/indirect depth draw、receiver-driven resolution、确定性 update budget 和 1/2/4/8 CSM
+cadence。静态 slice 不再记录 Shadow Pass；移动 local light 只重绘对应 face，rigid GPU
+caster 不回读 visible count，不满足 GPU Scene 合同的 caster 保留共享 CPU fallback。geometry
+bounds 变化、skin/morph 仍保守失效相关全部 slice。
+
+第二层已交付固定 atlas 内的 128 像素页 residency 首版：dirty slice
+revision 分页请求，旧页在预算不足时继续有效，page-scissored
+clear/draw 与 residency 只在 submission 后提交，rollback 会确定重试；`RendererDiagnostics.frame.shadow*`
+暴露 request/update/defer/resident/overflow。这不是最终 virtual page table：页目前固定映射到 stable
+atlas，尚无 GPU receiver/depth request、任意 physical-page allocation/remap、directional
+clipmap，GPU caster cull 也仍以 slice frustum 保守生成每页 draw list。
 
 这里的 virtual shadow
 page 不等同于 SVT/RVT。SVT 是从磁盘按 tile 流送纹理，RVT 是运行时生成并缓存材质或地形 shading 数据；两者可以承载 lightmap 或 shadow
@@ -837,9 +847,10 @@ report、类型消费和 package 验证必须同版本完成。
   atmosphere/cloud/cloud-shadow 场景。**仍缺**：shared shadow-atlas volumetric
   sampling、透明介质参与和对应性能证据；
 - **Streaming 未有**：后续场景需覆盖低带宽冷启动、快速 teleport、取消、内存压力与 device loss；
-- **Shadow cache 已有首版**：单元/生产接线覆盖静态 hit、local-light face 局部失效、失败回滚、atlas
-  detach 与 recovery；**仍缺** GPU caster cull、receiver/update
-  budget、快速 camera 压力场景与 virtual page overflow。
+- **Shadow cache/固定页已有首版**：单元/生产接线覆盖静态 hit、local-light face 局部失效、GPU caster
+  cull、receiver/update budget、CSM cadence、page overflow、失败回滚、atlas
+  detach 与 recovery；**仍缺**快速 camera 物理 GPU 压力证据、GPU receiver/depth
+  request、任意 page-table remap 与 directional clipmap。
 
 不能把验收 example 的“算法跑通”当成 production baseline，也不能通过 CPU readback visible
 count 来驱动下一步 draw。功能完成必须同时回答：更少的 CPU work、更稳定的 GPU

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -87,11 +87,18 @@ bounds 变化、skin 和 morph 则保守失效全部相关 slice。脏 slice 通
 fullscreen triangle 在 viewport/scissor 内局部清理，Render Pass 使用 `load`
 保留其他 tile，避免整张 atlas clear 破坏缓存。内容 revision 只在有效 submission 后提交，graph
 build/prepare/execute 失败会回滚并在下一帧重试；atlas resize、detach、资源释放和 device/context
-recovery 都会明确失效。注册 `RendererDiagnostics` 后，`caches.shadowAtlas`
-提供累计 hit/miss/replacement/live-slice 观测。
+recovery 都会明确失效。Clustered GPU Scene 中的 rigid caster 由 compute 按 shadow
+slice 裁剪并写入固定 bucket indirect draw；不满足 GPU Scene 合同的 caster 仍走共享 CPU depth
+path。high-end profile 依据 receiver 覆盖缩放 local
+light 与远级联分辨率，以 1/2/4/8 帧 cadence 更新 CSM，并由确定性 slice/page
+budget 延后 caster-only 失效。每个 slice 再拆为 128 像素固定物理页，逐页 scissor 重绘；页 revision、residency 和失败回滚均在有效 submission 后提交，旧页在缺页期间继续提供确定内容。注册
+`RendererDiagnostics` 后，`caches.shadowAtlas`
+提供累计hit/miss/replacement/live-slice，`frame.shadow*` 提供 slice/page
+request、update、defer、resident 和 overflow 观测。
 
-这一切仍是稳定 tile 的生产缓存层，不宣称已经实现 GPU caster culling、receiver-driven
-budget 或 virtual shadow page table/residency。
+当前页层仍使用 stable atlas 内的固定物理映射；尚未实现 GPU receiver/depth page
+request、任意 physical-page remap/page table 或 directional clipmap，因此不宣称等价于完整 Virtual
+Shadow Maps。
 
 Sprite 仍是 Mesh：共享单位 quad、按 atlas Texture 共享 SpriteMaterial，先按 Node 级
 `sortingLayer / zIndex / stable scene traversal` 确定显示顺序，再仅对相邻兼容项合批，并把 UV

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -91,7 +91,7 @@ recovery 都会明确失效。Clustered GPU Scene 中的 rigid caster 由 comput
 slice 裁剪并写入固定 bucket indirect draw；不满足 GPU Scene 合同的 caster 仍走共享 CPU depth
 path。high-end profile 依据 receiver 覆盖缩放 local
 light 与远级联分辨率，以 1/2/4/8 帧 cadence 更新 CSM，并由确定性 slice/page
-budget 延后 caster-only 失效。每个 slice 再拆为 128 像素固定物理页，逐页 scissor 重绘；页 revision、residency 和失败回滚均在有效 submission 后提交，旧页在缺页期间继续提供确定内容。注册
+budget 延后 caster-only 失效。每个 slice 再拆为 128 像素固定物理页；同帧相邻 dirty 页先合并为 scissor 矩形再重绘，完整 slice 因此只重复录制一次 caster 队列。页 revision、residency 和失败回滚均在有效 submission 后提交，旧页在缺页期间继续提供确定内容。注册
 `RendererDiagnostics` 后，`caches.shadowAtlas`
 提供累计hit/miss/replacement/live-slice，`frame.shadow*` 提供 slice/page
 request、update、defer、resident 和 overflow 观测。

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -8159,7 +8159,7 @@ export interface RenderPipelineContext {
     readonly graph: ScriptableRenderGraph;
     readonly output: RenderPipelineOutput;
     prepareScene(): void;
-    recordShadows(cullingResults: CullingResultsHandle): Readonly<RenderPipelineShadowResources> | null;
+    recordShadows(cullingResults: CullingResultsHandle, options?: Readonly<RenderPipelineShadowOptions>): Readonly<RenderPipelineShadowResources> | null;
     readonly scene: RendererScene;
     readonly viewport: RendererViewport;
     writeStorageBuffer(buffer: StorageBuffer, byteOffset: number, data: ArrayBufferView): void;
@@ -8298,6 +8298,22 @@ export interface RenderPipelineRequirements {
 }
 
 // @public
+export interface RenderPipelineShadowOptions {
+    readonly excludeMeshes?: readonly Mesh[];
+}
+
+// @public
+export interface RenderPipelineShadowPageRegion {
+    readonly height: number;
+    readonly pageX: number;
+    readonly pageY: number;
+    readonly slicePhysicalIndex: number;
+    readonly width: number;
+    readonly x: number;
+    readonly y: number;
+}
+
+// @public
 export interface RenderPipelineShadowResources {
     readonly atlas: RenderGraphTextureHandle;
     readonly atlasRects: Float32Array;
@@ -8309,14 +8325,30 @@ export interface RenderPipelineShadowResources {
     readonly directionalCascadeSplits: Float32Array;
     readonly directionalLights: readonly DirectionalLight[];
     readonly directionalShadowCount: number;
+    readonly pageRegions: readonly Readonly<RenderPipelineShadowPageRegion>[];
     readonly pointBiases: Float32Array;
     readonly pointLights: readonly PointLight[];
     readonly pointMatrices: Float32Array;
     readonly pointShadowCount: number;
+    readonly slices: readonly Readonly<RenderPipelineShadowSlice>[];
     readonly spotBiases: Float32Array;
     readonly spotLights: readonly SpotLight[];
     readonly spotMatrices: Float32Array;
     readonly spotShadowCount: number;
+}
+
+// @public
+export interface RenderPipelineShadowSlice {
+    readonly cascade: number | null;
+    readonly dirty: boolean;
+    readonly face: number | null;
+    readonly far: number;
+    readonly kind: 'directional' | 'spot' | 'point';
+    readonly near: number;
+    readonly physicalIndex: number;
+    readonly sliceIndex: number;
+    readonly viewport: RendererViewport;
+    readonly viewProjectionMatrix: Float32Array;
 }
 
 // @public

--- a/examples/shadow_residency_sanctum.css
+++ b/examples/shadow_residency_sanctum.css
@@ -1,0 +1,383 @@
+:root {
+    color-scheme: dark;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        sans-serif;
+}
+
+body {
+    overflow: hidden;
+    color: #f1eee9;
+    background: #02030a;
+}
+
+.hilo3dStats {
+    display: none !important;
+}
+
+#container,
+#container canvas {
+    width: 100%;
+    height: 100%;
+}
+
+.sanctumHeader,
+.sanctumIntro,
+.sanctumConsole,
+.sanctumLegend,
+.sanctumHint,
+.sanctumCaption {
+    position: fixed;
+    z-index: 5;
+}
+
+.sanctumHeader {
+    top: clamp(24px, 3.6vw, 52px);
+    right: clamp(24px, 4.2vw, 68px);
+    left: clamp(24px, 4.2vw, 68px);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    pointer-events: none;
+}
+
+.sanctumHeader p,
+.sanctumCaption {
+    margin: 0;
+    color: rgb(226 234 255 / 32%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 8px;
+    letter-spacing: 0.21em;
+    text-transform: uppercase;
+}
+
+.sanctumBrand {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    color: rgb(247 242 234 / 88%);
+    font-size: 10px;
+    font-weight: 760;
+    letter-spacing: 0.22em;
+    text-decoration: none;
+    text-transform: uppercase;
+    pointer-events: auto;
+}
+
+.sanctumBrand span {
+    width: 24px;
+    height: 1px;
+    background: linear-gradient(90deg, #60ddff, #ec467b);
+    box-shadow: 0 0 18px rgb(84 208 255 / 72%);
+}
+
+.sanctumIntro {
+    top: 46%;
+    left: clamp(24px, 5vw, 82px);
+    width: min(330px, 27vw);
+    pointer-events: none;
+    transform: translateY(-50%);
+}
+
+.sanctumIntro::before {
+    position: absolute;
+    z-index: -1;
+    inset: -100px -110px -110px -80px;
+    background: radial-gradient(ellipse at 24% 52%, rgb(2 4 12 / 68%), transparent 69%);
+    content: '';
+}
+
+.sanctumEyebrow {
+    margin: 0 0 18px;
+    color: #79dcf4;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 8px;
+    font-weight: 690;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+}
+
+.sanctumIntro h1 {
+    margin: 0;
+    color: #efede9;
+    font-family: 'Iowan Old Style', 'Palatino Linotype', Georgia, serif;
+    font-size: clamp(54px, 5.8vw, 88px);
+    font-weight: 400;
+    letter-spacing: -0.085em;
+    line-height: 0.8;
+    text-shadow: 0 28px 90px rgb(0 0 0 / 82%);
+}
+
+.sanctumIntro h1 em {
+    display: inline-block;
+    margin-left: 0.28em;
+    color: rgb(238 169 128 / 86%);
+    font-weight: 400;
+}
+
+.sanctumDescription {
+    max-width: 286px;
+    margin: 25px 0 0;
+    color: rgb(231 229 225 / 48%);
+    font-size: 10px;
+    letter-spacing: 0.018em;
+    line-height: 1.82;
+}
+
+.sanctumConsole {
+    right: clamp(22px, 3.6vw, 54px);
+    bottom: clamp(22px, 3vw, 42px);
+    width: min(448px, 46vw);
+    overflow: hidden;
+    border: 1px solid rgb(203 221 255 / 12%);
+    border-radius: 15px;
+    background: linear-gradient(145deg, rgb(6 8 17 / 72%), rgb(11 8 17 / 58%));
+    box-shadow: 0 24px 80px rgb(0 0 0 / 52%);
+    backdrop-filter: blur(20px) saturate(125%);
+}
+
+.sanctumMetrics,
+.sanctumActions {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.sanctumMetrics {
+    border-bottom: 1px solid rgb(221 230 255 / 9%);
+}
+
+.sanctumMetrics div {
+    min-width: 0;
+    padding: 13px 14px 12px;
+    border-right: 1px solid rgb(221 230 255 / 7%);
+}
+
+.sanctumMetrics div:last-child {
+    border-right: 0;
+}
+
+.sanctumMetrics span,
+.sanctumActions small {
+    display: block;
+    margin-bottom: 5px;
+    color: rgb(213 225 250 / 31%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 7px;
+    font-weight: 580;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+}
+
+.sanctumMetrics strong,
+.sanctumActions strong {
+    color: rgb(245 241 235 / 84%);
+    font-size: 10px;
+    font-weight: 720;
+    letter-spacing: 0.085em;
+    text-transform: uppercase;
+}
+
+.sanctumActions {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.sanctumActions button {
+    position: relative;
+    min-height: 56px;
+    padding: 11px 12px 10px 40px;
+    border: 0;
+    border-right: 1px solid rgb(221 230 255 / 7%);
+    color: inherit;
+    background: transparent;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background 160ms ease;
+}
+
+.sanctumActions button:last-child {
+    border-right: 0;
+}
+
+.sanctumActions button:hover,
+.sanctumActions button:focus-visible {
+    background: rgb(103 168 255 / 8%);
+    outline: none;
+}
+
+.sanctumPulse,
+.sanctumRune {
+    position: absolute;
+    top: 21px;
+    left: 16px;
+    width: 9px;
+    height: 9px;
+    color: #7bdfff;
+}
+
+.sanctumPulse {
+    border-radius: 50%;
+    background: #7bdfff;
+    box-shadow: 0 0 15px rgb(88 216 255 / 88%);
+}
+
+#motionToggle[aria-pressed='false'] .sanctumPulse {
+    background: #6f7481;
+    box-shadow: none;
+}
+
+.sanctumRune {
+    top: 17px;
+    font-family: Georgia, serif;
+    font-size: 18px;
+    line-height: 1;
+}
+
+#veilToggle[aria-pressed='true'] .sanctumRune {
+    color: #f05283;
+    text-shadow: 0 0 16px rgb(240 65 121 / 78%);
+}
+
+.sanctumLegend {
+    top: 50%;
+    right: clamp(24px, 3.6vw, 54px);
+    display: grid;
+    width: 152px;
+    grid-template-columns: 22px 1fr;
+    align-items: center;
+    gap: 7px 8px;
+    pointer-events: none;
+    transform: translateY(-78%);
+}
+
+.sanctumLegend span {
+    color: rgb(116 217 246 / 65%);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 7px;
+}
+
+.sanctumLegend p {
+    margin: 0;
+    color: rgb(231 235 246 / 25%);
+    font-size: 8px;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+}
+
+.sanctumLegend i {
+    grid-column: 2;
+    width: 32px;
+    height: 1px;
+    margin: 1px 0 2px;
+    background: rgb(187 209 255 / 12%);
+}
+
+.sanctumHint {
+    bottom: clamp(28px, 4.2vw, 64px);
+    left: clamp(24px, 5vw, 82px);
+    margin: 0;
+    color: rgb(231 235 246 / 28%);
+    font-size: 8px;
+    letter-spacing: 0.07em;
+}
+
+.sanctumCaption {
+    top: 50%;
+    right: clamp(22px, 2vw, 34px);
+    writing-mode: vertical-rl;
+    opacity: 0.72;
+    transform: translateY(-50%);
+}
+
+.sanctumVeil,
+.sanctumGrain {
+    position: fixed;
+    z-index: 3;
+    inset: 0;
+    pointer-events: none;
+}
+
+.sanctumVeil {
+    background:
+        linear-gradient(
+            90deg,
+            rgb(1 2 8 / 32%),
+            transparent 29%,
+            transparent 84%,
+            rgb(1 2 8 / 24%)
+        ),
+        radial-gradient(circle at 56% 43%, transparent 28%, rgb(1 2 7 / 21%) 88%);
+}
+
+.sanctumGrain {
+    opacity: 0.2;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 160 160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.92' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.14'/%3E%3C/svg%3E");
+    mix-blend-mode: soft-light;
+}
+
+body[data-sanctum-ready='false'] .sanctumConsole,
+body[data-sanctum-ready='false'] .sanctumIntro,
+body[data-sanctum-ready='false'] .sanctumLegend {
+    opacity: 0;
+}
+
+body[data-sanctum-ready='true'] .sanctumConsole,
+body[data-sanctum-ready='true'] .sanctumIntro,
+body[data-sanctum-ready='true'] .sanctumLegend {
+    opacity: 1;
+    transition: opacity 900ms ease;
+}
+
+@media (max-width: 820px) {
+    .sanctumIntro {
+        top: 35%;
+        width: min(340px, 76vw);
+    }
+
+    .sanctumIntro h1 {
+        font-size: clamp(50px, 15vw, 78px);
+    }
+
+    .sanctumDescription,
+    .sanctumLegend,
+    .sanctumCaption {
+        display: none;
+    }
+
+    .sanctumConsole {
+        right: 18px;
+        bottom: 22px;
+        left: 18px;
+        width: auto;
+    }
+
+    .sanctumMetrics div {
+        padding: 12px 10px;
+    }
+
+    .sanctumActions button {
+        padding-left: 39px;
+    }
+
+    .sanctumPulse,
+    .sanctumRune {
+        left: 14px;
+    }
+
+    .sanctumHint {
+        display: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/examples/shadow_residency_sanctum.html
+++ b/examples/shadow_residency_sanctum.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0"
+        />
+        <meta
+            name="description"
+            content="A cinematic WebGPU shadow-page residency installation built with Hilo3D Clustered Forward+."
+        />
+        <title>Hilo3D Umbra Sanctum — Shadow Page Residency</title>
+        <link rel="stylesheet" href="./example.css" />
+        <link rel="stylesheet" href="./shadow_residency_sanctum.css" />
+    </head>
+    <body data-sanctum-phase="loading" data-sanctum-ready="false">
+        <div id="container"></div>
+        <div class="sanctumVeil" aria-hidden="true"></div>
+        <div class="sanctumGrain" aria-hidden="true"></div>
+
+        <header class="sanctumHeader">
+            <a href="./index.html" class="sanctumBrand" aria-label="Back to Hilo3D examples">
+                <span></span>Hilo3D
+            </a>
+            <p>shadow residency study · 07</p>
+        </header>
+
+        <main class="sanctumIntro">
+            <p class="sanctumEyebrow">Clustered Forward+ · fixed physical pages</p>
+            <h1>Umbra<br /><em>Sanctum</em></h1>
+            <p class="sanctumDescription">
+                Twelve votive blades keep a measured orbit around an impossible moon. Their moving
+                penumbrae cross a page-budgeted atlas while the nave keeps its memory of darkness.
+            </p>
+        </main>
+
+        <section class="sanctumConsole" aria-label="Shadow residency controls">
+            <div class="sanctumMetrics">
+                <div><span>budget / demand</span><strong id="pageMetric">—</strong></div>
+                <div><span>resident</span><strong id="residentMetric">—</strong></div>
+                <div><span>deferred</span><strong id="deferredMetric">—</strong></div>
+                <div><span>backend</span><strong id="backendMetric">—</strong></div>
+            </div>
+            <div class="sanctumActions">
+                <button id="motionToggle" type="button" aria-pressed="true">
+                    <span class="sanctumPulse"></span>
+                    <small>caster field</small><strong id="motionLabel">kinetic</strong>
+                </button>
+                <button id="veilToggle" type="button" aria-pressed="false">
+                    <span class="sanctumRune">◒</span>
+                    <small>layer witness</small><strong id="veilLabel">excluded</strong>
+                </button>
+                <button id="viewButton" type="button">
+                    <span class="sanctumRune">↗</span>
+                    <small>composition</small><strong>next view</strong>
+                </button>
+            </div>
+        </section>
+
+        <aside class="sanctumLegend">
+            <span>01</span>
+            <p>caster cadence</p>
+            <i></i>
+            <span>02</span>
+            <p>fair page circulation</p>
+            <i></i>
+            <span>03</span>
+            <p>camera-layer isolation</p>
+        </aside>
+
+        <p class="sanctumHint">Drag to orbit · wheel to cross the threshold</p>
+        <p class="sanctumCaption">Procedural geometry · live GPU culling · no baked shadows</p>
+
+        <script type="module" src="./shadow_residency_sanctum.ts"></script>
+    </body>
+</html>

--- a/examples/shadow_residency_sanctum.ts
+++ b/examples/shadow_residency_sanctum.ts
@@ -1,0 +1,589 @@
+import * as Hilo3d from '../src/Hilo3d';
+import {
+    registerRendererDiagnostics,
+    unregisterRendererDiagnostics
+} from '../src/render/diagnostics/RendererDiagnosticsRegistry';
+
+interface SanctumEvidence {
+    readonly backend: 'webgpu';
+    readonly movingCasters: number;
+    readonly shadowRequestedPages: number;
+    readonly shadowUpdatedPages: number;
+    readonly shadowDeferredPages: number;
+    readonly shadowResidentPages: number;
+    readonly hiddenLayerEnabled: boolean;
+    readonly drawCount: number;
+}
+
+const TAU = Math.PI * 2;
+const DEFAULT_LAYER = 1;
+const VEILED_LAYER = 2;
+const search = new URLSearchParams(location.search);
+const testMode = search.get('test') === '1';
+const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+function requireElement<ElementType extends HTMLElement>(
+    selector: string,
+    constructor: new () => ElementType
+): ElementType {
+    const element = document.querySelector(selector);
+    if (!(element instanceof constructor)) throw new Error(`Umbra Sanctum is missing ${selector}`);
+    return element;
+}
+
+const container = requireElement('#container', HTMLElement);
+const pageMetric = requireElement('#pageMetric', HTMLElement);
+const residentMetric = requireElement('#residentMetric', HTMLElement);
+const deferredMetric = requireElement('#deferredMetric', HTMLElement);
+const backendMetric = requireElement('#backendMetric', HTMLElement);
+const motionToggle = requireElement('#motionToggle', HTMLButtonElement);
+const motionLabel = requireElement('#motionLabel', HTMLElement);
+const veilToggle = requireElement('#veilToggle', HTMLButtonElement);
+const veilLabel = requireElement('#veilLabel', HTMLElement);
+const viewButton = requireElement('#viewButton', HTMLButtonElement);
+
+const canvas = document.createElement('canvas');
+canvas.setAttribute('aria-label', 'Umbra Sanctum WebGPU shadow residency installation');
+const rendererDiagnostics = registerRendererDiagnostics(canvas);
+
+const boxGeometry = new Hilo3d.BoxGeometry();
+const sphereGeometry = new Hilo3d.SphereGeometry({
+    radius: 1,
+    widthSegments: testMode ? 20 : 36,
+    heightSegments: testMode ? 12 : 22
+});
+
+type MaterialOptions = ConstructorParameters<typeof Hilo3d.PBRMaterial>[0];
+function material(options: MaterialOptions): Hilo3d.PBRMaterial {
+    return new Hilo3d.PBRMaterial(options);
+}
+
+const voidStone = material({
+    baseColor: new Hilo3d.Color(0.02, 0.026, 0.042),
+    metallic: 0.42,
+    roughness: 0.28
+});
+const wetBasalt = material({
+    baseColor: new Hilo3d.Color(0.018, 0.026, 0.04),
+    metallic: 0.3,
+    roughness: 0.4
+});
+const alabaster = material({
+    baseColor: new Hilo3d.Color(0.7, 0.62, 0.51),
+    metallic: 0.02,
+    roughness: 0.58
+});
+const oldGold = material({
+    baseColor: new Hilo3d.Color(0.62, 0.31, 0.07),
+    metallic: 0.84,
+    roughness: 0.34,
+    emission: new Hilo3d.Color(0.82, 0.16, 0.018),
+    emissionFactor: new Hilo3d.Color(0.038, 0.008, 0.001)
+});
+const lunar = material({
+    baseColor: new Hilo3d.Color(0.48, 0.62, 0.82),
+    metallic: 0.08,
+    roughness: 0.28,
+    emission: new Hilo3d.Color(0.22, 0.55, 1),
+    emissionFactor: new Hilo3d.Color(0.22, 1.3, 3.9)
+});
+const roseFire = material({
+    baseColor: new Hilo3d.Color(0.68, 0.04, 0.16),
+    metallic: 0.12,
+    roughness: 0.24,
+    emission: new Hilo3d.Color(1, 0.035, 0.18),
+    emissionFactor: new Hilo3d.Color(5.8, 0.12, 0.72)
+});
+const cyanFire = material({
+    baseColor: new Hilo3d.Color(0.025, 0.44, 0.55),
+    metallic: 0.08,
+    roughness: 0.22,
+    emission: new Hilo3d.Color(0.025, 0.74, 1),
+    emissionFactor: new Hilo3d.Color(0.08, 3.6, 6.2)
+});
+const materials = [voidStone, wetBasalt, alabaster, oldGold, lunar, roseFire, cyanFire] as const;
+const buckets: Hilo3d.GPUSceneBucket[] = [];
+for (const geometry of [boxGeometry, sphereGeometry] as const) {
+    for (const bucketMaterial of materials) {
+        buckets.push(Object.freeze({ geometry, material: bucketMaterial }));
+    }
+}
+
+const pipeline = new Hilo3d.ClusteredForwardPlusPipelineFactory({
+    buckets,
+    maxObjects: 256,
+    maxLights: 48,
+    maxLightIndices: 131_072,
+    maxLightsPerCluster: 48,
+    tileSize: 32,
+    zSlices: 20,
+    maxViewportWidth: testMode ? 960 : 2560,
+    maxViewportHeight: testMode ? 600 : 1440,
+    hiZ: true,
+    temporalAA: {
+        renderScale: testMode ? 0.6 : 0.94,
+        historyWeight: 0.93,
+        depthThreshold: 0.022,
+        varianceGamma: 1.18,
+        sharpness: 0.14
+    },
+    groundTruthAmbientOcclusion: {
+        resolutionScale: testMode ? 0.25 : 0.5,
+        radius: 2.5,
+        directionCount: testMode ? 4 : 8,
+        stepCount: testMode ? 3 : 5,
+        power: 1.18
+    },
+    screenSpaceReflections: {
+        resolutionScale: testMode ? 0.5 : 1,
+        maxRayDistance: 28,
+        thickness: 0.18,
+        stride: 0.08,
+        maxSteps: testMode ? 32 : 80,
+        roughnessCutoff: 0.48,
+        edgeFade: 0.16,
+        historyWeight: 0.94,
+        depthThreshold: 0.032,
+        intensity: 0.58
+    },
+    volumetricLighting: {
+        quality: testMode ? 'low' : 'high',
+        resolutionScale: testMode ? 0.25 : 0.5,
+        shadowSteps: testMode ? 1 : 2,
+        density: 0.0054,
+        baseHeight: -0.6,
+        heightFalloff: 0.065,
+        maxDistance: 48,
+        albedo: new Hilo3d.Color(0.68, 0.78, 1),
+        anisotropy: 0.38,
+        ambientStrength: 0.045,
+        jitterStrength: 0.62,
+        historyWeight: 0.93,
+        depthThreshold: 0.038,
+        localVolumes: [
+            {
+                shape: 'box',
+                center: new Hilo3d.Vector3(0, 3.4, -3),
+                halfExtents: new Hilo3d.Vector3(10, 4.5, 13),
+                density: 0.0065,
+                edgeFalloff: 0.24,
+                albedo: new Hilo3d.Color(0.5, 0.65, 1)
+            },
+            {
+                shape: 'sphere',
+                center: new Hilo3d.Vector3(-4.8, 2.8, -4),
+                radius: 4.6,
+                density: 0.009,
+                edgeFalloff: 0.46,
+                albedo: new Hilo3d.Color(0.18, 0.78, 1)
+            },
+            {
+                shape: 'sphere',
+                center: new Hilo3d.Vector3(5.1, 3.2, -6),
+                radius: 4.4,
+                density: 0.0085,
+                edgeFalloff: 0.44,
+                albedo: new Hilo3d.Color(1, 0.14, 0.38)
+            }
+        ]
+    },
+    bloomStrength: 0.58,
+    exposure: 1.08
+});
+
+const width = testMode ? 960 : Math.max(innerWidth, 1);
+const height = testMode ? 600 : Math.max(innerHeight, 1);
+const camera = new Hilo3d.PerspectiveCamera({
+    aspect: width / height,
+    fov: 40,
+    near: 0.06,
+    far: 90,
+    depthMode: 'reversed',
+    visibility: DEFAULT_LAYER
+});
+
+document.body.dataset['sanctumPhase'] = 'creating-stage';
+const stage = await Hilo3d.Stage.create<'webgpu'>({
+    backend: 'webgpu',
+    container,
+    canvas,
+    camera,
+    width,
+    height,
+    pixelRatio: testMode ? 1 : Math.min(devicePixelRatio, 1.5),
+    antialias: false,
+    alpha: false,
+    clearColor: new Hilo3d.Color(0.0015, 0.002, 0.007),
+    useInstanced: true,
+    renderingProfile: 'high-end',
+    renderPipeline: pipeline
+});
+
+function box(
+    selectedMaterial: Hilo3d.PBRMaterial,
+    position: readonly [number, number, number],
+    scale: readonly [number, number, number],
+    rotation: readonly [number, number, number] = [0, 0, 0],
+    layer = DEFAULT_LAYER
+): Hilo3d.Mesh {
+    return new Hilo3d.Mesh({
+        geometry: boxGeometry,
+        material: selectedMaterial,
+        x: position[0],
+        y: position[1],
+        z: position[2],
+        scaleX: scale[0],
+        scaleY: scale[1],
+        scaleZ: scale[2],
+        rotationX: rotation[0],
+        rotationY: rotation[1],
+        rotationZ: rotation[2],
+        layer,
+        castShadows: true,
+        receiveShadows: true,
+        pointerEnabled: false
+    }).addTo(stage);
+}
+
+function sphere(
+    selectedMaterial: Hilo3d.PBRMaterial,
+    position: readonly [number, number, number],
+    radius: number,
+    layer = DEFAULT_LAYER
+): Hilo3d.Mesh {
+    return new Hilo3d.Mesh({
+        geometry: sphereGeometry,
+        material: selectedMaterial,
+        x: position[0],
+        y: position[1],
+        z: position[2],
+        scaleX: radius,
+        scaleY: radius,
+        scaleZ: radius,
+        layer,
+        castShadows: true,
+        receiveShadows: true,
+        pointerEnabled: false
+    }).addTo(stage);
+}
+
+document.body.dataset['sanctumPhase'] = 'building-installation';
+box(wetBasalt, [0, -0.34, -3], [16, 0.42, 27]);
+box(voidStone, [0, 0.01, -5.5], [7.8, 0.16, 18]);
+box(oldGold, [-1.34, 0.12, -4.5], [0.055, 0.025, 16]);
+box(oldGold, [1.34, 0.12, -4.5], [0.055, 0.025, 16]);
+for (let step = 0; step < 7; step += 1) {
+    box(
+        step % 2 === 0 ? alabaster : oldGold,
+        [0, 0.12 + step * 0.12, -9.2 - step * 0.68],
+        [4.8 - step * 0.32, 0.11, 0.94]
+    );
+}
+for (const side of [-1, 1] as const) {
+    for (let bay = 0; bay < 6; bay += 1) {
+        const z = 3.5 - bay * 3.55;
+        box(voidStone, [side * 8.35, 3.2, z], [0.82, 6.6, 0.92]);
+        box(alabaster, [side * 7.2, 2.75, z], [0.32, 5.5, 0.56]);
+        box(oldGold, [side * 6.86, 2.82, z], [0.07, 4.65, 0.62]);
+    }
+}
+for (let rib = 0; rib < 6; rib += 1) {
+    box(oldGold, [0, 7.35, 3.5 - rib * 3.55], [14.4, 0.09, 0.16]);
+}
+
+const haloCenter: readonly [number, number, number] = [0, 3.45, -13.35];
+box(oldGold, haloCenter, [0.11, 5.2, 0.13], [0, 0, 45]);
+box(oldGold, haloCenter, [0.11, 5.2, 0.13], [0, 0, -45]);
+for (let segment = 0; segment < 52; segment += 1) {
+    const angle = (segment / 52) * TAU;
+    box(
+        segment % 6 === 0 ? lunar : oldGold,
+        [
+            haloCenter[0] + Math.cos(angle) * 3.05,
+            haloCenter[1] + Math.sin(angle) * 3.05,
+            haloCenter[2]
+        ],
+        [0.08, segment % 6 === 0 ? 0.42 : 0.28, 0.1],
+        [0, 0, -(angle * 180) / Math.PI]
+    );
+}
+sphere(voidStone, [0, 3.45, -13.55], 2.12);
+sphere(lunar, [0, 3.45, -11.45], 0.78);
+box(oldGold, [0, 1.42, -13.15], [0.34, 2.5, 0.34], [0, 0, 45]);
+box(oldGold, [0, 1.42, -13.15], [0.34, 2.5, 0.34], [0, 0, -45]);
+
+for (const side of [-1, 1] as const) {
+    for (let lantern = 0; lantern < 3; lantern += 1) {
+        const z = -2.5 - lantern * 3.55;
+        const x = side * (4.25 - lantern * 0.24);
+        sphere(side < 0 ? cyanFire : roseFire, [x, 0.82, z], 0.17);
+        box(alabaster, [x, 0.28, z], [0.48, 0.54, 0.48]);
+        box(oldGold, [x, 0.6, z], [0.11, 0.36, 0.11]);
+    }
+}
+
+const movingCasters: Hilo3d.Mesh[] = [];
+for (let index = 0; index < 12; index += 1) {
+    const angle = (index / 12) * TAU;
+    const caster = box(
+        index % 4 === 0 ? lunar : index % 2 === 0 ? alabaster : oldGold,
+        [
+            haloCenter[0] + Math.cos(angle) * 3.72,
+            haloCenter[1] + Math.sin(angle) * 2.72,
+            -11.95 + Math.sin(angle * 2) * 0.24
+        ],
+        [0.19, index % 3 === 0 ? 1.62 : 1.34, 0.34],
+        [0, Math.sin(angle) * 12, -(angle * 180) / Math.PI]
+    );
+    movingCasters.push(caster);
+}
+
+// This caster is deliberately outside the active camera layer. Its long, high silhouette is kept
+// outside the hero framing while its projected shadow crosses the nave when the veil is enabled.
+const veiledCaster = box(voidStone, [-8.9, 7.8, -8], [3.2, 4.8, 1.8], [0, 20, -16], VEILED_LAYER);
+veiledCaster.name = 'Veiled layer shadow witness';
+
+// A boundary-crossing blade explicitly disables CPU/GPU frustum tests. Its center sits beyond the
+// fitted slice edge while the long geometry still reaches the visible floor.
+const unboundedBlade = box(oldGold, [8.85, 5.6, -12], [0.11, 4.8, 0.42], [0, 0, 18]);
+unboundedBlade.frustumTest = false;
+unboundedBlade.name = 'Unbounded frustum witness';
+
+new Hilo3d.AmbientLight({
+    color: new Hilo3d.Color(0.14, 0.22, 0.4),
+    amount: 0.3
+}).addTo(stage);
+new Hilo3d.DirectionalLight({
+    color: new Hilo3d.Color(0.72, 0.82, 1),
+    amount: 3.9,
+    direction: new Hilo3d.Vector3(0.48, -1, 0.26),
+    shadow: {
+        width: 1024,
+        height: 1024,
+        minBias: 0.00018,
+        maxBias: 0.0024,
+        cascadeCount: 4,
+        cascadeSplitLambda: 0.62,
+        cascadeMaxDistance: 64,
+        cascadeBlend: 0.13,
+        stabilizeCascades: true,
+        shadowStrength: 1.35
+    }
+}).addTo(stage);
+
+const lightPlan = [
+    [-4.6, 3.5, -5.5, 0.03, 0.46, 1, 6.6],
+    [4.8, 3.8, -8.5, 1, 0.025, 0.16, 7],
+    [0, 4.2, -12, 0.25, 0.38, 1, 7.2]
+] as const;
+for (const [x, y, z, red, green, blue, amount] of lightPlan) {
+    new Hilo3d.PointLight({
+        x,
+        y,
+        z,
+        color: new Hilo3d.Color(red, green, blue),
+        amount,
+        range: 10
+    }).addTo(stage);
+}
+
+const shadowSpotPlan = [
+    [-5.6, 6.8, -1.5, 0.08, 0.62, 1],
+    [5.8, 6.4, -10.5, 1, 0.04, 0.22]
+] as const;
+for (const [x, y, z, red, green, blue] of shadowSpotPlan) {
+    new Hilo3d.SpotLight({
+        x,
+        y,
+        z,
+        color: new Hilo3d.Color(red, green, blue),
+        direction: new Hilo3d.Vector3(-x, 1.1 - y, -7 - z).normalize(),
+        amount: 6.2,
+        range: 24,
+        cutoff: 27,
+        outerCutoff: 36,
+        shadow: {
+            width: 512,
+            height: 512,
+            minBias: 0.00022,
+            maxBias: 0.0032
+        }
+    }).addTo(stage);
+}
+
+const controls = new Hilo3d.OrbitControls(stage, {
+    camera,
+    target: new Hilo3d.Vector3(0, 2.55, -8.4),
+    enablePan: false,
+    minDistance: 7,
+    maxDistance: 28,
+    minPolarAngle: Math.PI * 0.2,
+    maxPolarAngle: Math.PI * 0.7,
+    rotateSpeed: 0.58,
+    zoomSpeed: 0.78
+});
+const views = [
+    {
+        position: new Hilo3d.Vector3(2.15, 4.85, 16.8),
+        target: new Hilo3d.Vector3(0, 2.65, -9.2)
+    },
+    {
+        position: new Hilo3d.Vector3(-5.2, 4.65, 7.2),
+        target: new Hilo3d.Vector3(0, 3.1, -11.2)
+    },
+    {
+        position: new Hilo3d.Vector3(1.2, 8.1, 11.4),
+        target: new Hilo3d.Vector3(0, 1.45, -7.2)
+    }
+] as const;
+let viewIndex = 0;
+controls.setView(views[0].position, views[0].target);
+
+let elapsed = 0;
+let motionEnabled = !reducedMotion;
+let veilEnabled = false;
+const animation: Hilo3d.Tickable = {
+    tick(deltaTime): void {
+        if (!motionEnabled) return;
+        elapsed += Math.min(deltaTime, 50) / 1000;
+        for (let index = 0; index < movingCasters.length; index += 1) {
+            const caster = movingCasters[index];
+            if (caster === undefined) continue;
+            const phase = (index / movingCasters.length) * TAU;
+            const orbit = elapsed * (0.1 + (index % 3) * 0.008) + phase;
+            caster.x = haloCenter[0] + Math.cos(orbit) * 3.72;
+            caster.y = haloCenter[1] + Math.sin(orbit) * 2.72;
+            caster.z = -11.95 + Math.sin(orbit * 2) * 0.24;
+            caster.rotationX = Math.sin(orbit * 1.7) * 7;
+            caster.rotationY = Math.cos(orbit) * 12;
+            caster.rotationZ = -(orbit * 180) / Math.PI + Math.sin(elapsed * 0.45 + phase) * 5;
+        }
+    }
+};
+
+const ticker = new Hilo3d.Ticker(60);
+ticker.addTick(animation);
+ticker.addTick(stage);
+
+function updateControls(): void {
+    motionToggle.setAttribute('aria-pressed', String(motionEnabled));
+    motionLabel.textContent = motionEnabled ? 'kinetic' : 'held';
+    veilToggle.setAttribute('aria-pressed', String(veilEnabled));
+    veilLabel.textContent = veilEnabled ? 'revealed' : 'excluded';
+}
+
+function updateMetrics(): SanctumEvidence {
+    const frame = rendererDiagnostics.snapshot().frame;
+    peakRequestedPages = Math.max(peakRequestedPages, frame.shadowRequestedPages);
+    peakUpdatedPages = Math.max(peakUpdatedPages, frame.shadowUpdatedPages);
+    peakDeferredPages = Math.max(peakDeferredPages, frame.shadowDeferredPages);
+    pageMetric.textContent = `${String(peakUpdatedPages)} / ${String(peakRequestedPages)}`;
+    residentMetric.textContent = String(frame.shadowResidentPages);
+    deferredMetric.textContent = String(peakDeferredPages);
+    backendMetric.textContent = stage.renderer.backend.toUpperCase();
+    const evidence: SanctumEvidence = {
+        backend: 'webgpu',
+        movingCasters: movingCasters.length,
+        shadowRequestedPages: frame.shadowRequestedPages,
+        shadowUpdatedPages: frame.shadowUpdatedPages,
+        shadowDeferredPages: frame.shadowDeferredPages,
+        shadowResidentPages: frame.shadowResidentPages,
+        hiddenLayerEnabled: veilEnabled,
+        drawCount: stage.renderer.renderInfo.drawCount
+    };
+    window.__HILO3D_SHADOW_SANCTUM_RESULT__ = evidence;
+    return evidence;
+}
+
+let peakRequestedPages = 0;
+let peakUpdatedPages = 0;
+let peakDeferredPages = 0;
+const diagnosticsAnimation: Hilo3d.Tickable = {
+    tick(): void {
+        updateMetrics();
+    }
+};
+ticker.addTick(diagnosticsAnimation);
+
+async function stepFrames(frameCount: number): Promise<SanctumEvidence> {
+    for (let frame = 0; frame < frameCount; frame += 1) {
+        if (testMode) animation.tick(1000 / 60);
+        stage.tick(1000 / 60);
+        await stage.renderer.waitForIdle();
+    }
+    return updateMetrics();
+}
+
+async function setVeil(value: boolean): Promise<SanctumEvidence> {
+    veilEnabled = value;
+    camera.visibility = value ? DEFAULT_LAYER | VEILED_LAYER : DEFAULT_LAYER;
+    updateControls();
+    return stepFrames(value ? 4 : 3);
+}
+
+motionToggle.addEventListener('click', () => {
+    motionEnabled = !motionEnabled;
+    updateControls();
+});
+veilToggle.addEventListener('click', () => void setVeil(!veilEnabled));
+viewButton.addEventListener('click', () => {
+    viewIndex = (viewIndex + 1) % views.length;
+    const view = views[viewIndex];
+    if (view === undefined) throw new Error('Umbra Sanctum view archive is incomplete');
+    controls.setView(view.position, view.target);
+});
+
+const resize = (): void => {
+    if (testMode) return;
+    const nextWidth = Math.max(innerWidth, 1);
+    const nextHeight = Math.max(innerHeight, 1);
+    camera.aspect = nextWidth / nextHeight;
+    stage.resize(nextWidth, nextHeight, Math.min(devicePixelRatio, 1.5));
+};
+window.addEventListener('resize', resize);
+
+updateControls();
+document.body.dataset['sanctumPhase'] = 'warming-shadow-pages';
+await stepFrames(testMode ? 6 : 4);
+window.__HILO3D_SHADOW_SANCTUM_TEST_API__ = {
+    async settle(frames = 8): Promise<SanctumEvidence> {
+        return stepFrames(frames);
+    },
+    async setMotion(value: boolean): Promise<SanctumEvidence> {
+        motionEnabled = value;
+        updateControls();
+        return stepFrames(2);
+    },
+    setVeil,
+    async nextView(): Promise<SanctumEvidence> {
+        viewButton.click();
+        return stepFrames(4);
+    }
+};
+document.body.dataset['sanctumReady'] = 'true';
+document.body.dataset['sanctumPhase'] = 'ready';
+if (!testMode) ticker.start();
+
+window.addEventListener(
+    'pagehide',
+    () => {
+        window.removeEventListener('resize', resize);
+        ticker.stop();
+        controls.dispose();
+        unregisterRendererDiagnostics(canvas, rendererDiagnostics);
+        stage.destroy();
+    },
+    { once: true }
+);
+
+declare global {
+    interface Window {
+        __HILO3D_SHADOW_SANCTUM_RESULT__?: SanctumEvidence;
+        __HILO3D_SHADOW_SANCTUM_TEST_API__?: Readonly<{
+            settle(frames?: number): Promise<SanctumEvidence>;
+            setMotion(value: boolean): Promise<SanctumEvidence>;
+            setVeil(value: boolean): Promise<SanctumEvidence>;
+            nextView(): Promise<SanctumEvidence>;
+        }>;
+    }
+}

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -107,6 +107,7 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'clustered_forward_plus_sponza.html': 'Sponza Clustered Forward+ Lighting Lab',
     'volumetric_neon_reliquary.html': 'Neon Reliquary — Froxel Volumetric Lighting',
     'stormfront_observatory.html': 'Tempest Reliquary — Physical Atmosphere',
+    'shadow_residency_sanctum.html': 'Umbra Sanctum — Shadow Page Residency',
     'screen_space_reflections_palace.html': 'Afterimage — Screen-space Reflections',
     'screen_space_global_illumination_chapel.html':
         'Prismatic Vespers — Screen-space Global Illumination',
@@ -145,6 +146,8 @@ const DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
         'Enter Khronos Sponza as a neon reliquary where temporal froxels, local fog volumes, clustered spotlights, and depth-aware visibility turn light into architecture.',
     'stormfront_observatory.html':
         'Unseal a gilded Khronos dragon beneath a Rayleigh–Mie–ozone storm sky with GPU histogram exposure, temporal half-resolution clouds, cloud shadows, aerial perspective, and froxel light shafts.',
+    'shadow_residency_sanctum.html':
+        'Enter a procedural moonlit nave where moving GPU Scene casters, fair page circulation, camera-layer isolation, CSM cadence, volumetric shafts, SSR, GTAO, and bloom exercise submission-aware shadow residency.',
     'screen_space_reflections_palace.html':
         'Stage the Khronos Car Concept in a seamless smoked-lacquer studio with hierarchical ray tracing, confidence filtering, and temporal reflection resolve.',
     'screen_space_global_illumination_chapel.html':
@@ -236,6 +239,7 @@ const FEATURED_PATHS = new Set([
     'clustered_forward_plus_sponza.html',
     'volumetric_neon_reliquary.html',
     'stormfront_observatory.html',
+    'shadow_residency_sanctum.html',
     'screen_space_reflections_palace.html',
     'screen_space_global_illumination_chapel.html',
     'ground_truth_ambient_occlusion.html',
@@ -364,6 +368,7 @@ function createEntry(path: string): ExampleCatalogEntry {
                 path === 'clustered_forward_plus_sponza.html' ||
                 path === 'volumetric_neon_reliquary.html' ||
                 path === 'stormfront_observatory.html' ||
+                path === 'shadow_residency_sanctum.html' ||
                 path === 'screen_space_reflections_palace.html' ||
                 path === 'temporal_aa_observatory.html' ||
                 path === 'compute_gpu_driven.html' ||

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:ui:webgl2": "npm run test:ui:contract && playwright test test/ui/examples.spec.ts test/ui/post-processing.spec.ts test/ui/runtime-parity.spec.ts --project=chromium --grep @webgl2",
     "test:ui:webgl2:ci": "playwright test test/ui/examples.spec.ts test/ui/post-processing.spec.ts test/ui/runtime-parity.spec.ts test/ui/visual.spec.ts --project=chromium --grep \"@webgl2|through webgl2\"",
     "test:ui:webgpu": "npm run test:ui:contract && playwright test test/ui/examples.spec.ts test/ui/post-processing.spec.ts test/ui/runtime-parity.spec.ts --project=chromium --grep @webgpu",
-    "test:webgpu": "playwright test test/ui/webgpu.spec.ts test/ui/compute-effects.spec.ts test/ui/compute-particles.spec.ts test/ui/compute-eclipse-shrine.spec.ts test/ui/compute-raytracing.spec.ts test/ui/screen-space-reflections.spec.ts test/ui/clustered-forward-plus-scale.spec.ts --project=chromium",
+    "test:webgpu": "playwright test test/ui/webgpu.spec.ts test/ui/compute-effects.spec.ts test/ui/compute-particles.spec.ts test/ui/compute-eclipse-shrine.spec.ts test/ui/compute-raytracing.spec.ts test/ui/screen-space-reflections.spec.ts test/ui/clustered-forward-plus-scale.spec.ts test/ui/shadow-residency-sanctum.spec.ts --project=chromium",
     "test:webgpu:native": "playwright test test/ui/native-webgpu.spec.ts test/ui/clustered-forward-plus-scale.spec.ts test/ui/volumetric-lighting.spec.ts test/ui/stormfront-observatory.spec.ts --project=chromium-native-webgpu",
     "test:gpu-scene-scale": "playwright test test/ui/clustered-forward-plus-scale.spec.ts --project=chromium",
     "test:visual": "playwright test --project=chromium --grep @visual",

--- a/src/render/RendererDiagnostics.ts
+++ b/src/render/RendererDiagnostics.ts
@@ -102,6 +102,22 @@ export interface RendererFrameDiagnosticsSnapshot {
     readonly uploads: number;
     readonly submissions: number;
     readonly arenaGrowths: number;
+    /** Shadow slices requesting fresh contents this frame. */
+    readonly shadowRequestedSlices: number;
+    /** Shadow slices whose complete desired contents were scheduled this frame. */
+    readonly shadowUpdatedSlices: number;
+    /** Shadow slices retaining prior contents because of cadence or budget. */
+    readonly shadowDeferredSlices: number;
+    /** Non-resident shadow pages requested this frame. */
+    readonly shadowRequestedPages: number;
+    /** Shadow page redraws scheduled this frame. */
+    readonly shadowUpdatedPages: number;
+    /** Requested pages retaining prior contents because of the page budget. */
+    readonly shadowDeferredPages: number;
+    /** Pages committed resident before this frame's submission. */
+    readonly shadowResidentPages: number;
+    /** Mandatory page updates beyond the configured soft budget. */
+    readonly shadowBudgetOverflowPages: number;
 }
 
 export interface RendererDiagnosticsSnapshot {
@@ -187,7 +203,15 @@ const FRAME_COMPUTE_BIND_GROUP_SWITCHES = FRAME_COMPUTE_PIPELINE_SWITCHES + 1;
 const FRAME_UPLOADS = FRAME_COMPUTE_BIND_GROUP_SWITCHES + 1;
 const FRAME_SUBMISSIONS = FRAME_UPLOADS + 1;
 const FRAME_ARENA_GROWTHS = FRAME_SUBMISSIONS + 1;
-const COUNTER_COUNT = FRAME_ARENA_GROWTHS + 1;
+const FRAME_SHADOW_REQUESTED_SLICES = FRAME_ARENA_GROWTHS + 1;
+const FRAME_SHADOW_UPDATED_SLICES = FRAME_SHADOW_REQUESTED_SLICES + 1;
+const FRAME_SHADOW_DEFERRED_SLICES = FRAME_SHADOW_UPDATED_SLICES + 1;
+const FRAME_SHADOW_REQUESTED_PAGES = FRAME_SHADOW_DEFERRED_SLICES + 1;
+const FRAME_SHADOW_UPDATED_PAGES = FRAME_SHADOW_REQUESTED_PAGES + 1;
+const FRAME_SHADOW_DEFERRED_PAGES = FRAME_SHADOW_UPDATED_PAGES + 1;
+const FRAME_SHADOW_RESIDENT_PAGES = FRAME_SHADOW_DEFERRED_PAGES + 1;
+const FRAME_SHADOW_BUDGET_OVERFLOW_PAGES = FRAME_SHADOW_RESIDENT_PAGES + 1;
+const COUNTER_COUNT = FRAME_SHADOW_BUDGET_OVERFLOW_PAGES + 1;
 
 function nativeObjectBase(kind: RendererNativeObjectKind): number {
     switch (kind) {
@@ -478,6 +502,38 @@ export class RendererDiagnostics implements RenderGraphTimelineSink {
         this.increment(FRAME_ARENA_GROWTHS, count);
     }
 
+    /** Accumulate shadow update work and replace the current residency gauge for this frame. */
+    recordShadowScheduling(values: {
+        readonly requestedSlices: number;
+        readonly updatedSlices: number;
+        readonly deferredSlices: number;
+        readonly requestedPages: number;
+        readonly updatedPages: number;
+        readonly deferredPages: number;
+        readonly residentPages: number;
+        readonly budgetOverflowPages: number;
+    }): void {
+        const entries: readonly (readonly [number, number])[] = [
+            [FRAME_SHADOW_REQUESTED_SLICES, values.requestedSlices],
+            [FRAME_SHADOW_UPDATED_SLICES, values.updatedSlices],
+            [FRAME_SHADOW_DEFERRED_SLICES, values.deferredSlices],
+            [FRAME_SHADOW_REQUESTED_PAGES, values.requestedPages],
+            [FRAME_SHADOW_UPDATED_PAGES, values.updatedPages],
+            [FRAME_SHADOW_DEFERRED_PAGES, values.deferredPages],
+            [FRAME_SHADOW_RESIDENT_PAGES, values.residentPages],
+            [FRAME_SHADOW_BUDGET_OVERFLOW_PAGES, values.budgetOverflowPages]
+        ];
+        for (const [, value] of entries) {
+            if (!Number.isSafeInteger(value) || value < 0) {
+                throw new RangeError('Shadow diagnostics must be non-negative safe integers');
+            }
+        }
+        for (const [counter, value] of entries) {
+            if (counter === FRAME_SHADOW_RESIDENT_PAGES) this.setValue(counter, value);
+            else this.increment(counter, value);
+        }
+    }
+
     resetFrame(): void {
         this.#counters.fill(0, FRAME_START);
     }
@@ -527,7 +583,15 @@ export class RendererDiagnostics implements RenderGraphTimelineSink {
                 computeBindGroupSwitches: this.value(FRAME_COMPUTE_BIND_GROUP_SWITCHES),
                 uploads: this.value(FRAME_UPLOADS),
                 submissions: this.value(FRAME_SUBMISSIONS),
-                arenaGrowths: this.value(FRAME_ARENA_GROWTHS)
+                arenaGrowths: this.value(FRAME_ARENA_GROWTHS),
+                shadowRequestedSlices: this.value(FRAME_SHADOW_REQUESTED_SLICES),
+                shadowUpdatedSlices: this.value(FRAME_SHADOW_UPDATED_SLICES),
+                shadowDeferredSlices: this.value(FRAME_SHADOW_DEFERRED_SLICES),
+                shadowRequestedPages: this.value(FRAME_SHADOW_REQUESTED_PAGES),
+                shadowUpdatedPages: this.value(FRAME_SHADOW_UPDATED_PAGES),
+                shadowDeferredPages: this.value(FRAME_SHADOW_DEFERRED_PAGES),
+                shadowResidentPages: this.value(FRAME_SHADOW_RESIDENT_PAGES),
+                shadowBudgetOverflowPages: this.value(FRAME_SHADOW_BUDGET_OVERFLOW_PAGES)
             }),
             renderGraph: this.#renderGraphTimeline
         });

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -65,7 +65,9 @@ import type {
     RenderPipelineOutput,
     RenderPipelineOutputColorAttachment,
     RenderPipelineOutputDepthStencilAttachment,
-    RenderPipelineShadowResources
+    RenderPipelineShadowResources,
+    RenderPipelineShadowOptions,
+    RenderPipelineShadowSlice
 } from '../pipeline/RenderPipeline';
 import {
     acquireRenderPassParameters,
@@ -159,6 +161,7 @@ import { importSurfaceColor, importSurfaceDepthStencil } from '../renderer/Surfa
 import { SharedDrawPassParameters } from '../renderer/passes/SharedDrawPass';
 import type { ShadowAtlasScenePlan } from '../renderer/ShadowAtlasSceneAdapter';
 import type { ShadowAtlasResourceRecord } from '../renderer/ShadowAtlasResourceCache';
+import type { ShadowAtlasPageRegion } from '../renderer/ShadowAtlasPageResidency';
 import { refreshShadowAtlasSceneBinding } from '../renderer/ShadowAtlasTextureBinding';
 import { depthClearValue } from '../renderer/DepthConvention';
 
@@ -486,6 +489,7 @@ export interface ScriptableRenderPipelineServices {
     ): void;
     recordScriptableShadows(
         meshes: readonly Mesh[],
+        cacheMeshes: readonly Mesh[],
         camera: Camera,
         viewport: Readonly<RHIViewport>,
         width: number,
@@ -503,6 +507,21 @@ export interface ScriptableShadowAtlasBuild {
     readonly texture: RGTextureHandle;
     readonly atlas: Readonly<ShadowAtlasResourceRecord>;
     readonly plan: Readonly<ShadowAtlasScenePlan>;
+    readonly dirtySlices: readonly boolean[];
+    readonly pageRegions: readonly Readonly<ShadowAtlasPageRegion>[];
+}
+
+interface MutableRenderPipelineShadowSlice {
+    kind: RenderPipelineShadowSlice['kind'];
+    sliceIndex: number;
+    physicalIndex: number;
+    face: number | null;
+    cascade: number | null;
+    readonly viewport: [number, number, number, number];
+    readonly viewProjectionMatrix: Float32Array;
+    near: number;
+    far: number;
+    dirty: boolean;
 }
 
 /** @internal Runtime-scoped ownership identities for persistent SRP targets. */
@@ -3967,10 +3986,11 @@ class RenderPipelineContextLease implements RenderPipelineContext, ScriptableRen
     }
 
     recordShadows(
-        cullingResults: CullingResultsHandle
+        cullingResults: CullingResultsHandle,
+        options?: Readonly<RenderPipelineShadowOptions>
     ): Readonly<RenderPipelineShadowResources> | null {
         this.#owner.assertLeaseActive(this.#lease);
-        return this.#owner.recordShadows(cullingResults);
+        return this.#owner.recordShadows(cullingResults, options);
     }
 
     acquirePassParameters<P extends object>(pool: RenderPassParameterPool<P>): P {
@@ -4125,6 +4145,9 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
     readonly #eventMeshes: Mesh[] = [];
     readonly #eventMeshSet = new Set<Mesh>();
     readonly #cleanupFailures: unknown[] = [];
+    readonly #shadowExcludedMeshes = new Set<Mesh>();
+    readonly #shadowDrawMeshes: Mesh[] = [];
+    readonly #shadowSliceRecords: MutableRenderPipelineShadowSlice[] = [];
 
     #scope: RenderGraphFrameBuildScope | null = null;
     #scene: RendererScene | null = null;
@@ -4467,7 +4490,8 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
     }
 
     recordShadows(
-        cullingResults: CullingResultsHandle
+        cullingResults: CullingResultsHandle,
+        options: Readonly<RenderPipelineShadowOptions> = {}
     ): Readonly<RenderPipelineShadowResources> | null {
         this.assertActive();
         if (this.#shadowsRecorded) {
@@ -4485,7 +4509,26 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         }
         this.#shadowCulling = culling;
         const camera = culling.activate(this.services);
+        this.#shadowExcludedMeshes.clear();
+        const excludedMeshes: unknown = options.excludeMeshes;
+        if (excludedMeshes !== undefined) {
+            if (!Array.isArray(excludedMeshes)) {
+                throw new TypeError('Shadow excludeMeshes must be an array');
+            }
+            for (let index = 0; index < excludedMeshes.length; index += 1) {
+                const mesh: unknown = excludedMeshes[index];
+                if (!(mesh instanceof Mesh)) {
+                    throw new TypeError(`Shadow excludeMeshes[${String(index)}] must be a Mesh`);
+                }
+                this.#shadowExcludedMeshes.add(mesh);
+            }
+        }
+        this.#shadowDrawMeshes.length = 0;
+        for (const mesh of culling.visibleMeshes) {
+            if (!this.#shadowExcludedMeshes.has(mesh)) this.#shadowDrawMeshes.push(mesh);
+        }
         const shadowBuild = this.services.recordScriptableShadows(
+            this.#shadowDrawMeshes,
             culling.visibleMeshes,
             camera,
             this.rhiViewport,
@@ -4517,6 +4560,40 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
         }).handle;
         const block = shadowBuild.plan.lightBlock;
         const manager = this.services.lightManager;
+        this.#shadowSliceRecords.length = shadowBuild.plan.slices.length;
+        for (let index = 0; index < shadowBuild.plan.slices.length; index += 1) {
+            const slice = shadowBuild.plan.slices[index];
+            if (slice === undefined) throw new Error('Shadow slice metadata is incomplete');
+            let record = this.#shadowSliceRecords[index];
+            if (record === undefined) {
+                record = {
+                    kind: 'directional',
+                    sliceIndex: 0,
+                    physicalIndex: 0,
+                    face: null,
+                    cascade: null,
+                    viewport: [0, 0, 0, 0],
+                    viewProjectionMatrix: new Float32Array(16),
+                    near: 0,
+                    far: 0,
+                    dirty: false
+                };
+                this.#shadowSliceRecords[index] = record;
+            }
+            record.kind = slice.kind;
+            record.sliceIndex = slice.sliceIndex;
+            record.physicalIndex = slice.physicalIndex;
+            record.face = slice.face;
+            record.cascade = slice.cascade;
+            record.viewport[0] = slice.viewport.x;
+            record.viewport[1] = slice.viewport.y;
+            record.viewport[2] = slice.viewport.width;
+            record.viewport[3] = slice.viewport.height;
+            record.viewProjectionMatrix.set(slice.viewProjectionMatrix.elements);
+            record.near = slice.near;
+            record.far = slice.far;
+            record.dirty = shadowBuild.dirtySlices[index] === true;
+        }
         return Object.freeze({
             atlas: atlasHandle,
             atlasSize: block.atlasSize,
@@ -4535,7 +4612,9 @@ export class ScriptableRenderPipelineContextImpl implements ScriptableComputeGra
             spotBiases: block.spotBiases,
             spotMatrices: block.spotMatrices,
             pointBiases: block.pointBiases,
-            pointMatrices: block.pointMatrices
+            pointMatrices: block.pointMatrices,
+            slices: this.#shadowSliceRecords,
+            pageRegions: shadowBuild.pageRegions
         });
     }
 

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -93,10 +93,15 @@ import { RendererRecoveringError, type ResourceRegistryHandle } from '../rendere
 import { ShaderArtifactCompiler } from '../renderer/ShaderArtifactCompiler';
 import { ShadowAtlasMeshPreparer } from '../renderer/ShadowAtlasMeshPreparer';
 import { ShadowAtlasContentCache } from '../renderer/ShadowAtlasContentCache';
+import {
+    ShadowAtlasPageResidency,
+    type ShadowAtlasPageRegion
+} from '../renderer/ShadowAtlasPageResidency';
 import { ShadowAtlasRenderer } from '../renderer/ShadowAtlasRenderer';
 import { ShadowAtlasResourceCache } from '../renderer/ShadowAtlasResourceCache';
 import { ShadowAtlasSceneAdapter } from '../renderer/ShadowAtlasSceneAdapter';
 import { ShadowAtlasTextureBinding } from '../renderer/ShadowAtlasTextureBinding';
+import { ShadowAtlasUpdateScheduler } from '../renderer/ShadowAtlasUpdateScheduler';
 import { ComputePipelineResourceCache } from '../renderer/ComputePipelineResourceCache';
 import { ComputeSamplerResourceCache } from '../renderer/ComputeSamplerResourceCache';
 import { GPUDrivenPipelineResourceCache } from '../renderer/GPUDrivenPipelineResourceCache';
@@ -135,6 +140,8 @@ interface RenderingResources {
     readonly scriptableBindGroups: ScriptableBindGroupResourceCache;
     readonly shadowScene: ShadowAtlasSceneAdapter;
     readonly shadowContent: ShadowAtlasContentCache;
+    readonly shadowUpdates: ShadowAtlasUpdateScheduler;
+    readonly shadowPages: ShadowAtlasPageResidency;
     readonly shadowResources: ShadowAtlasResourceCache;
     readonly shadowRenderer: ShadowAtlasRenderer;
     readonly shadowPreparer: ShadowAtlasMeshPreparer;
@@ -147,12 +154,20 @@ interface RenderingResources {
         readonly sampleCount: 1;
     };
     readonly shadowOwner: object;
-    readonly shadowPrepareOptions: { width: number; height: number };
+    readonly shadowPrepareOptions: {
+        width: number;
+        height: number;
+        receiverDrivenResolution: boolean;
+        minimumResolution: number;
+        frameIndex: number;
+        cascadeUpdateIntervals: readonly number[];
+    };
     readonly shadowRenderOptions: {
         label: string;
         preparer: ShadowAtlasMeshPreparer;
         depthClearValue: number;
         dirtySlices: readonly boolean[] | undefined;
+        pageRegions: readonly ShadowAtlasPageRegion[] | undefined;
         sliceClearDraw: PreparedDraw | undefined;
     };
     readonly shadowViewport: {
@@ -905,6 +920,7 @@ class SharedRendererDriver
 
     recordScriptableShadows(
         meshes: readonly Mesh[],
+        cacheMeshes: readonly Mesh[],
         camera: Camera,
         viewport: Readonly<RHIViewport>,
         width: number,
@@ -913,7 +929,7 @@ class SharedRendererDriver
         const resources = this.requireResources();
         const context = this.createContext(camera, viewport);
         this.ensureMeshFrame(context);
-        return this.renderSceneShadows(resources, context, meshes, width, height);
+        return this.renderSceneShadows(resources, context, meshes, cacheMeshes, width, height);
     }
 
     recordScriptablePass(passCount: number): void {
@@ -1490,6 +1506,13 @@ class SharedRendererDriver
         const scriptableBindGroups = new ScriptableBindGroupResourceCache(processor.registry);
         const shadowScene = new ShadowAtlasSceneAdapter();
         const shadowContent = new ShadowAtlasContentCache();
+        const shadowUpdates = new ShadowAtlasUpdateScheduler({
+            maxUpdatesPerFrame: this.renderingProfile === 'high-end' ? 8 : 4
+        });
+        const shadowPages = new ShadowAtlasPageResidency({
+            pageSize: 128,
+            maxPageUpdatesPerFrame: this.renderingProfile === 'high-end' ? 32 : 16
+        });
         const shadowResources = new ShadowAtlasResourceCache(processor.registry);
         const shadowRenderer = new ShadowAtlasRenderer(
             processor.registry,
@@ -1520,12 +1543,23 @@ class SharedRendererDriver
             sampleCount: 1 as const
         };
         const shadowOwner = Object.freeze({ renderer: this });
-        const shadowPrepareOptions = { width: 1, height: 1 };
+        const shadowPrepareOptions = {
+            width: 1,
+            height: 1,
+            receiverDrivenResolution: this.renderingProfile === 'high-end',
+            minimumResolution: 128,
+            frameIndex: 0,
+            cascadeUpdateIntervals:
+                this.renderingProfile === 'high-end'
+                    ? Object.freeze([1, 2, 4, 8])
+                    : Object.freeze([1, 1, 1, 1])
+        };
         const shadowRenderOptions = {
             label: 'Shadow atlas',
             preparer: shadowPreparer,
             depthClearValue: 1,
             dirtySlices: undefined,
+            pageRegions: undefined,
             sliceClearDraw: undefined
         };
         const shadowViewport = {
@@ -1552,6 +1586,7 @@ class SharedRendererDriver
         recovery.registerSynchronizer({
             synchronizeAfterRecovery: () => {
                 shadowContent.invalidateAll();
+                shadowPages.invalidateAll();
             }
         });
         recovery.registerSynchronizer({
@@ -1585,6 +1620,8 @@ class SharedRendererDriver
             scriptableBindGroups,
             shadowScene,
             shadowContent,
+            shadowUpdates,
+            shadowPages,
             shadowResources,
             shadowRenderer,
             shadowPreparer,
@@ -1698,6 +1735,9 @@ class SharedRendererDriver
         });
         attempt(() => {
             resources.shadowContent.destroy();
+        });
+        attempt(() => {
+            resources.shadowPages.destroy();
         });
         attempt(() => {
             resources.shadowPreparer.destroy();
@@ -1846,6 +1886,7 @@ class SharedRendererDriver
             resources,
             context,
             visible,
+            visible,
             target.width,
             target.height
         );
@@ -1896,12 +1937,14 @@ class SharedRendererDriver
         resources: RenderingResources,
         context: RenderGraphFrameContext,
         meshes: readonly Mesh[],
+        cacheMeshes: readonly Mesh[],
         defaultWidth: number,
         defaultHeight: number
     ): Readonly<ScriptableShadowAtlasBuild> | null {
         const prepareOptions = resources.shadowPrepareOptions;
         prepareOptions.width = positiveSurfaceDimension(defaultWidth, this.width);
         prepareOptions.height = positiveSurfaceDimension(defaultHeight, this.height);
+        prepareOptions.frameIndex = context.frameIndex;
 
         // Frame planning resets LightManager's public atlas fields. Also remove the private active
         // binding before shadow preparation so any failure cannot revive last frame's atlas through
@@ -1917,6 +1960,17 @@ class SharedRendererDriver
         if (plan.atlas.sliceCount === 0) {
             const uploads = this.#pipelineHost.requireActiveScope().uploads;
             resources.shadowContent.stageEmpty(uploads);
+            resources.shadowPages.stageEmpty(uploads);
+            this.rendererDiagnosticsSink?.recordShadowScheduling({
+                requestedSlices: 0,
+                updatedSlices: 0,
+                deferredSlices: 0,
+                requestedPages: 0,
+                updatedPages: 0,
+                deferredPages: 0,
+                residentPages: 0,
+                budgetOverflowPages: 0
+            });
             resources.shadowPreparer.retireAll(uploads);
             resources.shadowResources.detach(resources.shadowOwner);
             return null;
@@ -1928,10 +1982,35 @@ class SharedRendererDriver
             context.camera.depthMode
         );
         const scope = this.#pipelineHost.requireActiveScope();
-        const content = resources.shadowContent.stage(atlas, plan, meshes, scope.uploads);
+        const content = resources.shadowContent.stage(atlas, plan, cacheMeshes, scope.uploads);
+        const updates = resources.shadowUpdates.schedule(plan, content, context.frameIndex);
+        const pages = resources.shadowPages.stage(
+            plan,
+            content,
+            updates.scheduledSlices,
+            scope.uploads
+        );
+        let completedUpdateCount = 0;
+        for (let index = 0; index < content.sliceCount; index += 1) {
+            if (content.dirtySlices[index] === true && pages.completedSlices[index] === true) {
+                completedUpdateCount++;
+            }
+        }
+        this.rendererDiagnosticsSink?.recordShadowScheduling({
+            requestedSlices: updates.requestedUpdateCount,
+            updatedSlices: completedUpdateCount,
+            deferredSlices: updates.requestedUpdateCount - completedUpdateCount,
+            requestedPages: pages.requestedPageCount,
+            updatedPages: pages.scheduledPageCount,
+            deferredPages: pages.deferredPageCount,
+            residentPages: pages.residentPageCount,
+            budgetOverflowPages: pages.budgetOverflowCount
+        });
+        resources.shadowContent.deferUnscheduled(pages.completedSlices);
         resources.shadowRenderOptions.depthClearValue = depthClearValue(context.camera.depthMode);
-        resources.shadowRenderOptions.dirtySlices = content.dirtySlices;
-        if (content.dirtySliceCount > 0) {
+        resources.shadowRenderOptions.dirtySlices = updates.scheduledSlices;
+        resources.shadowRenderOptions.pageRegions = pages.updateRegions;
+        if (pages.scheduledPageCount > 0) {
             this.beginScriptableFullscreenPass(context);
             const depthMode = context.camera.depthMode;
             resources.shadowClearTarget.depthStencilFormat = plan.atlas.format;
@@ -1966,7 +2045,9 @@ class SharedRendererDriver
             passCount: build.passCount,
             texture: build.texture,
             atlas,
-            plan
+            plan,
+            dirtySlices: updates.scheduledSlices,
+            pageRegions: pages.updateRegions
         });
     }
 

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -221,9 +221,13 @@ const OBJECT_HIZ_STABLE_FLAG = 4;
 const OBJECT_MOTION_HISTORY_FLAG = 8;
 const OBJECT_MOTION_CHANGED_FLAG = 16;
 const OBJECT_RECEIVE_SHADOW_FLAG = 32;
+const OBJECT_CAST_SHADOW_FLAG = 64;
 const LIGHT_COOKIE_FLAG = 1;
 const LIGHT_IES_FLAG = 2;
 const CULL_WORKGROUP_SIZE = 64;
+const SHADOW_FRAME_STRIDE_BYTES = 768;
+const SHADOW_FRAME_WORDS = SHADOW_FRAME_STRIDE_BYTES / 4;
+const SHADOW_FRAME_BINDING_BYTES = FRAME_BASE_VEC4_COUNT * 16;
 const PREFIX_WORKGROUP_SIZE = 256;
 const DEFAULT_MAX_OBJECTS = 16_384;
 const DEFAULT_MAX_LIGHTS = 512;
@@ -659,6 +663,7 @@ interface PhysicalBucket {
     tangent1Revision: number;
     indexRevision: number;
     depthPass: GPUDrivenRenderPass;
+    shadowPass: GPUDrivenRenderPass;
     colorPass: GPUDrivenRenderPass;
     colorShadowed: boolean;
     materialAttributesPass: GPUDrivenRenderPass | null;
@@ -706,6 +711,8 @@ interface GPUSceneObjectRecord {
     committedFrustumTest: boolean;
     pendingReceiveShadows: boolean;
     committedReceiveShadows: boolean;
+    pendingCastShadows: boolean;
+    committedCastShadows: boolean;
     pendingBoundsRevision: number;
     committedBoundsRevision: number;
     pendingOcclusionStable: boolean;
@@ -1691,6 +1698,58 @@ function gpuSceneCullBindings(hiZLevelCount: number): readonly ComputeShaderBind
 }
 
 const GPU_SCENE_CULL_PASS = computePass(gpuSceneCullShader(0));
+
+const GPU_SHADOW_CULL_PASS = computePass(
+    new ComputeShader({
+        label: 'GPU Scene shadow caster frustum culling',
+        source: `${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read> objects: array<ObjectRecord>;
+@group(0) @binding(2) var<storage, read> buckets: array<BucketRecord>;
+@group(0) @binding(3) var<storage, read_write> selectedPhysicalBuckets: array<u32>;
+@group(0) @binding(4) var<storage, read_write> indirectArguments: array<atomic<u32>>;
+@group(0) @binding(5) var<storage, read_write> cullStats: array<atomic<u32>>;
+@compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= frameData.counts.x || id.x >= frameData.budgets.x) { return; }
+    selectedPhysicalBuckets[id.x] = 0xffffffffu;
+    let object = objects[id.x];
+    let flags = object.metadata.z;
+    if (
+        (flags & ${String(OBJECT_ACTIVE_FLAG | OBJECT_CAST_SHADOW_FLAG)}u) !=
+        ${String(OBJECT_ACTIVE_FLAG | OBJECT_CAST_SHADOW_FLAG)}u ||
+        (object.metadata.y & frameData.budgets.w) == 0u
+    ) { return; }
+    let model = objectModel(object);
+    let localCenter = vec4<f32>(object.bounds.xyz, 1.0);
+    let center = (model * localCenter).xyz;
+    let radius = object.bounds.w * maximumScale(model);
+    let clip = frameData.currentViewProjection * vec4<f32>(center, 1.0);
+    let rowX = vec3<f32>(
+        frameData.currentViewProjection[0].x,
+        frameData.currentViewProjection[1].x,
+        frameData.currentViewProjection[2].x
+    );
+    let rowY = vec3<f32>(
+        frameData.currentViewProjection[0].y,
+        frameData.currentViewProjection[1].y,
+        frameData.currentViewProjection[2].y
+    );
+    let radiusX = radius * length(rowX);
+    let radiusY = radius * length(rowY);
+    if ((flags & ${String(OBJECT_FRUSTUM_CULLING_FLAG)}u) != 0u) {
+        if (clip.x + radiusX < -clip.w || clip.x - radiusX > clip.w) { return; }
+        if (clip.y + radiusY < -clip.w || clip.y - radiusY > clip.w) { return; }
+    }
+    let bucket = buckets[object.metadata.x].indices0.x;
+    _ = atomicAdd(&indirectArguments[bucket * 5u + 1u], 1u);
+    selectedPhysicalBuckets[id.x] = bucket;
+    _ = atomicAdd(&cullStats[0], 1u);
+}`,
+        workgroupSize: [CULL_WORKGROUP_SIZE],
+        bindings: gpuSceneCullBindings(0)
+    })
+);
 
 const GPU_SCENE_BUCKET_PREFIX_PASS = computePass(
     new ComputeShader({
@@ -3743,6 +3802,21 @@ class MutableComputeParameters implements ComputeRenderPassParameters {
         const binding = this.buffers[index];
         if (binding === undefined) throw new RangeError('Compute buffer slot is unavailable');
         binding.buffer = buffer;
+        delete binding.byteOffset;
+        delete binding.byteLength;
+    }
+
+    setBufferRange(
+        index: number,
+        buffer: RenderGraphBufferHandle,
+        byteOffset: number,
+        byteLength: number
+    ): void {
+        const binding = this.buffers[index];
+        if (binding === undefined) throw new RangeError('Compute buffer slot is unavailable');
+        binding.buffer = buffer;
+        binding.byteOffset = byteOffset;
+        binding.byteLength = byteLength;
     }
 
     setTexture(index: number, texture: RenderGraphTextureAccessHandle): void {
@@ -3802,6 +3876,8 @@ class MutableGPUDrivenParameters implements GPUDrivenRenderPassParameters {
         const binding = this.buffers[index];
         if (binding === undefined) throw new RangeError('GPU-driven buffer slot is unavailable');
         binding.buffer = buffer;
+        delete binding.byteOffset;
+        delete binding.byteLength;
     }
 
     setBufferRange(
@@ -3837,6 +3913,8 @@ class MutableGPUDrivenBatchParameters implements GPUDrivenRenderBatchPassParamet
     readonly parameters: GPUDrivenRenderPassParameters[] = [];
     readonly colorAttachments: RenderPipelineColorAttachment[] = [];
     depthStencilAttachment?: RenderPipelineDepthStencilAttachment;
+    viewport?: readonly [number, number, number, number];
+    scissor?: readonly [number, number, number, number];
 
     add(pass: GPUDrivenRenderPass, parameters: GPUDrivenRenderPassParameters): void {
         this.passes.push(pass);
@@ -3848,6 +3926,8 @@ class MutableGPUDrivenBatchParameters implements GPUDrivenRenderBatchPassParamet
         this.parameters.length = 0;
         this.colorAttachments.length = 0;
         delete this.depthStencilAttachment;
+        delete this.viewport;
+        delete this.scissor;
     }
 }
 
@@ -4139,6 +4219,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly usesRenderGraphTimeline: boolean;
     readonly #options: Readonly<NormalizedOptions>;
     readonly #frameData: StorageBuffer;
+    readonly #shadowFrameData: StorageBuffer;
     readonly #objects: StorageBuffer;
     readonly #bucketData: StorageBuffer;
     readonly #materialDatabase: SharedMaterialRecordDatabase<PBRMaterial>;
@@ -4163,6 +4244,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #logicalBucketByGeometry = new Map<Geometry, Map<PBRMaterial, number>>();
     readonly #logicalGPUCompatible: Uint8Array;
     readonly #gpuManagedMeshes: Mesh[] = [];
+    readonly #gpuShadowMeshes: Mesh[] = [];
     readonly #fallbackOpaqueMeshes: Mesh[] = [];
     readonly #clusteredOpaqueMeshes: Mesh[] = [];
     readonly #fallbackOpaqueExcludedMeshes: Mesh[] = [];
@@ -4193,6 +4275,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #frameBytes = new ArrayBuffer(FRAME_RECORD_BYTES);
     readonly #frameFloats = new Float32Array(this.#frameBytes);
     readonly #frameUInts = new Uint32Array(this.#frameBytes);
+    readonly #shadowFrameBytes = new ArrayBuffer(
+        MAX_SHADOW_ATLAS_SLICES * SHADOW_FRAME_STRIDE_BYTES
+    );
+    readonly #shadowFrameFloats = new Float32Array(this.#shadowFrameBytes);
+    readonly #shadowFrameUInts = new Uint32Array(this.#shadowFrameBytes);
     readonly #lightFloats: Float32Array;
     readonly #lightUInts: Uint32Array;
     readonly #localLightFloats: Float32Array;
@@ -4311,12 +4398,22 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #depthDrawPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenParameters(4, 1)
     );
+    readonly #shadowDrawPool = new RenderPassParameterPool(
+        () => new MutableGPUDrivenParameters(5, 1)
+    );
     readonly #depthBatchPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenBatchParameters(),
         parameters => {
             parameters.reset();
         }
     );
+    readonly #shadowBatchPool = new RenderPassParameterPool(
+        () => new MutableGPUDrivenBatchParameters(),
+        parameters => {
+            parameters.reset();
+        }
+    );
+    readonly #shadowPageScissors: [number, number, number, number][] = [];
     readonly #colorDrawPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenParameters(8, 2)
     );
@@ -4356,6 +4453,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     );
     readonly #displayPass: FullscreenRenderPass;
     readonly #depthBatchPass = new GPUDrivenRenderBatchPass('GPU Scene depth buckets');
+    readonly #shadowBatchPass = new GPUDrivenRenderBatchPass('GPU Scene shadow caster buckets');
     readonly #colorBatchPass = new GPUDrivenRenderBatchPass('Clustered PBR buckets');
     readonly #materialAttributesBatchPass = new GPUDrivenRenderBatchPass(
         'GPU Scene GTAO material attributes'
@@ -4561,6 +4659,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#frameData = create({
             label: 'Clustered Forward+ frame database',
             byteLength: FRAME_RECORD_BYTES,
+            usage: ['storage', 'copy-destination'],
+            recovery: 'cpu-shadow'
+        });
+        this.#shadowFrameData = create({
+            label: 'GPU Scene shadow slice frame database',
+            byteLength: this.#shadowFrameBytes.byteLength,
             usage: ['storage', 'copy-destination'],
             recovery: 'cpu-shadow'
         });
@@ -4792,11 +4896,18 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const renderHeight = Math.max(1, Math.floor(context.output.height * sceneScale));
         this.refreshGPUCompatibility();
         this.collectScene(context);
+        this.#materialDatabase.stage(context);
+        this.syncGeometryDatabases(context);
         let fallbackCulling: CullingResultsHandle | null = null;
         let shadowResources: Readonly<RenderPipelineShadowResources> | null = null;
         if (this.#fallbackObjectCount !== 0 || this.#hasShadowLights) {
             fallbackCulling = context.cull();
-            shadowResources = context.recordShadows(fallbackCulling);
+            shadowResources = context.recordShadows(fallbackCulling, {
+                excludeMeshes: this.#gpuShadowMeshes
+            });
+            if (shadowResources !== null && this.#gpuShadowMeshes.length !== 0) {
+                this.recordGPUShadows(context, shadowResources);
+            }
         }
         this.packLights(context, shadowResources);
         this.packShadowFrame(shadowResources);
@@ -4809,8 +4920,6 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 this.#clusteredTransparentObjectCount
         );
         this.refreshShadowCompatibility(shadowResources !== null);
-        this.#materialDatabase.stage(context);
-        this.syncGeometryDatabases(context);
         const frame = this.packFrame(context, renderWidth, renderHeight);
         context.writeStorageBuffer(this.#frameData, 0, new Uint8Array(this.#frameBytes));
 
@@ -5336,6 +5445,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 record.committedWorldVersion = record.pendingWorldVersion;
                 record.committedFrustumTest = record.pendingFrustumTest;
                 record.committedReceiveShadows = record.pendingReceiveShadows;
+                record.committedCastShadows = record.pendingCastShadows;
                 record.committedBoundsRevision = record.pendingBoundsRevision;
                 record.committedOcclusionStable = record.pendingOcclusionStable;
                 record.committedMotionChanged = record.pendingMotionChanged;
@@ -5451,6 +5561,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#pendingRejectedMaterialVariants.clear();
         const buffers: StorageBuffer[] = [
             this.#frameData,
+            this.#shadowFrameData,
             this.#objects,
             this.#bucketData,
             this.#lights,
@@ -5667,6 +5778,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                         validated.indexFormat,
                         variant
                     ),
+                    shadowPass: this.createShadowPass(
+                        logical,
+                        physicalIndex,
+                        validated.indexFormat,
+                        variant
+                    ),
                     colorPass: this.createColorPass(
                         logical,
                         physicalIndex,
@@ -5698,6 +5815,21 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         return new GPUDrivenRenderPass({
             name: `GPU Scene depth bucket ${String(physicalIndex)}`,
             shader: gpuSceneMaskedDepthShader(variant, this.#options.temporalAA !== null),
+            pipelineState: requireBucketPassState(logical.material, 'depth-only'),
+            vertexLayouts: gpuSceneDepthVertexLayouts(variant),
+            indexFormat
+        });
+    }
+
+    private createShadowPass(
+        logical: Readonly<NormalizedBucket>,
+        physicalIndex: number,
+        indexFormat: 'uint16' | 'uint32',
+        variant: Readonly<PBRMaterialVariant>
+    ): GPUDrivenRenderPass {
+        return new GPUDrivenRenderPass({
+            name: `GPU Scene shadow bucket ${String(physicalIndex)}`,
+            shader: gpuSceneMaskedDepthShader(variant, false),
             pipelineState: requireBucketPassState(logical.material, 'depth-only'),
             vertexLayouts: gpuSceneDepthVertexLayouts(variant),
             indexFormat
@@ -5807,6 +5939,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 bucket.indexFormat,
                 variant
             );
+            bucket.shadowPass = this.createShadowPass(
+                logical,
+                bucket.physicalIndex,
+                bucket.indexFormat,
+                variant
+            );
             bucket.colorPass = this.createColorPass(
                 logical,
                 bucket.physicalIndex,
@@ -5856,6 +5994,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const cameraVisibility = context.camera.visibility >>> 0;
         const ambient = this.#frameFloats;
         this.#gpuManagedMeshes.length = 0;
+        this.#gpuShadowMeshes.length = 0;
         this.#fallbackOpaqueMeshes.length = 0;
         this.#clusteredOpaqueMeshes.length = 0;
         this.#fallbackOpaqueExcludedMeshes.length = 0;
@@ -5912,6 +6051,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                                 committedFrustumTest: node.frustumTest,
                                 pendingReceiveShadows: node.receiveShadows,
                                 committedReceiveShadows: node.receiveShadows,
+                                pendingCastShadows: node.castShadows,
+                                committedCastShadows: node.castShadows,
                                 pendingBoundsRevision: -1,
                                 committedBoundsRevision: -1,
                                 pendingOcclusionStable: false,
@@ -5937,6 +6078,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                         }
                     } else {
                         this.#gpuManagedMeshes.push(node);
+                        if (node.castShadows) this.#gpuShadowMeshes.push(node);
                         record.seenFrame = this.#frameSerial;
                         const bounds = this.#logicalBounds[logicalIndex];
                         if (bounds === undefined) {
@@ -5960,6 +6102,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                             record.committedWorldVersion !== node.worldMatrixVersion ||
                             record.committedFrustumTest !== node.frustumTest ||
                             record.committedReceiveShadows !== node.receiveShadows ||
+                            record.committedCastShadows !== node.castShadows ||
                             !boundsStable ||
                             record.committedOcclusionStable !== occlusionStable ||
                             record.committedMotionChanged !== motionChanged ||
@@ -6352,7 +6495,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             (occlusionStable ? OBJECT_HIZ_STABLE_FLAG : 0) |
             (motionHistoryValid ? OBJECT_MOTION_HISTORY_FLAG : 0) |
             (motionChanged ? OBJECT_MOTION_CHANGED_FLAG : 0) |
-            (mesh.receiveShadows ? OBJECT_RECEIVE_SHADOW_FLAG : 0);
+            (mesh.receiveShadows ? OBJECT_RECEIVE_SHADOW_FLAG : 0) |
+            (mesh.castShadows ? OBJECT_CAST_SHADOW_FLAG : 0);
         this.#objectUInts[floatOffset + 51] = this.#materialDatabase.getHandle(
             bucket.material
         ).recordIndex;
@@ -6360,6 +6504,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         record.pendingWorldVersion = mesh.worldMatrixVersion;
         record.pendingFrustumTest = mesh.frustumTest;
         record.pendingReceiveShadows = mesh.receiveShadows;
+        record.pendingCastShadows = mesh.castShadows;
         record.pendingBoundsRevision = sphere.revision;
         record.pendingOcclusionStable = occlusionStable;
         record.pendingMotionHistoryValid = motionHistoryValid;
@@ -6768,6 +6913,167 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             previous: Object.freeze(previous),
             current: Object.freeze(current)
         });
+    }
+
+    /**
+     * Cull registered rigid shadow casters per dirty atlas slice and append fixed-bucket indirect
+     * draws after the shared fallback/clear pass. The visible count remains GPU-only.
+     */
+    private recordGPUShadows(
+        context: RenderPipelineContext,
+        shadows: Readonly<RenderPipelineShadowResources>
+    ): void {
+        let highestSlice = 0;
+        let pageWorkIndex = 0;
+        for (const region of shadows.pageRegions) {
+            const slice = shadows.slices[region.slicePhysicalIndex];
+            if (slice === undefined) throw new Error('GPU shadow page references a missing slice');
+            highestSlice = Math.max(highestSlice, slice.physicalIndex + 1);
+            this.packShadowSliceFrame(slice, context.camera.visibility >>> 0);
+        }
+        if (highestSlice === 0) return;
+        context.writeStorageBuffer(
+            this.#shadowFrameData,
+            0,
+            new Uint8Array(this.#shadowFrameBytes, 0, highestSlice * SHADOW_FRAME_STRIDE_BYTES)
+        );
+
+        const shadowFrames = context.graph.importStorageBuffer(this.#shadowFrameData);
+        const objects = context.graph.importStorageBuffer(this.#objects);
+        const bucketData = context.graph.importStorageBuffer(this.#bucketData);
+        const materials = context.graph.importStorageBuffer(this.#materialDatabase.buffer);
+        const visible = context.graph.importStorageBuffer(this.#visibleIndices);
+        const selected = context.graph.importStorageBuffer(this.#selectedPhysicalBuckets);
+        const cursors = context.graph.importStorageBuffer(this.#visibleBucketCursors);
+        const offsets = context.graph.importStorageBuffer(this.#visibleBucketOffsets);
+        const indirect = context.graph.importStorageBuffer(this.#indirectArguments);
+        const stats = context.graph.importStorageBuffer(this.#cullStats);
+
+        for (const region of shadows.pageRegions) {
+            const slice = shadows.slices[region.slicePhysicalIndex];
+            if (slice === undefined) throw new Error('GPU shadow page references a missing slice');
+            const frameOffset = slice.physicalIndex * SHADOW_FRAME_STRIDE_BYTES;
+            const clear = context.acquirePassParameters(this.#clearPool);
+            clear.add(stats, 0, STATS_BYTES);
+            for (let index = 0; index < this.#physicalBuckets.length; index += 1) {
+                clear.add(indirect, index * INDIRECT_ARGUMENT_BYTES + 4, 4);
+            }
+            context.graph.addPass(this.#clearPass, clear);
+
+            const cull = context.acquirePassParameters(this.#cullPool);
+            cull.setBufferRange(0, shadowFrames, frameOffset, SHADOW_FRAME_BINDING_BYTES);
+            cull.setBuffer(1, objects);
+            cull.setBuffer(2, bucketData);
+            cull.setBuffer(3, selected);
+            cull.setBuffer(4, indirect);
+            cull.setBuffer(5, stats);
+            cull.setDispatch(
+                Math.max(1, Math.ceil(this.#activeObjectHighWater / CULL_WORKGROUP_SIZE))
+            );
+            context.graph.addPass(GPU_SHADOW_CULL_PASS, cull);
+
+            const prefix = context.acquirePassParameters(this.#bucketPrefixPool);
+            prefix.setBufferRange(0, shadowFrames, frameOffset, SHADOW_FRAME_BINDING_BYTES);
+            prefix.setBuffer(1, indirect);
+            prefix.setBuffer(2, cursors);
+            prefix.setBuffer(3, offsets);
+            prefix.setDispatch(1);
+            context.graph.addPass(GPU_SCENE_BUCKET_PREFIX_PASS, prefix);
+
+            const compact = context.acquirePassParameters(this.#visibleCompactPool);
+            compact.setBufferRange(0, shadowFrames, frameOffset, SHADOW_FRAME_BINDING_BYTES);
+            compact.setBuffer(1, selected);
+            compact.setBuffer(2, cursors);
+            compact.setBuffer(3, offsets);
+            compact.setBuffer(4, visible);
+            compact.setDispatch(
+                Math.max(1, Math.ceil(this.#activeObjectHighWater / CULL_WORKGROUP_SIZE))
+            );
+            context.graph.addPass(GPU_SCENE_VISIBLE_COMPACT_PASS, compact);
+
+            const depthAttachment: RenderPipelineDepthStencilAttachment = {
+                texture: shadows.atlas,
+                depthLoadOp: 'load',
+                depthStoreOp: 'store',
+                depthClearValue: depthClearValue(shadows.depthMode)
+            };
+            const batch = context.acquirePassParameters(this.#shadowBatchPool);
+            batch.depthStencilAttachment = depthAttachment;
+            batch.viewport = slice.viewport;
+            let scissor = this.#shadowPageScissors[pageWorkIndex];
+            if (scissor === undefined) {
+                scissor = [0, 0, 0, 0];
+                this.#shadowPageScissors[pageWorkIndex] = scissor;
+            }
+            scissor[0] = region.x;
+            scissor[1] = region.y;
+            scissor[2] = region.width;
+            scissor[3] = region.height;
+            batch.scissor = scissor;
+            pageWorkIndex++;
+            for (let index = 0; index < this.#physicalBuckets.length; index += 1) {
+                const bucket = this.#physicalBuckets[index];
+                if (bucket === undefined) continue;
+                const variant = bucket.materialVariant;
+                const coverage = coverageTextures(variant);
+                const parameters = context.acquirePassParameters(this.#shadowDrawPool);
+                parameters.configure(bucket.shadowPass.vertexLayouts.length, coverage.length);
+                parameters.configureStorageBufferCount(variant.coverageMode === 'mask' ? 5 : 4);
+                parameters.setBufferRange(0, shadowFrames, frameOffset, SHADOW_FRAME_BINDING_BYTES);
+                parameters.setBuffer(1, objects);
+                parameters.setBuffer(2, visible);
+                parameters.setBufferRange(3, offsets, index * BUCKET_OFFSET_STRIDE_BYTES, 4);
+                if (variant.coverageMode === 'mask') parameters.setBuffer(4, materials);
+                parameters.setVertexBuffer(0, context.graph.importStorageBuffer(bucket.position));
+                let vertexSlot = 1;
+                if (coverage.some(binding => binding.uv === 0)) {
+                    if (bucket.uv0 === null) throw new Error('GPU shadow UV0 is unavailable');
+                    parameters.setVertexBuffer(
+                        vertexSlot++,
+                        context.graph.importStorageBuffer(bucket.uv0)
+                    );
+                }
+                if (coverage.some(binding => binding.uv === 1)) {
+                    if (bucket.uv1 === null) throw new Error('GPU shadow UV1 is unavailable');
+                    parameters.setVertexBuffer(
+                        vertexSlot,
+                        context.graph.importStorageBuffer(bucket.uv1)
+                    );
+                }
+                for (let textureIndex = 0; textureIndex < coverage.length; textureIndex += 1) {
+                    const texture = coverage[textureIndex]?.texture;
+                    if (texture === undefined) continue;
+                    parameters.setTexture(textureIndex, context.graph.importTexture(texture));
+                    parameters.samplers[textureIndex] = this.samplerFor(texture);
+                }
+                parameters.indexBuffer.buffer = context.graph.importStorageBuffer(bucket.index);
+                parameters.draw.buffer = indirect;
+                parameters.draw.byteOffset = index * INDIRECT_ARGUMENT_BYTES;
+                parameters.colorAttachments.length = 0;
+                parameters.depthStencilAttachment = depthAttachment;
+                batch.add(bucket.shadowPass, parameters);
+            }
+            context.graph.addPass(this.#shadowBatchPass, batch);
+        }
+    }
+
+    private packShadowSliceFrame(
+        slice: RenderPipelineShadowResources['slices'][number],
+        visibilityMask: number
+    ): void {
+        const wordOffset = slice.physicalIndex * SHADOW_FRAME_WORDS;
+        this.#shadowFrameFloats.set(slice.viewProjectionMatrix, wordOffset);
+        this.#shadowFrameFloats.set(slice.viewProjectionMatrix, wordOffset + 16);
+        this.#shadowFrameFloats[wordOffset + 96] = slice.viewport[0];
+        this.#shadowFrameFloats[wordOffset + 97] = slice.viewport[1];
+        this.#shadowFrameFloats[wordOffset + 98] = slice.viewport[2];
+        this.#shadowFrameFloats[wordOffset + 99] = slice.viewport[3];
+        this.#shadowFrameFloats[wordOffset + 100] = slice.near;
+        this.#shadowFrameFloats[wordOffset + 101] = slice.far;
+        this.#shadowFrameUInts[wordOffset + 112] = this.#activeObjectHighWater;
+        this.#shadowFrameUInts[wordOffset + 113] = this.#physicalBuckets.length;
+        this.#shadowFrameUInts[wordOffset + 116] = this.#visibleBucketCapacity;
+        this.#shadowFrameUInts[wordOffset + 119] = visibilityMask;
     }
 
     private recordDepthPrepass(

--- a/src/render/pipeline/RenderPipeline.ts
+++ b/src/render/pipeline/RenderPipeline.ts
@@ -25,6 +25,7 @@ import type { RenderGraphTextureHandle, ScriptableRenderGraph } from './Scriptab
 import type { RenderPipelineTextureFormat } from './RenderPipelineTexture';
 import type { RenderGraphTimelineSnapshot } from '../graph/RenderGraphTimeline';
 import type StorageGraphicsShader from '../compute/StorageGraphicsShader';
+import type Mesh from '../../core/Mesh';
 
 /** Optional renderer capabilities exposed only after their complete SRP/RHI path is available. */
 export type RenderPipelineCapabilityName =
@@ -232,6 +233,61 @@ export interface RenderPipelineShadowResources {
     readonly pointBiases: Float32Array;
     /** Six view-space-to-shadow-clip face matrices per shadowed point light. */
     readonly pointMatrices: Float32Array;
+    /** Physical atlas slices in dense render order. Values are valid only for this invocation. */
+    readonly slices: readonly Readonly<RenderPipelineShadowSlice>[];
+    /** Page-granular atlas updates recorded this frame, in render order. */
+    readonly pageRegions: readonly Readonly<RenderPipelineShadowPageRegion>[];
+}
+
+/** One frame-scoped physical page update within a shadow slice. */
+export interface RenderPipelineShadowPageRegion {
+    /** Dense physical slice containing this page. */
+    readonly slicePhysicalIndex: number;
+    /** Zero-based horizontal virtual-page coordinate within the slice. */
+    readonly pageX: number;
+    /** Zero-based vertical virtual-page coordinate within the slice. */
+    readonly pageY: number;
+    /** Physical atlas X origin in pixels. */
+    readonly x: number;
+    /** Physical atlas Y origin in pixels. */
+    readonly y: number;
+    /** Physical page width in pixels; edge pages may be smaller than the page size. */
+    readonly width: number;
+    /** Physical page height in pixels; edge pages may be smaller than the page size. */
+    readonly height: number;
+}
+
+/** One frame-scoped shadow-atlas slice exposed for GPU-driven caster work. */
+export interface RenderPipelineShadowSlice {
+    /** Light projection represented by the slice. */
+    readonly kind: 'directional' | 'spot' | 'point';
+    /** Stable LightBlock ABI index. */
+    readonly sliceIndex: number;
+    /** Dense physical placement index within the atlas. */
+    readonly physicalIndex: number;
+    /** Point-light cube face, or null for planar shadows. */
+    readonly face: number | null;
+    /** Directional cascade index, or null for local lights. */
+    readonly cascade: number | null;
+    /** Atlas viewport as `[x, y, width, height]`. */
+    readonly viewport: RendererViewport;
+    /** World-space to shadow clip-space transform. */
+    readonly viewProjectionMatrix: Float32Array;
+    /** Shadow-camera near plane. */
+    readonly near: number;
+    /** Shadow-camera far plane. */
+    readonly far: number;
+    /** Whether the submission-aware cache scheduled this slice for update. */
+    readonly dirty: boolean;
+}
+
+/** Optional hybrid-shadow selection used by GPU-managed pipelines. */
+export interface RenderPipelineShadowOptions {
+    /**
+     * Mesh identities omitted from CPU shadow draws while remaining part of cache invalidation.
+     * The caller must record equivalent atlas writes for every exposed `pageRegions` entry.
+     */
+    readonly excludeMeshes?: readonly Mesh[];
 }
 
 /** Frame-scoped recording context; retaining it after record() returns is an error. */
@@ -265,7 +321,8 @@ export interface RenderPipelineContext {
      * active. The returned arrays are frame-scoped and must not be retained after `record()`.
      */
     recordShadows(
-        cullingResults: CullingResultsHandle
+        cullingResults: CullingResultsHandle,
+        options?: Readonly<RenderPipelineShadowOptions>
     ): Readonly<RenderPipelineShadowResources> | null;
     /** Acquire one runtime-owned, high-water reusable parameter slot. */
     acquirePassParameters<P extends object>(pool: RenderPassParameterPool<P>): P;

--- a/src/render/renderer/ShadowAtlasContentCache.ts
+++ b/src/render/renderer/ShadowAtlasContentCache.ts
@@ -26,6 +26,8 @@ export interface ShadowAtlasContentDecision {
     readonly dirtySlices: readonly boolean[];
     /** First exact invalidation cause for each physical slice, or `null` on a cache hit. */
     readonly reasons: readonly (ShadowAtlasInvalidationReason | null)[];
+    /** Stable desired-content revision for each dirty slice; zero identifies a cache hit. */
+    readonly updateIds: readonly number[];
     readonly sliceCount: number;
     readonly dirtySliceCount: number;
     readonly cachedSliceCount: number;
@@ -81,6 +83,7 @@ interface SliceRecord {
     pending: SliceSnapshot;
     committedValid: boolean;
     pendingEpoch: number;
+    pendingUpdateId: number;
 }
 
 function createCasterSnapshot(): CasterSnapshot {
@@ -225,6 +228,7 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
     readonly #slices: SliceRecord[] = [];
     readonly #dirtySlices: boolean[] = [];
     readonly #reasons: (ShadowAtlasInvalidationReason | null)[] = [];
+    readonly #updateIds: number[] = [];
     #transactionEpoch = 0;
     #transactionActive = false;
     #pendingSliceCount = 0;
@@ -232,6 +236,7 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
     #pendingReplacements = 0;
     #pendingRemovals = 0;
     #nextCasterRevision = 1;
+    #nextSliceUpdateId = 1;
     #destroyed = false;
 
     stage(
@@ -249,6 +254,7 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
         const sliceCount = plan.slices.length;
         this.#dirtySlices.length = sliceCount;
         this.#reasons.length = sliceCount;
+        this.#updateIds.length = sliceCount;
         this.#pendingSliceCount = sliceCount;
         this.#pendingInsertions = 0;
         this.#pendingReplacements = 0;
@@ -274,10 +280,21 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
                 slice
             );
             const dirty = reason !== null;
+            let updateId = 0;
+            if (dirty) {
+                const repeatsPendingRequest =
+                    record.pendingUpdateId !== 0 &&
+                    this.sliceInvalidationReason(record.pending, atlas.token, slice) === null;
+                updateId = repeatsPendingRequest
+                    ? record.pendingUpdateId
+                    : this.allocateSliceUpdateId();
+            }
             this.copySlice(record.pending, atlas.token, slice);
             record.pendingEpoch = this.#transactionEpoch;
+            record.pendingUpdateId = updateId;
             this.#dirtySlices[physicalIndex] = dirty;
             this.#reasons[physicalIndex] = reason;
+            this.#updateIds[physicalIndex] = updateId;
             if (dirty) {
                 dirtySliceCount++;
                 this.metrics.recordMiss();
@@ -293,6 +310,7 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
         return Object.freeze({
             dirtySlices: this.#dirtySlices,
             reasons: this.#reasons,
+            updateIds: this.#updateIds,
             sliceCount,
             dirtySliceCount,
             cachedSliceCount: sliceCount - dirtySliceCount
@@ -309,6 +327,30 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
         this.#pendingRemovals = 0;
         for (const record of this.#slices) {
             if (record.committedValid) this.#pendingRemovals++;
+        }
+    }
+
+    /**
+     * Keep committed contents for dirty slices that an update scheduler deferred this frame.
+     * Deferred slices remain dirty on the next stage because their pending snapshot is not
+     * committed. Newly allocated slices cannot be deferred because they have no valid contents.
+     */
+    deferUnscheduled(scheduledSlices: readonly boolean[]): void {
+        this.assertAlive();
+        if (!this.#transactionActive) {
+            throw new Error('Shadow content cache has no staged transaction to schedule');
+        }
+        if (scheduledSlices.length !== this.#pendingSliceCount) {
+            throw new RangeError('Shadow update schedule must cover every pending atlas slice');
+        }
+        for (let index = 0; index < this.#pendingSliceCount; index += 1) {
+            if (this.#dirtySlices[index] !== true || scheduledSlices[index] === true) continue;
+            const record = this.#slices[index];
+            if (!record?.committedValid) {
+                throw new Error('A shadow slice without committed contents cannot be deferred');
+            }
+            record.pendingEpoch = 0;
+            if (this.#pendingReplacements > 0) this.#pendingReplacements--;
         }
     }
 
@@ -374,6 +416,7 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
         this.#slices.length = 0;
         this.#dirtySlices.length = 0;
         this.#reasons.length = 0;
+        this.#updateIds.length = 0;
         this.#destroyed = true;
     }
 
@@ -387,6 +430,15 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
             this.#activeCasterRecords.clear();
         }
         uploads.enlist(this);
+    }
+
+    private allocateSliceUpdateId(): number {
+        const revision = this.#nextSliceUpdateId;
+        if (!Number.isSafeInteger(revision)) {
+            throw new RangeError('Shadow slice update revision space is exhausted');
+        }
+        this.#nextSliceUpdateId++;
+        return revision;
     }
 
     private captureCasters(meshes: readonly Mesh[]): void {
@@ -631,7 +683,8 @@ export class ShadowAtlasContentCache implements RHIUploadBatchParticipant {
                 committed: createSliceSnapshot(),
                 pending: createSliceSnapshot(),
                 committedValid: false,
-                pendingEpoch: 0
+                pendingEpoch: 0,
+                pendingUpdateId: 0
             };
             this.#slices[index] = record;
         }

--- a/src/render/renderer/ShadowAtlasPageResidency.ts
+++ b/src/render/renderer/ShadowAtlasPageResidency.ts
@@ -1,0 +1,453 @@
+import type { RHIUploadBatch, RHIUploadBatchParticipant } from '../frame/RHIUploadBatch';
+import type { RHISubmission } from '../rhi/core';
+import type { ShadowAtlasContentDecision } from './ShadowAtlasContentCache';
+import type { ShadowAtlasScenePlan } from './ShadowAtlasSceneAdapter';
+
+export interface ShadowAtlasPageRegion {
+    readonly slicePhysicalIndex: number;
+    readonly pageX: number;
+    readonly pageY: number;
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+}
+
+export interface ShadowAtlasPageResidencyDecision {
+    /** Reused page update list. It remains valid only until the next `stage` call. */
+    readonly updateRegions: readonly Readonly<ShadowAtlasPageRegion>[];
+    /** Dirty slices whose complete desired revision will be resident after this submission. */
+    readonly completedSlices: readonly boolean[];
+    readonly requestedPageCount: number;
+    readonly scheduledPageCount: number;
+    readonly deferredPageCount: number;
+    readonly residentPageCount: number;
+    readonly mandatoryPageCount: number;
+    readonly budgetOverflowCount: number;
+}
+
+interface MutablePageRegion {
+    slicePhysicalIndex: number;
+    pageX: number;
+    pageY: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+interface PageRecord {
+    committedUpdateId: number;
+    pendingUpdateId: number;
+    pendingEpoch: number;
+}
+
+interface SliceRecord {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    columns: number;
+    rows: number;
+    readonly pages: PageRecord[];
+    committedCursor: number;
+    pendingCursor: number;
+    pendingCursorEpoch: number;
+}
+
+interface MutableDecisionState {
+    requestedPageCount: number;
+    scheduledPageCount: number;
+    deferredPageCount: number;
+    residentPageCount: number;
+    mandatoryPageCount: number;
+    budgetOverflowCount: number;
+}
+
+function positiveSafeInteger(value: number, label: string): number {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new RangeError(`${label} must be a positive safe integer`);
+    }
+    return value;
+}
+
+function createSliceRecord(): SliceRecord {
+    return {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        columns: 0,
+        rows: 0,
+        pages: [],
+        committedCursor: 0,
+        pendingCursor: 0,
+        pendingCursorEpoch: 0
+    };
+}
+
+/**
+ * Submission-aware fixed-atlas virtual-page residency for shadow updates. Receiver-driven slice
+ * sizing determines the requested virtual grid; dirty pages are redrawn with page scissoring and
+ * committed only after a valid RHI submission. Missing pages retain the previous slice contents.
+ */
+export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
+    readonly pageSize: number;
+    readonly maxPageUpdatesPerFrame: number;
+    readonly #slices: SliceRecord[] = [];
+    readonly #regions: MutablePageRegion[] = [];
+    readonly #completedSlices: boolean[] = [];
+    readonly #remainingPages: number[] = [];
+    readonly #state: MutableDecisionState = {
+        requestedPageCount: 0,
+        scheduledPageCount: 0,
+        deferredPageCount: 0,
+        residentPageCount: 0,
+        mandatoryPageCount: 0,
+        budgetOverflowCount: 0
+    };
+    readonly #decision: Readonly<ShadowAtlasPageResidencyDecision>;
+    #regionCount = 0;
+    #activeSliceCount = 0;
+    #committedSliceCursor = 0;
+    #pendingSliceCursor = 0;
+    #pendingSliceCursorEpoch = 0;
+    #transactionEpoch = 0;
+    #transactionActive = false;
+    #destroyed = false;
+
+    constructor(
+        options: { readonly pageSize?: number; readonly maxPageUpdatesPerFrame?: number } = {}
+    ) {
+        this.pageSize = positiveSafeInteger(options.pageSize ?? 128, 'Shadow pageSize');
+        this.maxPageUpdatesPerFrame = positiveSafeInteger(
+            options.maxPageUpdatesPerFrame ?? 32,
+            'Shadow maxPageUpdatesPerFrame'
+        );
+        const state = this.#state;
+        this.#decision = Object.freeze({
+            updateRegions: this.#regions,
+            completedSlices: this.#completedSlices,
+            get requestedPageCount() {
+                return state.requestedPageCount;
+            },
+            get scheduledPageCount() {
+                return state.scheduledPageCount;
+            },
+            get deferredPageCount() {
+                return state.deferredPageCount;
+            },
+            get residentPageCount() {
+                return state.residentPageCount;
+            },
+            get mandatoryPageCount() {
+                return state.mandatoryPageCount;
+            },
+            get budgetOverflowCount() {
+                return state.budgetOverflowCount;
+            }
+        });
+    }
+
+    stage(
+        plan: Readonly<ShadowAtlasScenePlan>,
+        content: Readonly<ShadowAtlasContentDecision>,
+        scheduledSlices: readonly boolean[],
+        uploads: RHIUploadBatch
+    ): Readonly<ShadowAtlasPageResidencyDecision> {
+        this.assertAlive();
+        const sliceCount = plan.slices.length;
+        if (
+            content.sliceCount !== sliceCount ||
+            content.updateIds.length !== sliceCount ||
+            scheduledSlices.length !== sliceCount
+        ) {
+            throw new TypeError('Shadow page residency requires matching dense slice inputs');
+        }
+        this.beginTransaction(uploads);
+        this.#activeSliceCount = sliceCount;
+        this.#regionCount = 0;
+        this.#completedSlices.length = sliceCount;
+        this.#completedSlices.fill(false);
+        let requested = 0;
+        let scheduled = 0;
+        let mandatory = 0;
+        let budgetRemaining = this.maxPageUpdatesPerFrame;
+        this.#remainingPages.length = sliceCount;
+        this.#remainingPages.fill(0);
+
+        for (let sliceIndex = 0; sliceIndex < sliceCount; sliceIndex += 1) {
+            if (content.dirtySlices[sliceIndex] !== true || scheduledSlices[sliceIndex] !== true) {
+                continue;
+            }
+            const slice = plan.slices[sliceIndex];
+            const targetUpdateId = content.updateIds[sliceIndex] ?? 0;
+            if (slice === undefined || targetUpdateId === 0) {
+                throw new Error('Dirty shadow pages require a slice and non-zero update revision');
+            }
+            const record = this.sliceAt(sliceIndex);
+            this.configureSlice(record, slice.viewport);
+            const reason = content.reasons[sliceIndex];
+            const forceComplete =
+                reason === 'allocation' || reason === 'layout' || reason === 'light';
+            const pageCount = record.columns * record.rows;
+            let missing = 0;
+            for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+                const page = record.pages[pageIndex];
+                if (page === undefined) throw new Error('Shadow page storage is incomplete');
+                if (!this.pageMatchesTarget(page, targetUpdateId)) missing++;
+            }
+            requested += missing;
+            this.#remainingPages[sliceIndex] = missing;
+            this.#completedSlices[sliceIndex] = missing === 0;
+            if (!forceComplete) continue;
+            while ((this.#remainingPages[sliceIndex] ?? 0) > 0) {
+                if (!this.scheduleNextPage(sliceIndex, targetUpdateId, record)) {
+                    throw new Error('Mandatory shadow page scheduling made no progress');
+                }
+                this.#remainingPages[sliceIndex] = (this.#remainingPages[sliceIndex] ?? 0) - 1;
+                mandatory++;
+                scheduled++;
+                if (budgetRemaining > 0) budgetRemaining--;
+            }
+            this.#completedSlices[sliceIndex] = true;
+        }
+
+        let sliceCursor =
+            this.#pendingSliceCursorEpoch === this.#transactionEpoch
+                ? this.#pendingSliceCursor
+                : this.#committedSliceCursor;
+        while (budgetRemaining > 0 && sliceCount > 0) {
+            let selectedSlice = -1;
+            for (let offset = 0; offset < sliceCount; offset += 1) {
+                const candidate = (sliceCursor + offset) % sliceCount;
+                if (
+                    (this.#remainingPages[candidate] ?? 0) > 0 &&
+                    content.dirtySlices[candidate] === true &&
+                    scheduledSlices[candidate] === true
+                ) {
+                    selectedSlice = candidate;
+                    break;
+                }
+            }
+            if (selectedSlice < 0) break;
+            const slice = plan.slices[selectedSlice];
+            const record = this.#slices[selectedSlice];
+            const targetUpdateId = content.updateIds[selectedSlice] ?? 0;
+            if (
+                slice === undefined ||
+                record === undefined ||
+                targetUpdateId === 0 ||
+                !this.scheduleNextPage(selectedSlice, targetUpdateId, record)
+            ) {
+                throw new Error('Budgeted shadow page scheduling made no progress');
+            }
+            this.#remainingPages[selectedSlice] = (this.#remainingPages[selectedSlice] ?? 0) - 1;
+            this.#completedSlices[selectedSlice] = this.#remainingPages[selectedSlice] === 0;
+            scheduled++;
+            budgetRemaining--;
+            sliceCursor = (selectedSlice + 1) % sliceCount;
+            this.#pendingSliceCursor = sliceCursor;
+            this.#pendingSliceCursorEpoch = this.#transactionEpoch;
+        }
+        this.#regions.length = this.#regionCount;
+        this.#state.requestedPageCount = requested;
+        this.#state.scheduledPageCount = scheduled;
+        this.#state.deferredPageCount = requested - scheduled;
+        this.#state.mandatoryPageCount = mandatory;
+        this.#state.budgetOverflowCount = Math.max(0, scheduled - this.maxPageUpdatesPerFrame);
+        this.#state.residentPageCount = this.residentPageCount();
+        return this.#decision;
+    }
+
+    stageEmpty(uploads: RHIUploadBatch): void {
+        this.assertAlive();
+        this.beginTransaction(uploads);
+        this.#activeSliceCount = 0;
+        this.#regionCount = 0;
+        this.#regions.length = 0;
+        this.#completedSlices.length = 0;
+        this.#remainingPages.length = 0;
+        this.#state.requestedPageCount = 0;
+        this.#state.scheduledPageCount = 0;
+        this.#state.deferredPageCount = 0;
+        this.#state.mandatoryPageCount = 0;
+        this.#state.budgetOverflowCount = 0;
+    }
+
+    invalidateAll(): void {
+        this.assertAlive();
+        this.rollback();
+        for (const slice of this.#slices) {
+            for (const page of slice.pages) page.committedUpdateId = 0;
+        }
+        this.#state.residentPageCount = 0;
+    }
+
+    prepareCommit(_submission: RHISubmission): void {
+        this.assertAlive();
+        if (!this.#transactionActive) {
+            throw new Error('Shadow page residency has no staged transaction to commit');
+        }
+    }
+
+    commit(_submission: RHISubmission): void {
+        if (!this.#transactionActive) return;
+        for (let sliceIndex = 0; sliceIndex < this.#activeSliceCount; sliceIndex += 1) {
+            const slice = this.#slices[sliceIndex];
+            if (slice === undefined) continue;
+            for (const page of slice.pages) {
+                if (page.pendingEpoch !== this.#transactionEpoch) continue;
+                page.committedUpdateId = page.pendingUpdateId;
+            }
+            if (slice.pendingCursorEpoch === this.#transactionEpoch) {
+                slice.committedCursor = slice.pendingCursor;
+            }
+        }
+        for (
+            let sliceIndex = this.#activeSliceCount;
+            sliceIndex < this.#slices.length;
+            sliceIndex += 1
+        ) {
+            const slice = this.#slices[sliceIndex];
+            if (slice === undefined) continue;
+            for (const page of slice.pages) page.committedUpdateId = 0;
+            slice.committedCursor = 0;
+        }
+        if (this.#pendingSliceCursorEpoch === this.#transactionEpoch) {
+            this.#committedSliceCursor = this.#pendingSliceCursor;
+        }
+        this.#state.residentPageCount = this.residentPageCount();
+        this.#transactionActive = false;
+    }
+
+    rollback(): void {
+        this.#transactionActive = false;
+    }
+
+    destroy(): void {
+        if (this.#destroyed) return;
+        this.rollback();
+        this.#slices.length = 0;
+        this.#regions.length = 0;
+        this.#completedSlices.length = 0;
+        this.#remainingPages.length = 0;
+        this.#destroyed = true;
+    }
+
+    private beginTransaction(uploads: RHIUploadBatch): void {
+        if (!this.#transactionActive) {
+            if (!Number.isSafeInteger(this.#transactionEpoch + 1)) {
+                throw new RangeError('Shadow page residency transaction space is exhausted');
+            }
+            this.#transactionEpoch++;
+            this.#transactionActive = true;
+        }
+        uploads.enlist(this);
+    }
+
+    private sliceAt(index: number): SliceRecord {
+        let record = this.#slices[index];
+        if (record === undefined) {
+            record = createSliceRecord();
+            this.#slices[index] = record;
+        }
+        return record;
+    }
+
+    private configureSlice(
+        record: SliceRecord,
+        viewport: Readonly<{ x: number; y: number; width: number; height: number }>
+    ): void {
+        const columns = Math.ceil(viewport.width / this.pageSize);
+        const rows = Math.ceil(viewport.height / this.pageSize);
+        record.x = viewport.x;
+        record.y = viewport.y;
+        record.width = viewport.width;
+        record.height = viewport.height;
+        record.columns = columns;
+        record.rows = rows;
+        const pageCount = columns * rows;
+        while (record.pages.length < pageCount) {
+            record.pages.push({ committedUpdateId: 0, pendingUpdateId: 0, pendingEpoch: 0 });
+        }
+        if (pageCount > 0) record.committedCursor %= pageCount;
+    }
+
+    private pageMatchesTarget(page: Readonly<PageRecord>, targetUpdateId: number): boolean {
+        return (
+            page.committedUpdateId === targetUpdateId ||
+            (page.pendingEpoch === this.#transactionEpoch &&
+                page.pendingUpdateId === targetUpdateId)
+        );
+    }
+
+    private scheduleNextPage(
+        slicePhysicalIndex: number,
+        targetUpdateId: number,
+        slice: SliceRecord
+    ): boolean {
+        const pageCount = slice.columns * slice.rows;
+        if (pageCount === 0) return false;
+        const start =
+            slice.pendingCursorEpoch === this.#transactionEpoch
+                ? slice.pendingCursor % pageCount
+                : slice.committedCursor % pageCount;
+        for (let offset = 0; offset < pageCount; offset += 1) {
+            const pageIndex = (start + offset) % pageCount;
+            const page = slice.pages[pageIndex];
+            if (page === undefined) throw new Error('Shadow page storage is incomplete');
+            if (this.pageMatchesTarget(page, targetUpdateId)) continue;
+            page.pendingUpdateId = targetUpdateId;
+            page.pendingEpoch = this.#transactionEpoch;
+            slice.pendingCursor = (pageIndex + 1) % pageCount;
+            slice.pendingCursorEpoch = this.#transactionEpoch;
+            this.writeRegion(
+                slicePhysicalIndex,
+                pageIndex % slice.columns,
+                Math.floor(pageIndex / slice.columns),
+                slice
+            );
+            return true;
+        }
+        return false;
+    }
+
+    private writeRegion(
+        slicePhysicalIndex: number,
+        pageX: number,
+        pageY: number,
+        slice: Readonly<SliceRecord>
+    ): void {
+        let region = this.#regions[this.#regionCount];
+        if (region === undefined) {
+            region = { slicePhysicalIndex: 0, pageX: 0, pageY: 0, x: 0, y: 0, width: 0, height: 0 };
+            this.#regions[this.#regionCount] = region;
+        }
+        region.slicePhysicalIndex = slicePhysicalIndex;
+        region.pageX = pageX;
+        region.pageY = pageY;
+        region.x = slice.x + pageX * this.pageSize;
+        region.y = slice.y + pageY * this.pageSize;
+        region.width = Math.min(this.pageSize, slice.width - pageX * this.pageSize);
+        region.height = Math.min(this.pageSize, slice.height - pageY * this.pageSize);
+        this.#regionCount++;
+    }
+
+    private residentPageCount(): number {
+        let count = 0;
+        for (let sliceIndex = 0; sliceIndex < this.#activeSliceCount; sliceIndex += 1) {
+            const slice = this.#slices[sliceIndex];
+            if (slice === undefined) continue;
+            const activePages = slice.columns * slice.rows;
+            for (let pageIndex = 0; pageIndex < activePages; pageIndex += 1) {
+                if (slice.pages[pageIndex]?.committedUpdateId !== 0) count++;
+            }
+        }
+        return count;
+    }
+
+    private assertAlive(): void {
+        if (this.#destroyed) throw new Error('ShadowAtlasPageResidency is destroyed');
+    }
+}

--- a/src/render/renderer/ShadowAtlasPageResidency.ts
+++ b/src/render/renderer/ShadowAtlasPageResidency.ts
@@ -86,16 +86,51 @@ function createSliceRecord(): SliceRecord {
     };
 }
 
+function horizontalRegionOrder(
+    left: Readonly<MutablePageRegion>,
+    right: Readonly<MutablePageRegion>
+): number {
+    return (
+        left.slicePhysicalIndex - right.slicePhysicalIndex ||
+        left.pageY - right.pageY ||
+        left.pageX - right.pageX
+    );
+}
+
+function verticalRegionOrder(
+    left: Readonly<MutablePageRegion>,
+    right: Readonly<MutablePageRegion>
+): number {
+    return (
+        left.slicePhysicalIndex - right.slicePhysicalIndex ||
+        left.x - right.x ||
+        left.width - right.width ||
+        left.y - right.y
+    );
+}
+
+function copyRegion(target: MutablePageRegion, source: Readonly<MutablePageRegion>): void {
+    target.slicePhysicalIndex = source.slicePhysicalIndex;
+    target.pageX = source.pageX;
+    target.pageY = source.pageY;
+    target.x = source.x;
+    target.y = source.y;
+    target.width = source.width;
+    target.height = source.height;
+}
+
 /**
  * Submission-aware fixed-atlas virtual-page residency for shadow updates. Receiver-driven slice
- * sizing determines the requested virtual grid; dirty pages are redrawn with page scissoring and
- * committed only after a valid RHI submission. Missing pages retain the previous slice contents.
+ * sizing determines the requested virtual grid; dirty pages are redrawn through coalesced scissor
+ * rectangles and committed only after a valid RHI submission. Missing pages retain the previous
+ * slice contents.
  */
 export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
     readonly pageSize: number;
     readonly maxPageUpdatesPerFrame: number;
     readonly #slices: SliceRecord[] = [];
     readonly #regions: MutablePageRegion[] = [];
+    readonly #spareRegions: MutablePageRegion[] = [];
     readonly #completedSlices: boolean[] = [];
     readonly #remainingPages: number[] = [];
     readonly #state: MutableDecisionState = {
@@ -250,7 +285,8 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
             this.#pendingSliceCursor = sliceCursor;
             this.#pendingSliceCursorEpoch = this.#transactionEpoch;
         }
-        this.#regions.length = this.#regionCount;
+        this.truncateRegions(this.#regionCount);
+        this.coalesceUpdateRegions();
         this.#state.requestedPageCount = requested;
         this.#state.scheduledPageCount = scheduled;
         this.#state.deferredPageCount = requested - scheduled;
@@ -265,7 +301,7 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
         this.beginTransaction(uploads);
         this.#activeSliceCount = 0;
         this.#regionCount = 0;
-        this.#regions.length = 0;
+        this.truncateRegions(0);
         this.#completedSlices.length = 0;
         this.#remainingPages.length = 0;
         this.#state.requestedPageCount = 0;
@@ -330,6 +366,7 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
         this.rollback();
         this.#slices.length = 0;
         this.#regions.length = 0;
+        this.#spareRegions.length = 0;
         this.#completedSlices.length = 0;
         this.#remainingPages.length = 0;
         this.#destroyed = true;
@@ -421,7 +458,15 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
     ): void {
         let region = this.#regions[this.#regionCount];
         if (region === undefined) {
-            region = { slicePhysicalIndex: 0, pageX: 0, pageY: 0, x: 0, y: 0, width: 0, height: 0 };
+            region = this.#spareRegions.pop() ?? {
+                slicePhysicalIndex: 0,
+                pageX: 0,
+                pageY: 0,
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0
+            };
             this.#regions[this.#regionCount] = region;
         }
         region.slicePhysicalIndex = slicePhysicalIndex;
@@ -432,6 +477,66 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
         region.width = Math.min(this.pageSize, slice.width - pageX * this.pageSize);
         region.height = Math.min(this.pageSize, slice.height - pageY * this.pageSize);
         this.#regionCount++;
+    }
+
+    private coalesceUpdateRegions(): void {
+        if (this.#regionCount < 2) return;
+        this.#regions.sort(horizontalRegionOrder);
+        let horizontalCount = 0;
+        for (let sourceIndex = 0; sourceIndex < this.#regionCount; sourceIndex += 1) {
+            const source = this.#regions[sourceIndex];
+            if (source === undefined) throw new Error('Shadow page region storage is incomplete');
+            const previous = this.#regions[horizontalCount - 1];
+            if (
+                previous?.slicePhysicalIndex === source.slicePhysicalIndex &&
+                previous.pageY === source.pageY &&
+                previous.y === source.y &&
+                previous.height === source.height &&
+                previous.x + previous.width === source.x
+            ) {
+                previous.width += source.width;
+                continue;
+            }
+            const target = this.#regions[horizontalCount];
+            if (target === undefined) throw new Error('Shadow page region storage is incomplete');
+            if (target !== source) copyRegion(target, source);
+            horizontalCount++;
+        }
+        this.truncateRegions(horizontalCount);
+        if (horizontalCount < 2) {
+            this.#regionCount = horizontalCount;
+            return;
+        }
+
+        this.#regions.sort(verticalRegionOrder);
+        let compactCount = 0;
+        for (let sourceIndex = 0; sourceIndex < horizontalCount; sourceIndex += 1) {
+            const source = this.#regions[sourceIndex];
+            if (source === undefined) throw new Error('Shadow page region storage is incomplete');
+            const previous = this.#regions[compactCount - 1];
+            if (
+                previous?.slicePhysicalIndex === source.slicePhysicalIndex &&
+                previous.x === source.x &&
+                previous.width === source.width &&
+                previous.y + previous.height === source.y
+            ) {
+                previous.height += source.height;
+                continue;
+            }
+            const target = this.#regions[compactCount];
+            if (target === undefined) throw new Error('Shadow page region storage is incomplete');
+            if (target !== source) copyRegion(target, source);
+            compactCount++;
+        }
+        this.#regionCount = compactCount;
+        this.truncateRegions(compactCount);
+    }
+
+    private truncateRegions(length: number): void {
+        while (this.#regions.length > length) {
+            const region = this.#regions.pop();
+            if (region !== undefined) this.#spareRegions.push(region);
+        }
     }
 
     private residentPageCount(): number {

--- a/src/render/renderer/ShadowAtlasPlanner.ts
+++ b/src/render/renderer/ShadowAtlasPlanner.ts
@@ -15,6 +15,10 @@ export interface ShadowAtlasLightRequest<Owner extends object = object> {
     readonly height: number;
     /** Directional requests only. Omitted requests use one compatibility cascade. */
     readonly cascadeCount?: number;
+    /** Optional per-slice widths for directional cascades or point faces. */
+    readonly sliceWidths?: readonly number[];
+    /** Optional per-slice heights for directional cascades or point faces. */
+    readonly sliceHeights?: readonly number[];
 }
 
 export interface ShadowAtlasRequests<Owner extends object = object> {
@@ -418,9 +422,12 @@ export class ShadowAtlasPlanner<Owner extends object = object> {
             requirePositiveSafeInteger(request.width, `${kind} shadow width`);
             requirePositiveSafeInteger(request.height, `${kind} shadow height`);
             if (kind === 'directional') {
-                this.directionalRequestCascadeCount(request);
+                const count = this.directionalRequestCascadeCount(request);
+                this.validateSliceDimensions(request, count, kind);
             } else if (request.cascadeCount !== undefined) {
                 throw new TypeError('Only directional shadow requests may specify cascadeCount');
+            } else {
+                this.validateSliceDimensions(request, kind === 'point' ? 6 : 1, kind);
             }
             requireOwner(request.owner, kind, index);
             if (this.#seenOwners.has(request.owner)) {
@@ -504,14 +511,16 @@ export class ShadowAtlasPlanner<Owner extends object = object> {
                 slice.physicalIndex = physicalIndex;
                 slice.viewport.x = x;
                 slice.viewport.y = y;
-                slice.viewport.width = tileWidth;
-                slice.viewport.height = tileHeight;
+                const sliceWidth = request.sliceWidths?.[subIndex] ?? tileWidth;
+                const sliceHeight = request.sliceHeights?.[subIndex] ?? tileHeight;
+                slice.viewport.width = sliceWidth;
+                slice.viewport.height = sliceHeight;
                 slice.viewport.minDepth = 0;
                 slice.viewport.maxDepth = 1;
                 slice.uvRect.x = x / atlasWidth;
                 slice.uvRect.y = y / atlasHeight;
-                slice.uvRect.width = tileWidth / atlasWidth;
-                slice.uvRect.height = tileHeight / atlasHeight;
+                slice.uvRect.width = sliceWidth / atlasWidth;
+                slice.uvRect.height = sliceHeight / atlasHeight;
                 physicalIndex++;
             }
         }
@@ -538,6 +547,32 @@ export class ShadowAtlasPlanner<Owner extends object = object> {
             );
         }
         return count;
+    }
+
+    private validateSliceDimensions(
+        request: ShadowAtlasLightRequest<Owner>,
+        count: number,
+        kind: ShadowAtlasLightKind
+    ): void {
+        for (const [name, values] of [
+            ['sliceWidths', request.sliceWidths],
+            ['sliceHeights', request.sliceHeights]
+        ] as const) {
+            if (values === undefined) continue;
+            if (values.length !== count) {
+                throw new RangeError(
+                    `${kind} shadow ${name} must contain exactly ${String(count)} values`
+                );
+            }
+            for (let index = 0; index < values.length; index += 1) {
+                const value = values[index];
+                requirePositiveSafeInteger(value ?? 0, `${kind} shadow ${name}[${String(index)}]`);
+                const maximum = name === 'sliceWidths' ? request.width : request.height;
+                if ((value ?? 0) > maximum) {
+                    throw new RangeError(`${kind} shadow ${name} cannot exceed its request size`);
+                }
+            }
+        }
     }
 
     private recordOwner(

--- a/src/render/renderer/ShadowAtlasRenderer.ts
+++ b/src/render/renderer/ShadowAtlasRenderer.ts
@@ -36,7 +36,7 @@ export interface ShadowAtlasRenderOptions<Owner extends object = object> {
     readonly depthClearValue?: number;
     /** Physical-index update mask supplied by the submission-aware S0 content cache. */
     readonly dirtySlices?: readonly boolean[] | undefined;
-    /** Optional page-granular update list. When present, each entry records one scissored pass. */
+    /** Optional coalesced page update list. Each rectangle records one scissored pass. */
     readonly pageRegions?: readonly Readonly<ShadowAtlasPageRegion>[] | undefined;
     /** Portable depth-only fullscreen draw used to clear one scissored dirty slice. */
     readonly sliceClearDraw?: PreparedDraw | undefined;
@@ -183,7 +183,9 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
                     else pass.addDraw(options.sliceClearDraw);
                 }
                 const draws =
-                    options.preparer?.prepare(slice) ?? options.sliceDraws?.[index] ?? EMPTY_DRAWS;
+                    options.preparer?.prepare(slice) ??
+                    options.sliceDraws?.[sliceIndex] ??
+                    EMPTY_DRAWS;
                 for (const draw of draws) {
                     if (meshFrameStarted) pass.addDrawSnapshot(draw);
                     else pass.addDraw(draw);

--- a/src/render/renderer/ShadowAtlasRenderer.ts
+++ b/src/render/renderer/ShadowAtlasRenderer.ts
@@ -10,6 +10,7 @@ import type { RenderTargetGraphBridge } from './RenderTargetGraphBridge';
 import type { ResourceRegistry } from './ResourceRegistry';
 import type { ShadowAtlasPlan, ShadowAtlasSlice } from './ShadowAtlasPlanner';
 import type { ShadowAtlasResourceRecord } from './ShadowAtlasResourceCache';
+import type { ShadowAtlasPageRegion } from './ShadowAtlasPageResidency';
 import { SubmissionResourceTracker } from './SubmissionResourceTracker';
 import { ShadowPassTemplate, SharedDrawPassParameters } from './passes';
 
@@ -35,6 +36,8 @@ export interface ShadowAtlasRenderOptions<Owner extends object = object> {
     readonly depthClearValue?: number;
     /** Physical-index update mask supplied by the submission-aware S0 content cache. */
     readonly dirtySlices?: readonly boolean[] | undefined;
+    /** Optional page-granular update list. When present, each entry records one scissored pass. */
+    readonly pageRegions?: readonly Readonly<ShadowAtlasPageRegion>[] | undefined;
     /** Portable depth-only fullscreen draw used to clear one scissored dirty slice. */
     readonly sliceClearDraw?: PreparedDraw | undefined;
 }
@@ -145,11 +148,16 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
 
             let previousPass: RGPassHandle | null = null;
             let builtPassCount = 0;
-            for (let index = 0; index < plan.slices.length; index += 1) {
-                const slice = plan.slices[index];
+            const workCount = options.pageRegions?.length ?? plan.slices.length;
+            for (let index = 0; index < workCount; index += 1) {
+                const region = options.pageRegions?.[index];
+                const sliceIndex = region?.slicePhysicalIndex ?? index;
+                const slice = plan.slices[sliceIndex];
                 if (slice === undefined)
                     throw new Error('Shadow atlas plan contains a sparse slice');
-                if (options.dirtySlices?.[index] === false) continue;
+                if (options.pageRegions === undefined && options.dirtySlices?.[index] === false) {
+                    continue;
+                }
                 const pass = this.passAt(this.#passCursor++);
                 pass.reset();
                 pass.label = `${options.label ?? 'Shadow atlas'} ${slice.kind} ${String(slice.sliceIndex)}`;
@@ -164,10 +172,10 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
                 });
                 pass.setViewport(slice.viewport);
                 pass.setScissor({
-                    x: Math.floor(slice.viewport.x),
-                    y: Math.floor(slice.viewport.y),
-                    width: Math.floor(slice.viewport.width),
-                    height: Math.floor(slice.viewport.height)
+                    x: Math.floor(region?.x ?? slice.viewport.x),
+                    y: Math.floor(region?.y ?? slice.viewport.y),
+                    width: Math.floor(region?.width ?? slice.viewport.width),
+                    height: Math.floor(region?.height ?? slice.viewport.height)
                 });
                 if (previousPass !== null) pass.dependsOn(previousPass);
                 if (options.sliceClearDraw !== undefined) {
@@ -263,6 +271,30 @@ export class ShadowAtlasRenderer<Owner extends object = object> {
             options.dirtySlices.length !== plan.slices.length
         ) {
             throw new RangeError('Shadow dirtySlices must match plan.slices order and count');
+        }
+        if (options.pageRegions !== undefined) {
+            for (const region of options.pageRegions) {
+                const slice = plan.slices[region.slicePhysicalIndex];
+                if (
+                    slice === undefined ||
+                    !Number.isSafeInteger(region.pageX) ||
+                    !Number.isSafeInteger(region.pageY) ||
+                    region.pageX < 0 ||
+                    region.pageY < 0 ||
+                    !Number.isSafeInteger(region.x) ||
+                    !Number.isSafeInteger(region.y) ||
+                    !Number.isSafeInteger(region.width) ||
+                    !Number.isSafeInteger(region.height) ||
+                    region.width <= 0 ||
+                    region.height <= 0 ||
+                    region.x < slice.viewport.x ||
+                    region.y < slice.viewport.y ||
+                    region.x + region.width > slice.viewport.x + slice.viewport.width ||
+                    region.y + region.height > slice.viewport.y + slice.viewport.height
+                ) {
+                    throw new RangeError('Shadow page region must fit its physical atlas slice');
+                }
+            }
         }
         if (
             options.dirtySlices !== undefined &&

--- a/src/render/renderer/ShadowAtlasSceneAdapter.ts
+++ b/src/render/renderer/ShadowAtlasSceneAdapter.ts
@@ -39,6 +39,14 @@ export interface ShadowAtlasScenePrepareOptions {
     readonly width: number;
     /** Default planar shadow-map height. Point lights use the smaller dimension. */
     readonly height: number;
+    /** Scale local lights and distant cascades from main-camera receiver coverage. */
+    readonly receiverDrivenResolution?: boolean;
+    /** Lower bound used by receiver-driven sizing. Defaults to 128 pixels. */
+    readonly minimumResolution?: number;
+    /** Monotonic renderer frame used by directional-cascade update cadence. Defaults to zero. */
+    readonly frameIndex?: number;
+    /** Per-cascade camera update intervals. Omitted intervals update every frame. */
+    readonly cascadeUpdateIntervals?: readonly number[];
 }
 
 /** Fixed-capacity arrays ready for the canonical LightBlock writer. */
@@ -106,6 +114,8 @@ interface MutableRequest extends ShadowAtlasLightRequest<ShadowAtlasSceneLight> 
     width: number;
     height: number;
     cascadeCount?: number;
+    sliceWidths?: number[];
+    sliceHeights?: number[];
 }
 
 interface StagedPlanarLight<LightType extends SpotLight, CameraType extends Camera> {
@@ -123,6 +133,8 @@ interface StagedDirectionalLight {
     readonly cameras: readonly OrthographicCamera[];
     readonly lightSpaceMatrices: readonly Matrix4[];
     readonly splits: Float32Array;
+    readonly renderWidths: Float64Array;
+    readonly renderHeights: Float64Array;
     cascadeCount: number;
     cascadeBlend: number;
     shadowStrength: number;
@@ -146,6 +158,13 @@ interface CommittedLightRecord {
     kind: ShadowAtlasLightKind;
     readonly cameras: Camera[];
     readonly lightSpaceMatrices: Matrix4[];
+    readonly lightWorldMatrix: Matrix4;
+    readonly lightDirection: Vector3;
+    readonly directionalSplits: Float32Array;
+    readonly directionalRenderWidths: Float64Array;
+    readonly directionalRenderHeights: Float64Array;
+    directionalCascadeCount: number;
+    directionalStateValid: boolean;
     activeSliceCount: number;
     epoch: number;
 }
@@ -193,6 +212,7 @@ interface MutableLightBlockState {
 const tempMatrix = new Matrix4();
 const tempTarget = new Vector3();
 const tempCascadePoint = new Vector3();
+const tempReceiverPosition = new Vector3();
 const tempBounds: Bounds = {
     x: 0,
     y: 0,
@@ -738,6 +758,75 @@ function createMutableRequest(): MutableRequest {
     return { owner: null as unknown as ShadowAtlasSceneLight, width: 1, height: 1 };
 }
 
+function quantizedReceiverDimension(value: number, minimum: number, maximum: number): number {
+    if (maximum <= minimum) return maximum;
+    const bounded = Math.min(maximum, Math.max(minimum, value));
+    return Math.min(maximum, Math.max(minimum, 2 ** Math.ceil(Math.log2(bounded))));
+}
+
+function sameNumbers(left: ArrayLike<number>, right: ArrayLike<number>, count: number): boolean {
+    for (let index = 0; index < count; index += 1) {
+        if (!Object.is(left[index], right[index])) return false;
+    }
+    return true;
+}
+
+function receiverDrivenLocalDimensions(
+    request: MutableRequest,
+    light: SpotLight | PointLight,
+    camera: Camera,
+    minimum: number
+): void {
+    if (!(camera instanceof PerspectiveCamera) || light.range <= 0) return;
+    const originalWidth = request.width;
+    const originalHeight = request.height;
+    light.updateMatrixWorld(true);
+    const world = light.worldMatrix.elements;
+    tempReceiverPosition.set(world[12], world[13], world[14]).transformMat4(camera.viewMatrix);
+    const depth = -tempReceiverPosition.z;
+    const focalPixels = originalHeight / (2 * Math.tan((camera.fov * Math.PI) / 360));
+    const diameterPixels =
+        depth <= 0 ? 0 : (2 * light.range * focalPixels) / Math.max(depth, camera.near);
+    const scale = Math.min(1, diameterPixels / Math.max(originalWidth, originalHeight));
+    const width = quantizedReceiverDimension(originalWidth * scale, minimum, originalWidth);
+    const height = quantizedReceiverDimension(originalHeight * scale, minimum, originalHeight);
+    const sliceCount = light instanceof PointLight ? 6 : 1;
+    const widths = request.sliceWidths ?? [];
+    const heights = request.sliceHeights ?? [];
+    widths.length = sliceCount;
+    heights.length = sliceCount;
+    widths.fill(width);
+    heights.fill(height);
+    request.sliceWidths = widths;
+    request.sliceHeights = heights;
+}
+
+function configureDirectionalSliceDimensions(
+    request: MutableRequest,
+    cascadeCount: number,
+    minimum: number
+): void {
+    const widths = request.sliceWidths ?? [];
+    const heights = request.sliceHeights ?? [];
+    widths.length = cascadeCount;
+    heights.length = cascadeCount;
+    for (let cascade = 0; cascade < cascadeCount; cascade += 1) {
+        const divisor = 2 ** cascade;
+        widths[cascade] = quantizedReceiverDimension(
+            request.width / divisor,
+            minimum,
+            request.width
+        );
+        heights[cascade] = quantizedReceiverDimension(
+            request.height / divisor,
+            minimum,
+            request.height
+        );
+    }
+    request.sliceWidths = widths;
+    request.sliceHeights = heights;
+}
+
 function createMutableSceneSlice(): MutableSceneSlice {
     return {
         light: null,
@@ -866,18 +955,49 @@ export class ShadowAtlasSceneAdapter {
         }
         const defaultWidth = positiveSafeInteger(options.width, 'Shadow atlas default width');
         const defaultHeight = positiveSafeInteger(options.height, 'Shadow atlas default height');
+        const minimumResolution = positiveSafeInteger(
+            options.minimumResolution ?? 128,
+            'Shadow atlas minimum receiver resolution'
+        );
+        const frameIndex = options.frameIndex ?? 0;
+        if (!Number.isSafeInteger(frameIndex) || frameIndex < 0) {
+            throw new RangeError('Shadow frameIndex must be a non-negative safe integer');
+        }
+        const cascadeUpdateIntervals = options.cascadeUpdateIntervals;
+        if (cascadeUpdateIntervals !== undefined) {
+            for (let index = 0; index < cascadeUpdateIntervals.length; index += 1) {
+                positiveSafeInteger(
+                    cascadeUpdateIntervals[index] ?? 0,
+                    `Shadow cascadeUpdateIntervals[${String(index)}]`
+                );
+            }
+        }
         mainCamera.updateViewProjectionMatrix();
         finiteMatrix(mainCamera.worldMatrix, 'Active camera worldMatrix');
         finiteMatrix(mainCamera.viewProjectionMatrix, 'Active camera viewProjectionMatrix');
 
-        this.collectRequests(manager, mainCamera, defaultWidth, defaultHeight);
+        this.collectRequests(
+            manager,
+            mainCamera,
+            defaultWidth,
+            defaultHeight,
+            options.receiverDrivenResolution === true,
+            minimumResolution
+        );
         this.validateCounts();
         const tileWidth = this.stageTileDimension(defaultWidth, 'width');
         const tileHeight = this.stageTileDimension(defaultHeight, 'height');
         const tileAspect = tileWidth / tileHeight;
         // Keep every fallible scene/camera calculation before build(): the planner mutates its
         // reusable public plan only after its own validation succeeds.
-        this.stageCameras(mainCamera, tileWidth, tileHeight, tileAspect);
+        this.stageCameras(
+            mainCamera,
+            tileWidth,
+            tileHeight,
+            tileAspect,
+            frameIndex,
+            cascadeUpdateIntervals
+        );
 
         const atlas = this.planner.build(this.#stageRequests, capabilities);
         this.finishStagedLightBlock(atlas);
@@ -943,7 +1063,9 @@ export class ShadowAtlasSceneAdapter {
         manager: LightManager,
         mainCamera: Camera,
         width: number,
-        height: number
+        height: number,
+        receiverDriven: boolean,
+        minimumResolution: number
     ): void {
         this.#stageDirectionalRequests.length = 0;
         this.#stageSpotRequests.length = 0;
@@ -951,9 +1073,30 @@ export class ShadowAtlasSceneAdapter {
         if (!manager.shadowEnabled) return;
         this.#seenLights.clear();
         try {
-            this.collectDirectional(manager.directionalLights, mainCamera, width, height);
-            this.collectSpot(manager.spotLights, width, height);
-            this.collectPoint(manager.pointLights, width, height);
+            this.collectDirectional(
+                manager.directionalLights,
+                mainCamera,
+                width,
+                height,
+                receiverDriven,
+                minimumResolution
+            );
+            this.collectSpot(
+                manager.spotLights,
+                mainCamera,
+                width,
+                height,
+                receiverDriven,
+                minimumResolution
+            );
+            this.collectPoint(
+                manager.pointLights,
+                mainCamera,
+                width,
+                height,
+                receiverDriven,
+                minimumResolution
+            );
         } finally {
             this.#seenLights.clear();
         }
@@ -963,7 +1106,9 @@ export class ShadowAtlasSceneAdapter {
         lights: readonly DirectionalLight[],
         mainCamera: Camera,
         width: number,
-        height: number
+        height: number,
+        receiverDriven: boolean,
+        minimumResolution: number
     ): void {
         for (const light of lights) {
             if (!(light instanceof DirectionalLight)) {
@@ -983,11 +1128,25 @@ export class ShadowAtlasSceneAdapter {
             finiteDirection(light);
             validateCameraInfo(light.shadow.cameraInfo, 'Directional shadow cameraInfo');
             configureDirectionalCascades(staged, light.shadow, mainCamera);
+            if (receiverDriven) {
+                configureDirectionalSliceDimensions(
+                    staged.request,
+                    staged.cascadeCount,
+                    minimumResolution
+                );
+            }
             this.#stageDirectionalRequests.push(staged.request);
         }
     }
 
-    private collectSpot(lights: readonly SpotLight[], width: number, height: number): void {
+    private collectSpot(
+        lights: readonly SpotLight[],
+        mainCamera: Camera,
+        width: number,
+        height: number,
+        receiverDriven: boolean,
+        minimumResolution: number
+    ): void {
         for (const light of lights) {
             if (!(light instanceof SpotLight)) {
                 throw new TypeError('Spot shadow lists must contain SpotLight values');
@@ -1001,13 +1160,23 @@ export class ShadowAtlasSceneAdapter {
             }
             const staged = this.spotStageAt(index);
             this.stageRequest(staged, light, light.shadow, width, height, false);
+            if (receiverDriven) {
+                receiverDrivenLocalDimensions(staged.request, light, mainCamera, minimumResolution);
+            }
             finiteDirection(light);
             validateCameraInfo(light.shadow.cameraInfo, 'Spot shadow cameraInfo');
             this.#stageSpotRequests.push(staged.request);
         }
     }
 
-    private collectPoint(lights: readonly PointLight[], width: number, height: number): void {
+    private collectPoint(
+        lights: readonly PointLight[],
+        mainCamera: Camera,
+        width: number,
+        height: number,
+        receiverDriven: boolean,
+        minimumResolution: number
+    ): void {
         for (const light of lights) {
             if (!(light instanceof PointLight)) {
                 throw new TypeError('Point shadow lists must contain PointLight values');
@@ -1021,6 +1190,9 @@ export class ShadowAtlasSceneAdapter {
             }
             const staged = this.pointStageAt(index);
             this.stageRequest(staged, light, light.shadow, width, height, true);
+            if (receiverDriven) {
+                receiverDrivenLocalDimensions(staged.request, light, mainCamera, minimumResolution);
+            }
             validateCameraInfo(light.shadow.cameraInfo, 'Point shadow cameraInfo');
             this.#stagePointRequests.push(staged.request);
         }
@@ -1064,6 +1236,8 @@ export class ShadowAtlasSceneAdapter {
         staged.request.width = width;
         staged.request.height = height;
         delete staged.request.cascadeCount;
+        delete staged.request.sliceWidths;
+        delete staged.request.sliceHeights;
         writeShadowBias(shadow, staged);
     }
 
@@ -1116,7 +1290,9 @@ export class ShadowAtlasSceneAdapter {
         mainCamera: Camera,
         tileWidth: number,
         tileHeight: number,
-        tileAspect: number
+        tileAspect: number,
+        frameIndex: number,
+        cascadeUpdateIntervals: readonly number[] | undefined
     ): void {
         clearLightBlockState(this.#stageLightBlock);
         this.#stageLightBlock.directionalShadowCount = this.#stageDirectionalRequests.length;
@@ -1129,6 +1305,14 @@ export class ShadowAtlasSceneAdapter {
                 throw new Error('Directional shadow staging is incomplete');
             }
             light.updateMatrixWorld(true);
+            const committed = this.#records.get(light);
+            const lightStateStable =
+                committed?.kind === 'directional' &&
+                committed.directionalStateValid &&
+                committed.lightWorldMatrix.equals(light.worldMatrix) &&
+                committed.lightDirection.equals(light.direction) &&
+                committed.directionalCascadeCount === staged.cascadeCount &&
+                sameNumbers(committed.directionalSplits, staged.splits, staged.cascadeCount);
             this.#stageLightBlock.directionalBiases[index * 2] = staged.minBias;
             this.#stageLightBlock.directionalBiases[index * 2 + 1] = staged.maxBias;
             this.#stageLightBlock.directionalCascadeSplits.set(staged.splits, index * 4);
@@ -1146,7 +1330,23 @@ export class ShadowAtlasSceneAdapter {
                 if (!camera || !matrix || cascadeFar === undefined) {
                     throw new Error('Directional cascade staging is incomplete');
                 }
-                if (!staged.useCascadeFit) {
+                const interval = cascadeUpdateIntervals?.[cascade] ?? 1;
+                const committedCamera = committed?.cameras[cascade];
+                const renderWidth = staged.request.sliceWidths?.[cascade] ?? tileWidth;
+                const renderHeight = staged.request.sliceHeights?.[cascade] ?? tileHeight;
+                staged.renderWidths[cascade] = renderWidth;
+                staged.renderHeights[cascade] = renderHeight;
+                const reuseCommitted =
+                    lightStateStable &&
+                    interval > 1 &&
+                    frameIndex % interval !== 0 &&
+                    committedCamera instanceof OrthographicCamera &&
+                    committedCamera.depthMode === mainCamera.depthMode &&
+                    committed.directionalRenderWidths[cascade] === renderWidth &&
+                    committed.directionalRenderHeights[cascade] === renderHeight;
+                if (reuseCommitted) {
+                    copyCamera(committedCamera, camera);
+                } else if (!staged.useCascadeFit) {
                     stageDirectionalCamera(camera, light, mainCamera);
                 } else {
                     let fitNear = cascadeNear;
@@ -1169,8 +1369,8 @@ export class ShadowAtlasSceneAdapter {
                         mainCamera,
                         fitNear,
                         cascadeFar,
-                        tileWidth,
-                        tileHeight,
+                        renderWidth,
+                        renderHeight,
                         staged.stabilize
                     );
                 }
@@ -1237,12 +1437,18 @@ export class ShadowAtlasSceneAdapter {
         this.#stageLightBlock.atlasSize[2] = 1 / atlas.width;
         this.#stageLightBlock.atlasSize[3] = 1 / atlas.height;
         for (let index = 0; index < this.#stageDirectionalRequests.length; index += 1) {
-            this.#stageLightBlock.directionalMapSizes[index * 2] = atlas.tileWidth;
-            this.#stageLightBlock.directionalMapSizes[index * 2 + 1] = atlas.tileHeight;
+            const request = this.#stageDirectionalRequests[index];
+            this.#stageLightBlock.directionalMapSizes[index * 2] =
+                request?.sliceWidths?.[0] ?? atlas.tileWidth;
+            this.#stageLightBlock.directionalMapSizes[index * 2 + 1] =
+                request?.sliceHeights?.[0] ?? atlas.tileHeight;
         }
         for (let index = 0; index < this.#stageSpotRequests.length; index += 1) {
-            this.#stageLightBlock.spotMapSizes[index * 2] = atlas.tileWidth;
-            this.#stageLightBlock.spotMapSizes[index * 2 + 1] = atlas.tileHeight;
+            const request = this.#stageSpotRequests[index];
+            this.#stageLightBlock.spotMapSizes[index * 2] =
+                request?.sliceWidths?.[0] ?? atlas.tileWidth;
+            this.#stageLightBlock.spotMapSizes[index * 2 + 1] =
+                request?.sliceHeights?.[0] ?? atlas.tileHeight;
         }
         for (const slice of atlas.slices) {
             const offset = slice.sliceIndex * 4;
@@ -1328,6 +1534,14 @@ export class ShadowAtlasSceneAdapter {
                 if (sourceCamera && camera) copyCamera(sourceCamera, camera);
                 if (sourceMatrix && matrix) matrix.copy(sourceMatrix);
             }
+            light.updateMatrixWorld(true);
+            record.lightWorldMatrix.copy(light.worldMatrix);
+            record.lightDirection.copy(light.direction);
+            record.directionalSplits.set(staged.splits);
+            record.directionalRenderWidths.set(staged.renderWidths);
+            record.directionalRenderHeights.set(staged.renderHeights);
+            record.directionalCascadeCount = staged.cascadeCount;
+            record.directionalStateValid = true;
         }
     }
 
@@ -1396,6 +1610,13 @@ export class ShadowAtlasSceneAdapter {
             kind,
             cameras,
             lightSpaceMatrices,
+            lightWorldMatrix: new Matrix4(),
+            lightDirection: new Vector3(),
+            directionalSplits: new Float32Array(MAX_DIRECTIONAL_SHADOW_CASCADES),
+            directionalRenderWidths: new Float64Array(MAX_DIRECTIONAL_SHADOW_CASCADES),
+            directionalRenderHeights: new Float64Array(MAX_DIRECTIONAL_SHADOW_CASCADES),
+            directionalCascadeCount: 0,
+            directionalStateValid: false,
             activeSliceCount: 0,
             epoch: 0
         };
@@ -1411,6 +1632,7 @@ export class ShadowAtlasSceneAdapter {
 
     private releaseRecord(record: CommittedLightRecord, pool: boolean): void {
         record.light = null;
+        record.directionalStateValid = false;
         record.activeSliceCount = 0;
         record.epoch = 0;
         for (const camera of record.cameras) {
@@ -1441,6 +1663,24 @@ export class ShadowAtlasSceneAdapter {
             target.height = source.height;
             if (source.cascadeCount === undefined) delete target.cascadeCount;
             else target.cascadeCount = source.cascadeCount;
+            if (source.sliceWidths === undefined) delete target.sliceWidths;
+            else {
+                const widths = target.sliceWidths ?? [];
+                widths.length = source.sliceWidths.length;
+                for (let slice = 0; slice < widths.length; slice += 1) {
+                    widths[slice] = source.sliceWidths[slice] ?? 1;
+                }
+                target.sliceWidths = widths;
+            }
+            if (source.sliceHeights === undefined) delete target.sliceHeights;
+            else {
+                const heights = target.sliceHeights ?? [];
+                heights.length = source.sliceHeights.length;
+                for (let slice = 0; slice < heights.length; slice += 1) {
+                    heights[slice] = source.sliceHeights[slice] ?? 1;
+                }
+                target.sliceHeights = heights;
+            }
         }
     }
 
@@ -1474,6 +1714,8 @@ export class ShadowAtlasSceneAdapter {
                     () => new Matrix4()
                 ),
                 splits: new Float32Array(MAX_DIRECTIONAL_SHADOW_CASCADES),
+                renderWidths: new Float64Array(MAX_DIRECTIONAL_SHADOW_CASCADES),
+                renderHeights: new Float64Array(MAX_DIRECTIONAL_SHADOW_CASCADES),
                 cascadeCount: 1,
                 cascadeBlend: 0.1,
                 shadowStrength: 1,

--- a/src/render/renderer/ShadowAtlasUpdateScheduler.ts
+++ b/src/render/renderer/ShadowAtlasUpdateScheduler.ts
@@ -1,0 +1,198 @@
+import type { ShadowAtlasContentDecision } from './ShadowAtlasContentCache';
+import type { ShadowAtlasScenePlan, ShadowAtlasSceneSlice } from './ShadowAtlasSceneAdapter';
+
+export interface ShadowAtlasUpdateSchedulerOptions {
+    /** Soft per-frame slice update budget. Mandatory allocation/layout/light updates may exceed it. */
+    readonly maxUpdatesPerFrame?: number;
+    /** Directional-cascade update intervals, in frames, ordered from near to far. */
+    readonly cascadeIntervals?: readonly number[];
+}
+
+export interface ShadowAtlasUpdateSchedule {
+    /** Reused physical-index mask. It remains valid only until the next `schedule` call. */
+    readonly scheduledSlices: readonly boolean[];
+    readonly sliceCount: number;
+    readonly requestedUpdateCount: number;
+    readonly scheduledUpdateCount: number;
+    readonly deferredUpdateCount: number;
+    readonly cadenceDeferredCount: number;
+    readonly mandatoryUpdateCount: number;
+    /** Number of mandatory updates above the configured soft budget. */
+    readonly budgetOverflowCount: number;
+}
+
+interface MutableScheduleState {
+    sliceCount: number;
+    requestedUpdateCount: number;
+    scheduledUpdateCount: number;
+    deferredUpdateCount: number;
+    cadenceDeferredCount: number;
+    mandatoryUpdateCount: number;
+    budgetOverflowCount: number;
+}
+
+const DEFAULT_CASCADE_INTERVALS: readonly number[] = Object.freeze([1, 2, 4, 8]);
+
+function positiveSafeInteger(value: number, label: string): number {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new RangeError(`${label} must be a positive safe integer`);
+    }
+    return value;
+}
+
+function updatePriority(slice: Readonly<ShadowAtlasSceneSlice>): number {
+    const area = slice.viewport.width * slice.viewport.height;
+    if (slice.kind === 'directional') {
+        return 3_000_000_000 - (slice.cascade ?? 0) * 1_000_000 + area;
+    }
+    if (slice.kind === 'spot') return 2_000_000_000 + area;
+    return 1_000_000_000 + area;
+}
+
+/**
+ * Deterministic receiver-priority shadow update scheduler. It keeps allocation, layout, and light
+ * changes mandatory, while caster-only invalidations may be spread across frames. Directional
+ * cascades use progressively slower default cadences of 1/2/4/8 frames.
+ */
+export class ShadowAtlasUpdateScheduler {
+    readonly maxUpdatesPerFrame: number;
+    readonly cascadeIntervals: readonly number[];
+    readonly #scheduledSlices: boolean[] = [];
+    readonly #state: MutableScheduleState = {
+        sliceCount: 0,
+        requestedUpdateCount: 0,
+        scheduledUpdateCount: 0,
+        deferredUpdateCount: 0,
+        cadenceDeferredCount: 0,
+        mandatoryUpdateCount: 0,
+        budgetOverflowCount: 0
+    };
+    readonly #schedule: Readonly<ShadowAtlasUpdateSchedule>;
+
+    constructor(options: Readonly<ShadowAtlasUpdateSchedulerOptions> = {}) {
+        this.maxUpdatesPerFrame = positiveSafeInteger(
+            options.maxUpdatesPerFrame ?? 8,
+            'Shadow maxUpdatesPerFrame'
+        );
+        const intervals = options.cascadeIntervals ?? DEFAULT_CASCADE_INTERVALS;
+        this.cascadeIntervals = Object.freeze(
+            Array.from(intervals, (value, index) =>
+                positiveSafeInteger(value, `Shadow cascadeIntervals[${String(index)}]`)
+            )
+        );
+        if (this.cascadeIntervals.length === 0) {
+            throw new RangeError('Shadow cascadeIntervals must not be empty');
+        }
+        const state = this.#state;
+        this.#schedule = Object.freeze({
+            scheduledSlices: this.#scheduledSlices,
+            get sliceCount() {
+                return state.sliceCount;
+            },
+            get requestedUpdateCount() {
+                return state.requestedUpdateCount;
+            },
+            get scheduledUpdateCount() {
+                return state.scheduledUpdateCount;
+            },
+            get deferredUpdateCount() {
+                return state.deferredUpdateCount;
+            },
+            get cadenceDeferredCount() {
+                return state.cadenceDeferredCount;
+            },
+            get mandatoryUpdateCount() {
+                return state.mandatoryUpdateCount;
+            },
+            get budgetOverflowCount() {
+                return state.budgetOverflowCount;
+            }
+        });
+    }
+
+    schedule(
+        plan: Readonly<ShadowAtlasScenePlan>,
+        content: Readonly<ShadowAtlasContentDecision>,
+        frameIndex: number
+    ): Readonly<ShadowAtlasUpdateSchedule> {
+        if (!Number.isSafeInteger(frameIndex) || frameIndex < 0) {
+            throw new RangeError(
+                'Shadow scheduling frameIndex must be a non-negative safe integer'
+            );
+        }
+        if (
+            content.sliceCount !== plan.slices.length ||
+            content.dirtySlices.length !== content.sliceCount ||
+            content.reasons.length !== content.sliceCount
+        ) {
+            throw new TypeError(
+                'Shadow update scheduling requires matching dense plan and content'
+            );
+        }
+
+        const count = content.sliceCount;
+        this.#scheduledSlices.length = count;
+        this.#scheduledSlices.fill(false);
+        let requested = 0;
+        let scheduled = 0;
+        let mandatory = 0;
+        let cadenceDeferred = 0;
+
+        for (let index = 0; index < count; index += 1) {
+            if (content.dirtySlices[index] !== true) continue;
+            requested++;
+            const reason = content.reasons[index];
+            if (reason === 'allocation' || reason === 'layout' || reason === 'light') {
+                this.#scheduledSlices[index] = true;
+                mandatory++;
+                scheduled++;
+                continue;
+            }
+            const slice = plan.slices[index];
+            if (slice?.kind !== 'directional') continue;
+            const cascade = slice.cascade ?? 0;
+            const interval =
+                this.cascadeIntervals[Math.min(cascade, this.cascadeIntervals.length - 1)] ?? 1;
+            if (frameIndex % interval !== 0) cadenceDeferred++;
+        }
+
+        let remaining = Math.max(0, this.maxUpdatesPerFrame - scheduled);
+        while (remaining > 0) {
+            let selected = -1;
+            let selectedPriority = -Infinity;
+            for (let index = 0; index < count; index += 1) {
+                if (content.dirtySlices[index] !== true || this.#scheduledSlices[index] === true) {
+                    continue;
+                }
+                const slice = plan.slices[index];
+                if (slice === undefined) continue;
+                if (slice.kind === 'directional') {
+                    const cascade = slice.cascade ?? 0;
+                    const interval =
+                        this.cascadeIntervals[
+                            Math.min(cascade, this.cascadeIntervals.length - 1)
+                        ] ?? 1;
+                    if (frameIndex % interval !== 0) continue;
+                }
+                const priority = updatePriority(slice);
+                if (priority > selectedPriority) {
+                    selected = index;
+                    selectedPriority = priority;
+                }
+            }
+            if (selected < 0) break;
+            this.#scheduledSlices[selected] = true;
+            scheduled++;
+            remaining--;
+        }
+
+        this.#state.sliceCount = count;
+        this.#state.requestedUpdateCount = requested;
+        this.#state.scheduledUpdateCount = scheduled;
+        this.#state.deferredUpdateCount = requested - scheduled;
+        this.#state.cadenceDeferredCount = cadenceDeferred;
+        this.#state.mandatoryUpdateCount = mandatory;
+        this.#state.budgetOverflowCount = Math.max(0, mandatory - this.maxUpdatesPerFrame);
+        return this.#schedule;
+    }
+}

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -1606,9 +1606,11 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 hiZ: false,
                 bloomStrength: 0
             });
+            const canvas = document.createElement('canvas');
+            const rendererDiagnostics = registerRendererDiagnostics(canvas);
             const renderer = await Renderer.create({
                 backend: 'webgpu',
-                domElement: document.createElement('canvas'),
+                domElement: canvas,
                 width: 64,
                 height: 64,
                 antialias: false,
@@ -1668,7 +1670,16 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                     fallbackObjectCount: 0,
                     lightCount: 1
                 });
+                expect(
+                    rendererDiagnostics.snapshot().renderGraph?.passes.map(pass => pass.name)
+                ).toEqual(
+                    expect.arrayContaining([
+                        'GPU Scene shadow caster frustum culling',
+                        'GPU Scene shadow caster buckets'
+                    ])
+                );
             } finally {
+                unregisterRendererDiagnostics(canvas, rendererDiagnostics);
                 target.destroy();
                 renderer.destroy();
             }

--- a/test/spec/renderer/RendererDiagnostics.test.ts
+++ b/test/spec/renderer/RendererDiagnostics.test.ts
@@ -196,6 +196,26 @@ describe('RendererDiagnostics', () => {
         diagnostics.recordUpload(2);
         diagnostics.recordSubmission();
         diagnostics.recordArenaGrowth(2);
+        diagnostics.recordShadowScheduling({
+            requestedSlices: 5,
+            updatedSlices: 3,
+            deferredSlices: 2,
+            requestedPages: 12,
+            updatedPages: 8,
+            deferredPages: 4,
+            residentPages: 20,
+            budgetOverflowPages: 1
+        });
+        diagnostics.recordShadowScheduling({
+            requestedSlices: 2,
+            updatedSlices: 1,
+            deferredSlices: 1,
+            requestedPages: 3,
+            updatedPages: 2,
+            deferredPages: 1,
+            residentPages: 24,
+            budgetOverflowPages: 2
+        });
 
         expect(diagnostics.snapshot().frame).toEqual({
             draws: 8,
@@ -210,7 +230,15 @@ describe('RendererDiagnostics', () => {
             computeBindGroupSwitches: 3,
             uploads: 2,
             submissions: 1,
-            arenaGrowths: 2
+            arenaGrowths: 2,
+            shadowRequestedSlices: 7,
+            shadowUpdatedSlices: 4,
+            shadowDeferredSlices: 3,
+            shadowRequestedPages: 15,
+            shadowUpdatedPages: 10,
+            shadowDeferredPages: 5,
+            shadowResidentPages: 24,
+            shadowBudgetOverflowPages: 3
         });
 
         diagnostics.resetFrame();
@@ -229,7 +257,15 @@ describe('RendererDiagnostics', () => {
             computeBindGroupSwitches: 0,
             uploads: 0,
             submissions: 0,
-            arenaGrowths: 0
+            arenaGrowths: 0,
+            shadowRequestedSlices: 0,
+            shadowUpdatedSlices: 0,
+            shadowDeferredSlices: 0,
+            shadowRequestedPages: 0,
+            shadowUpdatedPages: 0,
+            shadowDeferredPages: 0,
+            shadowResidentPages: 0,
+            shadowBudgetOverflowPages: 0
         });
         expect(snapshot.nativeObjects.vertexArray.live).toBe(2);
         expect(snapshot.caches.vertexArray).toMatchObject({ hits: 1, size: 2, highWater: 2 });

--- a/test/spec/renderer/ShadowAtlasContentCache.test.ts
+++ b/test/spec/renderer/ShadowAtlasContentCache.test.ts
@@ -95,6 +95,26 @@ describe('ShadowAtlasContentCache', () => {
         await committedSubmission.done;
         expect(content.metrics).toMatchObject({ size: 1, highWater: 1 });
 
+        mesh.x = 2;
+        mesh.updateMatrixWorld();
+        const deferredBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], deferredBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            reasons: ['caster-transform']
+        });
+        content.deferUnscheduled([false]);
+        const deferredSubmission = submit(device, deferredBatch);
+        await deferredSubmission.done;
+
+        const deferredRetryBatch = new RHIUploadBatch(new FrameArena());
+        expect(content.stage(atlas, plan, [mesh], deferredRetryBatch)).toMatchObject({
+            dirtySliceCount: 1,
+            reasons: ['caster-transform']
+        });
+        content.deferUnscheduled([true]);
+        const deferredRetrySubmission = submit(device, deferredRetryBatch);
+        await deferredRetrySubmission.done;
+
         mesh.x = 10_000;
         mesh.updateMatrixWorld();
         const distantBatch = new RHIUploadBatch(new FrameArena());

--- a/test/spec/renderer/ShadowAtlasPageResidency.test.ts
+++ b/test/spec/renderer/ShadowAtlasPageResidency.test.ts
@@ -1,0 +1,146 @@
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import { FrameArena } from '../../../src/render/frame/FrameArena';
+import { RHIUploadBatch } from '../../../src/render/frame/RHIUploadBatch';
+import DirectionalLight from '../../../src/light/DirectionalLight';
+import LightManager from '../../../src/light/LightManager';
+import Vector3 from '../../../src/math/Vector3';
+import type {
+    ShadowAtlasContentDecision,
+    ShadowAtlasInvalidationReason
+} from '../../../src/render/renderer/ShadowAtlasContentCache';
+import { ShadowAtlasPageResidency } from '../../../src/render/renderer/ShadowAtlasPageResidency';
+import { ShadowAtlasSceneAdapter } from '../../../src/render/renderer/ShadowAtlasSceneAdapter';
+import { describe, expect, it } from 'vitest';
+import { FakeWebGLRHIBackend } from '../rhi/portable/FakeRHIBackend';
+
+function decision(
+    reason: ShadowAtlasInvalidationReason,
+    updateId: number
+): Readonly<ShadowAtlasContentDecision> {
+    return {
+        dirtySlices: [true],
+        reasons: [reason],
+        updateIds: [updateId],
+        sliceCount: 1,
+        dirtySliceCount: 1,
+        cachedSliceCount: 0
+    };
+}
+
+describe('ShadowAtlasPageResidency', () => {
+    it('commits mandatory pages and advances budgeted replacement pages across submissions', async () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+        const manager = new LightManager();
+        manager.addLight(new DirectionalLight({ shadow: { width: 256, height: 256 } }));
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.setPosition(0, 1, 5).lookAt(new Vector3());
+        camera.updateViewProjectionMatrix();
+        const adapter = new ShadowAtlasSceneAdapter();
+        const plan = adapter.prepare(manager, camera, device.capabilities, {
+            width: 256,
+            height: 256
+        });
+        const pages = new ShadowAtlasPageResidency({
+            pageSize: 128,
+            maxPageUpdatesPerFrame: 1
+        });
+
+        const firstBatch = new RHIUploadBatch(new FrameArena());
+        const first = pages.stage(plan, decision('allocation', 1), [true], firstBatch);
+        expect(first.updateRegions).toHaveLength(4);
+        expect(first.completedSlices).toEqual([true]);
+        expect(first).toMatchObject({
+            requestedPageCount: 4,
+            scheduledPageCount: 4,
+            mandatoryPageCount: 4,
+            budgetOverflowCount: 3
+        });
+        const firstCommands = device.graphicsQueue.beginFrame();
+        firstBatch.flush(firstCommands);
+        const firstSubmission = device.graphicsQueue.endFrame(firstCommands);
+        firstBatch.commit(firstSubmission);
+        await firstSubmission.done;
+
+        const replacement = decision('caster-transform', 2);
+        const failedBatch = new RHIUploadBatch(new FrameArena());
+        const failed = pages.stage(plan, replacement, [true], failedBatch);
+        expect(failed.updateRegions).toHaveLength(1);
+        const failedRegion = { ...failed.updateRegions[0] };
+        failedBatch.rollback();
+
+        for (let update = 0; update < 4; update += 1) {
+            const batch = new RHIUploadBatch(new FrameArena());
+            const staged = pages.stage(plan, replacement, [true], batch);
+            expect(staged.updateRegions).toHaveLength(1);
+            if (update === 0) expect(staged.updateRegions[0]).toEqual(failedRegion);
+            expect(staged.completedSlices).toEqual([update === 3]);
+            const commands = device.graphicsQueue.beginFrame();
+            batch.flush(commands);
+            const submission = device.graphicsQueue.endFrame(commands);
+            batch.commit(submission);
+            await submission.done;
+        }
+
+        const stableBatch = new RHIUploadBatch(new FrameArena());
+        const stable = pages.stage(plan, replacement, [true], stableBatch);
+        expect(stable).toMatchObject({
+            requestedPageCount: 0,
+            scheduledPageCount: 0,
+            deferredPageCount: 0,
+            residentPageCount: 4
+        });
+        expect(stable.completedSlices).toEqual([true]);
+        stableBatch.rollback();
+
+        pages.destroy();
+        adapter.destroy();
+        backend.destroy();
+    });
+
+    it('rotates budgeted pages when moving casters produce a new revision every frame', async () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+        const manager = new LightManager();
+        manager.addLight(new DirectionalLight({ shadow: { width: 256, height: 256 } }));
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.setPosition(0, 1, 5).lookAt(new Vector3());
+        camera.updateViewProjectionMatrix();
+        const adapter = new ShadowAtlasSceneAdapter();
+        const plan = adapter.prepare(manager, camera, device.capabilities, {
+            width: 256,
+            height: 256
+        });
+        const pages = new ShadowAtlasPageResidency({
+            pageSize: 128,
+            maxPageUpdatesPerFrame: 1
+        });
+        const submit = async (batch: RHIUploadBatch): Promise<void> => {
+            const commands = device.graphicsQueue.beginFrame();
+            batch.flush(commands);
+            const submission = device.graphicsQueue.endFrame(commands);
+            batch.commit(submission);
+            await submission.done;
+        };
+
+        const allocationBatch = new RHIUploadBatch(new FrameArena());
+        pages.stage(plan, decision('allocation', 1), [true], allocationBatch);
+        await submit(allocationBatch);
+
+        const visited = new Set<string>();
+        for (let updateId = 2; updateId <= 5; updateId += 1) {
+            const batch = new RHIUploadBatch(new FrameArena());
+            const staged = pages.stage(plan, decision('caster-transform', updateId), [true], batch);
+            expect(staged.updateRegions).toHaveLength(1);
+            const region = staged.updateRegions[0];
+            if (region === undefined) throw new Error('Expected one rotating shadow page');
+            visited.add(`${String(region.pageX)}:${String(region.pageY)}`);
+            await submit(batch);
+        }
+
+        expect(visited).toEqual(new Set(['0:0', '1:0', '0:1', '1:1']));
+        pages.destroy();
+        adapter.destroy();
+        backend.destroy();
+    });
+});

--- a/test/spec/renderer/ShadowAtlasPageResidency.test.ts
+++ b/test/spec/renderer/ShadowAtlasPageResidency.test.ts
@@ -48,7 +48,17 @@ describe('ShadowAtlasPageResidency', () => {
 
         const firstBatch = new RHIUploadBatch(new FrameArena());
         const first = pages.stage(plan, decision('allocation', 1), [true], firstBatch);
-        expect(first.updateRegions).toHaveLength(4);
+        expect(first.updateRegions).toEqual([
+            {
+                slicePhysicalIndex: 0,
+                pageX: 0,
+                pageY: 0,
+                x: 0,
+                y: 0,
+                width: 256,
+                height: 256
+            }
+        ]);
         expect(first.completedSlices).toEqual([true]);
         expect(first).toMatchObject({
             requestedPageCount: 4,
@@ -92,6 +102,36 @@ describe('ShadowAtlasPageResidency', () => {
         });
         expect(stable.completedSlices).toEqual([true]);
         stableBatch.rollback();
+
+        const groupedPages = new ShadowAtlasPageResidency({
+            pageSize: 128,
+            maxPageUpdatesPerFrame: 3
+        });
+        const groupedAllocationBatch = new RHIUploadBatch(new FrameArena());
+        groupedPages.stage(plan, decision('allocation', 1), [true], groupedAllocationBatch);
+        const groupedAllocationCommands = device.graphicsQueue.beginFrame();
+        groupedAllocationBatch.flush(groupedAllocationCommands);
+        const groupedAllocationSubmission =
+            device.graphicsQueue.endFrame(groupedAllocationCommands);
+        groupedAllocationBatch.commit(groupedAllocationSubmission);
+        await groupedAllocationSubmission.done;
+        const groupedReplacementBatch = new RHIUploadBatch(new FrameArena());
+        const groupedReplacement = groupedPages.stage(
+            plan,
+            replacement,
+            [true],
+            groupedReplacementBatch
+        );
+        expect(groupedReplacement.scheduledPageCount).toBe(3);
+        expect(groupedReplacement.updateRegions).toHaveLength(2);
+        expect(groupedReplacement.updateRegions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ x: 0, y: 0, width: 256, height: 128 }),
+                expect.objectContaining({ x: 0, y: 128, width: 128, height: 128 })
+            ])
+        );
+        groupedReplacementBatch.rollback();
+        groupedPages.destroy();
 
         pages.destroy();
         adapter.destroy();

--- a/test/spec/renderer/ShadowAtlasSceneAdapter.test.ts
+++ b/test/spec/renderer/ShadowAtlasSceneAdapter.test.ts
@@ -246,6 +246,69 @@ describe.each([
         backend.destroy();
     });
 
+    it('updates directional cascade cameras at configured near-to-far cadences', () => {
+        const backend = createBackend();
+        const device = backend.createDevice();
+        const manager = new LightManager();
+        const directional = new DirectionalLight({
+            direction: new Vector3(-0.5, -1, 0.25),
+            shadow: { width: 64, height: 64, cascadeCount: 4, cascadeMaxDistance: 60 }
+        });
+        manager.addLight(directional);
+        const adapter = new ShadowAtlasSceneAdapter();
+        const camera = mainCamera();
+        const options = {
+            width: 64,
+            height: 64,
+            frameIndex: 0,
+            cascadeUpdateIntervals: [1, 2, 4, 8]
+        };
+        const first = adapter.prepare(manager, camera, device.capabilities, options);
+        const originalProjections = first.slices.map(slice =>
+            Array.from(slice.viewProjectionMatrix.elements)
+        );
+
+        camera.setPosition(8, 4, 8).lookAt(new Vector3());
+        options.frameIndex = 1;
+        const second = adapter.prepare(manager, camera, device.capabilities, options);
+        expect(Array.from(second.slices[0]?.viewProjectionMatrix.elements ?? [])).not.toEqual(
+            originalProjections[0]
+        );
+        for (let cascade = 1; cascade < 4; cascade += 1) {
+            expect(Array.from(second.slices[cascade]?.viewProjectionMatrix.elements ?? [])).toEqual(
+                originalProjections[cascade]
+            );
+        }
+
+        camera.setPosition(10, 4, 8).lookAt(new Vector3());
+        options.frameIndex = 2;
+        const secondFrameProjections = second.slices.map(slice =>
+            Array.from(slice.viewProjectionMatrix.elements)
+        );
+        const third = adapter.prepare(manager, camera, device.capabilities, options);
+        expect(Array.from(third.slices[1]?.viewProjectionMatrix.elements ?? [])).not.toEqual(
+            secondFrameProjections[1]
+        );
+        expect(Array.from(third.slices[2]?.viewProjectionMatrix.elements ?? [])).toEqual(
+            secondFrameProjections[2]
+        );
+        expect(Array.from(third.slices[3]?.viewProjectionMatrix.elements ?? [])).toEqual(
+            secondFrameProjections[3]
+        );
+
+        if (directional.shadow === null) throw new Error('Directional shadow options are missing');
+        directional.shadow.cascadeMaxDistance = 30;
+        options.frameIndex = 3;
+        const priorFarProjection = Array.from(third.slices[3]?.viewProjectionMatrix.elements ?? []);
+        const configurationChanged = adapter.prepare(manager, camera, device.capabilities, options);
+        expect(
+            Array.from(configurationChanged.slices[3]?.viewProjectionMatrix.elements ?? [])
+        ).not.toEqual(priorFarProjection);
+
+        adapter.destroy();
+        backend.destroy();
+    });
+
     it('locks point faces and matrices to +X,-X,+Y,-Y,+Z,-Z order', () => {
         const backend = createBackend();
         const device = backend.createDevice();

--- a/test/spec/renderer/ShadowAtlasUpdateScheduler.test.ts
+++ b/test/spec/renderer/ShadowAtlasUpdateScheduler.test.ts
@@ -1,0 +1,103 @@
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import DirectionalLight from '../../../src/light/DirectionalLight';
+import LightManager from '../../../src/light/LightManager';
+import Vector3 from '../../../src/math/Vector3';
+import type {
+    ShadowAtlasContentDecision,
+    ShadowAtlasInvalidationReason
+} from '../../../src/render/renderer/ShadowAtlasContentCache';
+import { ShadowAtlasSceneAdapter } from '../../../src/render/renderer/ShadowAtlasSceneAdapter';
+import { ShadowAtlasUpdateScheduler } from '../../../src/render/renderer/ShadowAtlasUpdateScheduler';
+import { describe, expect, it } from 'vitest';
+import { FakeWebGLRHIBackend } from '../rhi/portable/FakeRHIBackend';
+
+function decision(
+    reasons: readonly (ShadowAtlasInvalidationReason | null)[]
+): Readonly<ShadowAtlasContentDecision> {
+    const dirtySlices = reasons.map(reason => reason !== null);
+    const dirtySliceCount = dirtySlices.filter(Boolean).length;
+    return {
+        dirtySlices,
+        reasons,
+        updateIds: reasons.map((reason, index) => (reason === null ? 0 : index + 1)),
+        sliceCount: reasons.length,
+        dirtySliceCount,
+        cachedSliceCount: reasons.length - dirtySliceCount
+    };
+}
+
+describe('ShadowAtlasUpdateScheduler', () => {
+    it('applies near-to-far CSM cadence and a deterministic soft update budget', () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+        const manager = new LightManager();
+        manager.addLight(
+            new DirectionalLight({
+                shadow: { width: 64, height: 64, cascadeCount: 4, cascadeMaxDistance: 40 }
+            })
+        );
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.setPosition(0, 1, 5).lookAt(new Vector3());
+        camera.updateViewProjectionMatrix();
+        const adapter = new ShadowAtlasSceneAdapter();
+        const plan = adapter.prepare(manager, camera, device.capabilities, {
+            width: 64,
+            height: 64
+        });
+        const scheduler = new ShadowAtlasUpdateScheduler({ maxUpdatesPerFrame: 2 });
+
+        const first = scheduler.schedule(
+            plan,
+            decision([
+                'caster-transform',
+                'caster-transform',
+                'caster-transform',
+                'caster-transform'
+            ]),
+            1
+        );
+        expect(first).toMatchObject({
+            requestedUpdateCount: 4,
+            scheduledUpdateCount: 1,
+            deferredUpdateCount: 3,
+            cadenceDeferredCount: 3,
+            budgetOverflowCount: 0
+        });
+        expect(first.scheduledSlices).toEqual([true, false, false, false]);
+
+        const identity = first;
+        const budgeted = scheduler.schedule(
+            plan,
+            decision([
+                'caster-transform',
+                'caster-transform',
+                'caster-transform',
+                'caster-transform'
+            ]),
+            8
+        );
+        expect(budgeted).toBe(identity);
+        expect(budgeted.scheduledSlices).toEqual([true, true, false, false]);
+        expect(budgeted).toMatchObject({
+            scheduledUpdateCount: 2,
+            deferredUpdateCount: 2,
+            cadenceDeferredCount: 0
+        });
+
+        const mandatory = scheduler.schedule(
+            plan,
+            decision(['allocation', 'layout', 'light', 'allocation']),
+            9
+        );
+        expect(mandatory.scheduledSlices).toEqual([true, true, true, true]);
+        expect(mandatory).toMatchObject({
+            scheduledUpdateCount: 4,
+            mandatoryUpdateCount: 4,
+            budgetOverflowCount: 2,
+            deferredUpdateCount: 0
+        });
+
+        adapter.destroy();
+        backend.destroy();
+    });
+});

--- a/test/ui/example-paths.contract.ts
+++ b/test/ui/example-paths.contract.ts
@@ -238,12 +238,14 @@ describe('example release matrix contract', () => {
         ]);
         expect(NON_RENDERING_EXAMPLE_PATHS).toEqual([]);
         expect(DEDICATED_RELEASE_TEST_EXAMPLE_PATHS).toEqual([
+            'cascaded_shadows.html',
             'clustered_forward_plus_sponza.html',
             'volumetric_neon_reliquary.html',
             'stormfront_observatory.html',
             'shadow_residency_sanctum.html',
             'shaderToy.html'
         ]);
+        expect(exampleUsesDedicatedReleaseTest('cascaded_shadows.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('clustered_forward_plus_sponza.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('volumetric_neon_reliquary.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('stormfront_observatory.html')).toBe(true);
@@ -256,12 +258,15 @@ describe('example release matrix contract', () => {
         const dedicatedCases = DEDICATED_RELEASE_TEST_EXAMPLE_PATHS.flatMap(path =>
             backendsForExample(path).map(backend => ({ path, backend }))
         );
-        expect(genericCases).toHaveLength(157);
+        expect(genericCases).toHaveLength(155);
         expect(
             [...genericCases, ...dedicatedCases].map(item => `${item.path}:${item.backend}`).sort()
         ).toEqual(exampleCases.map(item => `${item.path}:${item.backend}`).sort());
         expect(genericReleaseTestSource).toContain(
             'if (exampleUsesDedicatedReleaseTest(examplePath)) continue;'
+        );
+        expect(genericReleaseTestSource).toContain(
+            'cascaded shadow garden exposes live controls through ${backend}'
         );
         expect(nativeReleaseTestSource).toContain(
             'Sponza Forward+ exposes stable camera and lighting controls @webgpu'

--- a/test/ui/example-paths.contract.ts
+++ b/test/ui/example-paths.contract.ts
@@ -67,11 +67,11 @@ describe('example release matrix contract', () => {
     it('discovers every HTML entry recursively with no hand-maintained gallery omissions', () => {
         expect(examplePaths).toEqual(independentlyDiscoverHtml());
         expect(new Set(examplePaths).size).toBe(examplePaths.length);
-        expect(examplePaths).toHaveLength(87);
+        expect(examplePaths).toHaveLength(88);
     });
 
-    it('expands 87 pages into the complete 162-case backend matrix', () => {
-        expect(exampleCases).toHaveLength(162);
+    it('expands 88 pages into the complete 163-case backend matrix', () => {
+        expect(exampleCases).toHaveLength(163);
         expect(new Set(exampleCases.map(item => `${item.path}:${item.backend}`)).size).toBe(
             exampleCases.length
         );
@@ -83,6 +83,7 @@ describe('example release matrix contract', () => {
                         path === 'clustered_forward_plus_sponza.html' ||
                         path === 'volumetric_neon_reliquary.html' ||
                         path === 'stormfront_observatory.html' ||
+                        path === 'shadow_residency_sanctum.html' ||
                         path === 'screen_space_reflections_palace.html' ||
                         path === 'temporal_aa_observatory.html' ||
                         path === 'compute_gpu_driven.html' ||
@@ -102,7 +103,7 @@ describe('example release matrix contract', () => {
 
     it('builds complete, categorized gallery metadata with valid source links', () => {
         const catalog = createExampleCatalog(examplePaths);
-        expect(catalog).toHaveLength(85);
+        expect(catalog).toHaveLength(86);
         expect(new Set(catalog.map(entry => entry.id)).size).toBe(catalog.length);
         expect(new Set(catalog.map(entry => entry.path))).toEqual(
             new Set(examplePaths.filter(path => path !== 'index.html' && path !== 'list.html'))
@@ -112,7 +113,7 @@ describe('example release matrix contract', () => {
         );
         expect(catalog[0]?.id).toBe('quickStart');
         expect(examplesForBackend(catalog, 'webgl2')).toHaveLength(74);
-        expect(examplesForBackend(catalog, 'webgpu')).toHaveLength(84);
+        expect(examplesForBackend(catalog, 'webgpu')).toHaveLength(85);
         expect(catalog.filter(entry => entry.featured).length).toBeGreaterThan(12);
         expect(catalog.filter(entry => entry.featured).length).toBeLessThan(catalog.length);
         expect(
@@ -226,6 +227,7 @@ describe('example release matrix contract', () => {
             'clustered_forward_plus_sponza.html',
             'volumetric_neon_reliquary.html',
             'stormfront_observatory.html',
+            'shadow_residency_sanctum.html',
             'screen_space_reflections_palace.html',
             'temporal_aa_observatory.html',
             'compute_gpu_driven.html',
@@ -239,11 +241,13 @@ describe('example release matrix contract', () => {
             'clustered_forward_plus_sponza.html',
             'volumetric_neon_reliquary.html',
             'stormfront_observatory.html',
+            'shadow_residency_sanctum.html',
             'shaderToy.html'
         ]);
         expect(exampleUsesDedicatedReleaseTest('clustered_forward_plus_sponza.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('volumetric_neon_reliquary.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('stormfront_observatory.html')).toBe(true);
+        expect(exampleUsesDedicatedReleaseTest('shadow_residency_sanctum.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('shaderToy.html')).toBe(true);
         expect(exampleUsesDedicatedReleaseTest('quickStart.html')).toBe(false);
         const genericCases = exampleCases.filter(
@@ -283,6 +287,7 @@ describe('example release matrix contract', () => {
             'particle_gpu_nebula.html': { test: '1' },
             'screen_space_global_illumination_chapel.html': { test: '1' },
             'screen_space_reflections_palace.html': { test: '1' },
+            'shadow_residency_sanctum.html': { test: '1' },
             'stormfront_observatory.html': { test: '1' },
             'temporal_aa_observatory.html': { test: '1' }
         });

--- a/test/ui/example-paths.ts
+++ b/test/ui/example-paths.ts
@@ -19,6 +19,7 @@ export const WEBGPU_ONLY_EXAMPLE_PATHS = [
     'clustered_forward_plus_sponza.html',
     'volumetric_neon_reliquary.html',
     'stormfront_observatory.html',
+    'shadow_residency_sanctum.html',
     'screen_space_reflections_palace.html',
     'temporal_aa_observatory.html',
     'compute_gpu_driven.html',
@@ -32,6 +33,7 @@ export const DEDICATED_RELEASE_TEST_EXAMPLE_PATHS = [
     'clustered_forward_plus_sponza.html',
     'volumetric_neon_reliquary.html',
     'stormfront_observatory.html',
+    'shadow_residency_sanctum.html',
     'shaderToy.html'
 ] as const;
 export const EXAMPLE_QUERY_PARAMETERS: Readonly<
@@ -43,6 +45,7 @@ export const EXAMPLE_QUERY_PARAMETERS: Readonly<
     'screen_space_global_illumination_chapel.html': { test: '1' },
     'screen_space_reflections_palace.html': { test: '1' },
     'stormfront_observatory.html': { test: '1' },
+    'shadow_residency_sanctum.html': { test: '1' },
     'temporal_aa_observatory.html': { test: '1' },
     'glTFViewer/index.html': { url: '/examples/models/Tmall/Tmall.gltf' }
 };

--- a/test/ui/example-paths.ts
+++ b/test/ui/example-paths.ts
@@ -30,6 +30,7 @@ export const WEBGPU_ONLY_EXAMPLE_PATHS = [
 ] as const;
 export const NON_RENDERING_EXAMPLE_PATHS = [] as const;
 export const DEDICATED_RELEASE_TEST_EXAMPLE_PATHS = [
+    'cascaded_shadows.html',
     'clustered_forward_plus_sponza.html',
     'volumetric_neon_reliquary.html',
     'stormfront_observatory.html',

--- a/test/ui/shadow-residency-sanctum.spec.ts
+++ b/test/ui/shadow-residency-sanctum.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test } from '@playwright/test';
+import { PNG } from 'pngjs';
+import {
+    assertStableInstrumentationHealth,
+    awaitTrackedGPUQueues,
+    completedRenderCommands,
+    installRenderHealthProbe,
+    readRenderHealth,
+    waitForStableAnimationFrames
+} from './render-health';
+
+interface SanctumEvidence {
+    readonly backend: 'webgpu';
+    readonly movingCasters: number;
+    readonly shadowRequestedPages: number;
+    readonly shadowUpdatedPages: number;
+    readonly shadowDeferredPages: number;
+    readonly shadowResidentPages: number;
+    readonly hiddenLayerEnabled: boolean;
+    readonly drawCount: number;
+}
+
+declare global {
+    interface Window {
+        __HILO3D_SHADOW_SANCTUM_TEST_API__?: Readonly<{
+            settle(frames?: number): Promise<SanctumEvidence>;
+            setMotion(value: boolean): Promise<SanctumEvidence>;
+            setVeil(value: boolean): Promise<SanctumEvidence>;
+            nextView(): Promise<SanctumEvidence>;
+        }>;
+    }
+}
+
+interface ImageStatistics {
+    readonly darkRatio: number;
+    readonly brightRatio: number;
+    readonly range: number;
+}
+
+function imageStatistics(buffer: Buffer): ImageStatistics {
+    const image = PNG.sync.read(buffer);
+    let dark = 0;
+    let bright = 0;
+    let minimum = 255;
+    let maximum = 0;
+    const pixelCount = image.width * image.height;
+    for (let offset = 0; offset < image.data.length; offset += 4) {
+        const luminance =
+            (image.data[offset] ?? 0) * 0.2126 +
+            (image.data[offset + 1] ?? 0) * 0.7152 +
+            (image.data[offset + 2] ?? 0) * 0.0722;
+        if (luminance < 28) dark++;
+        if (luminance > 118) bright++;
+        minimum = Math.min(minimum, luminance);
+        maximum = Math.max(maximum, luminance);
+    }
+    return {
+        darkRatio: dark / pixelCount,
+        brightRatio: bright / pixelCount,
+        range: maximum - minimum
+    };
+}
+
+function differingPixelRatio(referenceBuffer: Buffer, candidateBuffer: Buffer): number {
+    const reference = PNG.sync.read(referenceBuffer);
+    const candidate = PNG.sync.read(candidateBuffer);
+    expect(candidate.width).toBe(reference.width);
+    expect(candidate.height).toBe(reference.height);
+    let changed = 0;
+    const pixelCount = reference.width * reference.height;
+    for (let offset = 0; offset < reference.data.length; offset += 4) {
+        const delta = Math.max(
+            Math.abs((reference.data[offset] ?? 0) - (candidate.data[offset] ?? 0)),
+            Math.abs((reference.data[offset + 1] ?? 0) - (candidate.data[offset + 1] ?? 0)),
+            Math.abs((reference.data[offset + 2] ?? 0) - (candidate.data[offset + 2] ?? 0))
+        );
+        if (delta > 5) changed++;
+    }
+    return changed / pixelCount;
+}
+
+test('Umbra Sanctum keeps moving shadow pages budgeted and camera layers isolated @webgpu', async ({
+    page
+}) => {
+    test.setTimeout(120_000);
+    await installRenderHealthProbe(page);
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    page.on('console', message => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    await page.setViewportSize({ width: 960, height: 600 });
+    await page.goto('/examples/shadow_residency_sanctum.html?backend=webgpu&test=1', {
+        waitUntil: 'load'
+    });
+    await expect(page.locator('body')).toHaveAttribute('data-sanctum-ready', 'true', {
+        timeout: 90_000
+    });
+
+    const moving = await page.evaluate(async () =>
+        window.__HILO3D_SHADOW_SANCTUM_TEST_API__?.settle(3)
+    );
+    expect(moving).toMatchObject({
+        backend: 'webgpu',
+        movingCasters: 12,
+        hiddenLayerEnabled: false
+    });
+    expect(moving?.shadowRequestedPages).toBeGreaterThan(32);
+    expect(moving?.shadowUpdatedPages).toBeGreaterThan(0);
+    expect(moving?.shadowUpdatedPages).toBeLessThanOrEqual(32);
+    expect(moving?.shadowDeferredPages).toBeGreaterThan(0);
+    expect(moving?.shadowResidentPages).toBeGreaterThan(32);
+
+    await page.evaluate(async () => window.__HILO3D_SHADOW_SANCTUM_TEST_API__?.setMotion(false));
+    await page.evaluate(async () => window.__HILO3D_SHADOW_SANCTUM_TEST_API__?.settle(4));
+    const canvas = page.locator('canvas');
+    const excluded = await canvas.screenshot({ animations: 'disabled' });
+    const statistics = imageStatistics(excluded);
+    expect(statistics.range).toBeGreaterThan(90);
+    expect(statistics.darkRatio).toBeGreaterThan(0.12);
+    expect(statistics.brightRatio).toBeGreaterThan(0.001);
+
+    const revealedEvidence = await page.evaluate(async () =>
+        window.__HILO3D_SHADOW_SANCTUM_TEST_API__?.setVeil(true)
+    );
+    expect(revealedEvidence).toMatchObject({ hiddenLayerEnabled: true });
+    const revealed = await canvas.screenshot({ animations: 'disabled' });
+    expect(differingPixelRatio(excluded, revealed)).toBeGreaterThan(0.01);
+
+    await page.evaluate(async () => window.__HILO3D_SHADOW_SANCTUM_TEST_API__?.nextView());
+    const alternate = await canvas.screenshot({ animations: 'disabled' });
+    expect(differingPixelRatio(revealed, alternate)).toBeGreaterThan(0.08);
+
+    await waitForStableAnimationFrames(page);
+    await awaitTrackedGPUQueues(page);
+    const health = await readRenderHealth(page);
+    expect(completedRenderCommands(health, 'webgpu')).toBeGreaterThan(0);
+    await assertStableInstrumentationHealth('webgpu', 'Umbra Sanctum', {
+        waitForStableAnimationFrames: () => waitForStableAnimationFrames(page),
+        awaitTrackedGPUQueues: () => awaitTrackedGPUQueues(page),
+        readRenderHealth: () => readRenderHealth(page)
+    });
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- add receiver-priority shadow update scheduling and submission-aware fixed-atlas page residency with fair round-robin progress across continuously changing revisions
- execute GPU Scene shadow-caster culling per slice while preserving camera visibility masks and explicit `frustumTest=false` semantics
- render only scheduled shadow page regions, keep cache revisions rollback-safe, and expose accumulated scheduling/residency diagnostics
- add the WebGPU-only Umbra Sanctum presentation example with TAA, GTAO, SSR, volumetric lighting, Bloom, live budget telemetry, camera-layer isolation, and dedicated browser coverage
- update the public API report, rendering architecture, roadmap, changelog, example catalog, and release matrix

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm run api:check`
- targeted shadow/GPU Scene/diagnostics Vitest coverage — 24 passed
- `npm run test:render:architecture` — 144 passed
- `npm run test:rhi` — portable 213 passed; native 3 passed, 1 skipped
- `npm run test:ui:contract` — 12 passed
- `npm run examples:build`
- `npm run test:webgpu` — 19 passed
- four fixed-viewport browser screenshot comparison rounds across all three Umbra Sanctum views and the camera-layer witness state

## Scope boundary

- [ ] I ran `npm run test:browser` locally and all browser GPU tests passed.

Full `npm run validate`, the complete WebGL2 UI/visual matrix, and the physical-GPU `npm run test:webgpu:native` lane were not run. The new example and GPU shadow-culling path are WebGPU-only; portable RHI and architecture suites passed.