### PR TITLE
feat(render): harden production screen-space reflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@
 
 ### Changes
 
+- Upgrade WebGPU high-end SSR with response-aware 8×8 tile masks, coherent prefix compaction,
+  indirect stochastic visible-GGX tracing, roughness-adaptive ray budgets, refined depth crossings,
+  hit-normal facing validation, and explicit uncertain/backface outcomes. Evaluate receiver- and
+  hit-motion-domain history candidates against real previous material/depth state, authored reactive
+  masks, YCoCg neighborhood variance and roughness-adaptive sample counts; replace four fixed
+  filters with one adaptive bilateral hole-fill and a full-resolution edge-aware resolve. Align
+  clearcoat/anisotropy trace lobes with forward IBL, keep fallback removal independent from SSR
+  intensity, replace absolute half-float hit UVs with motion/depth state, compress material
+  attributes to `rgba8unorm`, prefer `rg11b10ufloat` reflection MRTs when supported, and expose
+  mutually exclusive uncertain/backface and history diagnostics alongside active/hit/miss counters.
+  Cap compacted active-tile indirect work to a two-dimensional 65,535-wide dispatch, retain
+  reflection-response/material identity in temporal history and spatial filtering, and make ordinary
+  Forward reflection MRTs reuse the main PBR GTAO visibility and iridescence parameters.
 - Add the first S0 production shadow-cache slice. Stable atlas tiles now use exact light/caster
   snapshots, scissored portable depth clears, per-slice invalidation, submission commit/rollback,
   recovery invalidation, and `RendererDiagnostics.caches.shadowAtlas`; static slices issue no shadow
@@ -184,17 +197,17 @@
   non-black and on/off pixel coverage. Keep the deployed glTF beside its external binary payload,
   and make the site link gate validate nested glTF buffer, image, and extension URIs before publish.
 - Add production WebGPU high-end screen-space reflections to `ClusteredForwardPlusPipelineFactory`.
-  The opt-in path adds a strict built-in `material-attributes` `rgba16float` ABI, GPU Scene MRT and
-  ordinary Forward fallback coverage, RG32F min/max Hi-Z, hierarchical coarse-to-fine tracing,
-  roughness radiance cones, edge/distance/roughness confidence, motion/log-depth temporal rejection
-  and confidence-aware depth/normal à-trous filtering before HDR composition and TAA/TAAU. Keep the
-  disabled path allocation- and pass-free, fail closed without Hi-Z or TemporalAA, and reset history
-  across camera cuts/identity changes, resize, discarded frames and device recovery. Feed ordinary
-  Forward opaque through a `depth-only` fallback prepass before current Hi-Z construction so layered
-  PBR objects are present in both the radiance source and hierarchical depth trace. Add `rg32float`
-  to the public compute storage-texture formats, add the repository-bundled Khronos Car Concept to
-  the dedicated Afterimage SSR showcase, and cover real WebGPU on/off pixels plus GPU validation.
-  The existing Temporal Observatory remains focused on TAA/TAAU.
+  The opt-in path adds a strict built-in `material-attributes` `rgba8unorm` ABI, matching HDR GPU
+  Scene MRT and ordinary Forward fallback coverage, RG32F min/max Hi-Z, hierarchical coarse-to-fine
+  tracing, roughness radiance cones, edge/distance/roughness confidence, motion/log-depth temporal
+  rejection and confidence-aware depth/normal à-trous filtering before HDR composition and TAA/TAAU.
+  Keep the disabled path allocation- and pass-free, fail closed without Hi-Z or TemporalAA, and
+  reset history across camera cuts/identity changes, resize, discarded frames and device recovery.
+  Feed ordinary Forward opaque through a `depth-only` fallback prepass before current Hi-Z
+  construction so layered PBR objects are present in both the radiance source and hierarchical depth
+  trace. Add `rg32float` to the public compute storage-texture formats, add the repository-bundled
+  Khronos Car Concept to the dedicated Afterimage SSR showcase, and cover real WebGPU on/off pixels
+  plus GPU validation. The existing Temporal Observatory remains focused on TAA/TAAU.
 - Add the `TemporalAA` Forward feature with native-resolution TAA and fixed-scale TAAU. Built-in
   opaque/masked materials now expose a strict single-sample `rgba16float` motion pass containing
   current-to-previous UV velocity, expected previous logarithmic view depth, and current logarithmic

--- a/documentation/GROUND_TRUTH_AMBIENT_OCCLUSION.md
+++ b/documentation/GROUND_TRUTH_AMBIENT_OCCLUSION.md
@@ -54,7 +54,7 @@ opaque depth prepass
 depth、attribute 与 motion 都由内置 material semantic pass 生成，alpha-mask
 coverage、skinning、morph 和 instancing 仍使用共享材质/几何准备路径。GTAO 不绕过 Render
 Graph，也不从后端 framebuffer 抓取数据。Forward 与 Clustered 都要求可作为 attachment 且可 filterable
-sample 的 `rgba16float`。
+sample 的 `rgba8unorm` material attributes；bent-normal AO/history 继续使用 `rgba16float`。
 
 AO history/output packing 为：
 

--- a/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
+++ b/documentation/MATERIAL_SYSTEM_MODERNIZATION.md
@@ -121,15 +121,15 @@ const material = new Hilo3d.ShaderMaterial({
 
 Pipeline 通过 role 请求材质，而不是读取 `material.passes[]` 并让材质控制执行顺序。
 
-| Role                  | 当前内置支持 | 合同                                                                                             |
-| --------------------- | ------------ | ------------------------------------------------------------------------------------------------ |
-| `forward`             | 是           | 普通 surface/unlit color 输出                                                                    |
-| `depth-only`          | 是           | 复用 deformation 与 coverage，无 color attachment                                                |
-| `shadow-caster`       | 是           | 复用 deformation、coverage、cull 和 alpha cutoff                                                 |
-| `picking`             | 是           | 复用 geometry/coverage，输出稳定对象 ID                                                          |
-| `motion-vector`       | 是           | opaque/masked 输出 single-sample `rgba16float` UV velocity 与 previous/current log-view-depth    |
-| `material-attributes` | 是           | single-sample `rgba16float`：oct view normal、roughness、receiver/metallic packing；SSR 按需使用 |
-| `user:*`              | 自定义       | 只有自定义 Pipeline 显式请求才运行                                                               |
+| Role                  | 当前内置支持 | 合同                                                                                                                            |
+| --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `forward`             | 是           | 普通 surface/unlit color 输出                                                                                                   |
+| `depth-only`          | 是           | 复用 deformation 与 coverage，无 color attachment                                                                               |
+| `shadow-caster`       | 是           | 复用 deformation、coverage、cull 和 alpha cutoff                                                                                |
+| `picking`             | 是           | 复用 geometry/coverage，输出稳定对象 ID                                                                                         |
+| `motion-vector`       | 是           | opaque/masked 输出 single-sample `rgba16float` UV velocity 与 previous/current log-view-depth                                   |
+| `material-attributes` | 是           | single-sample `rgba8unorm` 属性；SSR 时扩展两个 matching HDR MRT，写 reflection response 与 environment/probe specular baseline |
+| `user:*`              | 自定义       | 只有自定义 Pipeline 显式请求才运行                                                                                              |
 
 [`MaterialCompiler.ts`](../src/material/MaterialCompiler.ts) 负责 role 解析、target
 contract 验证和稳定 variant key。fallback 只有三种：
@@ -261,7 +261,7 @@ default 对象而发生串改。
 | Shared GPU Material Database | 已完成（PBR）   | 私有 PBR table 已抽取、共享、去重，并具备 dirty upload、提交回滚与 recovery                     |
 | Variant manifest / warmup    | high-end 已完成 | Clustered manifest 异步 warmup、固定预算、事务式运行时准入与诊断                                |
 | Motion vectors               | 已完成生产切片  | opaque/masked、skin/morph/instance history、固定/动态 TAAU，以及透明/粒子 reactive 与短 history |
-| Material attributes          | 已完成首版      | oct view normal/roughness/receiver/metallic ABI，SSR opt-in 时按需创建附件                      |
+| Material attributes          | 已完成生产 ABI  | oct normal/roughness/receiver/metallic；SSR opt-in 再写 response 与 fallback specular MRT       |
 | Advanced surface families    | 后续            | sheen/specular/dispersion、subsurface、hair 等按真实内容和预算推进                              |
 
 首个共享 GPU Material Database 已满足：

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -125,7 +125,7 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 | Forward+                             | high-end P0 完成  | 3D cluster、有界预算、storage GGX PBR、共享 shadow/LTC、透明/变形/layered consumer、analytic cookie/IES 与 uint32 light-layer ABI 已闭环                                                                      |
 | Temporal rendering                   | high-end P0 完成  | opaque TAAU、GPU-time dynamic resolution、authored reactive，以及透明/transmission/GPU-particle 独立 short history 与 resurrection 已完成                                                                     |
 | Exposure / display transform         | WebGPU 生产切片   | 独立 Forward `AutoExposure` 与 Clustered 集成都具备 GPU histogram、asymmetric eye adaptation、submission-aware history；`ColorUber` 有参数化 filmic，Clustered 有 compact filmic                              |
-| Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；透明/离屏几何不参与 trace，probe/BVH fallback 待 GI0                                                                               |
+| Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；SSR miss 保留 forward environment/probe baseline，透明/离屏几何不参与 trace，BVH/SDF fallback 待 GI0                               |
 | Volumetrics / atmosphere             | high-end 生产切片 | WebGPU Clustered froxel、height/local fog、screen-space caster visibility、physical atmosphere LUT、aerial perspective、temporal clouds，以及 surface/froxel cloud shadow 已落地                              |
 | Geometry / texture streaming         | 仅 bucket LOD     | GPU Scene 已有 projected-radius geometry bucket LOD；没有 meshlet/cluster streaming、KTX 2/Basis 或 mip residency，KTX loader 仅支持 KTX 1.1 单面 2D 容器                                                     |
 | GPU profiling / graph debugging      | 生产基线          | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 且无内部 timing consumer 时不创建 query                                                                              |
@@ -366,8 +366,9 @@ MAT0 不采用有序 `material.passes[]`。Pipeline/Render
 Graph 继续拥有 Pass 顺序、attachment 和资源依赖；材质只声明能为
 `forward`、`depth-only`、`shadow-caster`、`motion-vector`、 `material-attributes` 与 `picking`
 等语义角色生成什么 Shader、状态和绑定。motion 的 `rgba16float` velocity/log-depth + `r8unorm`
-reactive MRT、material-attributes 的 oct-normal/roughness/metallic/receiver ABI，以及 shadow
-coverage 都已经由生产消费者验证。当前剩余项是扩展更多 surface family，并增加 variant
+reactive MRT、`rgba8unorm` material-attributes 的 oct-normal/roughness/metallic/receiver
+ABI，以及 shadow coverage 都已经由生产消费者验证。当前剩余项是扩展更多 surface
+family，并增加 variant
 manifest/warmup；它们是独立后续工作，不再阻塞 T0/Q0。完整设计、兼容策略和验收矩阵见
 [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 
@@ -607,7 +608,8 @@ diagnostics 是后续增强，不属于 E0 已完成合同。
 - effect 只在声明需要时创建 attribute/history
   resource，默认 Forward/Clustered 快路径不付费（GTAO、SSR、SSGI 已验证）。
 
-当前 SSR 的 screen-edge/off-screen fallback 是确定性零贡献；GTAO 的屏幕外遮挡同样不参与 horizon
+当前 SSR 的 screen-edge/off-screen trace 是确定性无命中并保留 forward environment/probe
+baseline；GTAO 的屏幕外遮挡同样不参与 horizon
 search。SSGI 已完成屏幕内时域漫反射传输，但屏幕外/被遮挡 geometry 仍是零贡献；probe/BVH/SDF
 off-screen GI 补偿属于 GI0，而不是未完成的 Q0。实现与上线证据见
 [`GROUND_TRUTH_AMBIENT_OCCLUSION.md`](./GROUND_TRUTH_AMBIENT_OCCLUSION.md) 与

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -204,16 +204,26 @@ buffer，也不执行对应 clear/write，保持默认 Clustered 路径无 TAA �
 
 `ClusteredForwardPlusPipelineFactory.screenSpaceReflections` 显式启用 WebGPU high-end Hi-Z
 SSR，并要求同时启用 `hiZ` 与 `temporalAA`。GPU Scene opaque PBR 在 color MRT 写 view
-normal、roughness 和 receiver/metallic；ordinary Forward opaque PBR 通过同一 `material-attributes`
-semantic pass 补写。current-frame RG32F min/max Hi-Z 驱动 hierarchical coarse-to-fine
-trace，四级 HDR radiance cone 近似粗糙反射；screen edge、distance、roughness 共同生成 hit
-confidence。
+normal、roughness、receiver/metallic、view-dependent reflection response 和已有 environment/probe
+specular baseline；ordinary Forward opaque PBR 通过同一 `material-attributes` semantic
+pass 补写。attributes 使用 `rgba8unorm`，两个 reflection MRT 优先使用 `rg11b10ufloat`。8×8
+response-aware receiver classification 先写 tile mask，再以 coherent prefix compaction 生成 active
+list，并在 GPU 上转换成单维不超过 65,535 的二维 indirect dispatch；current-frame RG32F min/max
+Hi-Z 由 indirect 低粗糙度确定性镜面与每帧四条 32-phase rotated low-discrepancy visible-GGX
+coarse-to-fine trace，四级 HDR radiance cone 近似粗糙反射，并执行 refined depth、hit-normal
+facing 和 uncertainty validation。
 
-SSR 使用 motion/log-depth 做 history reprojection、relative-depth reject 和 neighborhood
-clamp，在线性 HDR opaque color 中合成后再进入 TAA/TAAU。camera cut、camera
-identity、projection/depth convention、resize、失败 submission 与 device
-recovery 都遵守 history 初始化/回滚合同。默认关闭时没有 attribute、trace、cone 或 history 成本。屏幕外和完全遮挡内容返回零贡献；当前没有 probe/BVH/SDF
-fallback。完整参数、packing 和证据见
+SSR 同时评估 receiver 与 reflection-hit motion domain 的 history candidate，加上真实 previous
+normal/roughness/depth、reflection response/packed material、reactive mask、YCoCg variance/firefly
+clamp 和 roughness-adaptive sample count 做 reprojection/reject；confidence
+reconstruction、variance-guided stability、bounded residual-coverage cleanup 与 full-resolution
+resolve 完成 hole fill。最终 additive delta 为
+`gate * intensity * SSR - gate * confidence * fallback`，低 confidence 通过 smoothstep 淡回 forward
+baseline，因此 intensity 不会缩放 fallback removal；ordinary Forward baseline 与主 PBR 使用相同 GTAO
+visibility 和 iridescence 参数，之后再进入 TAA/TAAU。camera cut、camera identity、projection/depth
+convention、resize、失败 submission 与 device
+recovery 都遵守 history 初始化/回滚合同。默认关闭时没有 attribute、trace、cone 或 history 成本。屏幕外和完全遮挡内容保留 forward
+environment/probe fallback；当前没有 BVH/SDF fallback。完整参数、packing 和证据见
 [`SCREEN_SPACE_REFLECTIONS.md`](./SCREEN_SPACE_REFLECTIONS.md)。
 
 `ClusteredForwardPlusPipelineFactory.volumetricLighting`

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -132,14 +132,24 @@ XY 是 current-to-previous UV velocity，Z 是 expected previous `log2(1 + viewD
 `log2(1 + viewDepth)`。它复用 current/previous camera、model、instance、skin、morph 与 coverage
 ABI；首次出现、显隐/提交间断或任一 transform history 失效时写 invalid history
 marker，不能消费陈旧 pose；reactive 值来自材质的 `temporalReactiveFactor`（0–1）。内置
-`material-attributes` pass 固定接受 single-sample `rgba16float`，输出 octahedral view
-normal、perceptual roughness、metallic 与 reflection receiver flag；portable Forward
-GTAO 与 Clustered Hi-Z SSR/GTAO/SSGI 按需消费它。GTAO 以相同 attributes 和 logarithmic motion
-depth 执行 horizon visibility、temporal rejection、edge-aware filter 与 depth/normal
+`material-attributes` pass 默认接受一个 single-sample `rgba8unorm`，输出映射到 `[0, 1]`
+的 octahedral view normal、perceptual roughness、7-bit metallic 与 reflection receiver
+flag；SSR 启用时扩展两个 matching HDR MRT（优先 `rg11b10ufloat`，否则
+`rgba16float`），额外输出 view-dependent reflection response 和 forward environment/probe specular
+baseline。portable Forward GTAO 与 Clustered Hi-Z
+SSR/GTAO/SSGI 按需消费它。GTAO 以相同 attributes 和 logarithmic motion depth 执行 horizon
+visibility、temporal rejection、edge-aware filter 与 depth/normal
 upsample；SSGI 在 opaque 后复用或生成 attributes/motion，执行随机 view-space diffuse ray
 trace、YCoCg variance-clipped temporal resolve、depth/normal/luminance-aware a-trous
-filter、bilateral
-upsample 与线性 HDR 合成；SSR 用它们约束 confidence-aware 多尺度空间 filter。未启用对应 effect 时不创建 attribute、AO/GI/filter
+filter、bilateral upsample 与线性 HDR 合成；SSR 以 response-aware tile mask 和 coherent
+compaction 生成受单维 65,535 上限约束的二维间接 dispatch，执行低粗糙度确定性镜面与每帧四条 32-phase
+rotated low-discrepancy visible-GGX Hi-Z trace，区分 valid/uncertain/backface
+hit，以 receiver 和 reflection-hit 两端的 motion/depth/material response/packed identity
+continuity、reactive mask、YCoCg variance、firefly clamp 和 sample count 约束 temporal
+history，再用 confidence reconstruction、roughness-adaptive stability 与有界 residual-coverage
+cleanup 三级 filter 加 full-resolution bilateral resolve 完成 hole fill，并通过 additive
+delta 原位替换已有 fallback specular；ordinary Forward reflection MRT 与主 PBR 共享 GTAO
+visibility 和 iridescence 参数。未启用对应 effect 时不创建 attribute、AO/GI/filter
 target、history 或 fallback pass。
 
 portable material UBO 分为 448-byte `MaterialBlock` 与 1,920-byte

--- a/documentation/SCREEN_SPACE_GLOBAL_ILLUMINATION.md
+++ b/documentation/SCREEN_SPACE_GLOBAL_ILLUMINATION.md
@@ -68,6 +68,9 @@ depth 记录。Clustered 路径在未启用 GTAO 时由 opaque
 MRT 写 attributes，启用 GTAO 时则复用独立 attribute pass；普通 Forward
 fallback 继续通过共享 material semantic pass 覆盖。
 
+共享 material attributes 使用 filterable、renderable `rgba8unorm`，oct normal 映射到 `[0, 1]`；SSGI
+radiance、history、denoise 与 full-resolution 输出仍使用 `rgba16float` HDR target。
+
 trace 在 view-space normal 半球内使用逐帧旋转的低差异方向，以二次步长沿投影射线访问 scene
 depth。命中必须满足 view-space thickness、最大距离、屏幕边缘衰减、receiver cosine 和反向 emitter
 cosine。线性 HDR scene color 是 radiance source；`maxRadiance` 在单样本亮度上做有限 firefly

--- a/documentation/SCREEN_SPACE_REFLECTIONS.md
+++ b/documentation/SCREEN_SPACE_REFLECTIONS.md
@@ -25,7 +25,10 @@ const pipeline = new Hilo3d.ClusteredForwardPlusPipelineFactory({
 ```
 
 SSR 必须和 `hiZ`、`temporalAA`
-一起启用。显式缺少任一依赖会在 factory 构造时失败，不会静默降级到固定步长 trace 或无时序 resolve。
+一起启用。显式缺少任一依赖会在 factory 构造时失败，不会静默降级到固定步长 trace 或无时序 resolve。配置还要求
+`maxRayDistance >= 4 * stride` 且
+`maxRayDistance >= 2 * thickness`，避免参数分别合法、组合后却没有足够 trace 区间或整个 ray 都落入 thickness
+band。
 
 ## 帧内数据流
 
@@ -33,15 +36,24 @@ SSR 必须和 `hiZ`、`temporalAA`
 
 1. GPU Scene 与 ordinary Forward opaque 共用的 depth/motion prepass；
 2. current-frame RG32F Hi-Z min/max pyramid；
-3. Clustered opaque PBR color，同时写 material attributes；
-4. ordinary Forward opaque fallback color、material attributes 和 motion；
+3. 按需先写 GTAO 所需的 material attributes 并生成 ambient visibility；
+4. Clustered opaque PBR color 同时写 view-dependent reflection response 和已进入 scene
+   color 的 environment/probe specular baseline；ordinary Forward opaque fallback
+   color 后再以相同 GTAO visibility 补写三目标 reflection material ABI；
 5. HDR radiance cone pyramid；
-6. configurable-resolution hierarchical Hi-Z reflection trace；
-7. motion/depth rejection、3×3 neighborhood clamp、temporal accumulation 和 confidence-aware
-   depth/normal à-trous filter；
-8. 在线性 HDR 中把 reflection 合成回 opaque scene；
-9. TAA/TAAU resolve；
-10. transparent fallback、Bloom 和 display transform。
+6. 8×8 receiver tile classification，64-tile coherent compaction 和 indirect hierarchical Hi-Z
+   trace；
+7. 低粗糙度确定性镜面 ray、每帧四条 32-phase rotated scrambled Hammersley visible-GGX
+   ray、roughness-adaptive 距离/迭代预算、精确 depth refinement、hit-normal facing
+   validation，以及 valid/uncertain/backface/miss 分类；
+8. receiver-domain 与 hit-motion-domain 两路 history candidate、reactive rejection、YCoCg
+   neighborhood moments、roughness-adaptive firefly clamp 与最高 24-frame sample-count/confidence
+   accumulation；
+9. 一个固定邻域 confidence reconstruction、一个 roughness-adaptive variance-guided stability
+   pass、一个有界 residual-coverage cleanup pass 和 full-resolution depth/normal-aware
+   resolve，再以 additive delta 原位替换 opaque scene 中已有的 environment/probe specular；
+10. TAA/TAAU resolve；
+11. transparent fallback、Bloom 和 display transform。
 
 所有资源和依赖都由同一 Render
 Graph 声明；prepare 只创建可复用的 pipeline/binding，execute 才记录命令。SSR 不直接访问原生 `GPU*`
@@ -53,43 +65,108 @@ trace 却没有对应深度可命中；Car Concept 的 layered PBR 车身就是�
 
 ## Material attribute ABI
 
-`material-attributes` 是内置材质的正式 semantic pass，目标固定为 single-sample `rgba16float`：
+`material-attributes` 是内置材质的正式 semantic pass。普通消费者使用一个 single-sample `rgba8unorm`
+target；SSR 启用时再附加两个 matching HDR target。HDR target 在支持 renderable、filterable
+`rg11b10ufloat` 时使用该格式，否则回退到 `rgba16float`：
 
-| Channel    | Contract                                             |
-| ---------- | ---------------------------------------------------- |
-| RG         | view-space normal 的 octahedral 编码，范围 `[-1, 1]` |
-| B          | perceptual roughness，钳制到 `[0.045, 1]`            |
-| A bit 0    | surface 是否接收 SSR                                 |
-| A bits 1–8 | 8-bit quantized metallic                             |
+| Channel    | Contract                                              |
+| ---------- | ----------------------------------------------------- |
+| RG         | view-space normal 的 octahedral 编码，映射到 `[0, 1]` |
+| B          | perceptual roughness，钳制到 `[0.045, 1]`             |
+| A bit 0    | surface 是否接收 SSR                                  |
+| A bits 1–7 | 7-bit quantized metallic                              |
 
-这个整数 packing 最大为 511，可被 float16 精确表示。PBR surface 写 receiver
-bit；Basic、Geometry 等没有正式 PBR 反射参数的内置 family 写无效 receiver。GPU Scene storage
-PBR 和 ordinary Forward PBR 使用同一 ABI。自定义 opaque material 没有显式 `material-attributes`
+SSR 的 location 1 写当前视角的 RGB reflection response，location 2 写 forward color 中已经存在的 RGB
+environment/probe specular baseline。ordinary PBR 使用 IOR、metallic workflow 或 specular-glossiness
+workflow 计算 response，并复用材质 environment map/BRDF LUT 计算 baseline；GPU
+Scene 在没有 per-material environment map 的固定 bucket 路径使用 clustered ambient radiance
+fallback，并把同一值加入 forward color。有效 screen-space hit 因而执行
+`scene + gate * intensity * SSR - gate * confidence * baseline`，其中 `gate`
+对低于可靠区间的 confidence 做 smoothstep 淡入。`intensity` 只缩放新 SSR
+radiance，不会错误放大 fallback removal；miss 保留原 baseline，不再额外叠加一层高光。
+
+packed byte 最大为 255，通过 UNORM 精确往返。相较旧的 `rgba16float`
+attribute，常驻带宽和显存减半；两个 reflection target 在 `rg11b10ufloat` 可用时也各自减半。PBR
+surface 写 receiver bit；Basic、Geometry 等没有正式 PBR 反射参数的内置 family 写无效 receiver。GPU
+Scene storage PBR 和 ordinary Forward PBR 使用同一 ABI。自定义 opaque material 没有显式
+`material-attributes`
 pass 时保持清屏值并跳过 SSR，不会猜测 normal/roughness。alpha-mask 的属性 pass 重用同一 coverage
-discard。
+discard。clearcoat dominance 会把 trace normal/roughness 向 clearcoat
+lobe 混合；anisotropy 使用与 forward IBL 相同的旋转 tangent 和强度弯折 trace
+normal，避免 response、fallback 和 ray direction 来自不同材质 lobe。ordinary Forward 的 reflection
+response/baseline 还复用主 PBR 的 GTAO visibility 与 iridescence factor/IOR/thickness，保证 additive
+replacement 减掉的就是 opaque color 实际包含的 IBL。
 
 ## Trace、confidence 与粗糙度
 
 Hi-Z 每级保存 device-depth 的 min/max，因此 standard 与 reversed depth 共用同一金字塔；GPU occlusion
 culling 从相应边界读取 conservative farthest
-depth，SSR 则使用完整区间做 coarse-to-fine 推进和精确 scene-depth
-thickness 测试。命中辐射按 roughness 与 ray distance 选择四级 HDR color
-cone。最终 confidence 同时包含 screen-edge、ray-distance 和 roughness
-fade，未命中、离屏、背景、背向或超过 roughness cutoff 的像素返回零贡献。
+depth，SSR 则使用完整区间做 coarse-to-fine 推进、line-segment refinement、grazing/depth-adaptive
+thickness 和 hit-normal facing 测试。背景 crossing、过深 penetration 和背面候选不会被当作普通 valid
+hit。trace 不假设反射 ray 必须远离相机，因此 camera-facing vertical
+mirror 也能追踪位于镜面与相机之间的屏幕内物体。命中辐射按 roughness 与 ray distance 选择四级 HDR
+color cone。perceptual roughness 不高于 0.1 时使用确定性镜面 ray；这与 Unreal legacy SSR 的
+`Roughness < 0.1` 镜面退化一致。更粗糙 receiver 每帧使用四条完整分层的 scrambled Hammersley
+visible-GGX ray，并用 32-phase Cranley-Patterson
+rotation 扩展时间覆盖，而不是把四条射线聚集在长序列的相邻区间或逐帧使用无结构 hash。四条射线的 radiance/confidence 按总 ray
+count 归一化，因此 miss 保留已有 environment/probe
+fallback，不会把半分辨率命中轮廓放大成黑块。最大 ray distance 和 iteration
+count 也随 roughness 收缩。最终 confidence 同时包含 screen-edge、ray-distance 和 roughness
+fade，未命中、离屏、背景或超过 roughness cutoff 的像素不替换 fallback。
 
-时序结果在合成前经过多尺度 confidence-aware à-trous filter。filter 只在 receiver、roughness、view
-normal 和 logarithmic
-depth 连续的像素间传播有效命中，因此可以柔化局部 trace 空洞而不把车身、地面和背景跨边界涂抹到一起。
+classification 同时检查 depth、receiver、roughness 和 reflection-response energy，先写每 tile
+mask，再以 64-tile workgroup prefix scan 写出空间相干的 compact list；trace 通过 GPU-authored
+indirect dispatch 执行。compact count 会在 GPU 上转换为 `x <= 65535` 的二维 indirect
+dispatch，shader 再以真实 active count 做尾部越界保护，因此 4K full-resolution
+trace 不会超过 WebGPU 单维 workgroup 上限。`ClusteredForwardPlusDiagnostics` 除 active
+tile/pixel 与 hit/miss 外，还暴露 uncertain、backface-rejected、history
+accepted/rejected 计数；uncertain 与 backface-rejected 是互斥 miss 子类，可直接验证命中质量和 temporal
+rejection。同一 indirect list 也驱动昂贵的 temporal neighborhood 与 adaptive
+filter；它们先用低成本 full-extent clear 确定 inactive pixel 状态，因此 sparse
+receiver 场景不会在空 tile 上执行 history/filter taps。HDR color
+cone 仍覆盖完整 scene，因为任一 active ray 都可能命中任意屏幕位置。
 
-这是纯 screen-space 效果：屏幕外、被前景完全遮挡或当前 color
-buffer 中不存在的信息没有可用命中。当前版本确定性返回零作为 fallback；它不伪装成 probe、BVH、SDF 或硬件 ray
-tracing。
+时序结果在合成前经过三级 filter。第一级用连续 3×3 邻域重建低 confidence 和 miss
+hole；第二级按 roughness 扩大到 1–3 个 trace
+pixel；第三级用连续 3×3 邻域和更强的中心权重清理低视角下残留的半分辨率覆盖缺口，避免稀疏样本被时序累积成横向条带或棋盘块，同时不把稳定反射过度模糊。三级都约束 receiver、roughness、view
+normal、receiver/hit logarithmic depth 和 luminance，中心权重还会随 history
+maturity 增长：未收敛像素优先借用邻域，成熟 history 则更保守。单帧亮度离群值在 temporal
+resolve 前按 YCoCg neighborhood
+variance 限幅，避免暗地面上的稀疏高亮成为 firefly。最终半分辨率到全分辨率 resolve 手动 gather 相邻 trace
+pixel，并再次用 full-resolution normal/depth/roughness 权重拒绝跨边界泄漏。
+
+这是纯 screen-space trace：屏幕外、被前景完全遮挡或当前 color
+buffer 中不存在的信息没有 screen-space 命中；这些位置确定性保留 forward
+PBR 已经计算的 environment/probe fallback。它不伪装成 BVH、SDF 或硬件 ray tracing。
 
 ## Temporal 与生命周期
 
-SSR history 是双缓冲 `rgba16float` radiance/confidence 加双缓冲 `r32float` log-view-depth。motion
-XY 负责 reprojection，motion Z 与 previous depth history 做 relative-depth disocclusion
-reject，当前 3×3 邻域限制旧 radiance，像素速度降低 history weight。
+SSR history 是双缓冲 `rgba16float` radiance/sample-count/confidence、双缓冲 `r32float` receiver
+log-view-depth、双缓冲 `rgba16float` receiver normal/roughness + hit log-view-depth
+state，以及双缓冲 `rgba16float` reflection response + packed material state。绝对 hit
+UV 不再写入 half-float history，避免高分辨率下 1–2
+pixel 量化；trace 直接写命中物体的 motion、expected-previous/current log
+depth。resolve 同时评估 receiver motion candidate 和 hit-motion candidate，用 previous
+state 中真实保存的 normal/roughness/depth/response/packed material 做 continuity，而不是在 history
+UV 上误采当前帧 attribute。authored/transparent reactive mask 会降低两路 candidate；三级 spatial
+filter 也用 response 与 packed material continuity 阻止跨材质边界借样。
+
+当前 3×3 radiance 在 YCoCg 中生成 mean/variance
+clamp，并在粗糙 stochastic 区域先抑制单帧 firefly；history alpha 的整数部分保存最高 31 的 capped
+sample count，小数部分保存 confidence。粗糙表面最多使用 24-frame
+accumulation，镜面、快速 motion、miss 和 disocclusion 更快响应；miss 可以短暂继承低 confidence
+history 完成局部 hole fill，但会持续衰减。
+
+实现细节同时对照了 Epic UE 5.8/5.8.x 与 `ue6-main` 源码：legacy SSR 的 GGX ray 与 hit-normal
+validation，以及 Lumen reflection 的 uncertain state、surface/hit temporal candidate、YCoCg
+variance/sample-count resolve 和 coherent tile dispatch。Hilo3D 没有复制 Lumen 的 surface
+cache、radiance cache 或硬件/软件 ray tracing；本引擎对应的是 roughness cutoff、active-tile indirect
+trace、forward environment/probe baseline 和 hit-aware temporal rejection。参考：
+[Epic UnrealEngine repository](https://github.com/EpicGames/UnrealEngine)、
+[06wj UnrealEngine mirror](https://github.com/06wj/UnrealEngine)、
+[UE 5.8 Lumen Performance Guide](https://dev.epicgames.com/documentation/en-us/unreal-engine/lumen-performance-guide-for-unreal-engine)、
+[Lumen Technical Details](https://dev.epicgames.com/documentation/en-us/unreal-engine/lumen-technical-details-in-unreal-engine)、
+[UE 5.8 Release Notes](https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-8-release-notes)。
 
 camera cut、投影/depth convention 改变、camera identity 切换、resize、device
 generation 改变和首次使用都会初始化 history。history 交换由 Render
@@ -99,9 +176,13 @@ recipe 重建资源，public pipeline identity 不变。
 ## 上线证据
 
 - `test/spec/renderer/ClusteredForwardPlus.test.ts`：配置/limit/format 合同，以及真实 WebGPU 的 GPU
-  Scene、ordinary fallback、camera cut、resize、standard/reversed depth 和 device recovery。
-- `test/ui/screen-space-reflections.spec.ts`：真实浏览器 GPU
-  validation、静态 history 收敛，以及同一视角 SSR on/off 的非零像素贡献。
+  Scene、ordinary fallback、active/hit/miss diagnostics、roughness cutoff、moving receiver、camera
+  cut、camera-facing reflection rays、resize、standard/reversed depth 和 device recovery。
+- `test/ui/screen-space-reflections.spec.ts`：默认 0.5× trace resolution、真实浏览器 GPU
+  validation、roughness 0.08 deterministic 与 0.16/0.24
+  stochastic 地面反射 ROI 连续帧的局部 changed-pixel/mean-delta 闪烁门槛、静态与 camera/hero motion
+  history 收敛、低视角 grazing ROI 连续帧门槛、roughness active-work
+  rejection、垂直镜面命中，以及同一视角 SSR on/off 的非零像素贡献。
 - `examples/screen_space_reflections_palace.html`：使用仓库内 Khronos Car Concept、镜头外 studio
   light field、ordinary Forward PBR 烟熏漆地面、TAA、Bloom 和高精度 Hi-Z SSR 的独立维护示例；
   `ssr=false` 可显示确定性无 SSR 对照。Car Concept 资产来源、CC BY 4.0 许可和 hash 记录在

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -819,6 +819,14 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly objectCount: number;
     readonly occludedObjectCount: number;
     readonly renderScale: number;
+    readonly screenSpaceReflectionActivePixelCount: number;
+    readonly screenSpaceReflectionActiveTileCount: number;
+    readonly screenSpaceReflectionBackfaceRejectedPixelCount: number;
+    readonly screenSpaceReflectionHistoryAcceptedPixelCount: number;
+    readonly screenSpaceReflectionHistoryRejectedPixelCount: number;
+    readonly screenSpaceReflectionHitPixelCount: number;
+    readonly screenSpaceReflectionMissPixelCount: number;
+    readonly screenSpaceReflectionUncertainPixelCount: number;
     readonly smoothedGPUFrameTimeMs: number | null;
     readonly visibleObjectCount: number;
     readonly volumetricFroxelCount: number;

--- a/examples/screen_space_reflections_palace.ts
+++ b/examples/screen_space_reflections_palace.ts
@@ -7,6 +7,15 @@ interface ReflectionPalaceEvidence {
     readonly fallbackObjectCount: number;
     readonly visibleObjectCount: number;
     readonly hiZValid: boolean;
+    readonly activeTileCount: number;
+    readonly activePixelCount: number;
+    readonly hitPixelCount: number;
+    readonly missPixelCount: number;
+    readonly uncertainPixelCount: number;
+    readonly backfaceRejectedPixelCount: number;
+    readonly historyAcceptedPixelCount: number;
+    readonly historyRejectedPixelCount: number;
+    readonly resolutionScale: 0.5;
     readonly screenSpaceReflections: boolean;
     readonly temporalAA: true;
     readonly surfaceFinish: 'smoked lacquer';
@@ -53,10 +62,10 @@ if (carModel.resourceErrors.length > 0) {
 }
 for (const material of carModel.materials) {
     if (!(material instanceof Hilo3d.PBRMaterial) || !material.name?.startsWith('Paint')) continue;
-    material.normalScale = Math.min(material.normalScale, 0.16);
-    material.roughness = Math.max(material.roughness, 0.32);
-    material.iridescenceFactor = Math.min(material.iridescenceFactor, 0.05);
-    material.specularEnvIntensity = Math.min(material.specularEnvIntensity, 0.96);
+    material.normalScale = Math.min(material.normalScale, 0.04);
+    material.roughness = Math.max(material.roughness, 0.36);
+    material.iridescenceFactor = Math.min(material.iridescenceFactor, 0.02);
+    material.specularEnvIntensity = Math.min(material.specularEnvIntensity, 0.9);
 }
 
 const floorGeometry = new Hilo3d.PlaneGeometry({ width: 80, height: 80 });
@@ -69,6 +78,16 @@ const floorMaterial = new Hilo3d.PBRMaterial({
     specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
     diffuseEnvIntensity: 0.05,
     specularEnvIntensity: 0.12
+});
+const verticalMirrorMaterial = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.025, 0.03, 0.045),
+    metallic: 0.72,
+    roughness: 0.11,
+    brdfLUT,
+    diffuseEnvMap: { texture: diffuseEnvMap, encoding: 'srgb' },
+    specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
+    diffuseEnvIntensity: 0.025,
+    specularEnvIntensity: 0.2
 });
 const gpuEvidenceGeometry = new Hilo3d.BoxGeometry({ width: 0.16, height: 0.08, depth: 0.16 });
 const gpuEvidenceMaterial = new Hilo3d.PBRMaterial({
@@ -99,7 +118,7 @@ const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
     },
     screenSpaceReflections: reflectionsEnabled
         ? {
-              resolutionScale: 1,
+              resolutionScale: 0.5,
               maxRayDistance: 56,
               thickness: 0.18,
               stride: 0.06,
@@ -182,6 +201,17 @@ const floor = new Hilo3d.Mesh({
     frustumTest: false
 }).addTo(stage);
 floor.receiveShadows = false;
+
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.PlaneGeometry({ width: 5.8, height: 3.3 }),
+    material: verticalMirrorMaterial,
+    x: -3.25,
+    y: -0.12,
+    z: -9.65,
+    rotationY: -8,
+    pointerEnabled: false,
+    frustumTest: false
+}).addTo(stage);
 
 new Hilo3d.Mesh({
     geometry: gpuEvidenceGeometry,
@@ -280,6 +310,15 @@ window.__HILO3D_SSR_PALACE_RESULT__ = {
     fallbackObjectCount: diagnostics.fallbackObjectCount,
     visibleObjectCount: diagnostics.visibleObjectCount,
     hiZValid: diagnostics.hiZValid,
+    activeTileCount: diagnostics.screenSpaceReflectionActiveTileCount,
+    activePixelCount: diagnostics.screenSpaceReflectionActivePixelCount,
+    hitPixelCount: diagnostics.screenSpaceReflectionHitPixelCount,
+    missPixelCount: diagnostics.screenSpaceReflectionMissPixelCount,
+    uncertainPixelCount: diagnostics.screenSpaceReflectionUncertainPixelCount,
+    backfaceRejectedPixelCount: diagnostics.screenSpaceReflectionBackfaceRejectedPixelCount,
+    historyAcceptedPixelCount: diagnostics.screenSpaceReflectionHistoryAcceptedPixelCount,
+    historyRejectedPixelCount: diagnostics.screenSpaceReflectionHistoryRejectedPixelCount,
+    resolutionScale: 0.5,
     screenSpaceReflections: reflectionsEnabled,
     temporalAA: true,
     surfaceFinish: 'smoked lacquer',
@@ -288,6 +327,23 @@ window.__HILO3D_SSR_PALACE_RESULT__ = {
 window.__HILO3D_SSR_PALACE_TEST_API__ = {
     async settle(frames = 8): Promise<void> {
         await stepFrames(frames);
+    },
+    async moveCamera(): Promise<void> {
+        controls.setView(new Hilo3d.Vector3(9.35, 1.08, 5.05), heroTarget);
+        await stepFrames(1);
+    },
+    async setGrazingCamera(): Promise<void> {
+        controls.setView(new Hilo3d.Vector3(9.85, -0.49, 5.45), heroTarget);
+        await stepFrames(1);
+    },
+    async moveHero(deltaX = 0.32): Promise<void> {
+        carModel.node.x += deltaX;
+        await stepFrames(1);
+    },
+    async setFloorRoughness(value: number): Promise<number> {
+        floorMaterial.roughness = value;
+        await stepFrames(2);
+        return (await factory.readDiagnostics()).screenSpaceReflectionActivePixelCount;
     }
 };
 statusLabel.textContent = reflectionsEnabled ? 'reflection history stable' : 'direct light only';
@@ -311,6 +367,10 @@ declare global {
         __HILO3D_SSR_PALACE_RESULT__?: ReflectionPalaceEvidence;
         __HILO3D_SSR_PALACE_TEST_API__?: {
             settle(frames?: number): Promise<void>;
+            moveCamera(): Promise<void>;
+            setGrazingCamera(): Promise<void>;
+            moveHero(deltaX?: number): Promise<void>;
+            setFloorRoughness(value: number): Promise<number>;
         };
     }
 }

--- a/src/material/MaterialCompiler.ts
+++ b/src/material/MaterialCompiler.ts
@@ -202,12 +202,16 @@ export class MaterialCompiler {
         }
         if (
             pass.fragmentOutput === 'material-attributes' &&
-            (request.target.colorFormats.length !== 1 ||
-                request.target.colorFormats[0] !== 'rgba16float' ||
-                request.target.sampleCount !== 1)
+            (request.target.sampleCount !== 1 ||
+                request.target.colorFormats[0] !== 'rgba8unorm' ||
+                (request.target.colorFormats.length !== 1 &&
+                    (request.target.colorFormats.length !== 3 ||
+                        request.target.colorFormats[1] !== request.target.colorFormats[2] ||
+                        (request.target.colorFormats[1] !== 'rgba16float' &&
+                            request.target.colorFormats[1] !== 'rg11b10ufloat'))))
         ) {
             throw new TypeError(
-                'Material attributes role requires one single-sample rgba16float color target'
+                'Material attributes role requires single-sample rgba8unorm attributes and optional matching HDR reflection targets'
             );
         }
         const state = role === 'forward' ? resolveForwardState(instance, pass) : pass.state;

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -131,6 +131,7 @@ import type {
     ScriptableRenderPassContext
 } from './ScriptableRenderGraph';
 import type { RenderGraphTimelineSnapshot } from '../graph/RenderGraphTimeline';
+import type { RenderPipelineTextureFormat } from './RenderPipelineTexture';
 import {
     TEMPORAL_AA_REQUIREMENTS,
     TEMPORAL_MOTION_CLEAR,
@@ -558,6 +559,22 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly volumetricFroxelCount: number;
     /** Whether the latest submitted volumetric resolve consumed temporal history. */
     readonly volumetricHistoryUsed: boolean;
+    /** Eight-by-eight SSR trace tiles containing at least one eligible receiver. */
+    readonly screenSpaceReflectionActiveTileCount: number;
+    /** Eligible SSR receiver pixels classified by the latest submitted frame. */
+    readonly screenSpaceReflectionActivePixelCount: number;
+    /** Eligible SSR receiver pixels that produced a valid screen-space hit. */
+    readonly screenSpaceReflectionHitPixelCount: number;
+    /** Eligible SSR receiver pixels that missed or left the screen. */
+    readonly screenSpaceReflectionMissPixelCount: number;
+    /** SSR misses whose hierarchy crossing could not be validated precisely. */
+    readonly screenSpaceReflectionUncertainPixelCount: number;
+    /** SSR candidates rejected because the hit surface faced away from the ray. */
+    readonly screenSpaceReflectionBackfaceRejectedPixelCount: number;
+    /** SSR temporal pixels that consumed valid surface- or hit-domain history. */
+    readonly screenSpaceReflectionHistoryAcceptedPixelCount: number;
+    /** SSR temporal pixels that rejected every available history candidate. */
+    readonly screenSpaceReflectionHistoryRejectedPixelCount: number;
     /** Latest adapted exposure in EV stops, or zero when auto exposure is disabled. */
     readonly autoExposureEV: number;
     /** Latest histogram-derived target exposure in EV stops, or zero when disabled. */
@@ -1113,6 +1130,15 @@ function bufferRequirementPlan(
             maxBufferSize = Math.max(maxBufferSize, largestGeometryBuffer);
         }
     }
+    const maximumSSRTileCount =
+        options.screenSpaceReflections === null
+            ? 1
+            : Math.ceil(
+                  (options.maxViewportWidth * options.screenSpaceReflections.resolutionScale) / 8
+              ) *
+              Math.ceil(
+                  (options.maxViewportHeight * options.screenSpaceReflections.resolutionScale) / 8
+              );
     const maxComputeWorkgroupsPerDimension = Math.max(
         Math.ceil(options.maxObjects / CULL_WORKGROUP_SIZE),
         Math.ceil(options.maxLights / CULL_WORKGROUP_SIZE),
@@ -1121,6 +1147,8 @@ function bufferRequirementPlan(
         capacity.maxTilesY,
         Math.ceil(options.maxViewportWidth / 8),
         Math.ceil(options.maxViewportHeight / 8),
+        Math.min(maximumSSRTileCount, 65_535),
+        Math.ceil(maximumSSRTileCount / 65_535),
         1
     );
     return Object.freeze({
@@ -2938,11 +2966,12 @@ float hiloClusteredShadow(
 function gpuScenePBRShader(
     variant: Readonly<PBRMaterialVariant>,
     withMaterialAttributes: boolean,
+    withReflectionData: boolean,
     withGroundTruthAmbientOcclusion: boolean,
     withCloudShadow: boolean,
     withShadows: boolean
 ): StorageGraphicsShader {
-    const cacheKey = `${variant.key}|attributes=${withMaterialAttributes ? '1' : '0'}|gtao=${withGroundTruthAmbientOcclusion ? '1' : '0'}|cloud-shadow=${withCloudShadow ? '1' : '0'}|shadows=${withShadows ? '1' : '0'}`;
+    const cacheKey = `${variant.key}|attributes=${withMaterialAttributes ? '1' : '0'}|reflections=${withReflectionData ? '1' : '0'}|gtao=${withGroundTruthAmbientOcclusion ? '1' : '0'}|cloud-shadow=${withCloudShadow ? '1' : '0'}|shadows=${withShadows ? '1' : '0'}`;
     const cached = GPU_SCENE_PBR_SHADER_CACHE.get(cacheKey);
     if (cached !== undefined) return cached;
     const textureDeclarations = variant.textures
@@ -3153,6 +3182,12 @@ flat in uint v_objectFlags;
 flat in uint v_objectLayer;
 layout(location=0) out vec4 color;
 ${withMaterialAttributes ? 'layout(location=1) out vec4 materialAttributes;' : ''}
+${
+    withReflectionData
+        ? `layout(location=${withMaterialAttributes ? '2' : '1'}) out vec4 reflectionResponse;
+layout(location=${withMaterialAttributes ? '3' : '2'}) out vec4 reflectionFallbackSpecular;`
+        : ''
+}
 ${encodingSource}
 ${portableCoordinatesSource}
 float hiloMaterialChannel(vec4 value, int channel) {
@@ -3370,11 +3405,12 @@ void main() {
         );
         encodedNormal = (1.0 - abs(encodedNormal.yx)) * octahedralSign;
     }
-    float metallicBits = floor(clamp(surface.metallic, 0.0, 1.0) * 255.0 + 0.5);
+    encodedNormal = encodedNormal * 0.5 + 0.5;
+    float metallicBits = floor(clamp(surface.metallic, 0.0, 1.0) * 127.0 + 0.5);
     materialAttributes = vec4(
         encodedNormal,
         surface.roughness,
-        1.0 + metallicBits * 2.0
+        (1.0 + metallicBits * 2.0) / 255.0
     );`
             : ''
     }
@@ -3396,6 +3432,21 @@ void main() {
     }
     vec3 lighting = frameData.values[31u].rgb * surface.iblDiffuseColor *
         ambientOcclusion * HILO_INVERSE_PI;
+    ${
+        withReflectionData
+            ? `float reflectionNdotV = max(abs(dot(normal, viewDirection)), 0.0001);
+    vec3 ssrReflectionResponse = hiloFresnelSchlick(
+        surface.specularColor,
+        reflectionNdotV
+    );
+    vec3 ssrFallbackSpecular = frameData.values[31u].rgb *
+        ssrReflectionResponse *
+        mix(1.0, 0.35, surface.roughness) * ambientOcclusion;
+    lighting += ssrFallbackSpecular;
+    reflectionResponse = vec4(ssrReflectionResponse, 1.0);
+    reflectionFallbackSpecular = vec4(ssrFallbackSpecular, 1.0);`
+            : ''
+    }
     float cloudShadow = 1.0;
     ${
         withCloudShadow
@@ -3425,9 +3476,11 @@ void main() {
 }
 
 function gpuSceneMaterialAttributesShader(
-    variant: Readonly<PBRMaterialVariant>
+    variant: Readonly<PBRMaterialVariant>,
+    withReflectionData: boolean
 ): StorageGraphicsShader {
-    const cached = GPU_SCENE_ATTRIBUTES_SHADER_CACHE.get(variant.key);
+    const cacheKey = `${variant.key}|reflections=${withReflectionData ? '1' : '0'}`;
+    const cached = GPU_SCENE_ATTRIBUTES_SHADER_CACHE.get(cacheKey);
     if (cached !== undefined) return cached;
     const textureDeclarations = variant.textures
         .map(binding => `uniform sampler2D ${binding.shaderName};`)
@@ -3513,6 +3566,7 @@ layout(location=0) in vec3 a_position;
 layout(location=1) in vec3 a_normal;
 ${vertexUVDeclarations}
 out vec3 v_viewNormal;
+out vec3 v_viewPosition;
 flat out uint v_materialIndex;
 ${GPU_SCENE_POSITION_TRANSFORM_SOURCE}
 ${GPU_SCENE_VISIBLE_INDEX_SOURCE}
@@ -3522,9 +3576,12 @@ mat3 readObjectNormalMatrix(uint base) {
 void main() {
     uint objectIndex = gpuSceneVisibleObjectIndex();
     uint objectBase = objectIndex * 13u;
-    mat3 viewNormalMatrix = mat3(readFrameMatrix(8u)) * readObjectNormalMatrix(objectBase);
+    mat4 model = readObjectMatrix(objectBase);
+    mat4 view = readFrameMatrix(8u);
+    mat3 viewNormalMatrix = mat3(view) * readObjectNormalMatrix(objectBase);
     vec3 viewNormal = normalize(viewNormalMatrix * a_normal);
     v_viewNormal = viewNormal;
+    v_viewPosition = (view * model * vec4(a_position, 1.0)).xyz;
     v_materialIndex = floatBitsToUint(objects.values[objectBase + 12u].w);
     ${vertexUVWrites}
     gl_Position = gpuSceneClipPosition(objectBase, a_position);
@@ -3532,12 +3589,15 @@ void main() {
         fragmentSource: `#version 310 es
 precision highp float;
 precision highp int;
+layout(std430) readonly buffer FrameDataBlock { vec4 values[]; } frameData;
 layout(std430) readonly buffer MaterialDataBlock { vec4 values[]; } materials;
 ${textureDeclarations}
 in vec3 v_viewNormal;
+in vec3 v_viewPosition;
 ${fragmentUVDeclarations}
 flat in uint v_materialIndex;
 layout(location=0) out vec4 materialAttributes;
+${withReflectionData ? 'layout(location=1) out vec4 reflectionResponse;\nlayout(location=2) out vec4 reflectionFallbackSpecular;' : ''}
 ${encodingSource}
 float hiloMaterialChannel(vec4 value, int channel) {
     if (channel == 0) return value.r;
@@ -3604,16 +3664,32 @@ void main() {
         );
         encodedNormal = (1.0 - abs(encodedNormal.yx)) * octahedralSign;
     }
-    float metallicBits = floor(clamp(metallic, 0.0, 1.0) * 255.0 + 0.5);
+    encodedNormal = encodedNormal * 0.5 + 0.5;
+    float metallicBits = floor(clamp(metallic, 0.0, 1.0) * 127.0 + 0.5);
     materialAttributes = vec4(
         encodedNormal,
         clamp(roughness, 0.045, 1.0),
-        1.0 + metallicBits * 2.0
+        (1.0 + metallicBits * 2.0) / 255.0
     );
+    ${
+        withReflectionData
+            ? `vec3 baseColor = baseMetallic.rgb * baseColorSample.rgb;
+    float ior = max(materialParameters.x, 1.0);
+    float dielectricF0 = pow((ior - 1.0) / (ior + 1.0), 2.0);
+    vec3 reflectionF0 = mix(vec3(dielectricF0), baseColor, clamp(metallic, 0.0, 1.0));
+    float reflectionNdotV = max(abs(dot(normal, normalize(-v_viewPosition))), 0.0001);
+    vec3 response = reflectionF0 + (vec3(1.0) - reflectionF0) *
+        pow(1.0 - reflectionNdotV, 5.0);
+    vec3 fallbackSpecular = frameData.values[31u].rgb * response *
+        mix(1.0, 0.35, clamp(roughness, 0.045, 1.0));
+    reflectionResponse = vec4(response, 1.0);
+    reflectionFallbackSpecular = vec4(fallbackSpecular, 1.0);`
+            : ''
+    }
 }`,
         bindings
     });
-    GPU_SCENE_ATTRIBUTES_SHADER_CACHE.set(variant.key, shader);
+    GPU_SCENE_ATTRIBUTES_SHADER_CACHE.set(cacheKey, shader);
     return shader;
 }
 
@@ -4324,6 +4400,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #groundTruthAmbientOcclusion: GroundTruthAmbientOcclusionController | null;
     readonly #screenSpaceGlobalIllumination: ScreenSpaceGlobalIlluminationController | null;
     readonly #screenSpaceReflections: ScreenSpaceReflectionsController | null;
+    readonly #reflectionDataFormat: RenderPipelineTextureFormat;
     readonly #volumetricLighting: VolumetricLightingController | null;
     readonly #autoExposure: AutoExposureController | null;
     readonly #atmosphere: AtmosphereWeatherController | null;
@@ -4599,11 +4676,17 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 : new ScreenSpaceGlobalIlluminationController(
                       options.screenSpaceGlobalIllumination
                   );
+        this.#reflectionDataFormat =
+            context.capabilities.supportsTextureFormat('rg11b10ufloat', 'color-attachment') &&
+            context.capabilities.supportsTextureFormat('rg11b10ufloat', 'filterable-sampled')
+                ? 'rg11b10ufloat'
+                : 'rgba16float';
         this.#screenSpaceReflections =
             options.screenSpaceReflections === null
                 ? null
                 : new ScreenSpaceReflectionsController(
                       options.screenSpaceReflections,
+                      context,
                       options.temporalAA?.renderScale ?? 1,
                       options.hiZLevelCount
                   );
@@ -4967,7 +5050,23 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             this.#groundTruthAmbientOcclusion === null
                 ? null
                 : context.graph.createTexture('Clustered Forward+ material attributes', {
-                      format: 'rgba16float',
+                      format: 'rgba8unorm',
+                      extent: { relativeTo: 'output', scale: sceneScale },
+                      sampleCount: 1
+                  });
+        const reflectionResponse =
+            this.#screenSpaceReflections === null
+                ? null
+                : context.graph.createTexture('Clustered Forward+ reflection response', {
+                      format: this.#reflectionDataFormat,
+                      extent: { relativeTo: 'output', scale: sceneScale },
+                      sampleCount: 1
+                  });
+        const fallbackSpecular =
+            this.#screenSpaceReflections === null
+                ? null
+                : context.graph.createTexture('Clustered Forward+ fallback environment specular', {
+                      format: this.#reflectionDataFormat,
                       extent: { relativeTo: 'output', scale: sceneScale },
                       sampleCount: 1
                   });
@@ -5134,14 +5233,19 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 materials,
                 indirect,
                 sceneDepth,
-                materialAttributes
+                materialAttributes,
+                reflectionResponse: null,
+                fallbackSpecular: null
             });
             if (fallbackCulling !== null && this.#fallbackHasOpaque) {
                 this.recordFallbackMaterialAttributes(
                     context,
                     fallbackCulling,
                     materialAttributes,
-                    sceneDepth
+                    null,
+                    null,
+                    sceneDepth,
+                    null
                 );
             }
         }
@@ -5222,6 +5326,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             sceneColor,
             sceneDepth,
             materialAttributes: groundTruthAmbientOcclusion === null ? materialAttributes : null,
+            reflectionResponse,
+            fallbackSpecular,
             ambientOcclusion,
             cloudShadow: atmospherePrerequisites?.cloudShadow ?? null,
             shadowResources
@@ -5249,16 +5355,19 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         this.recordGPUParticles(context, sceneColor, sceneDepth, 'opaque');
         if (
-            groundTruthAmbientOcclusion === null &&
             materialAttributes !== null &&
             fallbackCulling !== null &&
-            this.#fallbackHasOpaque
+            this.#fallbackHasOpaque &&
+            (groundTruthAmbientOcclusion === null || this.#screenSpaceReflections !== null)
         ) {
             this.recordFallbackMaterialAttributes(
                 context,
                 fallbackCulling,
                 materialAttributes,
-                sceneDepth
+                reflectionResponse,
+                fallbackSpecular,
+                sceneDepth,
+                ambientOcclusion
             );
         }
         let globallyIlluminatedSceneColor = sceneColor;
@@ -5279,7 +5388,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
         let reflectedSceneColor = globallyIlluminatedSceneColor;
         if (this.#screenSpaceReflections !== null) {
-            if (temporalFrame === null || temporalMotion === null || materialAttributes === null) {
+            if (
+                temporalFrame === null ||
+                temporalMotion === null ||
+                materialAttributes === null ||
+                reflectionResponse === null ||
+                fallbackSpecular === null ||
+                combinedTemporalReactiveMask === null
+            ) {
                 throw new Error('Clustered Forward+ screen-space reflection inputs are missing');
             }
             reflectedSceneColor = this.#screenSpaceReflections.record(context, {
@@ -5287,7 +5403,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 sceneColor: globallyIlluminatedSceneColor,
                 sceneDepth,
                 materialAttributes,
+                reflectionResponse,
+                fallbackSpecular,
                 motionDepth: temporalMotion,
+                reactiveMask: combinedTemporalReactiveMask,
                 sceneScale,
                 hiZ: histories.current,
                 historyValid: temporalFrame.historyValid && this.#committedCamera === context.camera
@@ -5515,6 +5634,19 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                       sampleCount: 0
                   })
                 : await this.#autoExposure.readDiagnostics();
+        const reflections =
+            this.#screenSpaceReflections === null
+                ? Object.freeze({
+                      activeTileCount: 0,
+                      activePixelCount: 0,
+                      hitPixelCount: 0,
+                      missPixelCount: 0,
+                      uncertainPixelCount: 0,
+                      backfaceRejectedPixelCount: 0,
+                      historyAcceptedPixelCount: 0,
+                      historyRejectedPixelCount: 0
+                  })
+                : await this.#screenSpaceReflections.readDiagnostics();
         const cullValues = new Uint32Array(
             cull.data.buffer,
             cull.data.byteOffset,
@@ -5543,6 +5675,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 this.#temporal?.dynamicResolutionDiagnostics?.smoothedGPUFrameTimeMs ?? null,
             volumetricFroxelCount: this.#volumetricLighting?.froxelCount ?? 0,
             volumetricHistoryUsed: this.#volumetricLighting?.historyUsed ?? false,
+            screenSpaceReflectionActiveTileCount: reflections.activeTileCount,
+            screenSpaceReflectionActivePixelCount: reflections.activePixelCount,
+            screenSpaceReflectionHitPixelCount: reflections.hitPixelCount,
+            screenSpaceReflectionMissPixelCount: reflections.missPixelCount,
+            screenSpaceReflectionUncertainPixelCount: reflections.uncertainPixelCount,
+            screenSpaceReflectionBackfaceRejectedPixelCount: reflections.backfaceRejectedPixelCount,
+            screenSpaceReflectionHistoryAcceptedPixelCount: reflections.historyAcceptedPixelCount,
+            screenSpaceReflectionHistoryRejectedPixelCount: reflections.historyRejectedPixelCount,
             autoExposureEV: exposure.actualEV,
             autoExposureTargetEV: exposure.targetEV,
             warmedMaterialVariantCount: this.#warmedMaterialVariantCount,
@@ -5850,6 +5990,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 (this.#options.screenSpaceReflections !== null ||
                     this.#options.screenSpaceGlobalIllumination !== null) &&
                     this.#options.groundTruthAmbientOcclusion === null,
+                this.#options.screenSpaceReflections !== null,
                 this.#options.groundTruthAmbientOcclusion !== null,
                 this.#options.atmosphere !== null && this.#options.atmosphere.clouds !== null,
                 withShadows
@@ -5872,7 +6013,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         if (this.#options.groundTruthAmbientOcclusion === null) return null;
         return new GPUDrivenRenderPass({
             name: `GPU Scene GTAO material attributes ${String(physicalIndex)}`,
-            shader: gpuSceneMaterialAttributesShader(variant),
+            shader: gpuSceneMaterialAttributesShader(variant, false),
             pipelineState: Object.freeze({
                 ...requireBucketPassState(logical.material, 'forward'),
                 depthWrite: false
@@ -6854,7 +6995,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#frameFloats[124] = Math.min(this.#frameFloats[124] ?? 0, 4);
         this.#frameFloats[125] = Math.min(this.#frameFloats[125] ?? 0, 4);
         this.#frameFloats[126] = Math.min(this.#frameFloats[126] ?? 0, 4);
-        this.#frameFloats[127] = 0;
+        this.#frameFloats[127] = this.#frameSerial % 32;
         const outputMapping = FRAME_OUTPUT_MAPPING_VEC4 * 4;
         this.#frameFloats[outputMapping] = context.output.width;
         this.#frameFloats[outputMapping + 1] = context.output.height;
@@ -7308,6 +7449,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             indirect: RenderGraphBufferHandle;
             sceneDepth: RenderGraphTextureHandle;
             materialAttributes: RenderGraphTextureHandle;
+            reflectionResponse: RenderGraphTextureHandle | null;
+            fallbackSpecular: RenderGraphTextureHandle | null;
         }>
     ): void {
         const batch = context.acquirePassParameters(this.#materialAttributesBatchPool);
@@ -7315,13 +7458,38 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             texture: resources.materialAttributes,
             loadOp: 'clear',
             storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 1, a: 0 }
+            clearValue: { r: 0.5, g: 0.5, b: 1, a: 0 }
         };
+        if ((resources.reflectionResponse === null) !== (resources.fallbackSpecular === null)) {
+            throw new Error('GPU Scene reflection material targets are incomplete');
+        }
+        const reflectionResponseAttachment: RenderPipelineColorAttachment | null =
+            resources.reflectionResponse === null
+                ? null
+                : {
+                      texture: resources.reflectionResponse,
+                      loadOp: 'clear',
+                      storeOp: 'store',
+                      clearValue: { r: 0, g: 0, b: 0, a: 0 }
+                  };
+        const fallbackSpecularAttachment: RenderPipelineColorAttachment | null =
+            resources.fallbackSpecular === null
+                ? null
+                : {
+                      texture: resources.fallbackSpecular,
+                      loadOp: 'clear',
+                      storeOp: 'store',
+                      clearValue: { r: 0, g: 0, b: 0, a: 0 }
+                  };
         const depthAttachment: RenderPipelineDepthStencilAttachment = {
             texture: resources.sceneDepth,
             depthReadOnly: true
         };
         batch.colorAttachments[0] = colorAttachment;
+        if (reflectionResponseAttachment !== null && fallbackSpecularAttachment !== null) {
+            batch.colorAttachments[1] = reflectionResponseAttachment;
+            batch.colorAttachments[2] = fallbackSpecularAttachment;
+        }
         batch.depthStencilAttachment = depthAttachment;
         for (let index = 0; index < this.#physicalBuckets.length; index += 1) {
             const bucket = this.#physicalBuckets[index];
@@ -7373,8 +7541,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.indexBuffer.buffer = context.graph.importStorageBuffer(bucket.index);
             parameters.draw.buffer = resources.indirect;
             parameters.draw.byteOffset = index * INDIRECT_ARGUMENT_BYTES;
-            parameters.colorAttachments.length = 1;
+            parameters.colorAttachments.length = reflectionResponseAttachment === null ? 1 : 3;
             parameters.colorAttachments[0] = colorAttachment;
+            if (reflectionResponseAttachment !== null && fallbackSpecularAttachment !== null) {
+                parameters.colorAttachments[1] = reflectionResponseAttachment;
+                parameters.colorAttachments[2] = fallbackSpecularAttachment;
+            }
             parameters.depthStencilAttachment = depthAttachment;
             batch.add(attributesPass, parameters);
         }
@@ -7396,6 +7568,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             sceneColor: RenderGraphTextureHandle;
             sceneDepth: RenderGraphTextureHandle;
             materialAttributes: RenderGraphTextureHandle | null;
+            reflectionResponse: RenderGraphTextureHandle | null;
+            fallbackSpecular: RenderGraphTextureHandle | null;
             ambientOcclusion: RenderGraphTextureHandle | null;
             cloudShadow: RenderGraphTextureHandle | null;
             shadowResources: Readonly<RenderPipelineShadowResources> | null;
@@ -7415,7 +7589,28 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                       texture: resources.materialAttributes,
                       loadOp: 'clear',
                       storeOp: 'store',
-                      clearValue: { r: 0, g: 0, b: 1, a: 0 }
+                      clearValue: { r: 0.5, g: 0.5, b: 1, a: 0 }
+                  };
+        if ((resources.reflectionResponse === null) !== (resources.fallbackSpecular === null)) {
+            throw new Error('Clustered PBR reflection material targets are incomplete');
+        }
+        const reflectionResponseAttachment: RenderPipelineColorAttachment | null =
+            resources.reflectionResponse === null
+                ? null
+                : {
+                      texture: resources.reflectionResponse,
+                      loadOp: 'clear',
+                      storeOp: 'store',
+                      clearValue: { r: 0, g: 0, b: 0, a: 0 }
+                  };
+        const fallbackSpecularAttachment: RenderPipelineColorAttachment | null =
+            resources.fallbackSpecular === null
+                ? null
+                : {
+                      texture: resources.fallbackSpecular,
+                      loadOp: 'clear',
+                      storeOp: 'store',
+                      clearValue: { r: 0, g: 0, b: 0, a: 0 }
                   };
         const depthAttachment: RenderPipelineDepthStencilAttachment = {
             texture: resources.sceneDepth,
@@ -7426,6 +7621,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         batch.colorAttachments[0] = colorAttachment;
         if (materialAttributesAttachment !== null) {
             batch.colorAttachments[1] = materialAttributesAttachment;
+        }
+        if (reflectionResponseAttachment !== null && fallbackSpecularAttachment !== null) {
+            const reflectionAttachmentIndex = materialAttributesAttachment === null ? 1 : 2;
+            batch.colorAttachments[reflectionAttachmentIndex] = reflectionResponseAttachment;
+            batch.colorAttachments[reflectionAttachmentIndex + 1] = fallbackSpecularAttachment;
         }
         batch.depthStencilAttachment = depthAttachment;
         for (let index = 0; index < this.#physicalBuckets.length; index += 1) {
@@ -7522,10 +7722,24 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.indexBuffer.buffer = context.graph.importStorageBuffer(bucket.index);
             parameters.draw.buffer = resources.indirect;
             parameters.draw.byteOffset = index * INDIRECT_ARGUMENT_BYTES;
-            parameters.colorAttachments.length = materialAttributesAttachment === null ? 1 : 2;
+            parameters.colorAttachments.length =
+                reflectionResponseAttachment !== null
+                    ? materialAttributesAttachment === null
+                        ? 3
+                        : 4
+                    : materialAttributesAttachment === null
+                      ? 1
+                      : 2;
             parameters.colorAttachments[0] = colorAttachment;
             if (materialAttributesAttachment !== null) {
                 parameters.colorAttachments[1] = materialAttributesAttachment;
+            }
+            if (reflectionResponseAttachment !== null && fallbackSpecularAttachment !== null) {
+                const reflectionAttachmentIndex = materialAttributesAttachment === null ? 1 : 2;
+                parameters.colorAttachments[reflectionAttachmentIndex] =
+                    reflectionResponseAttachment;
+                parameters.colorAttachments[reflectionAttachmentIndex + 1] =
+                    fallbackSpecularAttachment;
             }
             parameters.depthStencilAttachment = depthAttachment;
             batch.add(bucket.colorPass, parameters);
@@ -7838,7 +8052,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         context: RenderPipelineContext,
         cullingResults: CullingResultsHandle,
         materialAttributes: RenderGraphTextureHandle,
-        sceneDepth: RenderGraphTextureHandle
+        reflectionResponse: RenderGraphTextureHandle | null,
+        fallbackSpecular: RenderGraphTextureHandle | null,
+        sceneDepth: RenderGraphTextureHandle,
+        ambientOcclusion: RenderGraphTextureHandle | null
     ): void {
         this.#fallbackMaterialAttributesListDescriptor.cullingResults = cullingResults;
         const rendererList = context.createRendererList(
@@ -7851,10 +8068,28 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             throw new Error('Forward fallback material attributes attachment is unavailable');
         }
         color.texture = materialAttributes;
+        if ((reflectionResponse === null) !== (fallbackSpecular === null)) {
+            throw new Error('Forward fallback reflection material targets are incomplete');
+        }
+        if (reflectionResponse !== null && fallbackSpecular !== null) {
+            parameters.colorAttachments[1] = {
+                texture: reflectionResponse,
+                loadOp: 'load',
+                storeOp: 'store'
+            };
+            parameters.colorAttachments[2] = {
+                texture: fallbackSpecular,
+                loadOp: 'load',
+                storeOp: 'store'
+            };
+        }
         parameters.depthStencilAttachment = {
             texture: sceneDepth,
             depthReadOnly: true
         };
+        if (ambientOcclusion !== null) {
+            parameters.ambientOcclusionTexture = ambientOcclusion;
+        }
         context.graph.addPass(this.#fallbackMaterialAttributesPass, parameters);
     }
 
@@ -7964,6 +8199,20 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     format: 'rgba16float' as const,
                     use: 'filterable-sampled' as const
                 }),
+                ...(groundTruthAmbientOcclusion ||
+                screenSpaceGlobalIllumination ||
+                screenSpaceReflections
+                    ? [
+                          Object.freeze({
+                              format: 'rgba8unorm' as const,
+                              use: 'color-attachment' as const
+                          }),
+                          Object.freeze({
+                              format: 'rgba8unorm' as const,
+                              use: 'filterable-sampled' as const
+                          })
+                      ]
+                    : []),
                 ...(this.#options.temporalAA === null
                     ? []
                     : TEMPORAL_AA_REQUIREMENTS.requiredTextureFormats),
@@ -8004,7 +8253,7 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                         6 +
                         (cloudShadows ? 2 : 0),
                     screenSpaceReflections
-                        ? 1 + SCREEN_SPACE_REFLECTION_COLOR_LEVELS + 2 + reflectionHiZLevels + 1 + 1
+                        ? 3 + SCREEN_SPACE_REFLECTION_COLOR_LEVELS + 4 + reflectionHiZLevels + 1 + 2
                         : 0,
                     volumetricLighting ? 9 : 0,
                     autoExposure ? 5 : 0,
@@ -8018,7 +8267,7 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                         3 +
                         (cloudShadows ? 1 : 0),
                     screenSpaceReflections
-                        ? SCREEN_SPACE_REFLECTION_COLOR_LEVELS + 2 + reflectionHiZLevels
+                        ? SCREEN_SPACE_REFLECTION_COLOR_LEVELS + 4 + reflectionHiZLevels
                         : 0,
                     volumetricLighting ? 4 : 0,
                     autoExposure ? 3 : 0,
@@ -8031,8 +8280,11 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     (cloudShadows ? 1 : 0),
                 ...(hiZ || volumetricLighting || autoExposure || atmosphere
                     ? {
-                          maxStorageTexturesPerShaderStage:
-                              screenSpaceReflections || volumetricLighting || atmosphere ? 2 : 1
+                          maxStorageTexturesPerShaderStage: screenSpaceReflections
+                              ? 4
+                              : volumetricLighting || atmosphere
+                                ? 2
+                                : 1
                       }
                     : {}),
                 maxStorageBufferBindingSize: requirements.maxStorageBufferBindingSize,

--- a/src/render/postprocessing/GroundTruthAmbientOcclusion.ts
+++ b/src/render/postprocessing/GroundTruthAmbientOcclusion.ts
@@ -141,7 +141,9 @@ export function snapshotGroundTruthAmbientOcclusionOptions(
 export const GROUND_TRUTH_AMBIENT_OCCLUSION_REQUIREMENTS = Object.freeze({
     requiredTextureFormats: Object.freeze([
         Object.freeze({ format: 'rgba16float' as const, use: 'color-attachment' as const }),
-        Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const })
+        Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const }),
+        Object.freeze({ format: 'rgba8unorm' as const, use: 'color-attachment' as const }),
+        Object.freeze({ format: 'rgba8unorm' as const, use: 'filterable-sampled' as const })
     ])
 }) satisfies Readonly<RenderPipelineRequirements>;
 
@@ -173,6 +175,7 @@ layout(location = 0) out vec4 gtaoResult;
 const float PI = 3.141592653589793;
 
 vec3 decodeOctahedralNormal(vec2 encoded) {
+    encoded = encoded * 2.0 - 1.0;
     vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
     if (normal.z < 0.0) {
         vec2 original = normal.xy;
@@ -386,6 +389,7 @@ uniform sampler2D u_materialAttributes;
 uniform sampler2D u_motionDepth;
 layout(location = 0) out vec4 filtered;
 vec3 decodeOctahedralNormal(vec2 encoded) {
+    encoded = encoded * 2.0 - 1.0;
     vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
     if (normal.z < 0.0) {
         vec2 original = normal.xy;
@@ -435,6 +439,7 @@ uniform sampler2D u_materialAttributes;
 uniform sampler2D u_motionDepth;
 layout(location = 0) out vec4 fullResolutionAO;
 vec3 decodeOctahedralNormal(vec2 encoded) {
+    encoded = encoded * 2.0 - 1.0;
     vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
     if (normal.z < 0.0) {
         vec2 original = normal.xy;
@@ -891,7 +896,7 @@ class GroundTruthAmbientOcclusionRuntime implements ForwardRenderPipelineFeature
         const sceneScale = context.resources.sceneScale;
         const extent = Object.freeze({ relativeTo: 'output' as const, scale: sceneScale });
         const attributes = pipeline.graph.createTexture('GTAO material attributes', {
-            format: 'rgba16float',
+            format: 'rgba8unorm',
             extent,
             sampleCount: 1
         });
@@ -902,7 +907,7 @@ class GroundTruthAmbientOcclusionRuntime implements ForwardRenderPipelineFeature
             texture: attributes,
             loadOp: 'clear',
             storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 1, a: 0 }
+            clearValue: { r: 0.5, g: 0.5, b: 1, a: 0 }
         });
         attributeParameters.depthStencilAttachment = this.depthAttachment(pipeline, depth, false);
         pipeline.graph.addPass(this.#attributesPass, attributeParameters);

--- a/src/render/postprocessing/ScreenSpaceGlobalIllumination.ts
+++ b/src/render/postprocessing/ScreenSpaceGlobalIllumination.ts
@@ -184,7 +184,9 @@ export function snapshotScreenSpaceGlobalIlluminationOptions(
 export const SCREEN_SPACE_GLOBAL_ILLUMINATION_REQUIREMENTS = Object.freeze({
     requiredTextureFormats: Object.freeze([
         Object.freeze({ format: 'rgba16float' as const, use: 'color-attachment' as const }),
-        Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const })
+        Object.freeze({ format: 'rgba16float' as const, use: 'filterable-sampled' as const }),
+        Object.freeze({ format: 'rgba8unorm' as const, use: 'color-attachment' as const }),
+        Object.freeze({ format: 'rgba8unorm' as const, use: 'filterable-sampled' as const })
     ])
 }) satisfies Readonly<RenderPipelineRequirements>;
 
@@ -233,6 +235,7 @@ vec2 ssgiProjectViewPosition(vec3 position) {
     return ssgiUVForNDC(clip.xy / max(abs(clip.w), 1e-6) * sign(clip.w));
 }
 vec3 ssgiDecodeNormal(vec2 encoded) {
+    encoded = encoded * 2.0 - 1.0;
     vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
     if (normal.z < 0.0) {
         vec2 original = normal.xy;
@@ -977,7 +980,7 @@ class ScreenSpaceGlobalIlluminationRuntime implements ForwardRenderPipelineFeatu
         let attributes = context.resources.materialAttributes;
         if (attributes === null) {
             attributes = pipeline.graph.createTexture('SSGI material attributes', {
-                format: 'rgba16float',
+                format: 'rgba8unorm',
                 extent,
                 sampleCount: 1
             });
@@ -988,7 +991,7 @@ class ScreenSpaceGlobalIlluminationRuntime implements ForwardRenderPipelineFeatu
                 texture: attributes,
                 loadOp: 'clear',
                 storeOp: 'store',
-                clearValue: { r: 0, g: 0, b: 1, a: 0 }
+                clearValue: { r: 0.5, g: 0.5, b: 1, a: 0 }
             });
             parameters.depthStencilAttachment = {
                 texture: sceneDepth,

--- a/src/render/postprocessing/ScreenSpaceReflections.ts
+++ b/src/render/postprocessing/ScreenSpaceReflections.ts
@@ -3,11 +3,16 @@ import Shader from '../../shader/Shader';
 import ComputeKernel from '../compute/ComputeKernel';
 import ComputeSampler from '../compute/ComputeSampler';
 import ComputeShader, { type ComputeShaderBinding } from '../compute/ComputeShader';
-import type { RenderPipelineContext } from '../pipeline/RenderPipeline';
+import type { StorageBuffer } from '../StorageBuffer';
+import type {
+    RenderPipelineContext,
+    RenderPipelineCreateContext
+} from '../pipeline/RenderPipeline';
 import { RenderPassParameterPool } from '../pipeline/RenderPassParameterPool';
 import {
     ComputeRenderPass,
     FullscreenRenderPass,
+    type ComputeDispatch,
     type ComputeRenderPassParameters,
     type FullscreenRenderPassParameters
 } from '../pipeline/passes';
@@ -27,7 +32,33 @@ const INVALID_TEXTURE = 0 as RenderGraphTextureHandle;
 const TRACE_WORKGROUP_SIZE = 8;
 const MAX_TRACE_HIZ_LEVELS = 8;
 const COLOR_PYRAMID_LEVELS = 4;
-const SPATIAL_FILTER_STEPS = Object.freeze([1, 2, 4, 8] as const);
+const MIN_REFLECTION_RESPONSE = 1 / 1024;
+const SSR_DIAGNOSTIC_BYTES = 32;
+const TEMPORAL_SEQUENCE_LENGTH = 32;
+const DETERMINISTIC_REFLECTION_ROUGHNESS = 0.1;
+const STOCHASTIC_RAY_COUNT = 4;
+const MAX_HISTORY_SAMPLE_COUNT = 31;
+const MAX_INDIRECT_DISPATCH_X = 65_535;
+
+/** Submitted GPU work counters for the hierarchical SSR trace. */
+export interface ScreenSpaceReflectionsDiagnostics {
+    /** Eight-by-eight trace tiles containing at least one eligible receiver. */
+    readonly activeTileCount: number;
+    /** Eligible reflective receiver pixels classified in active tiles. */
+    readonly activePixelCount: number;
+    /** Eligible receiver pixels that produced a valid screen-space hit. */
+    readonly hitPixelCount: number;
+    /** Eligible receiver pixels that exhausted or left the screen-space trace. */
+    readonly missPixelCount: number;
+    /** Missed receiver pixels whose hierarchy crossing could not be validated precisely. */
+    readonly uncertainPixelCount: number;
+    /** Missed receiver pixels rejected because the visible hit faced away from the ray. */
+    readonly backfaceRejectedPixelCount: number;
+    /** Temporal pixels that consumed either surface- or hit-domain history. */
+    readonly historyAcceptedPixelCount: number;
+    /** Temporal pixels that rejected all available history candidates. */
+    readonly historyRejectedPixelCount: number;
+}
 
 /** Production controls for the WebGPU high-end hierarchical screen-space reflection path. */
 export interface ScreenSpaceReflectionsOptions {
@@ -49,7 +80,7 @@ export interface ScreenSpaceReflectionsOptions {
     readonly historyWeight?: number;
     /** Maximum relative reprojected view-depth error. Defaults to 0.03. */
     readonly depthThreshold?: number;
-    /** Linear HDR reflection multiplier. Defaults to 1. */
+    /** Linear HDR multiplier applied to SSR radiance, without scaling fallback removal. Defaults to 1. */
     readonly intensity?: number;
 }
 
@@ -89,7 +120,7 @@ function positiveInteger(value: number, minimum: number, maximum: number, label:
 export function snapshotScreenSpaceReflectionsOptions(
     options: Readonly<ScreenSpaceReflectionsOptions>
 ): Readonly<ScreenSpaceReflectionsSettings> {
-    return Object.freeze({
+    const settings: ScreenSpaceReflectionsSettings = {
         resolutionScale: finiteRange(
             options.resolutionScale ?? 0.5,
             0.25,
@@ -140,7 +171,18 @@ export function snapshotScreenSpaceReflectionsOptions(
             'Screen-space reflections depthThreshold'
         ),
         intensity: finiteRange(options.intensity ?? 1, 0, 4, 'Screen-space reflections intensity')
-    });
+    };
+    if (settings.stride * 4 > settings.maxRayDistance) {
+        throw new RangeError(
+            'Screen-space reflections maxRayDistance must cover at least four stride steps'
+        );
+    }
+    if (settings.thickness * 2 > settings.maxRayDistance) {
+        throw new RangeError(
+            'Screen-space reflections thickness must not exceed half maxRayDistance'
+        );
+    }
+    return Object.freeze(settings);
 }
 
 const FRAME_WGSL = `
@@ -214,6 +256,395 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     })
 );
 
+const TRACE_RESET_PASS = computePass(
+    new ComputeShader({
+        label: 'Screen-space reflections clear trace targets and counters',
+        source: `
+struct DispatchArguments {
+    x: atomic<u32>,
+    y: atomic<u32>,
+    z: atomic<u32>,
+};
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+@group(0) @binding(0) var<storage, read_write> dispatchArguments: DispatchArguments;
+@group(0) @binding(1) var<storage, read_write> diagnostics: TraceDiagnostics;
+@group(0) @binding(2) var reflectionOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(3) var hitOutput: texture_storage_2d<rgba16float, write>;
+@compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (all(id.xy == vec2<u32>(0u))) {
+        atomicStore(&dispatchArguments.x, 0u);
+        atomicStore(&dispatchArguments.y, 1u);
+        atomicStore(&dispatchArguments.z, 1u);
+        atomicStore(&diagnostics.activeTiles, 0u);
+        atomicStore(&diagnostics.activePixels, 0u);
+        atomicStore(&diagnostics.hitPixels, 0u);
+        atomicStore(&diagnostics.missPixels, 0u);
+        atomicStore(&diagnostics.uncertainPixels, 0u);
+        atomicStore(&diagnostics.backfaceRejectedPixels, 0u);
+        atomicStore(&diagnostics.historyAcceptedPixels, 0u);
+        atomicStore(&diagnostics.historyRejectedPixels, 0u);
+    }
+    let outputSize = textureDimensions(reflectionOutput);
+    if (any(id.xy >= outputSize)) { return; }
+    textureStore(reflectionOutput, vec2<i32>(id.xy), vec4<f32>(0.0));
+    textureStore(hitOutput, vec2<i32>(id.xy), vec4<f32>(-1.0, -1.0, 0.0, 0.0));
+}`,
+        workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
+        bindings: [
+            {
+                name: 'dispatchArguments',
+                group: 0,
+                binding: 0,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            },
+            {
+                name: 'diagnostics',
+                group: 0,
+                binding: 1,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            },
+            {
+                name: 'reflectionOutput',
+                group: 0,
+                binding: 2,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            },
+            {
+                name: 'hitOutput',
+                group: 0,
+                binding: 3,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            }
+        ]
+    })
+);
+
+function tileClassificationPass(
+    settings: Readonly<ScreenSpaceReflectionsSettings>
+): ComputeRenderPass {
+    return computePass(
+        new ComputeShader({
+            label: 'Screen-space reflections active tile classification',
+            source: `${FRAME_WGSL}
+struct TileMask { values: array<u32> };
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read_write> tileMask: TileMask;
+@group(0) @binding(2) var<storage, read_write> diagnostics: TraceDiagnostics;
+@group(0) @binding(3) var sceneDepth: texture_depth_2d;
+@group(0) @binding(4) var materialAttributes: texture_2d<f32>;
+@group(0) @binding(5) var reflectionResponse: texture_2d<f32>;
+@group(0) @binding(6) var traceExtent: texture_2d<f32>;
+var<workgroup> eligibility: array<u32, ${String(TRACE_WORKGROUP_SIZE * TRACE_WORKGROUP_SIZE)}>;
+fn pixelFor(source: texture_2d<f32>, uv: vec2<f32>) -> vec2<i32> {
+    let dimensions = textureDimensions(source);
+    return clamp(
+        vec2<i32>(uv * vec2<f32>(dimensions)),
+        vec2<i32>(0),
+        vec2<i32>(dimensions) - vec2<i32>(1)
+    );
+}
+fn depthPixelFor(source: texture_depth_2d, uv: vec2<f32>) -> vec2<i32> {
+    let dimensions = textureDimensions(source);
+    return clamp(
+        vec2<i32>(uv * vec2<f32>(dimensions)),
+        vec2<i32>(0),
+        vec2<i32>(dimensions) - vec2<i32>(1)
+    );
+}
+@compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
+fn main(
+    @builtin(global_invocation_id) id: vec3<u32>,
+    @builtin(local_invocation_index) localIndex: u32,
+    @builtin(workgroup_id) groupId: vec3<u32>
+) {
+    let outputSize = textureDimensions(traceExtent);
+    eligibility[localIndex] = 0u;
+    if (all(id.xy < outputSize)) {
+        let uv = clamp(
+            (vec2<f32>(id.xy) + vec2<f32>(0.5)) / vec2<f32>(outputSize),
+            vec2<f32>(0.0),
+            vec2<f32>(1.0)
+        );
+        let depthPixel = depthPixelFor(sceneDepth, uv);
+        let deviceDepth = textureLoad(sceneDepth, depthPixel, 0);
+        let background = select(
+            deviceDepth >= 0.999999,
+            deviceDepth <= 0.000001,
+            frameData.depth.w > 0.5
+        );
+        let attributes = textureLoad(
+            materialAttributes,
+            pixelFor(materialAttributes, uv),
+            0
+        );
+        let packedMaterial = u32(clamp(round(attributes.w * 255.0), 0.0, 255.0));
+        let response = max(
+            textureLoad(reflectionResponse, pixelFor(reflectionResponse, uv), 0).rgb,
+            vec3<f32>(0.0)
+        );
+        let eligible = !background &&
+            (packedMaterial & 1u) != 0u &&
+            attributes.z < ${String(settings.roughnessCutoff)} &&
+            max(max(response.r, response.g), response.b) >= ${String(MIN_REFLECTION_RESPONSE)};
+        eligibility[localIndex] = select(0u, 1u, eligible);
+    }
+    workgroupBarrier();
+    if (localIndex == 0u) {
+        var activePixels = 0u;
+        for (var index = 0u; index < ${String(
+            TRACE_WORKGROUP_SIZE * TRACE_WORKGROUP_SIZE
+        )}u; index += 1u) {
+            activePixels += eligibility[index];
+        }
+        let tileCountX = (outputSize.x + ${String(TRACE_WORKGROUP_SIZE - 1)}u) /
+            ${String(TRACE_WORKGROUP_SIZE)}u;
+        let tileIndex = groupId.y * tileCountX + groupId.x;
+        tileMask.values[tileIndex] = select(0u, 1u, activePixels != 0u);
+        if (activePixels != 0u) { atomicAdd(&diagnostics.activePixels, activePixels); }
+    }
+}`,
+            workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
+            bindings: [
+                { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+                {
+                    name: 'tileMask',
+                    group: 0,
+                    binding: 1,
+                    kind: 'storage-buffer',
+                    access: 'write-discard'
+                },
+                {
+                    name: 'diagnostics',
+                    group: 0,
+                    binding: 2,
+                    kind: 'storage-buffer',
+                    access: 'read-write'
+                },
+                {
+                    name: 'sceneDepth',
+                    group: 0,
+                    binding: 3,
+                    kind: 'sampled-texture',
+                    sampleType: 'depth'
+                },
+                {
+                    name: 'materialAttributes',
+                    group: 0,
+                    binding: 4,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'reflectionResponse',
+                    group: 0,
+                    binding: 5,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'traceExtent',
+                    group: 0,
+                    binding: 6,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                }
+            ]
+        })
+    );
+}
+
+const TILE_COMPACTION_PASS = computePass(
+    new ComputeShader({
+        label: 'Screen-space reflections coherent tile compaction',
+        source: `
+struct DispatchArguments {
+    x: atomic<u32>,
+    y: atomic<u32>,
+    z: atomic<u32>,
+};
+struct TileMask { values: array<u32> };
+struct TileList { values: array<u32> };
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+@group(0) @binding(0) var<storage, read_write> dispatchArguments: DispatchArguments;
+@group(0) @binding(1) var<storage, read> tileMask: TileMask;
+@group(0) @binding(2) var<storage, read_write> tileList: TileList;
+@group(0) @binding(3) var<storage, read_write> diagnostics: TraceDiagnostics;
+@group(0) @binding(4) var traceExtent: texture_2d<f32>;
+var<workgroup> prefix: array<u32, 64>;
+var<workgroup> groupBase: u32;
+@compute @workgroup_size(64)
+fn main(
+    @builtin(global_invocation_id) id: vec3<u32>,
+    @builtin(local_invocation_index) localIndex: u32,
+    @builtin(workgroup_id) groupId: vec3<u32>
+) {
+    let outputSize = textureDimensions(traceExtent);
+    let tileCount = vec2<u32>(
+        (outputSize.x + ${String(TRACE_WORKGROUP_SIZE - 1)}u) /
+            ${String(TRACE_WORKGROUP_SIZE)}u,
+        (outputSize.y + ${String(TRACE_WORKGROUP_SIZE - 1)}u) /
+            ${String(TRACE_WORKGROUP_SIZE)}u
+    );
+    let totalTiles = tileCount.x * tileCount.y;
+    var tileIsActive = 0u;
+    if (id.x < totalTiles) { tileIsActive = tileMask.values[id.x]; }
+    prefix[localIndex] = tileIsActive;
+    workgroupBarrier();
+    var offset = 1u;
+    while (offset < 64u) {
+        var value = 0u;
+        if (localIndex >= offset) { value = prefix[localIndex - offset]; }
+        workgroupBarrier();
+        prefix[localIndex] += value;
+        workgroupBarrier();
+        offset *= 2u;
+    }
+    let groupCount = prefix[63u];
+    if (localIndex == 0u) {
+        groupBase = atomicAdd(&dispatchArguments.x, groupCount);
+        atomicAdd(&diagnostics.activeTiles, groupCount);
+    }
+    workgroupBarrier();
+    if (tileIsActive != 0u) {
+        let tileIndex = id.x;
+        let tile = vec2<u32>(tileIndex % tileCount.x, tileIndex / tileCount.x);
+        tileList.values[groupBase + prefix[localIndex] - 1u] =
+            (tile.y << 16u) | tile.x;
+    }
+}`,
+        workgroupSize: [64],
+        bindings: [
+            {
+                name: 'dispatchArguments',
+                group: 0,
+                binding: 0,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'tileMask',
+                group: 0,
+                binding: 1,
+                kind: 'read-only-storage-buffer'
+            },
+            {
+                name: 'tileList',
+                group: 0,
+                binding: 2,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            },
+            {
+                name: 'diagnostics',
+                group: 0,
+                binding: 3,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'traceExtent',
+                group: 0,
+                binding: 4,
+                kind: 'sampled-texture',
+                sampleType: 'float'
+            }
+        ]
+    })
+);
+
+const TILE_DISPATCH_FINALIZE_PASS = computePass(
+    new ComputeShader({
+        label: 'Screen-space reflections finalize indirect tile dispatch',
+        source: `
+struct DispatchArguments {
+    x: atomic<u32>,
+    y: atomic<u32>,
+    z: atomic<u32>,
+};
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+@group(0) @binding(0) var<storage, read_write> dispatchArguments: DispatchArguments;
+@group(0) @binding(1) var<storage, read_write> diagnostics: TraceDiagnostics;
+@compute @workgroup_size(1)
+fn main() {
+    let activeTileCount = atomicLoad(&diagnostics.activeTiles);
+    atomicStore(
+        &dispatchArguments.x,
+        min(activeTileCount, ${String(MAX_INDIRECT_DISPATCH_X)}u)
+    );
+    atomicStore(
+        &dispatchArguments.y,
+        max(
+            1u,
+            (activeTileCount + ${String(MAX_INDIRECT_DISPATCH_X - 1)}u) /
+                ${String(MAX_INDIRECT_DISPATCH_X)}u
+        )
+    );
+    atomicStore(&dispatchArguments.z, 1u);
+}`,
+        workgroupSize: [1],
+        bindings: [
+            {
+                name: 'dispatchArguments',
+                group: 0,
+                binding: 0,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'diagnostics',
+                group: 0,
+                binding: 1,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            }
+        ]
+    })
+);
+
 function traceShader(
     settings: Readonly<ScreenSpaceReflectionsSettings>,
     hiZLevelCount: number
@@ -221,11 +652,13 @@ function traceShader(
     const colorDeclarations = Array.from(
         { length: COLOR_PYRAMID_LEVELS },
         (_unused, index) =>
-            `@group(0) @binding(${String(1 + index)}) var sceneColor${String(index)}: texture_2d<f32>;`
+            `@group(0) @binding(${String(3 + index)}) var sceneColor${String(index)}: texture_2d<f32>;`
     ).join('\n');
-    const depthBinding = 1 + COLOR_PYRAMID_LEVELS;
+    const depthBinding = 3 + COLOR_PYRAMID_LEVELS;
     const attributesBinding = depthBinding + 1;
-    const hiZBinding = attributesBinding + 1;
+    const responseBinding = attributesBinding + 1;
+    const motionBinding = responseBinding + 1;
+    const hiZBinding = motionBinding + 1;
     const hiZDeclarations = Array.from(
         { length: hiZLevelCount },
         (_unused, index) =>
@@ -233,6 +666,7 @@ function traceShader(
     ).join('\n');
     const samplerBinding = hiZBinding + hiZLevelCount;
     const outputBinding = samplerBinding + 1;
+    const hitOutputBinding = outputBinding + 1;
     const colorCases = Array.from(
         { length: COLOR_PYRAMID_LEVELS - 1 },
         (_unused, index) =>
@@ -246,13 +680,21 @@ function traceShader(
     const lastColor = COLOR_PYRAMID_LEVELS - 1;
     const lastHiZ = hiZLevelCount - 1;
     const bindings: ComputeShaderBinding[] = [
-        { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' }
+        { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+        { name: 'tileList', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+        {
+            name: 'diagnostics',
+            group: 0,
+            binding: 2,
+            kind: 'storage-buffer',
+            access: 'read-write'
+        }
     ];
     for (let index = 0; index < COLOR_PYRAMID_LEVELS; index += 1) {
         bindings.push({
             name: `sceneColor${String(index)}`,
             group: 0,
-            binding: 1 + index,
+            binding: 3 + index,
             kind: 'sampled-texture',
             sampleType: 'float'
         });
@@ -268,6 +710,20 @@ function traceShader(
         name: 'materialAttributes',
         group: 0,
         binding: attributesBinding,
+        kind: 'sampled-texture',
+        sampleType: 'float'
+    });
+    bindings.push({
+        name: 'reflectionResponse',
+        group: 0,
+        binding: responseBinding,
+        kind: 'sampled-texture',
+        sampleType: 'float'
+    });
+    bindings.push({
+        name: 'motionDepth',
+        group: 0,
+        binding: motionBinding,
         kind: 'sampled-texture',
         sampleType: 'float'
     });
@@ -289,17 +745,41 @@ function traceShader(
         access: 'write-only',
         format: 'rgba16float'
     });
+    bindings.push({
+        name: 'hitOutput',
+        group: 0,
+        binding: hitOutputBinding,
+        kind: 'storage-texture',
+        access: 'write-only',
+        format: 'rgba16float'
+    });
     return new ComputeShader({
         label: 'Hierarchical screen-space reflection trace',
         source: `
 ${FRAME_WGSL}
 @group(0) @binding(0) var<storage, read> frameData: FrameData;
+struct TileList { values: array<u32> };
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+@group(0) @binding(1) var<storage, read> tileList: TileList;
+@group(0) @binding(2) var<storage, read_write> diagnostics: TraceDiagnostics;
 ${colorDeclarations}
 @group(0) @binding(${String(depthBinding)}) var sceneDepth: texture_depth_2d;
 @group(0) @binding(${String(attributesBinding)}) var materialAttributes: texture_2d<f32>;
+@group(0) @binding(${String(responseBinding)}) var reflectionResponse: texture_2d<f32>;
+@group(0) @binding(${String(motionBinding)}) var motionDepth: texture_2d<f32>;
 ${hiZDeclarations}
 @group(0) @binding(${String(samplerBinding)}) var linearSampler: sampler;
 @group(0) @binding(${String(outputBinding)}) var reflectionOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(${String(hitOutputBinding)}) var hitOutput: texture_storage_2d<rgba16float, write>;
 
 fn pixelFor(source: texture_2d<f32>, uv: vec2<f32>) -> vec2<i32> {
     let dimensions = textureDimensions(source);
@@ -318,7 +798,11 @@ ${hiZCases}
     }
 }
 fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
-    var normal = vec3<f32>(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
+    let encodedSigned = encoded * 2.0 - vec2<f32>(1.0);
+    var normal = vec3<f32>(
+        encodedSigned,
+        1.0 - abs(encodedSigned.x) - abs(encodedSigned.y)
+    );
     if (normal.z < 0.0) {
         let original = normal.xy;
         normal.x = (1.0 - abs(original.y)) * select(-1.0, 1.0, original.x >= 0.0);
@@ -348,94 +832,337 @@ fn rayIsInFront(rayDepth: f32, bounds: vec2<f32>) -> bool {
 fn rayIsBehind(rayDepth: f32, bounds: vec2<f32>) -> bool {
     return select((rayDepth > bounds.y), (rayDepth < bounds.x), frameData.depth.w > 0.5);
 }
+fn isBackgroundDepth(deviceDepth: f32) -> bool {
+    return select(
+        deviceDepth >= 0.999999,
+        deviceDepth <= 0.000001,
+        frameData.depth.w > 0.5
+    );
+}
+fn random2(pixel: vec2<u32>, sampleIndex: u32, phase: u32) -> vec2<f32> {
+    var scramble = pixel.x * 1973u + pixel.y * 9277u + 911u;
+    scramble ^= scramble >> 16u;
+    scramble *= 2246822519u;
+    scramble ^= scramble >> 13u;
+    scramble *= 3266489917u;
+    scramble ^= scramble >> 16u;
+    let temporalIndex = phase & ${String(TEMPORAL_SEQUENCE_LENGTH - 1)}u;
+    var reversed = sampleIndex;
+    reversed = (reversed << 16u) | (reversed >> 16u);
+    reversed = ((reversed & 1431655765u) << 1u) | ((reversed & 2863311530u) >> 1u);
+    reversed = ((reversed & 858993459u) << 2u) | ((reversed & 3435973836u) >> 2u);
+    reversed = ((reversed & 252645135u) << 4u) | ((reversed & 4042322160u) >> 4u);
+    reversed = ((reversed & 16711935u) << 8u) | ((reversed & 4278255360u) >> 8u);
+    let pixelRotation = vec2<f32>(
+        f32(scramble & 65535u),
+        f32((scramble >> 16u) & 65535u)
+    ) / 65536.0;
+    let temporalRotation = f32(temporalIndex) * vec2<f32>(
+        0.7548776662466927,
+        0.5698402909980532
+    );
+    let hammersley = vec2<f32>(
+        (f32(sampleIndex) + 0.5) / ${String(STOCHASTIC_RAY_COUNT)}.0,
+        f32(reversed ^ scramble) * 2.3283064365386963e-10
+    );
+    return fract(hammersley + pixelRotation + temporalRotation);
+}
+fn sampleVisibleGGX(
+    surfaceNormal: vec3<f32>,
+    viewDirection: vec3<f32>,
+    roughness: f32,
+    random: vec2<f32>
+) -> vec3<f32> {
+    let helper = select(
+        vec3<f32>(0.0, 1.0, 0.0),
+        vec3<f32>(0.0, 0.0, 1.0),
+        abs(surfaceNormal.z) < 0.999
+    );
+    let tangent = normalize(cross(helper, surfaceNormal));
+    let bitangent = cross(surfaceNormal, tangent);
+    let localView = vec3<f32>(
+        dot(viewDirection, tangent),
+        dot(viewDirection, bitangent),
+        max(dot(viewDirection, surfaceNormal), 1e-4)
+    );
+    let alpha = max(roughness * roughness, 0.002);
+    let stretchedView = normalize(vec3<f32>(
+        alpha * localView.x,
+        alpha * localView.y,
+        localView.z
+    ));
+    let lensq = dot(stretchedView.xy, stretchedView.xy);
+    var basisX = vec3<f32>(1.0, 0.0, 0.0);
+    if (lensq > 1e-7) {
+        basisX = vec3<f32>(-stretchedView.y, stretchedView.x, 0.0) / sqrt(lensq);
+    }
+    let basisY = cross(stretchedView, basisX);
+    let radius = sqrt(random.x);
+    let phi = 6.28318530718 * random.y;
+    let diskX = radius * cos(phi);
+    var diskY = radius * sin(phi);
+    let blend = 0.5 * (1.0 + stretchedView.z);
+    diskY = mix(sqrt(max(0.0, 1.0 - diskX * diskX)), diskY, blend);
+    let projected = diskX * basisX + diskY * basisY +
+        sqrt(max(0.0, 1.0 - diskX * diskX - diskY * diskY)) * stretchedView;
+    let localHalf = normalize(vec3<f32>(
+        alpha * projected.x,
+        alpha * projected.y,
+        max(projected.z, 0.0)
+    ));
+    return normalize(
+        tangent * localHalf.x + bitangent * localHalf.y + surfaceNormal * localHalf.z
+    );
+}
 @compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
-fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+fn main(
+    @builtin(workgroup_id) groupId: vec3<u32>,
+    @builtin(local_invocation_id) localId: vec3<u32>
+) {
+    let compactIndex = groupId.y * ${String(MAX_INDIRECT_DISPATCH_X)}u + groupId.x;
+    if (compactIndex >= atomicLoad(&diagnostics.activeTiles)) { return; }
+    let packedTile = tileList.values[compactIndex];
+    let tile = vec2<u32>(packedTile & 65535u, packedTile >> 16u);
+    let id = vec3<u32>(tile * ${String(TRACE_WORKGROUP_SIZE)}u + localId.xy, 0u);
     let outputSize = textureDimensions(reflectionOutput);
     if (any(id.xy >= outputSize)) { return; }
-    let uv = (vec2<f32>(id.xy) + vec2<f32>(0.5)) / vec2<f32>(outputSize);
     let depthSize = textureDimensions(sceneDepth);
+    let uv = clamp(
+        (vec2<f32>(id.xy) + vec2<f32>(0.5)) / vec2<f32>(outputSize),
+        vec2<f32>(0.0),
+        vec2<f32>(1.0)
+    );
     let depthPixel = clamp(vec2<i32>(uv * vec2<f32>(depthSize)), vec2<i32>(0), vec2<i32>(depthSize) - vec2<i32>(1));
     let deviceDepth = textureLoad(sceneDepth, depthPixel, 0);
-    let background = select(deviceDepth >= 0.999999, deviceDepth <= 0.000001, frameData.depth.w > 0.5);
     let attributes = textureLoad(materialAttributes, pixelFor(materialAttributes, uv), 0);
-    let packedMaterial = u32(max(round(attributes.w), 0.0));
+    let packedMaterial = u32(clamp(round(attributes.w * 255.0), 0.0, 255.0));
     let receivesReflection = (packedMaterial & 1u) != 0u;
     let roughness = clamp(attributes.z, 0.045, 1.0);
-    if (background || !receivesReflection || roughness >= ${String(settings.roughnessCutoff)}) {
-        textureStore(reflectionOutput, vec2<i32>(id.xy), vec4<f32>(0.0));
-        return;
-    }
+    let surfaceResponse = max(
+        textureLoad(reflectionResponse, pixelFor(reflectionResponse, uv), 0).rgb,
+        vec3<f32>(0.0)
+    );
+    let responseEnergy = max(max(surfaceResponse.r, surfaceResponse.g), surfaceResponse.b);
+    if (
+        isBackgroundDepth(deviceDepth) || !receivesReflection ||
+        roughness >= ${String(settings.roughnessCutoff)} ||
+        responseEnergy < ${String(MIN_REFLECTION_RESPONSE)}
+    ) { return; }
 
-    let origin = reconstructViewPosition(uv, deviceDepth);
+    let surfacePosition = reconstructViewPosition(uv, deviceDepth);
     let normal = decodeOctahedralNormal(attributes.xy);
-    let incident = normalize(origin);
-    let direction = normalize(reflect(incident, normal));
-    if (direction.z >= -0.0001) {
-        textureStore(reflectionOutput, vec2<i32>(id.xy), vec4<f32>(0.0));
-        return;
-    }
+    let incident = normalize(surfacePosition);
+    let viewDirection = -incident;
+    let mirrorDirection = normalize(reflect(incident, normal));
+    let originBias = max(${String(settings.thickness)} * 0.15, -surfacePosition.z * 0.0005);
+    let origin = surfacePosition + normal * originBias;
     let minimumStep = max(${String(settings.stride)}, -origin.z * 0.002);
-    let startDistance = max(${String(settings.thickness)} * 1.5, minimumStep);
-    var distance = startDistance;
-    var previousDistance = distance;
-    var level = 0u;
-    var hitUv = vec2<f32>(-1.0);
-    var hitDistance = 0.0;
-    for (var iteration = 0u; iteration < ${String(settings.maxSteps)}u; iteration += 1u) {
-        if (distance > ${String(settings.maxRayDistance)}) { break; }
-        let rayPoint = origin + direction * distance;
-        let projected = projectViewPosition(rayPoint);
-        if (
-            projected.x <= 0.0 || projected.y <= 0.0 ||
-            projected.x >= 1.0 || projected.y >= 1.0 || projected.z < 0.0 || projected.z > 1.0
-        ) { break; }
-        let bounds = sampleHiZ(level, projected.xy);
-        if (rayIsInFront(projected.z, bounds)) {
-            previousDistance = distance;
-            distance += minimumStep * exp2(f32(level));
-            level = min(level + 1u, ${String(lastHiZ)}u);
-            continue;
-        }
-        if (level > 0u) {
-            level -= 1u;
-            distance = max(startDistance, mix(previousDistance, distance, 0.5));
-            continue;
-        }
-        let exactPixel = clamp(vec2<i32>(projected.xy * vec2<f32>(depthSize)), vec2<i32>(0), vec2<i32>(depthSize) - vec2<i32>(1));
-        let exactDepth = textureLoad(sceneDepth, exactPixel, 0);
-        let scenePosition = reconstructViewPosition(projected.xy, exactDepth);
-        let penetration = (-rayPoint.z) - (-scenePosition.z);
-        let thickness = ${String(settings.thickness)} * (1.0 + max(-rayPoint.z, 0.0) * 0.002);
-        if (!rayIsBehind(projected.z, bounds) || (penetration >= -thickness * 0.25 && penetration <= thickness)) {
-            if (penetration >= -thickness * 0.25 && penetration <= thickness) {
-                hitUv = projected.xy;
-                hitDistance = distance;
-                break;
+    let startDistance = minimumStep;
+    let roughnessRatio = clamp(roughness / ${String(settings.roughnessCutoff)}, 0.0, 1.0);
+    let maximumDistance = mix(
+        ${String(settings.maxRayDistance)},
+        ${String(settings.maxRayDistance * 0.25)},
+        smoothstep(0.2, 1.0, roughnessRatio)
+    );
+    let maximumIterations = u32(max(
+        8.0,
+        floor(
+            ${String(settings.maxSteps)}.0 * mix(1.0, 0.35, roughnessRatio) *
+                select(1.0, 0.55, roughness > ${String(DETERMINISTIC_REFLECTION_ROUGHNESS)})
+        )
+    ));
+    let rayCount = select(
+        1u,
+        ${String(STOCHASTIC_RAY_COUNT)}u,
+        roughness > ${String(DETERMINISTIC_REFLECTION_ROUGHNESS)}
+    );
+    var accumulatedRadiance = vec3<f32>(0.0);
+    var accumulatedConfidence = 0.0;
+    var bestConfidence = 0.0;
+    var bestHitMotion = vec4<f32>(0.0);
+    var validRayCount = 0u;
+    var anyUncertain = false;
+    var anyBackfaceRejected = false;
+    for (var sampleIndex = 0u; sampleIndex < ${String(STOCHASTIC_RAY_COUNT)}u; sampleIndex += 1u) {
+        if (sampleIndex >= rayCount) { break; }
+        var direction = mirrorDirection;
+        if (rayCount > 1u) {
+            let halfVector = sampleVisibleGGX(
+                normal,
+                viewDirection,
+                roughness,
+                random2(
+                    id.xy,
+                    sampleIndex,
+                    u32(frameData.ambient.w)
+                )
+            );
+            let stochasticDirection = normalize(reflect(incident, halfVector));
+            if (dot(stochasticDirection, normal) > 1e-4) {
+                direction = stochasticDirection;
             }
         }
-        previousDistance = distance;
-        distance += minimumStep;
+        var distance = startDistance;
+        var previousDistance = 0.0;
+        var hasFrontSample = false;
+        var level = 0u;
+        var hitUv = vec2<f32>(-1.0);
+        var hitDistance = 0.0;
+        var uncertain = false;
+        var backfaceRejected = false;
+        for (var iteration = 0u; iteration < ${String(settings.maxSteps)}u; iteration += 1u) {
+            if (iteration >= maximumIterations || distance > maximumDistance) { break; }
+            let rayPoint = origin + direction * distance;
+            let projected = projectViewPosition(rayPoint);
+            if (
+                projected.x <= 0.0 || projected.y <= 0.0 ||
+                projected.x >= 1.0 || projected.y >= 1.0 ||
+                projected.z < 0.0 || projected.z > 1.0
+            ) { break; }
+            let bounds = sampleHiZ(level, projected.xy);
+            if (rayIsInFront(projected.z, bounds)) {
+                previousDistance = distance;
+                hasFrontSample = true;
+                distance += minimumStep * exp2(f32(level));
+                level = min(level + 1u, ${String(lastHiZ)}u);
+                continue;
+            }
+            if (level > 0u) {
+                level -= 1u;
+                distance = max(startDistance, mix(previousDistance, distance, 0.5));
+                continue;
+            }
+            let exactPixel = clamp(
+                vec2<i32>(projected.xy * vec2<f32>(depthSize)),
+                vec2<i32>(0),
+                vec2<i32>(depthSize) - vec2<i32>(1)
+            );
+            let exactDepth = textureLoad(sceneDepth, exactPixel, 0);
+            if (isBackgroundDepth(exactDepth)) {
+                uncertain = true;
+                break;
+            }
+            let scenePosition = reconstructViewPosition(projected.xy, exactDepth);
+            let penetration = (-rayPoint.z) - (-scenePosition.z);
+            let grazingScale = 1.0 / max(abs(dot(normal, direction)), 0.25);
+            let thickness = ${String(settings.thickness)} *
+                (1.0 + max(-rayPoint.z, 0.0) * 0.002) * min(grazingScale, 2.5);
+            if (
+                !rayIsBehind(projected.z, bounds) ||
+                (penetration >= -thickness * 0.25 && penetration <= thickness)
+            ) {
+                if (penetration >= -thickness * 0.25 && penetration <= thickness) {
+                    var refinedDistance = distance;
+                    if (hasFrontSample && previousDistance < distance) {
+                        let previousPoint = origin + direction * previousDistance;
+                        let previousProjected = projectViewPosition(previousPoint);
+                        let previousDepthPixel = clamp(
+                            vec2<i32>(previousProjected.xy * vec2<f32>(depthSize)),
+                            vec2<i32>(0),
+                            vec2<i32>(depthSize) - vec2<i32>(1)
+                        );
+                        let previousDepth = textureLoad(sceneDepth, previousDepthPixel, 0);
+                        if (!isBackgroundDepth(previousDepth)) {
+                            let previousScene = reconstructViewPosition(
+                                previousProjected.xy,
+                                previousDepth
+                            );
+                            let previousPenetration =
+                                (-previousPoint.z) - (-previousScene.z);
+                            let denominator = previousPenetration - penetration;
+                            if (abs(denominator) > 1e-5) {
+                                refinedDistance = mix(
+                                    previousDistance,
+                                    distance,
+                                    clamp(previousPenetration / denominator, 0.0, 1.0)
+                                );
+                            }
+                        }
+                    }
+                    let refinedUv = projectViewPosition(
+                        origin + direction * refinedDistance
+                    ).xy;
+                    let hitAttributes = textureLoad(
+                        materialAttributes,
+                        pixelFor(materialAttributes, refinedUv),
+                        0
+                    );
+                    let hitNormal = decodeOctahedralNormal(hitAttributes.xy);
+                    if (dot(hitNormal, direction) >= -0.01) {
+                        backfaceRejected = true;
+                        break;
+                    }
+                    hitUv = refinedUv;
+                    hitDistance = refinedDistance;
+                    break;
+                }
+            }
+            if (penetration > thickness) {
+                uncertain = true;
+                break;
+            }
+            previousDistance = distance;
+            distance += minimumStep;
+        }
+        anyUncertain = anyUncertain || uncertain;
+        anyBackfaceRejected = anyBackfaceRejected || backfaceRejected;
+        if (hitUv.x < 0.0) { continue; }
+        let edgeDistance = min(
+            min(hitUv.x, 1.0 - hitUv.x),
+            min(hitUv.y, 1.0 - hitUv.y)
+        );
+        let edgeConfidence = smoothstep(0.0, ${String(settings.edgeFade)}, edgeDistance);
+        let distanceConfidence = clamp(1.0 - hitDistance / maximumDistance, 0.0, 1.0);
+        let roughnessConfidence = clamp(
+            1.0 - roughness / ${String(settings.roughnessCutoff)},
+            0.0,
+            1.0
+        );
+        let coneLevel = min(
+            u32(clamp(
+                floor(
+                    roughness * 6.0 +
+                    log2(1.0 + hitDistance * roughness * 0.05)
+                ),
+                0.0,
+                ${String(lastColor)}.0
+            )),
+            ${String(lastColor)}u
+        );
+        let confidence = edgeConfidence * distanceConfidence * roughnessConfidence;
+        let hitMotion = textureLoad(motionDepth, pixelFor(motionDepth, hitUv), 0);
+        accumulatedRadiance += sampleColor(coneLevel, hitUv) * surfaceResponse * confidence;
+        accumulatedConfidence += confidence;
+        validRayCount += 1u;
+        if (confidence > bestConfidence) {
+            bestConfidence = confidence;
+            bestHitMotion = hitMotion;
+        }
     }
-    if (hitUv.x < 0.0) {
-        textureStore(reflectionOutput, vec2<i32>(id.xy), vec4<f32>(0.0));
+    if (validRayCount == 0u) {
+        if (anyBackfaceRejected) {
+            atomicAdd(&diagnostics.backfaceRejectedPixels, 1u);
+        } else if (anyUncertain) {
+            atomicAdd(&diagnostics.uncertainPixels, 1u);
+        }
+        atomicAdd(&diagnostics.missPixels, 1u);
         return;
     }
-    let edgeDistance = min(min(hitUv.x, 1.0 - hitUv.x), min(hitUv.y, 1.0 - hitUv.y));
-    let edgeConfidence = smoothstep(0.0, ${String(settings.edgeFade)}, edgeDistance);
-    let distanceConfidence = clamp(1.0 - hitDistance / ${String(settings.maxRayDistance)}, 0.0, 1.0);
-    let roughnessConfidence = clamp(1.0 - roughness / ${String(settings.roughnessCutoff)}, 0.0, 1.0);
-    let viewDirection = normalize(-origin);
-    let ndotv = clamp(dot(normal, viewDirection), 0.0, 1.0);
-    let metallic = f32((packedMaterial >> 1u) & 255u) / 255.0;
-    let f0 = mix(0.04, 0.9, metallic);
-    let fresnel = f0 + (1.0 - f0) * pow(1.0 - ndotv, 5.0);
-    let coneLevel = min(
-        u32(clamp(floor(roughness * roughness * 4.0 + log2(1.0 + hitDistance * roughness * 0.05)), 0.0, ${String(lastColor)}.0)),
-        ${String(lastColor)}u
+    let inverseRayCount = 1.0 / f32(rayCount);
+    textureStore(
+        reflectionOutput,
+        vec2<i32>(id.xy),
+        vec4<f32>(
+            accumulatedRadiance * inverseRayCount,
+            accumulatedConfidence * inverseRayCount
+        )
     );
-    let confidence = edgeConfidence * distanceConfidence * roughnessConfidence;
-    let radiance = sampleColor(coneLevel, hitUv) * fresnel * confidence;
-    textureStore(reflectionOutput, vec2<i32>(id.xy), vec4<f32>(radiance, confidence));
+    textureStore(
+        hitOutput,
+        vec2<i32>(id.xy),
+        bestHitMotion
+    );
+    atomicAdd(&diagnostics.hitPixels, 1u);
 }`,
         workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
         bindings
@@ -447,9 +1174,14 @@ const TEMPORAL_INITIALIZE_PASS = computePass(
         label: 'Screen-space reflections initialize temporal history',
         source: `
 @group(0) @binding(0) var currentReflection: texture_2d<f32>;
-@group(0) @binding(1) var motionDepth: texture_2d<f32>;
-@group(0) @binding(2) var historyOutput: texture_storage_2d<rgba16float, write>;
-@group(0) @binding(3) var depthOutput: texture_storage_2d<r32float, write>;
+@group(0) @binding(1) var currentHit: texture_2d<f32>;
+@group(0) @binding(2) var motionDepth: texture_2d<f32>;
+@group(0) @binding(3) var materialAttributes: texture_2d<f32>;
+@group(0) @binding(4) var reflectionResponse: texture_2d<f32>;
+@group(0) @binding(5) var historyOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(6) var depthOutput: texture_storage_2d<r32float, write>;
+@group(0) @binding(7) var stateOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(8) var responseStateOutput: texture_storage_2d<rgba16float, write>;
 @compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
 fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let outputSize = textureDimensions(historyOutput);
@@ -457,10 +1189,42 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let uv = (vec2<f32>(id.xy) + vec2<f32>(0.5)) / vec2<f32>(outputSize);
     let reflectionSize = textureDimensions(currentReflection);
     let reflectionPixel = clamp(vec2<i32>(uv * vec2<f32>(reflectionSize)), vec2<i32>(0), vec2<i32>(reflectionSize) - vec2<i32>(1));
+    let hitSize = textureDimensions(currentHit);
+    let hitPixel = clamp(vec2<i32>(uv * vec2<f32>(hitSize)), vec2<i32>(0), vec2<i32>(hitSize) - vec2<i32>(1));
     let motionSize = textureDimensions(motionDepth);
     let motionPixel = clamp(vec2<i32>(uv * vec2<f32>(motionSize)), vec2<i32>(0), vec2<i32>(motionSize) - vec2<i32>(1));
-    textureStore(historyOutput, vec2<i32>(id.xy), textureLoad(currentReflection, reflectionPixel, 0));
-    textureStore(depthOutput, vec2<i32>(id.xy), vec4<f32>(textureLoad(motionDepth, motionPixel, 0).w));
+    var current = textureLoad(currentReflection, reflectionPixel, 0);
+    let hit = textureLoad(currentHit, hitPixel, 0);
+    let attributesSize = textureDimensions(materialAttributes);
+    let attributesPixel = clamp(
+        vec2<i32>(uv * vec2<f32>(attributesSize)),
+        vec2<i32>(0),
+        vec2<i32>(attributesSize) - vec2<i32>(1)
+    );
+    let attributes = textureLoad(materialAttributes, attributesPixel, 0);
+    current.a = select(0.0, 1.0 + min(current.a, 0.999) * 0.5, current.a > 0.0);
+    textureStore(historyOutput, vec2<i32>(id.xy), current);
+    textureStore(
+        depthOutput,
+        vec2<i32>(id.xy),
+        vec4<f32>(textureLoad(motionDepth, motionPixel, 0).w)
+    );
+    textureStore(
+        stateOutput,
+        vec2<i32>(id.xy),
+        vec4<f32>(attributes.xy, attributes.z, hit.w)
+    );
+    let responseSize = textureDimensions(reflectionResponse);
+    let responsePixel = clamp(
+        vec2<i32>(uv * vec2<f32>(responseSize)),
+        vec2<i32>(0),
+        vec2<i32>(responseSize) - vec2<i32>(1)
+    );
+    textureStore(
+        responseStateOutput,
+        vec2<i32>(id.xy),
+        vec4<f32>(max(textureLoad(reflectionResponse, responsePixel, 0).rgb, vec3<f32>(0.0)), attributes.w)
+    );
 }`,
         workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
         bindings: [
@@ -472,16 +1236,37 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
                 sampleType: 'float'
             },
             {
-                name: 'motionDepth',
+                name: 'currentHit',
                 group: 0,
                 binding: 1,
                 kind: 'sampled-texture',
                 sampleType: 'float'
             },
             {
-                name: 'historyOutput',
+                name: 'motionDepth',
                 group: 0,
                 binding: 2,
+                kind: 'sampled-texture',
+                sampleType: 'float'
+            },
+            {
+                name: 'materialAttributes',
+                group: 0,
+                binding: 3,
+                kind: 'sampled-texture',
+                sampleType: 'float'
+            },
+            {
+                name: 'reflectionResponse',
+                group: 0,
+                binding: 4,
+                kind: 'sampled-texture',
+                sampleType: 'float'
+            },
+            {
+                name: 'historyOutput',
+                group: 0,
+                binding: 5,
                 kind: 'storage-texture',
                 access: 'write-only',
                 format: 'rgba16float'
@@ -489,10 +1274,107 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
             {
                 name: 'depthOutput',
                 group: 0,
-                binding: 3,
+                binding: 6,
                 kind: 'storage-texture',
                 access: 'write-only',
                 format: 'r32float'
+            },
+            {
+                name: 'stateOutput',
+                group: 0,
+                binding: 7,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            },
+            {
+                name: 'responseStateOutput',
+                group: 0,
+                binding: 8,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            }
+        ]
+    })
+);
+
+const TEMPORAL_HISTORY_RESET_PASS = computePass(
+    new ComputeShader({
+        label: 'Screen-space reflections clear temporal history targets',
+        source: `
+@group(0) @binding(0) var historyOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(1) var depthOutput: texture_storage_2d<r32float, write>;
+@group(0) @binding(2) var stateOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(3) var responseStateOutput: texture_storage_2d<rgba16float, write>;
+@compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let outputSize = textureDimensions(historyOutput);
+    if (any(id.xy >= outputSize)) { return; }
+    let pixel = vec2<i32>(id.xy);
+    textureStore(historyOutput, pixel, vec4<f32>(0.0));
+    textureStore(depthOutput, pixel, vec4<f32>(0.0));
+    textureStore(stateOutput, pixel, vec4<f32>(0.0));
+    textureStore(responseStateOutput, pixel, vec4<f32>(0.0));
+}`,
+        workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
+        bindings: [
+            {
+                name: 'historyOutput',
+                group: 0,
+                binding: 0,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            },
+            {
+                name: 'depthOutput',
+                group: 0,
+                binding: 1,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'r32float'
+            },
+            {
+                name: 'stateOutput',
+                group: 0,
+                binding: 2,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            },
+            {
+                name: 'responseStateOutput',
+                group: 0,
+                binding: 3,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
+            }
+        ]
+    })
+);
+
+const SPATIAL_FILTER_RESET_PASS = computePass(
+    new ComputeShader({
+        label: 'Screen-space reflections clear adaptive filter target',
+        source: `
+@group(0) @binding(0) var destination: texture_storage_2d<rgba16float, write>;
+@compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let outputSize = textureDimensions(destination);
+    if (any(id.xy >= outputSize)) { return; }
+    textureStore(destination, vec2<i32>(id.xy), vec4<f32>(0.0));
+}`,
+        workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
+        bindings: [
+            {
+                name: 'destination',
+                group: 0,
+                binding: 0,
+                kind: 'storage-texture',
+                access: 'write-only',
+                format: 'rgba16float'
             }
         ]
     })
@@ -505,20 +1387,97 @@ function temporalResolvePass(
         new ComputeShader({
             label: 'Screen-space reflections production temporal resolve',
             source: `
-@group(0) @binding(0) var currentReflection: texture_2d<f32>;
-@group(0) @binding(1) var motionDepth: texture_2d<f32>;
-@group(0) @binding(2) var previousHistory: texture_2d<f32>;
-@group(0) @binding(3) var previousDepth: texture_2d<f32>;
-@group(0) @binding(4) var linearSampler: sampler;
-@group(0) @binding(5) var historyOutput: texture_storage_2d<rgba16float, write>;
-@group(0) @binding(6) var depthOutput: texture_storage_2d<r32float, write>;
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+@group(0) @binding(0) var<storage, read_write> diagnostics: TraceDiagnostics;
+struct TileList { values: array<u32> };
+@group(0) @binding(1) var<storage, read> tileList: TileList;
+@group(0) @binding(2) var currentReflection: texture_2d<f32>;
+@group(0) @binding(3) var currentHit: texture_2d<f32>;
+@group(0) @binding(4) var motionDepth: texture_2d<f32>;
+@group(0) @binding(5) var materialAttributes: texture_2d<f32>;
+@group(0) @binding(6) var reactiveMask: texture_2d<f32>;
+@group(0) @binding(7) var currentResponse: texture_2d<f32>;
+@group(0) @binding(8) var previousHistory: texture_2d<f32>;
+@group(0) @binding(9) var previousDepth: texture_2d<f32>;
+@group(0) @binding(10) var previousState: texture_2d<f32>;
+@group(0) @binding(11) var previousResponseState: texture_2d<f32>;
+@group(0) @binding(12) var linearSampler: sampler;
+@group(0) @binding(13) var historyOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(14) var depthOutput: texture_storage_2d<r32float, write>;
+@group(0) @binding(15) var stateOutput: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(16) var responseStateOutput: texture_storage_2d<rgba16float, write>;
+fn pixelFor(source: texture_2d<f32>, uv: vec2<f32>) -> vec2<i32> {
+    let dimensions = textureDimensions(source);
+    return clamp(
+        vec2<i32>(uv * vec2<f32>(dimensions)),
+        vec2<i32>(0),
+        vec2<i32>(dimensions) - vec2<i32>(1)
+    );
+}
+fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
+    let encodedSigned = encoded * 2.0 - vec2<f32>(1.0);
+    var normal = vec3<f32>(
+        encodedSigned,
+        1.0 - abs(encodedSigned.x) - abs(encodedSigned.y)
+    );
+    if (normal.z < 0.0) {
+        let original = normal.xy;
+        normal.x = (1.0 - abs(original.y)) * select(-1.0, 1.0, original.x >= 0.0);
+        normal.y = (1.0 - abs(original.x)) * select(-1.0, 1.0, original.y >= 0.0);
+    }
+    return normalize(normal);
+}
 fn relativeDepthError(historyLogDepth: f32, expectedLogDepth: f32) -> f32 {
     let historyLinear = exp2(max(historyLogDepth, 0.0)) - 1.0;
     let expectedLinear = exp2(max(expectedLogDepth, 0.0)) - 1.0;
     return abs(historyLinear - expectedLinear) / max(expectedLinear, 0.001);
 }
+fn rgbToYCoCg(value: vec3<f32>) -> vec3<f32> {
+    return vec3<f32>(
+        value.r * 0.25 + value.g * 0.5 + value.b * 0.25,
+        value.r * 0.5 - value.b * 0.5,
+        -value.r * 0.25 + value.g * 0.5 - value.b * 0.25
+    );
+}
+fn yCoCgToRGB(value: vec3<f32>) -> vec3<f32> {
+    return vec3<f32>(value.x + value.y - value.z, value.x + value.z, value.x - value.y - value.z);
+}
+fn historySampleCount(packed: f32) -> f32 { return floor(max(packed, 0.0)); }
+fn historyConfidence(packed: f32) -> f32 {
+    return clamp(fract(max(packed, 0.0)) * 2.0, 0.0, 1.0);
+}
+fn packHistoryState(sampleCount: f32, confidence: f32) -> f32 {
+    return min(sampleCount, ${String(MAX_HISTORY_SAMPLE_COUNT)}.0) +
+        min(confidence, 0.999) * 0.5;
+}
+fn materialContinuity(currentPacked: f32, previousPacked: f32) -> f32 {
+    let currentBits = u32(clamp(round(currentPacked * 255.0), 0.0, 255.0));
+    let previousBits = u32(clamp(round(previousPacked * 255.0), 0.0, 255.0));
+    return select(0.0, 1.0, currentBits == previousBits);
+}
+fn responseContinuity(current: vec3<f32>, previous: vec3<f32>) -> f32 {
+    let scale = max(max(length(current), length(previous)), 0.05);
+    return exp2(-length(current - previous) * 6.0 / scale);
+}
 @compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
-fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+fn main(
+    @builtin(workgroup_id) groupId: vec3<u32>,
+    @builtin(local_invocation_id) localId: vec3<u32>
+) {
+    let compactIndex = groupId.y * ${String(MAX_INDIRECT_DISPATCH_X)}u + groupId.x;
+    if (compactIndex >= atomicLoad(&diagnostics.activeTiles)) { return; }
+    let packedTile = tileList.values[compactIndex];
+    let tile = vec2<u32>(packedTile & 65535u, packedTile >> 16u);
+    let id = vec3<u32>(tile * ${String(TRACE_WORKGROUP_SIZE)}u + localId.xy, 0u);
     let outputSize = textureDimensions(historyOutput);
     if (any(id.xy >= outputSize)) { return; }
     let pixel = vec2<i32>(id.xy);
@@ -526,82 +1485,355 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let currentSize = textureDimensions(currentReflection);
     let currentPixel = clamp(vec2<i32>(uv * vec2<f32>(currentSize)), vec2<i32>(0), vec2<i32>(currentSize) - vec2<i32>(1));
     let current = textureLoad(currentReflection, currentPixel, 0);
+    let currentHitValue = textureLoad(currentHit, pixelFor(currentHit, uv), 0);
     let motionSize = textureDimensions(motionDepth);
     let motionPixel = clamp(vec2<i32>(uv * vec2<f32>(motionSize)), vec2<i32>(0), vec2<i32>(motionSize) - vec2<i32>(1));
     let motion = textureLoad(motionDepth, motionPixel, 0);
-    let historyUv = uv - motion.xy;
+    let currentAttributes = textureLoad(
+        materialAttributes,
+        pixelFor(materialAttributes, uv),
+        0
+    );
+    let responseState = vec4<f32>(
+        max(textureLoad(currentResponse, pixelFor(currentResponse, uv), 0).rgb, vec3<f32>(0.0)),
+        currentAttributes.w
+    );
+    let packedMaterial = u32(clamp(round(currentAttributes.w * 255.0), 0.0, 255.0));
+    let eligible = (packedMaterial & 1u) != 0u &&
+        currentAttributes.z < ${String(settings.roughnessCutoff)};
+    if (!eligible) {
+        textureStore(historyOutput, pixel, vec4<f32>(0.0));
+        textureStore(depthOutput, pixel, vec4<f32>(motion.w));
+        textureStore(
+            stateOutput,
+            pixel,
+            vec4<f32>(currentAttributes.xy, currentAttributes.z, 0.0)
+        );
+        textureStore(responseStateOutput, pixel, responseState);
+        return;
+    }
+    let surfaceHistoryUv = uv - motion.xy;
+    let hitHistoryUv = uv - currentHitValue.xy;
     let halfTexel = vec2<f32>(0.5) / vec2<f32>(outputSize);
-    let inside = all(historyUv >= halfTexel) && all(historyUv <= vec2<f32>(1.0) - halfTexel);
-    var minimumValue = current.rgb;
-    var maximumValue = current.rgb;
+    let surfaceInside = all(surfaceHistoryUv >= halfTexel) &&
+        all(surfaceHistoryUv <= vec2<f32>(1.0) - halfTexel);
+    let hitInside = all(hitHistoryUv >= halfTexel) &&
+        all(hitHistoryUv <= vec2<f32>(1.0) - halfTexel);
+    var neighborhoodSum = vec3<f32>(0.0);
+    var neighborhoodSquaredSum = vec3<f32>(0.0);
+    var neighborhoodWeight = 0.0;
     for (var y = -1; y <= 1; y += 1) {
         for (var x = -1; x <= 1; x += 1) {
             let coordinate = clamp(currentPixel + vec2<i32>(x, y), vec2<i32>(0), vec2<i32>(currentSize) - vec2<i32>(1));
-            let value = textureLoad(currentReflection, coordinate, 0).rgb;
-            minimumValue = min(minimumValue, value);
-            maximumValue = max(maximumValue, value);
+            let sampleValue = textureLoad(currentReflection, coordinate, 0);
+            if (sampleValue.a > 0.0) {
+                let yCoCg = rgbToYCoCg(sampleValue.rgb);
+                neighborhoodSum += yCoCg;
+                neighborhoodSquaredSum += yCoCg * yCoCg;
+                neighborhoodWeight += 1.0;
+            }
         }
     }
-    var weight = 0.0;
-    var history = vec4<f32>(0.0);
-    if (inside && motion.z >= 0.0) {
-        history = textureSampleLevel(previousHistory, linearSampler, historyUv, 0.0);
-        let historyDepthSize = textureDimensions(previousDepth);
-        let historyDepthPixel = clamp(vec2<i32>(historyUv * vec2<f32>(historyDepthSize)), vec2<i32>(0), vec2<i32>(historyDepthSize) - vec2<i32>(1));
+    if (neighborhoodWeight < 0.5) {
+        let fallback = rgbToYCoCg(current.rgb);
+        neighborhoodSum = fallback;
+        neighborhoodSquaredSum = fallback * fallback;
+        neighborhoodWeight = 1.0;
+    }
+    let neighborhoodCenter = neighborhoodSum / neighborhoodWeight;
+    let neighborhoodVariance = max(
+        neighborhoodSquaredSum / neighborhoodWeight - neighborhoodCenter * neighborhoodCenter,
+        vec3<f32>(0.0)
+    );
+    let denoiseStrength = smoothstep(
+        0.0,
+        1.0,
+        clamp(
+            (currentAttributes.z - ${String(DETERMINISTIC_REFLECTION_ROUGHNESS)}) /
+                max(
+                    ${String(Math.min(settings.roughnessCutoff, 0.16))} -
+                        ${String(DETERMINISTIC_REFLECTION_ROUGHNESS)},
+                    0.01
+                ),
+            0.0,
+            1.0
+        )
+    );
+    let neighborhoodExtent = max(
+        sqrt(neighborhoodVariance) * mix(1.5, 2.5, denoiseStrength),
+        vec3<f32>(0.0125)
+    );
+    var stableCurrent = current.rgb;
+    if (current.a > 0.0 && neighborhoodWeight >= 3.0 && denoiseStrength > 0.0) {
+        let currentYCoCg = rgbToYCoCg(current.rgb);
+        let luminanceSigma = sqrt(neighborhoodVariance.x);
+        let fireflyCeiling = neighborhoodCenter.x + max(
+            0.025,
+            luminanceSigma * mix(3.0, 1.5, denoiseStrength)
+        );
+        if (currentYCoCg.x > fireflyCeiling) {
+            stableCurrent *= fireflyCeiling / max(currentYCoCg.x, 1e-5);
+        }
+    }
+    let currentNormal = decodeOctahedralNormal(currentAttributes.xy);
+    let reactive = textureLoad(reactiveMask, pixelFor(reactiveMask, uv), 0).r;
+
+    var surfaceHistory = vec4<f32>(0.0);
+    var surfaceScore = 0.0;
+    if (surfaceInside && motion.z >= 0.0) {
+        surfaceHistory = textureSampleLevel(
+            previousHistory,
+            linearSampler,
+            surfaceHistoryUv,
+            0.0
+        );
+        let surfaceState = textureLoad(
+            previousState,
+            pixelFor(previousState, surfaceHistoryUv),
+            0
+        );
+        let surfaceResponseState = textureLoad(
+            previousResponseState,
+            pixelFor(previousResponseState, surfaceHistoryUv),
+            0
+        );
         let depthError = relativeDepthError(
-            textureLoad(previousDepth, historyDepthPixel, 0).x,
+            textureLoad(previousDepth, pixelFor(previousDepth, surfaceHistoryUv), 0).x,
             motion.z
         );
-        let velocityPixels = length(motion.xy * vec2<f32>(motionSize));
-        let motionResponse = clamp(velocityPixels / 24.0, 0.0, 1.0);
-        let confidence = max(current.a, min(history.a, 0.25));
-        weight = select(
-            ${String(settings.historyWeight)} * confidence * (1.0 - motionResponse * 0.65),
-            0.0,
-            depthError > ${String(settings.depthThreshold)}
+        let normalWeight = smoothstep(
+            0.82,
+            0.98,
+            dot(currentNormal, decodeOctahedralNormal(surfaceState.xy))
         );
-        history = vec4<f32>(clamp(history.rgb, minimumValue, maximumValue), history.a);
+        let roughnessWeight = exp2(
+            -abs(currentAttributes.z - surfaceState.z) * 24.0
+        );
+        let surfaceMaterialWeight = materialContinuity(
+            currentAttributes.w,
+            surfaceResponseState.w
+        );
+        let surfaceResponseWeight = responseContinuity(
+            responseState.rgb,
+            surfaceResponseState.rgb
+        );
+        if (
+            depthError <= ${String(settings.depthThreshold)} &&
+            historyConfidence(surfaceHistory.a) > 0.0
+        ) {
+            surfaceScore = normalWeight * roughnessWeight *
+                surfaceMaterialWeight * surfaceResponseWeight;
+        }
     }
-    var resolved = mix(current, history, clamp(weight, 0.0, ${String(settings.historyWeight)}));
-    resolved.a = max(current.a, history.a * weight);
-    textureStore(historyOutput, pixel, resolved);
+
+    var hitHistory = vec4<f32>(0.0);
+    var hitScore = 0.0;
+    let dominantDirection = 1.0 - smoothstep(0.08, 0.45, currentAttributes.z);
+    if (
+        current.a > 0.0 && currentHitValue.z >= 0.0 && hitInside &&
+        dominantDirection > 0.0
+    ) {
+        hitHistory = textureSampleLevel(previousHistory, linearSampler, hitHistoryUv, 0.0);
+        let hitState = textureLoad(
+            previousState,
+            pixelFor(previousState, hitHistoryUv),
+            0
+        );
+        let hitResponseState = textureLoad(
+            previousResponseState,
+            pixelFor(previousResponseState, hitHistoryUv),
+            0
+        );
+        let hitDepthError = relativeDepthError(hitState.w, currentHitValue.z);
+        let hitNormalWeight = smoothstep(
+            0.82,
+            0.98,
+            dot(currentNormal, decodeOctahedralNormal(hitState.xy))
+        );
+        let hitRoughnessWeight = exp2(
+            -abs(currentAttributes.z - hitState.z) * 24.0
+        );
+        let hitMaterialWeight = materialContinuity(
+            currentAttributes.w,
+            hitResponseState.w
+        );
+        let hitResponseWeight = responseContinuity(
+            responseState.rgb,
+            hitResponseState.rgb
+        );
+        if (
+            hitDepthError <= ${String(Math.max(settings.depthThreshold * 2, 0.01))} &&
+            historyConfidence(hitHistory.a) > 0.0
+        ) {
+            hitScore = dominantDirection * hitNormalWeight * hitRoughnessWeight *
+                hitMaterialWeight * hitResponseWeight;
+        }
+    }
+    surfaceScore *= 1.0 - clamp(reactive, 0.0, 1.0);
+    hitScore *= 1.0 - clamp(reactive, 0.0, 1.0);
+
+    let surfaceYCoCg = rgbToYCoCg(surfaceHistory.rgb);
+    let hitYCoCg = rgbToYCoCg(hitHistory.rgb);
+    let surfaceError = select(
+        1e9,
+        length(surfaceYCoCg - neighborhoodCenter),
+        surfaceScore > 0.01
+    );
+    let hitError = select(
+        1e9,
+        length(hitYCoCg - neighborhoodCenter),
+        hitScore > 0.01
+    );
+    let useHitHistory = hitScore > 0.01 && hitError <= surfaceError + 0.01;
+    var selectedHistory = surfaceHistory;
+    var selectedScore = surfaceScore;
+    if (useHitHistory) {
+        selectedHistory = hitHistory;
+        selectedScore = hitScore;
+    }
+    let historyAvailable = selectedScore > 0.01;
+    let selectedYCoCg = clamp(
+        rgbToYCoCg(selectedHistory.rgb),
+        neighborhoodCenter - neighborhoodExtent,
+        neighborhoodCenter + neighborhoodExtent
+    );
+    let clampedHistory = max(yCoCgToRGB(selectedYCoCg), vec3<f32>(0.0));
+    let previousCount = historySampleCount(selectedHistory.a);
+    let previousConfidence = historyConfidence(selectedHistory.a);
+    let maxFrames = mix(
+        4.0,
+        24.0,
+        denoiseStrength
+    );
+    let velocityPixels = length(motion.xy * vec2<f32>(motionSize));
+    let motionResponse = clamp(velocityPixels / 24.0, 0.0, 1.0);
+    var resolvedRadiance = stableCurrent;
+    var resolvedConfidence = current.a;
+    var resolvedCount = select(0.0, 1.0, current.a > 0.0);
+    if (historyAvailable) {
+        atomicAdd(&diagnostics.historyAcceptedPixels, 1u);
+        if (current.a > 0.0) {
+            resolvedCount = min(previousCount * selectedScore + 1.0, maxFrames);
+            let blend = min(
+                ${String(settings.historyWeight)},
+                max(0.0, 1.0 - 1.0 / max(resolvedCount, 1.0))
+            ) * selectedScore * (1.0 - motionResponse * 0.65);
+            resolvedRadiance = mix(stableCurrent, clampedHistory, blend);
+            resolvedConfidence = max(current.a, previousConfidence * blend);
+        } else {
+            resolvedCount = max(previousCount * selectedScore - 0.25, 1.0);
+            resolvedRadiance = clampedHistory;
+            resolvedConfidence = previousConfidence * min(selectedScore, 0.82);
+        }
+    } else {
+        atomicAdd(&diagnostics.historyRejectedPixels, 1u);
+    }
+    textureStore(
+        historyOutput,
+        pixel,
+        vec4<f32>(
+            resolvedRadiance,
+            packHistoryState(resolvedCount, resolvedConfidence)
+        )
+    );
     textureStore(depthOutput, pixel, vec4<f32>(motion.w));
+    textureStore(
+        stateOutput,
+        pixel,
+        vec4<f32>(currentAttributes.xy, currentAttributes.z, currentHitValue.w)
+    );
+    textureStore(responseStateOutput, pixel, responseState);
 }`,
             workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
             bindings: [
                 {
-                    name: 'currentReflection',
+                    name: 'diagnostics',
                     group: 0,
                     binding: 0,
-                    kind: 'sampled-texture',
-                    sampleType: 'float'
+                    kind: 'storage-buffer',
+                    access: 'read-write'
                 },
                 {
-                    name: 'motionDepth',
+                    name: 'tileList',
                     group: 0,
                     binding: 1,
-                    kind: 'sampled-texture',
-                    sampleType: 'float'
+                    kind: 'read-only-storage-buffer'
                 },
                 {
-                    name: 'previousHistory',
+                    name: 'currentReflection',
                     group: 0,
                     binding: 2,
                     kind: 'sampled-texture',
                     sampleType: 'float'
                 },
                 {
-                    name: 'previousDepth',
+                    name: 'currentHit',
                     group: 0,
                     binding: 3,
                     kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'motionDepth',
+                    group: 0,
+                    binding: 4,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'materialAttributes',
+                    group: 0,
+                    binding: 5,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'reactiveMask',
+                    group: 0,
+                    binding: 6,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'currentResponse',
+                    group: 0,
+                    binding: 7,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'previousHistory',
+                    group: 0,
+                    binding: 8,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'previousDepth',
+                    group: 0,
+                    binding: 9,
+                    kind: 'sampled-texture',
                     sampleType: 'unfilterable-float'
                 },
-                { name: 'linearSampler', group: 0, binding: 4, kind: 'sampler' },
+                {
+                    name: 'previousState',
+                    group: 0,
+                    binding: 10,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'previousResponseState',
+                    group: 0,
+                    binding: 11,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                { name: 'linearSampler', group: 0, binding: 12, kind: 'sampler' },
                 {
                     name: 'historyOutput',
                     group: 0,
-                    binding: 5,
+                    binding: 13,
                     kind: 'storage-texture',
                     access: 'write-only',
                     format: 'rgba16float'
@@ -609,10 +1841,26 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
                 {
                     name: 'depthOutput',
                     group: 0,
-                    binding: 6,
+                    binding: 14,
                     kind: 'storage-texture',
                     access: 'write-only',
                     format: 'r32float'
+                },
+                {
+                    name: 'stateOutput',
+                    group: 0,
+                    binding: 15,
+                    kind: 'storage-texture',
+                    access: 'write-only',
+                    format: 'rgba16float'
+                },
+                {
+                    name: 'responseStateOutput',
+                    group: 0,
+                    binding: 16,
+                    kind: 'storage-texture',
+                    access: 'write-only',
+                    format: 'rgba16float'
                 }
             ]
         })
@@ -620,15 +1868,18 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
 }
 
 function spatialFilterPass(
-    step: number,
-    settings: Readonly<ScreenSpaceReflectionsSettings>
+    settings: Readonly<ScreenSpaceReflectionsSettings>,
+    stage: 'reconstruction' | 'stability' | 'cleanup'
 ): ComputeRenderPass {
+    const adaptiveRadius = stage === 'stability';
+    const maximumRadius = stage === 'stability' ? 3 : 1;
+    const minimumCenterWeight = stage === 'cleanup' ? 4 : stage === 'stability' ? 2 : 1;
+    const maximumCenterWeight = stage === 'cleanup' ? 10 : stage === 'stability' ? 6 : 4;
     const taps = [
         [-1, -1, 1],
         [0, -1, 2],
         [1, -1, 1],
         [-1, 0, 2],
-        [0, 0, 36],
         [1, 0, 2],
         [-1, 1, 1],
         [0, 1, 2],
@@ -639,12 +1890,13 @@ function spatialFilterPass(
             ([x, y, weight]) => `
     {
         let neighborCoordinate = clamp(
-            pixel + vec2<i32>(${String(x * step)}, ${String(y * step)}),
+            pixel + vec2<i32>(${String(x)}, ${String(y)}) * filterRadius,
             vec2<i32>(0),
             vec2<i32>(outputSize) - vec2<i32>(1)
         );
         let neighbor = textureLoad(sourceReflection, neighborCoordinate, 0);
-        if (neighbor.a > 0.0001) {
+        let neighborConfidence = historyConfidence(neighbor.a);
+        if (neighborConfidence > 0.0001) {
             let neighborUv = (vec2<f32>(neighborCoordinate) + vec2<f32>(0.5)) /
                 vec2<f32>(outputSize);
             let neighborAttributes = textureLoad(
@@ -652,7 +1904,12 @@ function spatialFilterPass(
                 pixelFor(materialAttributes, neighborUv),
                 0
             );
-            let neighborPacked = u32(max(round(neighborAttributes.w), 0.0));
+            let neighborResponseState = textureLoad(
+                responseHistory,
+                pixelFor(responseHistory, neighborUv),
+                0
+            );
+            let neighborPacked = u32(clamp(round(neighborAttributes.w * 255.0), 0.0, 255.0));
             if (
                 (neighborPacked & 1u) != 0u &&
                 neighborAttributes.z < ${String(settings.roughnessCutoff)}
@@ -668,10 +1925,52 @@ function spatialFilterPass(
                 let roughnessWeight = exp2(
                     -abs(centerAttributes.z - neighborAttributes.z) * 16.0
                 );
-                let confidenceWeight = clamp(0.25 + neighbor.a, 0.0, 1.0);
+                let materialWeight = select(0.0, 1.0, centerPacked == neighborPacked);
+                let responseScale = max(
+                    max(length(centerResponseState.rgb), length(neighborResponseState.rgb)),
+                    0.05
+                );
+                let responseWeight = exp2(
+                    -length(centerResponseState.rgb - neighborResponseState.rgb) *
+                        6.0 / responseScale
+                );
+                let neighborHitDepth = textureLoad(
+                    stateHistory,
+                    pixelFor(stateHistory, neighborUv),
+                    0
+                ).w;
+                let hitDepthContinuity = select(
+                    0.45,
+                    exp2(-abs(centerHitDepth - neighborHitDepth) * 4.0),
+                    centerHitDepth > 0.0 && neighborHitDepth > 0.0
+                );
+                let hitDepthWeight = mix(
+                    hitDepthContinuity,
+                    1.0,
+                    spatialDenoiseStrength * 0.85
+                );
+                let centerLuminance = dot(
+                    center.rgb,
+                    vec3<f32>(0.2126, 0.7152, 0.0722)
+                );
+                let neighborLuminance = dot(
+                    neighbor.rgb,
+                    vec3<f32>(0.2126, 0.7152, 0.0722)
+                );
+                let luminanceWeight = exp2(
+                    -abs(neighborLuminance - centerLuminance) /
+                        max(
+                            0.05 + max(centerLuminance, neighborLuminance) *
+                                mix(0.3, 0.8, spatialDenoiseStrength),
+                            0.05
+                        )
+                );
+                let confidenceWeight = clamp(0.25 + neighborConfidence, 0.0, 1.0);
                 let weight = ${String(weight)}.0 * normalWeight * depthWeight *
-                    roughnessWeight * confidenceWeight;
-                accumulation += neighbor * weight;
+                    roughnessWeight * materialWeight * responseWeight * hitDepthWeight *
+                    luminanceWeight * confidenceWeight;
+                accumulation += neighbor.rgb * weight;
+                confidenceAccumulation += neighborConfidence * weight;
                 totalWeight += weight;
             }
         }
@@ -680,12 +1979,32 @@ function spatialFilterPass(
         .join('\n');
     return computePass(
         new ComputeShader({
-            label: `Screen-space reflections confidence filter step ${String(step)}`,
+            label:
+                stage === 'reconstruction'
+                    ? 'Screen-space reflections adaptive confidence filter'
+                    : stage === 'stability'
+                      ? 'Screen-space reflections variance-guided stability filter'
+                      : 'Screen-space reflections residual coverage cleanup filter',
             source: `
-@group(0) @binding(0) var sourceReflection: texture_2d<f32>;
-@group(0) @binding(1) var motionDepth: texture_2d<f32>;
-@group(0) @binding(2) var materialAttributes: texture_2d<f32>;
-@group(0) @binding(3) var destination: texture_storage_2d<rgba16float, write>;
+struct TraceDiagnostics {
+    activeTiles: atomic<u32>,
+    activePixels: atomic<u32>,
+    hitPixels: atomic<u32>,
+    missPixels: atomic<u32>,
+    uncertainPixels: atomic<u32>,
+    backfaceRejectedPixels: atomic<u32>,
+    historyAcceptedPixels: atomic<u32>,
+    historyRejectedPixels: atomic<u32>,
+};
+struct TileList { values: array<u32> };
+@group(0) @binding(0) var<storage, read_write> diagnostics: TraceDiagnostics;
+@group(0) @binding(1) var<storage, read> tileList: TileList;
+@group(0) @binding(2) var sourceReflection: texture_2d<f32>;
+@group(0) @binding(3) var motionDepth: texture_2d<f32>;
+@group(0) @binding(4) var materialAttributes: texture_2d<f32>;
+@group(0) @binding(5) var stateHistory: texture_2d<f32>;
+@group(0) @binding(6) var responseHistory: texture_2d<f32>;
+@group(0) @binding(7) var destination: texture_storage_2d<rgba16float, write>;
 fn pixelFor(source: texture_2d<f32>, uv: vec2<f32>) -> vec2<i32> {
     let dimensions = textureDimensions(source);
     return clamp(
@@ -695,7 +2014,11 @@ fn pixelFor(source: texture_2d<f32>, uv: vec2<f32>) -> vec2<i32> {
     );
 }
 fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
-    var normal = vec3<f32>(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
+    let encodedSigned = encoded * 2.0 - vec2<f32>(1.0);
+    var normal = vec3<f32>(
+        encodedSigned,
+        1.0 - abs(encodedSigned.x) - abs(encodedSigned.y)
+    );
     if (normal.z < 0.0) {
         let original = normal.xy;
         normal.x = (1.0 - abs(original.y)) * select(-1.0, 1.0, original.x >= 0.0);
@@ -703,8 +2026,24 @@ fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
     }
     return normalize(normal);
 }
+fn historySampleCount(packed: f32) -> f32 { return floor(max(packed, 0.0)); }
+fn historyConfidence(packed: f32) -> f32 {
+    return clamp(fract(max(packed, 0.0)) * 2.0, 0.0, 1.0);
+}
+fn packHistoryState(sampleCount: f32, confidence: f32) -> f32 {
+    return min(sampleCount, ${String(MAX_HISTORY_SAMPLE_COUNT)}.0) +
+        min(confidence, 0.999) * 0.5;
+}
 @compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
-fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+fn main(
+    @builtin(workgroup_id) groupId: vec3<u32>,
+    @builtin(local_invocation_id) localId: vec3<u32>
+) {
+    let compactIndex = groupId.y * ${String(MAX_INDIRECT_DISPATCH_X)}u + groupId.x;
+    if (compactIndex >= atomicLoad(&diagnostics.activeTiles)) { return; }
+    let packedTile = tileList.values[compactIndex];
+    let tile = vec2<u32>(packedTile & 65535u, packedTile >> 16u);
+    let id = vec3<u32>(tile * ${String(TRACE_WORKGROUP_SIZE)}u + localId.xy, 0u);
     let outputSize = textureDimensions(destination);
     if (any(id.xy >= outputSize)) { return; }
     let pixel = vec2<i32>(id.xy);
@@ -714,7 +2053,12 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
         pixelFor(materialAttributes, uv),
         0
     );
-    let centerPacked = u32(max(round(centerAttributes.w), 0.0));
+    let centerPacked = u32(clamp(round(centerAttributes.w * 255.0), 0.0, 255.0));
+    let centerResponseState = textureLoad(
+        responseHistory,
+        pixelFor(responseHistory, uv),
+        0
+    );
     if (
         (centerPacked & 1u) == 0u ||
         centerAttributes.z >= ${String(settings.roughnessCutoff)}
@@ -724,11 +2068,58 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     }
     let centerNormal = decodeOctahedralNormal(centerAttributes.xy);
     let centerLogDepth = textureLoad(motionDepth, pixelFor(motionDepth, uv), 0).w;
-    var accumulation = vec4<f32>(0.0);
-    var totalWeight = 0.0;
+    let center = textureLoad(sourceReflection, pixel, 0);
+    let centerConfidence = historyConfidence(center.a);
+    if (centerAttributes.z <= 0.08 && centerConfidence > 0.0) {
+        textureStore(destination, pixel, center);
+        return;
+    }
+    let spatialDenoiseStrength = smoothstep(
+        0.0,
+        1.0,
+        clamp(
+            (centerAttributes.z - 0.08) /
+                max(${String(Math.min(settings.roughnessCutoff, 0.2) - 0.08)}, 0.01),
+            0.0,
+            1.0
+        )
+    );
+    let filterRadius = ${
+        adaptiveRadius
+            ? `i32(clamp(
+        ceil(spatialDenoiseStrength * ${String(maximumRadius)}.0),
+        1.0,
+        ${String(maximumRadius)}.0
+    ))`
+            : '1'
+    };
+    let centerHitDepth = textureLoad(stateHistory, pixelFor(stateHistory, uv), 0).w;
+    let historyMaturity = clamp(
+        historySampleCount(center.a) / ${String(MAX_HISTORY_SAMPLE_COUNT)}.0,
+        0.0,
+        1.0
+    );
+    let centerWeight = mix(
+        ${String(minimumCenterWeight)}.0,
+        ${String(maximumCenterWeight)}.0,
+        historyMaturity
+    );
+    var accumulation = center.rgb * centerConfidence * centerWeight;
+    var confidenceAccumulation = centerConfidence * centerConfidence * centerWeight;
+    var totalWeight = centerConfidence * centerWeight;
 ${tapSource}
     if (totalWeight > 0.0001) {
-        textureStore(destination, pixel, accumulation / totalWeight);
+        textureStore(
+            destination,
+            pixel,
+            vec4<f32>(
+                accumulation / totalWeight,
+                packHistoryState(
+                    historySampleCount(center.a),
+                    confidenceAccumulation / totalWeight
+                )
+            )
+        );
     } else {
         textureStore(destination, pixel, vec4<f32>(0.0));
     }
@@ -736,30 +2127,57 @@ ${tapSource}
             workgroupSize: [TRACE_WORKGROUP_SIZE, TRACE_WORKGROUP_SIZE],
             bindings: [
                 {
-                    name: 'sourceReflection',
+                    name: 'diagnostics',
                     group: 0,
                     binding: 0,
-                    kind: 'sampled-texture',
-                    sampleType: 'float'
+                    kind: 'storage-buffer',
+                    access: 'read-write'
                 },
                 {
-                    name: 'motionDepth',
+                    name: 'tileList',
                     group: 0,
                     binding: 1,
-                    kind: 'sampled-texture',
-                    sampleType: 'float'
+                    kind: 'read-only-storage-buffer'
                 },
                 {
-                    name: 'materialAttributes',
+                    name: 'sourceReflection',
                     group: 0,
                     binding: 2,
                     kind: 'sampled-texture',
                     sampleType: 'float'
                 },
                 {
-                    name: 'destination',
+                    name: 'motionDepth',
                     group: 0,
                     binding: 3,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'materialAttributes',
+                    group: 0,
+                    binding: 4,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'stateHistory',
+                    group: 0,
+                    binding: 5,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'responseHistory',
+                    group: 0,
+                    binding: 6,
+                    kind: 'sampled-texture',
+                    sampleType: 'float'
+                },
+                {
+                    name: 'destination',
+                    group: 0,
+                    binding: 7,
                     kind: 'storage-texture',
                     access: 'write-only',
                     format: 'rgba16float'
@@ -777,20 +2195,95 @@ function compositePass(intensity: number): FullscreenRenderPass {
             fs: `#version 300 es
 precision highp float;
 in vec2 v_uv;
-uniform sampler2D u_scene;
 uniform sampler2D u_reflection;
+uniform sampler2D u_fallbackSpecular;
+uniform sampler2D u_materialAttributes;
+uniform sampler2D u_motionDepth;
 layout(location=0) out vec4 color;
+vec3 decodeOctahedralNormal(vec2 encoded) {
+    encoded = encoded * 2.0 - 1.0;
+    vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
+    if (normal.z < 0.0) {
+        vec2 original = normal.xy;
+        normal.xy = (1.0 - abs(original.yx)) *
+            vec2(original.x >= 0.0 ? 1.0 : -1.0, original.y >= 0.0 ? 1.0 : -1.0);
+    }
+    return normalize(normal);
+}
+float historyConfidence(float packed) {
+    return clamp(fract(max(packed, 0.0)) * 2.0, 0.0, 1.0);
+}
+vec4 resolveReflection(vec2 uv) {
+    ivec2 reflectionSize = textureSize(u_reflection, 0);
+    ivec2 materialSize = textureSize(u_materialAttributes, 0);
+    if (all(equal(reflectionSize, materialSize))) {
+        vec4 resolved = texture(u_reflection, uv);
+        resolved.a = historyConfidence(resolved.a);
+        return resolved;
+    }
+    vec4 centerAttributes = texture(u_materialAttributes, uv);
+    vec3 centerNormal = decodeOctahedralNormal(centerAttributes.xy);
+    float centerLogDepth = texture(u_motionDepth, uv).w;
+    vec2 reflectionCoordinate = uv * vec2(reflectionSize) - 0.5;
+    ivec2 base = ivec2(floor(reflectionCoordinate));
+    vec2 fraction = fract(reflectionCoordinate);
+    vec3 radiance = vec3(0.0);
+    float confidence = 0.0;
+    float totalWeight = 0.0;
+    for (int y = 0; y <= 1; y += 1) {
+        for (int x = 0; x <= 1; x += 1) {
+            ivec2 coordinate = clamp(
+                base + ivec2(x, y),
+                ivec2(0),
+                reflectionSize - ivec2(1)
+            );
+            vec2 sampleUv = (vec2(coordinate) + 0.5) / vec2(reflectionSize);
+            vec4 sampleValue = texelFetch(u_reflection, coordinate, 0);
+            float sampleConfidence = historyConfidence(sampleValue.a);
+            vec4 sampleAttributes = texture(u_materialAttributes, sampleUv);
+            vec3 sampleNormal = decodeOctahedralNormal(sampleAttributes.xy);
+            float sampleLogDepth = texture(u_motionDepth, sampleUv).w;
+            vec2 bilinearAxis = vec2(
+                x == 0 ? 1.0 - fraction.x : fraction.x,
+                y == 0 ? 1.0 - fraction.y : fraction.y
+            );
+            float spatialWeight = bilinearAxis.x * bilinearAxis.y;
+            float normalWeight = pow(max(dot(centerNormal, sampleNormal), 0.0), 32.0);
+            float depthWeight = exp2(-abs(centerLogDepth - sampleLogDepth) * 32.0);
+            float roughnessWeight = exp2(
+                -abs(centerAttributes.z - sampleAttributes.z) * 20.0
+            );
+            float weight = spatialWeight * normalWeight * depthWeight * roughnessWeight;
+            weight *= max(sampleConfidence, 1e-3);
+            radiance += sampleValue.rgb * weight;
+            confidence += sampleConfidence * weight;
+            totalWeight += weight;
+        }
+    }
+    if (totalWeight <= 1e-5) return vec4(0.0);
+    return vec4(radiance / totalWeight, confidence / totalWeight);
+}
 void main() {
-    vec4 scene = texture(u_scene, v_uv);
-    vec4 reflection = texture(u_reflection, v_uv);
-    color = vec4(scene.rgb + reflection.rgb * ${String(intensity)}, scene.a);
+    vec4 reflection = resolveReflection(v_uv);
+    vec3 fallbackSpecular = texture(u_fallbackSpecular, v_uv).rgb;
+    float confidenceGate = smoothstep(0.08, 0.35, reflection.a);
+    float replacementConfidence = reflection.a * confidenceGate;
+    color = vec4(
+        reflection.rgb * (${String(intensity)} * confidenceGate) -
+            fallbackSpecular * replacementConfidence,
+        0.0
+    );
 }`
         }),
         pipelineState: {
             ...DEFAULT_MATERIAL_PIPELINE_STATE,
             depthTest: false,
             depthWrite: false,
-            cullMode: 'none'
+            cullMode: 'none',
+            blend: {
+                color: { operation: 'add', srcFactor: 'one', dstFactor: 'one' },
+                alpha: { operation: 'add', srcFactor: 'one', dstFactor: 'one' }
+            }
         }
     });
 }
@@ -807,7 +2300,7 @@ class MutableComputeParameters implements ComputeRenderPassParameters {
     readonly buffers: MutableBufferBinding[];
     readonly textures: MutableTextureBinding[];
     readonly samplers: ComputeSampler[];
-    readonly dispatch: { x: number; y: number; z: number } = { x: 1, y: 1, z: 1 };
+    dispatch: ComputeDispatch = { x: 1, y: 1, z: 1 };
 
     constructor(bufferCount: number, textureCount: number, samplerCount: number) {
         this.buffers = Array.from({ length: bufferCount }, () => ({ buffer: INVALID_BUFFER }));
@@ -828,9 +2321,11 @@ class MutableComputeParameters implements ComputeRenderPassParameters {
     }
 
     setDispatch(x: number, y: number): void {
-        this.dispatch.x = x;
-        this.dispatch.y = y;
-        this.dispatch.z = 1;
+        this.dispatch = { x, y, z: 1 };
+    }
+
+    setIndirectDispatch(buffer: RenderGraphBufferHandle): void {
+        this.dispatch = { indirectBuffer: buffer, indirectOffset: 0 };
     }
 }
 
@@ -851,7 +2346,13 @@ export interface ScreenSpaceReflectionsResources {
     readonly sceneColor: RenderGraphTextureHandle;
     readonly sceneDepth: RenderGraphTextureHandle;
     readonly materialAttributes: RenderGraphTextureHandle;
+    /** View-dependent reflection response written by the material-attributes ABI. */
+    readonly reflectionResponse: RenderGraphTextureHandle;
+    /** Environment/probe specular already present in sceneColor and replaced on valid SSR hits. */
+    readonly fallbackSpecular: RenderGraphTextureHandle;
     readonly motionDepth: RenderGraphTextureHandle;
+    /** Authored and transparency-derived temporal rejection signal. */
+    readonly reactiveMask: RenderGraphTextureHandle;
     /** Current internal scene resolution relative to the output. */
     readonly sceneScale: number;
     readonly hiZ: readonly RenderGraphTextureHandle[];
@@ -865,12 +2366,18 @@ export interface ScreenSpaceReflectionsResources {
 export class ScreenSpaceReflectionsController {
     readonly #settings: Readonly<ScreenSpaceReflectionsSettings>;
     readonly #traceHiZLevelCount: number;
+    readonly #tileClassificationPass: ComputeRenderPass;
     readonly #tracePass: ComputeRenderPass;
     readonly #temporalResolvePass: ComputeRenderPass;
-    readonly #spatialFilterPasses: readonly ComputeRenderPass[];
+    readonly #spatialReconstructionPass: ComputeRenderPass;
+    readonly #spatialStabilityPass: ComputeRenderPass;
+    readonly #spatialCleanupPass: ComputeRenderPass;
     readonly #compositePass: FullscreenRenderPass;
     readonly #colorHistoryKey = Object.freeze({});
     readonly #depthHistoryKey = Object.freeze({});
+    readonly #stateHistoryKey = Object.freeze({});
+    readonly #responseHistoryKey = Object.freeze({});
+    readonly #diagnostics: StorageBuffer;
     readonly #colorPyramidDescriptors: readonly Readonly<RenderPipelineTextureDescriptor>[];
     readonly #colorPyramidExtents: readonly {
         readonly relativeTo: 'output';
@@ -884,23 +2391,41 @@ export class ScreenSpaceReflectionsController {
         readonly minWidth: 1;
         readonly minHeight: 1;
     };
-    readonly #compositeExtent: { readonly relativeTo: 'output'; scale: number };
     readonly #reflectionDescriptor: Readonly<RenderPipelineTextureDescriptor>;
     readonly #colorHistoryDescriptor: Readonly<RenderPipelineHistoryTextureDescriptor>;
     readonly #depthHistoryDescriptor: Readonly<RenderPipelineHistoryTextureDescriptor>;
-    readonly #compositeDescriptor: Readonly<RenderPipelineTextureDescriptor>;
+    readonly #stateHistoryDescriptor: Readonly<RenderPipelineHistoryTextureDescriptor>;
+    readonly #responseHistoryDescriptor: Readonly<RenderPipelineHistoryTextureDescriptor>;
     readonly #downsamplePool = new RenderPassParameterPool(
         () => new MutableComputeParameters(0, 2, 1)
     );
     readonly #tracePool: RenderPassParameterPool<MutableComputeParameters>;
+    readonly #traceResetPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(2, 2, 0)
+    );
+    readonly #classificationPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(3, 4, 0)
+    );
+    readonly #compactionPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(4, 1, 0)
+    );
+    readonly #dispatchFinalizePool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(2, 0, 0)
+    );
     readonly #initializePool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(0, 9, 0)
+    );
+    readonly #historyResetPool = new RenderPassParameterPool(
         () => new MutableComputeParameters(0, 4, 0)
     );
     readonly #resolvePool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(0, 6, 1)
+        () => new MutableComputeParameters(2, 14, 1)
+    );
+    readonly #filterResetPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(0, 1, 0)
     );
     readonly #spatialFilterPool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(0, 4, 0)
+        () => new MutableComputeParameters(2, 6, 0)
     );
     readonly #compositePool = new RenderPassParameterPool(
         () => new MutableFullscreenParameters(),
@@ -912,6 +2437,7 @@ export class ScreenSpaceReflectionsController {
 
     constructor(
         settings: Readonly<ScreenSpaceReflectionsSettings>,
+        context: RenderPipelineCreateContext,
         sceneScale: number,
         hiZLevelCount: number
     ) {
@@ -920,17 +2446,24 @@ export class ScreenSpaceReflectionsController {
         if (this.#traceHiZLevelCount < 1) {
             throw new RangeError('Screen-space reflections require at least one Hi-Z level');
         }
+        this.#diagnostics = context.createStorageBuffer({
+            label: 'Screen-space reflections diagnostics',
+            byteLength: SSR_DIAGNOSTIC_BYTES,
+            usage: ['storage', 'copy-source'],
+            recovery: 'reinitialize'
+        });
+        this.#tileClassificationPass = tileClassificationPass(settings);
         this.#tracePass = computePass(traceShader(settings, this.#traceHiZLevelCount));
         this.#temporalResolvePass = temporalResolvePass(settings);
-        this.#spatialFilterPasses = Object.freeze(
-            SPATIAL_FILTER_STEPS.map(step => spatialFilterPass(step, settings))
-        );
+        this.#spatialReconstructionPass = spatialFilterPass(settings, 'reconstruction');
+        this.#spatialStabilityPass = spatialFilterPass(settings, 'stability');
+        this.#spatialCleanupPass = spatialFilterPass(settings, 'cleanup');
         this.#compositePass = compositePass(settings.intensity);
         this.#tracePool = new RenderPassParameterPool(
             () =>
                 new MutableComputeParameters(
-                    1,
-                    COLOR_PYRAMID_LEVELS + 2 + this.#traceHiZLevelCount + 1,
+                    3,
+                    COLOR_PYRAMID_LEVELS + 4 + this.#traceHiZLevelCount + 2,
                     1
                 )
         );
@@ -976,10 +2509,19 @@ export class ScreenSpaceReflectionsController {
             usage: Object.freeze(['sampled' as const, 'storage' as const]),
             bufferCount: 2
         });
-        this.#compositeExtent = { relativeTo: 'output' as const, scale: sceneScale };
-        this.#compositeDescriptor = Object.freeze({
+        this.#stateHistoryDescriptor = Object.freeze({
+            label: 'Screen-space reflections material and hit-depth history',
             format: 'rgba16float',
-            extent: this.#compositeExtent
+            extent: reflectionExtent,
+            usage: Object.freeze(['sampled' as const, 'storage' as const]),
+            bufferCount: 2
+        });
+        this.#responseHistoryDescriptor = Object.freeze({
+            label: 'Screen-space reflections response and material history',
+            format: 'rgba16float',
+            extent: reflectionExtent,
+            usage: Object.freeze(['sampled' as const, 'storage' as const]),
+            bufferCount: 2
         });
     }
 
@@ -996,7 +2538,6 @@ export class ScreenSpaceReflectionsController {
             if (extent !== undefined) extent.scale = resources.sceneScale / 2 ** (index + 1);
         }
         this.#reflectionExtent.scale = resources.sceneScale * this.#settings.resolutionScale;
-        this.#compositeExtent.scale = resources.sceneScale;
         const colorLevels: RenderGraphTextureHandle[] = [resources.sceneColor];
         let source = resources.sceneColor;
         for (let index = 0; index < COLOR_PYRAMID_LEVELS - 1; index += 1) {
@@ -1036,26 +2577,80 @@ export class ScreenSpaceReflectionsController {
             'Screen-space reflections current radiance and confidence',
             this.#reflectionDescriptor
         );
+        const currentHit = context.graph.createTexture(
+            'Screen-space reflections current hit motion and view depth',
+            this.#reflectionDescriptor
+        );
+        const reflectionScale = resources.sceneScale * this.#settings.resolutionScale;
+        const reflectionWidth = Math.max(1, Math.floor(context.output.width * reflectionScale));
+        const reflectionHeight = Math.max(1, Math.floor(context.output.height * reflectionScale));
+        const tileCountX = Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE));
+        const tileCountY = Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE));
+        const dispatchArguments = context.graph.createBuffer(
+            'Screen-space reflections indirect dispatch arguments',
+            { byteLength: 12 }
+        );
+        const tileMask = context.graph.createBuffer('Screen-space reflections active tile mask', {
+            byteLength: tileCountX * tileCountY * 4
+        });
+        const tileList = context.graph.createBuffer('Screen-space reflections active tile list', {
+            byteLength: tileCountX * tileCountY * 4
+        });
+        const diagnostics = context.graph.importStorageBuffer(this.#diagnostics);
+
+        const reset = context.acquirePassParameters(this.#traceResetPool);
+        reset.setBuffer(0, dispatchArguments);
+        reset.setBuffer(1, diagnostics);
+        reset.setTexture(0, currentReflection);
+        reset.setTexture(1, currentHit);
+        reset.setDispatch(tileCountX, tileCountY);
+        context.graph.addPass(TRACE_RESET_PASS, reset);
+
+        const classification = context.acquirePassParameters(this.#classificationPool);
+        classification.setBuffer(0, resources.frameBuffer);
+        classification.setBuffer(1, tileMask);
+        classification.setBuffer(2, diagnostics);
+        classification.setTexture(0, resources.sceneDepth);
+        classification.setTexture(1, resources.materialAttributes);
+        classification.setTexture(2, resources.reflectionResponse);
+        classification.setTexture(3, currentReflection);
+        classification.setDispatch(tileCountX, tileCountY);
+        context.graph.addPass(this.#tileClassificationPass, classification);
+
+        const compaction = context.acquirePassParameters(this.#compactionPool);
+        compaction.setBuffer(0, dispatchArguments);
+        compaction.setBuffer(1, tileMask);
+        compaction.setBuffer(2, tileList);
+        compaction.setBuffer(3, diagnostics);
+        compaction.setTexture(0, currentReflection);
+        compaction.setDispatch(Math.max(1, Math.ceil((tileCountX * tileCountY) / 64)), 1);
+        context.graph.addPass(TILE_COMPACTION_PASS, compaction);
+
+        const dispatchFinalize = context.acquirePassParameters(this.#dispatchFinalizePool);
+        dispatchFinalize.setBuffer(0, dispatchArguments);
+        dispatchFinalize.setBuffer(1, diagnostics);
+        dispatchFinalize.setDispatch(1, 1);
+        context.graph.addPass(TILE_DISPATCH_FINALIZE_PASS, dispatchFinalize);
+
         const trace = context.acquirePassParameters(this.#tracePool);
         trace.setBuffer(0, resources.frameBuffer);
+        trace.setBuffer(1, tileList);
+        trace.setBuffer(2, diagnostics);
         let textureIndex = 0;
         for (const color of colorLevels) trace.setTexture(textureIndex++, color);
         trace.setTexture(textureIndex++, resources.sceneDepth);
         trace.setTexture(textureIndex++, resources.materialAttributes);
+        trace.setTexture(textureIndex++, resources.reflectionResponse);
+        trace.setTexture(textureIndex++, resources.motionDepth);
         for (let index = 0; index < this.#traceHiZLevelCount; index += 1) {
             const hiZ = resources.hiZ[index];
             if (hiZ === undefined)
                 throw new Error('Screen-space reflections Hi-Z level is missing');
             trace.setTexture(textureIndex++, hiZ);
         }
-        trace.setTexture(textureIndex, currentReflection);
-        const reflectionScale = resources.sceneScale * this.#settings.resolutionScale;
-        const reflectionWidth = Math.max(1, Math.floor(context.output.width * reflectionScale));
-        const reflectionHeight = Math.max(1, Math.floor(context.output.height * reflectionScale));
-        trace.setDispatch(
-            Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
-            Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
-        );
+        trace.setTexture(textureIndex++, currentReflection);
+        trace.setTexture(textureIndex, currentHit);
+        trace.setIndirectDispatch(dispatchArguments);
         context.graph.addPass(this.#tracePass, trace);
 
         const colorHistory = context.graph.acquireHistoryTexture(
@@ -1066,31 +2661,66 @@ export class ScreenSpaceReflectionsController {
             this.#depthHistoryKey,
             this.#depthHistoryDescriptor
         );
+        const stateHistory = context.graph.acquireHistoryTexture(
+            this.#stateHistoryKey,
+            this.#stateHistoryDescriptor
+        );
+        const responseHistory = context.graph.acquireHistoryTexture(
+            this.#responseHistoryKey,
+            this.#responseHistoryDescriptor
+        );
         if (
             colorHistory.generation !== depthHistory.generation ||
-            colorHistory.valid !== depthHistory.valid
+            colorHistory.generation !== stateHistory.generation ||
+            colorHistory.generation !== responseHistory.generation ||
+            colorHistory.valid !== depthHistory.valid ||
+            colorHistory.valid !== stateHistory.valid ||
+            colorHistory.valid !== responseHistory.valid
         ) {
             throw new Error('Screen-space reflections history generations diverged');
         }
         if (resources.historyValid && colorHistory.valid) {
-            const resolve = context.acquirePassParameters(this.#resolvePool);
-            resolve.setTexture(0, currentReflection);
-            resolve.setTexture(1, resources.motionDepth);
-            resolve.setTexture(2, colorHistory.history());
-            resolve.setTexture(3, depthHistory.history());
-            resolve.setTexture(4, colorHistory.current);
-            resolve.setTexture(5, depthHistory.current);
-            resolve.setDispatch(
+            const historyReset = context.acquirePassParameters(this.#historyResetPool);
+            historyReset.setTexture(0, colorHistory.current);
+            historyReset.setTexture(1, depthHistory.current);
+            historyReset.setTexture(2, stateHistory.current);
+            historyReset.setTexture(3, responseHistory.current);
+            historyReset.setDispatch(
                 Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
                 Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
             );
+            context.graph.addPass(TEMPORAL_HISTORY_RESET_PASS, historyReset);
+
+            const resolve = context.acquirePassParameters(this.#resolvePool);
+            resolve.setBuffer(0, diagnostics);
+            resolve.setBuffer(1, tileList);
+            resolve.setTexture(0, currentReflection);
+            resolve.setTexture(1, currentHit);
+            resolve.setTexture(2, resources.motionDepth);
+            resolve.setTexture(3, resources.materialAttributes);
+            resolve.setTexture(4, resources.reactiveMask);
+            resolve.setTexture(5, resources.reflectionResponse);
+            resolve.setTexture(6, colorHistory.history());
+            resolve.setTexture(7, depthHistory.history());
+            resolve.setTexture(8, stateHistory.history());
+            resolve.setTexture(9, responseHistory.history());
+            resolve.setTexture(10, colorHistory.current);
+            resolve.setTexture(11, depthHistory.current);
+            resolve.setTexture(12, stateHistory.current);
+            resolve.setTexture(13, responseHistory.current);
+            resolve.setIndirectDispatch(dispatchArguments);
             context.graph.addPass(this.#temporalResolvePass, resolve);
         } else {
             const initialize = context.acquirePassParameters(this.#initializePool);
             initialize.setTexture(0, currentReflection);
-            initialize.setTexture(1, resources.motionDepth);
-            initialize.setTexture(2, colorHistory.current);
-            initialize.setTexture(3, depthHistory.current);
+            initialize.setTexture(1, currentHit);
+            initialize.setTexture(2, resources.motionDepth);
+            initialize.setTexture(3, resources.materialAttributes);
+            initialize.setTexture(4, resources.reflectionResponse);
+            initialize.setTexture(5, colorHistory.current);
+            initialize.setTexture(6, depthHistory.current);
+            initialize.setTexture(7, stateHistory.current);
+            initialize.setTexture(8, responseHistory.current);
             initialize.setDispatch(
                 Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
                 Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
@@ -1098,49 +2728,117 @@ export class ScreenSpaceReflectionsController {
             context.graph.addPass(TEMPORAL_INITIALIZE_PASS, initialize);
         }
 
-        let reflectionForComposite: RenderGraphTextureHandle = colorHistory.current;
-        for (let index = 0; index < this.#spatialFilterPasses.length; index += 1) {
-            const filterPass = this.#spatialFilterPasses[index];
-            if (filterPass === undefined) {
-                throw new Error('Screen-space reflections spatial filter pass is missing');
-            }
-            const filtered = context.graph.createTexture(
-                `Screen-space reflections confidence filter ${String(index + 1)}`,
-                this.#reflectionDescriptor
-            );
-            const filter = context.acquirePassParameters(this.#spatialFilterPool);
-            filter.setTexture(0, reflectionForComposite);
-            filter.setTexture(1, resources.motionDepth);
-            filter.setTexture(2, resources.materialAttributes);
-            filter.setTexture(3, filtered);
-            filter.setDispatch(
-                Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
-                Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
-            );
-            context.graph.addPass(filterPass, filter);
-            reflectionForComposite = filtered;
-        }
-
-        const composited = context.graph.createTexture(
-            'Screen-space reflections composited HDR scene',
-            this.#compositeDescriptor
+        const reconstructed = context.graph.createTexture(
+            'Screen-space reflections confidence reconstruction',
+            this.#reflectionDescriptor
         );
+        const reconstructionReset = context.acquirePassParameters(this.#filterResetPool);
+        reconstructionReset.setTexture(0, reconstructed);
+        reconstructionReset.setDispatch(
+            Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
+            Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
+        );
+        context.graph.addPass(SPATIAL_FILTER_RESET_PASS, reconstructionReset);
+
+        const reconstruction = context.acquirePassParameters(this.#spatialFilterPool);
+        reconstruction.setBuffer(0, diagnostics);
+        reconstruction.setBuffer(1, tileList);
+        reconstruction.setTexture(0, colorHistory.current);
+        reconstruction.setTexture(1, resources.motionDepth);
+        reconstruction.setTexture(2, resources.materialAttributes);
+        reconstruction.setTexture(3, stateHistory.current);
+        reconstruction.setTexture(4, responseHistory.current);
+        reconstruction.setTexture(5, reconstructed);
+        reconstruction.setIndirectDispatch(dispatchArguments);
+        context.graph.addPass(this.#spatialReconstructionPass, reconstruction);
+
+        const filtered = context.graph.createTexture(
+            'Screen-space reflections variance-guided stability filter',
+            this.#reflectionDescriptor
+        );
+        const filterReset = context.acquirePassParameters(this.#filterResetPool);
+        filterReset.setTexture(0, filtered);
+        filterReset.setDispatch(
+            Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
+            Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
+        );
+        context.graph.addPass(SPATIAL_FILTER_RESET_PASS, filterReset);
+
+        const filter = context.acquirePassParameters(this.#spatialFilterPool);
+        filter.setBuffer(0, diagnostics);
+        filter.setBuffer(1, tileList);
+        filter.setTexture(0, reconstructed);
+        filter.setTexture(1, resources.motionDepth);
+        filter.setTexture(2, resources.materialAttributes);
+        filter.setTexture(3, stateHistory.current);
+        filter.setTexture(4, responseHistory.current);
+        filter.setTexture(5, filtered);
+        filter.setIndirectDispatch(dispatchArguments);
+        context.graph.addPass(this.#spatialStabilityPass, filter);
+
+        const stabilized = context.graph.createTexture(
+            'Screen-space reflections residual coverage cleanup',
+            this.#reflectionDescriptor
+        );
+        const stabilityReset = context.acquirePassParameters(this.#filterResetPool);
+        stabilityReset.setTexture(0, stabilized);
+        stabilityReset.setDispatch(
+            Math.max(1, Math.ceil(reflectionWidth / TRACE_WORKGROUP_SIZE)),
+            Math.max(1, Math.ceil(reflectionHeight / TRACE_WORKGROUP_SIZE))
+        );
+        context.graph.addPass(SPATIAL_FILTER_RESET_PASS, stabilityReset);
+
+        const stability = context.acquirePassParameters(this.#spatialFilterPool);
+        stability.setBuffer(0, diagnostics);
+        stability.setBuffer(1, tileList);
+        stability.setTexture(0, filtered);
+        stability.setTexture(1, resources.motionDepth);
+        stability.setTexture(2, resources.materialAttributes);
+        stability.setTexture(3, stateHistory.current);
+        stability.setTexture(4, responseHistory.current);
+        stability.setTexture(5, stabilized);
+        stability.setIndirectDispatch(dispatchArguments);
+        context.graph.addPass(this.#spatialCleanupPass, stability);
+
         const composite = context.acquirePassParameters(this.#compositePool);
-        composite.inputTextures.length = 2;
-        composite.inputTextures[0] = resources.sceneColor;
-        composite.inputTextures[1] = reflectionForComposite;
+        composite.inputTextures.length = 4;
+        composite.inputTextures[0] = stabilized;
+        composite.inputTextures[1] = resources.fallbackSpecular;
+        composite.inputTextures[2] = resources.materialAttributes;
+        composite.inputTextures[3] = resources.motionDepth;
         composite.colorAttachments[0] = {
-            texture: composited,
-            loadOp: 'clear',
-            storeOp: 'store',
-            clearValue: { r: 0, g: 0, b: 0, a: 0 }
+            texture: resources.sceneColor,
+            loadOp: 'load',
+            storeOp: 'store'
         };
         context.graph.addPass(this.#compositePass, composite);
-        return composited;
+        return resources.sceneColor;
+    }
+
+    async readDiagnostics(): Promise<Readonly<ScreenSpaceReflectionsDiagnostics>> {
+        if (this.#destroyed) throw new Error('Screen-space reflections controller is destroyed');
+        const result = await this.#diagnostics.read();
+        const values = new Uint32Array(
+            result.data.buffer,
+            result.data.byteOffset,
+            result.data.byteLength / 4
+        );
+        return Object.freeze({
+            activeTileCount: values[0] ?? 0,
+            activePixelCount: values[1] ?? 0,
+            hitPixelCount: values[2] ?? 0,
+            missPixelCount: values[3] ?? 0,
+            uncertainPixelCount: values[4] ?? 0,
+            backfaceRejectedPixelCount: values[5] ?? 0,
+            historyAcceptedPixelCount: values[6] ?? 0,
+            historyRejectedPixelCount: values[7] ?? 0
+        });
     }
 
     destroy(): void {
+        if (this.#destroyed) return;
         this.#destroyed = true;
+        this.#diagnostics.destroy();
     }
 }
 

--- a/src/render/renderer/MeshDrawProcessor.ts
+++ b/src/render/renderer/MeshDrawProcessor.ts
@@ -12,7 +12,10 @@ import type {
 } from '../../material/MaterialInstance';
 import type { MaterialPassRole, MaterialPipelineState } from '../../material/MaterialDefinition';
 import { resolveMaterialPassState } from '../../material/MaterialCompiler';
-import Shader, { getTemporalReactiveShader } from '../../shader/Shader';
+import Shader, {
+    getMaterialReflectionDataShader,
+    getTemporalReactiveShader
+} from '../../shader/Shader';
 import Texture from '../../texture/Texture';
 import BuiltInUniformBlockManager from '../BuiltInUniformBlockManager';
 import type RendererCore from '../RendererCore';
@@ -183,15 +186,20 @@ function validateMaterialPassTarget(
         (target.colorFormats.length === 1 || target.colorFormats[1] === 'r8unorm') &&
         target.sampleCount === 1;
     if (motionTargetValid) return;
-    if (
-        target.colorFormats.length !== 1 ||
-        target.colorFormats[0] !== 'rgba16float' ||
-        target.sampleCount !== 1
-    ) {
+    const materialTargetValid =
+        role === 'material-attributes' &&
+        target.sampleCount === 1 &&
+        target.colorFormats[0] === 'rgba8unorm' &&
+        (target.colorFormats.length === 1 ||
+            (target.colorFormats.length === 3 &&
+                target.colorFormats[1] === target.colorFormats[2] &&
+                (target.colorFormats[1] === 'rg11b10ufloat' ||
+                    target.colorFormats[1] === 'rgba16float')));
+    if (!materialTargetValid) {
         throw new TypeError(
             role === 'motion-vector'
                 ? 'Motion-vector mesh draws require single-sample rgba16float motion and optional r8unorm reactive targets'
-                : 'Material-attributes mesh draws require one single-sample rgba16float color target'
+                : 'Material-attributes mesh draws require single-sample rgba8unorm attributes and optional matching HDR reflection targets'
         );
     }
 }
@@ -224,6 +232,7 @@ interface MeshShaderSnapshot {
     readonly role: MaterialPassRole;
     readonly groundTruthAmbientOcclusion: boolean;
     readonly temporalReactiveMask: boolean;
+    readonly materialReflectionData: boolean;
     readonly shader: Shader;
 }
 
@@ -1653,6 +1662,8 @@ export class MeshDrawProcessor {
             target.colorFormats[0] === 'rgba16float' || target.colorFormats[0] === 'rgba32float';
         const temporalReactiveMask =
             role === 'motion-vector' && target.colorFormats[1] === 'r8unorm';
+        const materialReflectionData =
+            role === 'material-attributes' && target.colorFormats.length === 3;
         const colors = Reflect.get(geometry, 'colors');
         if (
             snapshot?.geometry === geometry &&
@@ -1674,6 +1685,7 @@ export class MeshDrawProcessor {
             snapshot.role === role &&
             snapshot.groundTruthAmbientOcclusion === groundTruthAmbientOcclusion &&
             snapshot.temporalReactiveMask === temporalReactiveMask &&
+            snapshot.materialReflectionData === materialReflectionData &&
             commonShaderOptionsMatch(snapshot.commonOptions)
         ) {
             return snapshot.shader;
@@ -1692,18 +1704,31 @@ export class MeshDrawProcessor {
                   role,
                   groundTruthAmbientOcclusion
               )
-            : Shader.getShader(
-                  mesh,
-                  material,
-                  instanced,
-                  context.lightManager,
-                  context.fog,
-                  context.renderer.useLogDepth,
-                  context.renderer,
-                  linearOutput,
-                  role,
-                  groundTruthAmbientOcclusion
-              );
+            : materialReflectionData
+              ? getMaterialReflectionDataShader(
+                    mesh,
+                    material,
+                    instanced,
+                    context.lightManager,
+                    context.fog,
+                    context.renderer.useLogDepth,
+                    context.renderer,
+                    linearOutput,
+                    role,
+                    groundTruthAmbientOcclusion
+                )
+              : Shader.getShader(
+                    mesh,
+                    material,
+                    instanced,
+                    context.lightManager,
+                    context.fog,
+                    context.renderer.useLogDepth,
+                    context.renderer,
+                    linearOutput,
+                    role,
+                    groundTruthAmbientOcclusion
+                );
         if (!shader) throw new Error(`Material ${material.className} has no renderable shader`);
         if (!canUseSnapshot) {
             this.#shaderSnapshots.delete(mesh);
@@ -1726,6 +1751,7 @@ export class MeshDrawProcessor {
             role,
             groundTruthAmbientOcclusion,
             temporalReactiveMask,
+            materialReflectionData,
             shader
         });
         return shader;
@@ -1785,13 +1811,20 @@ export class MeshDrawProcessor {
             outputs.length === 2 &&
             outputs[0]?.location === 0 &&
             outputs[1]?.location === 1;
+        const builtInMaterialReflectionOutputs =
+            target.colorFormats.length === 3 &&
+            outputs.length === 3 &&
+            outputs[0]?.location === 0 &&
+            outputs[1]?.location === 1 &&
+            outputs[2]?.location === 2;
         if (
             !customMaterial &&
             !builtInReactiveOutputs &&
+            !builtInMaterialReflectionOutputs &&
             (outputs.length !== 1 || outputs[0]?.location !== 0)
         ) {
             throw new TypeError(
-                'Built-in mesh shaders require location zero and may write reactive data at location one'
+                'Built-in mesh shaders require location zero and may write temporal or reflection data to declared MRTs'
             );
         }
         for (let index = 0; index < outputs.length; index += 1) {

--- a/src/shader/Shader.ts
+++ b/src/shader/Shader.ts
@@ -490,6 +490,7 @@ class Shader {
             linearOutput,
             role,
             groundTruthAmbientOcclusion,
+            false,
             false
         );
     }
@@ -683,7 +684,8 @@ function getShaderVariant(
     linearOutput: boolean,
     role: MaterialPassRole,
     groundTruthAmbientOcclusion: boolean,
-    temporalReactiveMask: boolean
+    temporalReactiveMask: boolean,
+    materialReflectionData: boolean
 ): Shader | null {
     let header = Shader.getHeader(mesh, material, lightManager, fog, useLogDepth, role);
     header += `#define HILO_MATERIAL_ROLE_${role.replaceAll('-', '_').replaceAll(':', '_').toUpperCase()} 1\n`;
@@ -692,6 +694,7 @@ function getShaderVariant(
     else if (role === 'motion-vector') header += '#define HILO_MOTION_VECTOR_PASS 1\n';
     else if (role === 'material-attributes') {
         header += '#define HILO_MATERIAL_ATTRIBUTES_PASS 1\n';
+        if (materialReflectionData) header += '#define HILO_SSR_MATERIAL_DATA 1\n';
     } else if (role === 'picking') header += '#define HILO_PICKING_PASS 1\n';
     if (linearOutput) header += '#define HILO_LINEAR_OUTPUT 1\n';
     if (groundTruthAmbientOcclusion) header += '#define HILO_GTAO 1\n';
@@ -740,6 +743,36 @@ export function getTemporalReactiveShader(
         linearOutput,
         role,
         groundTruthAmbientOcclusion,
+        true,
+        false
+    );
+}
+
+/** @internal Resolve the built-in material-attributes variant with SSR response/fallback MRTs. */
+export function getMaterialReflectionDataShader(
+    mesh: Mesh,
+    material: Material,
+    isUseInstance: boolean,
+    lightManager: LightManager,
+    fog: Fog | null,
+    useLogDepth: boolean,
+    renderer?: ShaderPrecisionProvider,
+    linearOutput = false,
+    role: MaterialPassRole = 'material-attributes',
+    groundTruthAmbientOcclusion = false
+): Shader | null {
+    return getShaderVariant(
+        mesh,
+        material,
+        isUseInstance,
+        lightManager,
+        fog,
+        useLogDepth,
+        renderer,
+        linearOutput,
+        role,
+        groundTruthAmbientOcclusion,
+        false,
         true
     );
 }

--- a/src/shader/basic.frag
+++ b/src/shader/basic.frag
@@ -40,6 +40,9 @@ void main(void) {
             #include "./chunk/diffuse_main.frag"
             #include "./chunk/transparency_main.frag"
             hilo_FragColor = hiloMaterialAttributes(normal, 1.0, 0.0, 0.0);
+            #ifdef HILO_SSR_MATERIAL_DATA
+                hiloWriteMaterialReflectionData(vec3(0.0), vec3(0.0));
+            #endif
             #include "./chunk/logDepth_main.frag"
         }
     #else

--- a/src/shader/chunk/materialAttributes.frag
+++ b/src/shader/chunk/materialAttributes.frag
@@ -9,8 +9,18 @@ vec2 hiloEncodeOctahedralNormal(vec3 value) {
         );
         encoded = (1.0 - abs(encoded.yx)) * octahedralSign;
     }
-    return encoded;
+    return encoded * 0.5 + 0.5;
 }
+
+#ifdef HILO_SSR_MATERIAL_DATA
+layout(location=1) out vec4 hilo_ReflectionResponse;
+layout(location=2) out vec4 hilo_ReflectionFallbackSpecular;
+
+void hiloWriteMaterialReflectionData(vec3 response, vec3 fallbackSpecular) {
+    hilo_ReflectionResponse = vec4(max(response, vec3(0.0)), 1.0);
+    hilo_ReflectionFallbackSpecular = vec4(max(fallbackSpecular, vec3(0.0)), 1.0);
+}
+#endif
 
 vec4 hiloMaterialAttributes(
     vec3 viewNormal,
@@ -19,10 +29,11 @@ vec4 hiloMaterialAttributes(
     float reflectionReceiver
 ) {
     float receiverFlag = reflectionReceiver >= 0.5 ? 1.0 : 0.0;
-    float metallicBits = floor(clamp(metallic, 0.0, 1.0) * 255.0 + 0.5);
+    float metallicBits = floor(clamp(metallic, 0.0, 1.0) * 127.0 + 0.5);
+    float packedMaterial = receiverFlag + metallicBits * 2.0;
     return vec4(
         hiloEncodeOctahedralNormal(viewNormal),
         clamp(perceptualRoughness, 0.045, 1.0),
-        receiverFlag + metallicBits * 2.0
+        packedMaterial / 255.0
     );
 }

--- a/src/shader/geometry.frag
+++ b/src/shader/geometry.frag
@@ -39,6 +39,9 @@ void main(void) {
         #else
             hilo_FragColor = hiloMaterialAttributes(vec3(0.0, 0.0, 1.0), 1.0, 0.0, 0.0);
         #endif
+        #ifdef HILO_SSR_MATERIAL_DATA
+            hiloWriteMaterialReflectionData(vec3(0.0), vec3(0.0));
+        #endif
         #include "./chunk/logDepth_main.frag"
     #else
         #if defined(HILO_VERTEX_TYPE_POSITION)

--- a/src/shader/pbr.frag
+++ b/src/shader/pbr.frag
@@ -78,9 +78,287 @@ void main(void) {
                     materialMetallic *= materialMetallicRoughness.b;
                 #endif
             #endif
+            vec3 reflectionTraceNormal = normal;
+            float reflectionTraceRoughness = materialRoughness;
+            #ifdef HILO_SSR_MATERIAL_DATA
+                vec3 reflectionResponse = vec3(0.0);
+                vec3 fallbackSpecular = vec3(0.0);
+                vec3 reflectionAnisotropyT = normal;
+                float reflectionAnisotropyStrength = 0.0;
+                float reflectionClearcoatFactor = 0.0;
+                float reflectionClearcoatRoughness = materialRoughness;
+                #ifdef HILO_HAS_LIGHT
+                    vec3 reflectionView = normalize(-v_fragPos);
+                    #ifdef HILO_HAS_ANISOTROPY
+                        vec2 reflectionAnisotropyDirection = vec2(
+                            cos(u_anisotropyRotation),
+                            sin(u_anisotropyRotation)
+                        );
+                        reflectionAnisotropyStrength = clamp(
+                            u_anisotropyStrength,
+                            0.0,
+                            1.0
+                        );
+                        #ifdef HILO_ANISOTROPY_MAP
+                            vec3 reflectionAnisotropySample = HILO_TEXTURE_2D(
+                                u_anisotropyMap,
+                                HILO_ANISOTROPY_MAP
+                            ).rgb;
+                            vec2 reflectionTextureDirection =
+                                reflectionAnisotropySample.rg * 2.0 - 1.0;
+                            float reflectionTextureDirectionLength =
+                                length(reflectionTextureDirection);
+                            if (reflectionTextureDirectionLength > 1e-4) {
+                                reflectionTextureDirection /=
+                                    reflectionTextureDirectionLength;
+                                reflectionAnisotropyDirection = vec2(
+                                    reflectionAnisotropyDirection.x *
+                                        reflectionTextureDirection.x -
+                                        reflectionAnisotropyDirection.y *
+                                        reflectionTextureDirection.y,
+                                    reflectionAnisotropyDirection.x *
+                                        reflectionTextureDirection.y +
+                                        reflectionAnisotropyDirection.y *
+                                        reflectionTextureDirection.x
+                                );
+                            }
+                            reflectionAnisotropyStrength *=
+                                reflectionAnisotropySample.b;
+                        #endif
+                        reflectionAnisotropyT = normalize(
+                            v_TBN * vec3(reflectionAnisotropyDirection, 0.0)
+                        );
+                        reflectionAnisotropyT = normalize(
+                            reflectionAnisotropyT - normal *
+                                dot(reflectionAnisotropyT, normal)
+                        );
+                        vec3 reflectionAnisotropicNormal = cross(
+                            reflectionAnisotropyT,
+                            reflectionView
+                        );
+                        reflectionAnisotropicNormal = normalize(cross(
+                            reflectionAnisotropicNormal,
+                            reflectionAnisotropyT
+                        ));
+                        float reflectionAnisotropyBend =
+                            reflectionAnisotropyStrength *
+                            (1.0 - materialRoughness);
+                        reflectionTraceNormal = normalize(mix(
+                            normal,
+                            reflectionAnisotropicNormal,
+                            reflectionAnisotropyBend
+                        ));
+                    #endif
+                    #ifdef HILO_HAS_CLEARCOAT
+                        reflectionClearcoatFactor = clamp(
+                            u_clearcoatFactor,
+                            0.0,
+                            1.0
+                        );
+                        #ifdef HILO_CLEARCOAT_MAP
+                            reflectionClearcoatFactor *= HILO_TEXTURE_2D(
+                                u_clearcoatMap,
+                                HILO_CLEARCOAT_MAP
+                            ).r;
+                        #endif
+                        reflectionClearcoatRoughness = clamp(
+                            u_clearcoatRoughnessFactor,
+                            0.045,
+                            1.0
+                        );
+                        #ifdef HILO_CLEARCOAT_ROUGHNESS_MAP
+                            reflectionClearcoatRoughness *= HILO_TEXTURE_2D(
+                                u_clearcoatRoughnessMap,
+                                HILO_CLEARCOAT_ROUGHNESS_MAP
+                            ).g;
+                        #endif
+                        float reflectionTraceClearcoatFresnel =
+                            hiloFresnelSchlickScalar(
+                                0.04,
+                                max(abs(dot(clearcoatNormal, reflectionView)), 1e-4)
+                            );
+                        float reflectionClearcoatDominance = clamp(
+                            reflectionClearcoatFactor *
+                                reflectionTraceClearcoatFresnel,
+                            0.0,
+                            1.0
+                        );
+                        reflectionTraceNormal = normalize(mix(
+                            reflectionTraceNormal,
+                            clearcoatNormal,
+                            reflectionClearcoatDominance
+                        ));
+                        reflectionTraceRoughness = mix(
+                            materialRoughness,
+                            reflectionClearcoatRoughness,
+                            reflectionClearcoatDominance
+                        );
+                    #endif
+                    float reflectionNdotV = max(abs(dot(normal, reflectionView)), 1e-4);
+                    float reflectionAO = 1.0;
+                    #ifdef HILO_OCCLUSION_MAP
+                        reflectionAO = HILO_TEXTURE_2D(
+                            u_occlusionMap,
+                            HILO_OCCLUSION_MAP
+                        ).r;
+                    #endif
+                    #ifdef HILO_OCCLUSION_STRENGTH
+                        reflectionAO = hiloEvaluatePBROcclusion(
+                            reflectionAO,
+                            u_occlusionStrength
+                        );
+                    #endif
+                    #ifdef HILO_GTAO
+                        vec2 reflectionGTAOUV =
+                            (gl_FragCoord.xy - u_viewport.xy) /
+                            max(u_viewport.zw, vec2(1.0));
+                        reflectionAO *= clamp(
+                            texture(u_gtaoTexture, reflectionGTAOUV).b,
+                            0.0,
+                            1.0
+                        );
+                    #endif
+                    #ifdef HILO_PBR_SPECULAR_GLOSSINESS
+                        vec3 reflectionF0 = u_specularColor.rgb;
+                        #ifdef HILO_SPECULAR_GLOSSINESS_MAP
+                            reflectionF0 *= HILO_TEXTURE_2D(
+                                u_specularGlossinessMap,
+                                HILO_SPECULAR_GLOSSINESS_MAP
+                            ).rgb;
+                        #endif
+                    #else
+                        HiloMetallicRoughnessSurface reflectionSurface =
+                            hiloEvaluateMetallicRoughnessSurface(
+                                color,
+                                u_emissionFactor.rgb,
+                                materialMetallic,
+                                materialRoughness,
+                                reflectionAO,
+                                0.0,
+                                u_ior
+                            );
+                        vec3 reflectionF0 = reflectionSurface.specularColor;
+                    #endif
+                    #ifdef HILO_SPECULAR_ENV_MAP
+                        vec2 reflectionDFG = texture(
+                            u_brdfLUT,
+                            hiloTextureUV(vec2(
+                                reflectionNdotV,
+                                1.0 - materialRoughness
+                            ))
+                        ).rg;
+                        vec3 reflectionEnergyCompensation = vec3(1.0) +
+                            reflectionF0 *
+                            (1.0 / max(reflectionDFG.y, 0.04) - 1.0);
+                        reflectionResponse =
+                            (reflectionF0 * reflectionDFG.x + reflectionDFG.y) *
+                            reflectionEnergyCompensation;
+                    #else
+                        reflectionResponse = hiloFresnelSchlick(
+                            reflectionF0,
+                            reflectionNdotV
+                        );
+                    #endif
+                    float reflectionIridescenceFactor = 0.0;
+                    float reflectionIridescenceIor = 1.3;
+                    float reflectionIridescenceThickness = 0.0;
+                    #ifdef HILO_HAS_IRIDESCENCE
+                        reflectionIridescenceFactor = clamp(
+                            u_iridescenceFactor,
+                            0.0,
+                            1.0
+                        );
+                        reflectionIridescenceIor = max(u_iridescenceIor, 1.0);
+                        #ifdef HILO_IRIDESCENCE_MAP
+                            reflectionIridescenceFactor *= HILO_TEXTURE_2D(
+                                u_iridescenceMap,
+                                HILO_IRIDESCENCE_MAP
+                            ).r;
+                        #endif
+                        reflectionIridescenceThickness = max(
+                            u_iridescenceThicknessMaximum,
+                            0.0
+                        );
+                        #ifdef HILO_IRIDESCENCE_THICKNESS_MAP
+                            float reflectionIridescenceThicknessSample =
+                                HILO_TEXTURE_2D(
+                                    u_iridescenceThicknessMap,
+                                    HILO_IRIDESCENCE_THICKNESS_MAP
+                                ).g;
+                            reflectionIridescenceThickness = mix(
+                                u_iridescenceThicknessMinimum,
+                                u_iridescenceThicknessMaximum,
+                                reflectionIridescenceThicknessSample
+                            );
+                        #endif
+                        if (reflectionIridescenceThickness <= 0.0) {
+                            reflectionIridescenceFactor = 0.0;
+                        }
+                        reflectionResponse = mix(
+                            reflectionResponse,
+                            hiloEvaluateIridescence(
+                                1.0,
+                                reflectionIridescenceIor,
+                                reflectionNdotV,
+                                reflectionIridescenceThickness,
+                                reflectionF0
+                            ),
+                            reflectionIridescenceFactor
+                        );
+                    #endif
+                    float reflectionSpecularAO = clamp(
+                        pow(
+                            reflectionNdotV + reflectionAO,
+                            exp2(-16.0 * materialRoughness - 1.0)
+                        ) - 1.0 + reflectionAO,
+                        0.0,
+                        1.0
+                    );
+                    vec3 reflectionRay = -normalize(reflect(
+                        reflectionView,
+                        normal
+                    ));
+                    float reflectionHorizon = min(
+                        1.0 + dot(reflectionRay, normal),
+                        1.0
+                    );
+                    reflectionResponse *= reflectionSpecularAO *
+                        reflectionHorizon * reflectionHorizon;
+                    fallbackSpecular = hiloGetIBLSpecular(
+                        normal,
+                        reflectionView,
+                        reflectionAnisotropyT,
+                        reflectionF0,
+                        materialRoughness,
+                        reflectionAnisotropyStrength,
+                        reflectionIridescenceFactor,
+                        reflectionIridescenceIor,
+                        reflectionIridescenceThickness,
+                        reflectionAO
+                    );
+                    #ifdef HILO_HAS_CLEARCOAT
+                        float reflectionClearcoatFresnel =
+                            hiloFresnelSchlickScalar(
+                                0.04,
+                                max(abs(dot(clearcoatNormal, reflectionView)), 1e-4)
+                            );
+                        reflectionResponse = reflectionResponse *
+                            (1.0 - reflectionClearcoatFactor * reflectionClearcoatFresnel) +
+                            vec3(reflectionClearcoatFactor * reflectionClearcoatFresnel);
+                        fallbackSpecular = fallbackSpecular *
+                            (1.0 - reflectionClearcoatFactor * reflectionClearcoatFresnel) +
+                            reflectionClearcoatFactor * hiloGetIBLClearcoat(
+                                clearcoatNormal,
+                                reflectionView,
+                                reflectionClearcoatRoughness
+                            );
+                    #endif
+                #endif
+                hiloWriteMaterialReflectionData(reflectionResponse, fallbackSpecular);
+            #endif
             hilo_FragColor = hiloMaterialAttributes(
-                normal,
-                materialRoughness,
+                reflectionTraceNormal,
+                reflectionTraceRoughness,
                 materialMetallic,
                 1.0
             );

--- a/test/spec/material/Material.test.ts
+++ b/test/spec/material/Material.test.ts
@@ -145,7 +145,27 @@ describe('modern material model', () => {
             compiler.compile({
                 ...request,
                 target: {
-                    colorFormats: ['rgba16float'],
+                    colorFormats: ['rgba8unorm'],
+                    depthStencilFormat: 'depth32float',
+                    sampleCount: 1
+                }
+            })
+        ).not.toBeNull();
+        expect(
+            compiler.compile({
+                ...request,
+                target: {
+                    colorFormats: ['rgba8unorm', 'rgba16float', 'rgba16float'],
+                    depthStencilFormat: 'depth32float',
+                    sampleCount: 1
+                }
+            })
+        ).not.toBeNull();
+        expect(
+            compiler.compile({
+                ...request,
+                target: {
+                    colorFormats: ['rgba8unorm', 'rg11b10ufloat', 'rg11b10ufloat'],
                     depthStencilFormat: 'depth32float',
                     sampleCount: 1
                 }
@@ -155,12 +175,12 @@ describe('modern material model', () => {
             compiler.compile({
                 ...request,
                 target: {
-                    colorFormats: ['rgba8unorm'],
+                    colorFormats: ['rgba16float'],
                     depthStencilFormat: 'depth32float',
                     sampleCount: 1
                 }
             })
-        ).toThrow(/Material attributes role requires one single-sample rgba16float/u);
+        ).toThrow(/single-sample rgba8unorm attributes/u);
     });
 
     it('accepts the optional authored reactive target for motion vectors', () => {

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -167,7 +167,9 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             screenSpaceReflections: { resolutionScale: 1 }
         });
         expect(
-            fullResolution4KReflections.requirements.requiredLimits.maxComputeWorkgroupsPerDimension
+            fullResolution4KReflections.requirements.requiredLimits?.[
+                'maxComputeWorkgroupsPerDimension'
+            ]
         ).toBe(65_535);
 
         const withGTAO = new ClusteredForwardPlusPipelineFactory({

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -27,9 +27,15 @@ import {
     unregisterRendererDiagnostics
 } from '../../../src/render/diagnostics/RendererDiagnosticsRegistry';
 import { ClusteredForwardPlusPipelineFactory } from '../../../src/render/pipeline/ClusteredForwardPlus';
+import type { RenderPipelineCreateContext } from '../../../src/render/pipeline/RenderPipeline';
 import { FullscreenRenderPass } from '../../../src/render/pipeline/passes';
+import {
+    ScreenSpaceReflectionsController,
+    snapshotScreenSpaceReflectionsOptions
+} from '../../../src/render/postprocessing/ScreenSpaceReflections';
 import { MeshDrawProcessor } from '../../../src/render/renderer/MeshDrawProcessor';
 import type { RHIDevice } from '../../../src/render/rhi/core';
+import type { StorageBuffer } from '../../../src/render/StorageBuffer';
 import Texture from '../../../src/texture/Texture';
 import { RGBA, TEXTURE_2D, UNSIGNED_BYTE } from '../../../src/constants/webgl';
 import { RGBA8 } from '../../../src/constants/webgl2';
@@ -236,6 +242,50 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 { format: 'r32float', use: 'storage' }
             ])
         );
+    });
+
+    it('constructs, reads, and releases the screen-space reflection runtime', async () => {
+        const counters = new Uint32Array([1, 2, 3, 4, 5, 6, 7, 8]);
+        const destroy = vi.fn();
+        const read = vi.fn(() =>
+            Promise.resolve({
+                data: new Uint8Array(counters.buffer),
+                byteOffset: 0,
+                byteLength: counters.byteLength
+            })
+        );
+        const diagnostics = { destroy, read } as unknown as StorageBuffer;
+        const createStorageBuffer = vi.fn(() => diagnostics);
+        const context = { createStorageBuffer } as unknown as RenderPipelineCreateContext;
+        const settings = snapshotScreenSpaceReflectionsOptions({ maxSteps: 8 });
+
+        expect(() => new ScreenSpaceReflectionsController(settings, context, 1, 0)).toThrow(
+            /at least one Hi-Z level/u
+        );
+
+        const controller = new ScreenSpaceReflectionsController(settings, context, 0.75, 12);
+        expect(createStorageBuffer).toHaveBeenCalledOnce();
+        expect(createStorageBuffer).toHaveBeenCalledWith({
+            label: 'Screen-space reflections diagnostics',
+            byteLength: 32,
+            usage: ['storage', 'copy-source'],
+            recovery: 'reinitialize'
+        });
+        await expect(controller.readDiagnostics()).resolves.toEqual({
+            activeTileCount: 1,
+            activePixelCount: 2,
+            hitPixelCount: 3,
+            missPixelCount: 4,
+            uncertainPixelCount: 5,
+            backfaceRejectedPixelCount: 6,
+            historyAcceptedPixelCount: 7,
+            historyRejectedPixelCount: 8
+        });
+
+        controller.destroy();
+        controller.destroy();
+        expect(destroy).toHaveBeenCalledOnce();
+        await expect(controller.readDiagnostics()).rejects.toThrow(/is destroyed/u);
     });
 
     it('validates bucket identities, opaque materials, and unique LOD thresholds', () => {

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -140,17 +140,35 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             screenSpaceReflections: {}
         });
         expect(withReflections.requirements.requiredLimits).toMatchObject({
-            maxStorageTexturesPerShaderStage: 2,
-            maxSampledTexturesPerShaderStage: 14,
+            maxStorageTexturesPerShaderStage: 4,
+            maxSampledTexturesPerShaderStage: 16,
             maxColorAttachments: 4
         });
         expect(withReflections.requirements.requiredTextureFormats).toEqual(
             expect.arrayContaining([
                 { format: 'rgba16float', use: 'storage' },
                 { format: 'r32float', use: 'storage' },
-                { format: 'rg32float', use: 'storage' }
+                { format: 'rg32float', use: 'storage' },
+                { format: 'rgba8unorm', use: 'color-attachment' },
+                { format: 'rgba8unorm', use: 'filterable-sampled' }
             ])
         );
+
+        const fullResolution4KReflections = new ClusteredForwardPlusPipelineFactory({
+            buckets: [{ geometry, material }],
+            maxObjects: 1,
+            maxLights: 1,
+            maxLightIndices: 1,
+            maxLightsPerCluster: 1,
+            zSlices: 1,
+            maxViewportWidth: 3_840,
+            maxViewportHeight: 2_160,
+            temporalAA: {},
+            screenSpaceReflections: { resolutionScale: 1 }
+        });
+        expect(
+            fullResolution4KReflections.requirements.requiredLimits.maxComputeWorkgroupsPerDimension
+        ).toBe(65_535);
 
         const withGTAO = new ClusteredForwardPlusPipelineFactory({
             buckets: [{ geometry, material }],
@@ -360,6 +378,22 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                     screenSpaceReflections: { maxSteps: 7 }
                 })
         ).toThrow(/maxSteps/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    temporalAA: {},
+                    screenSpaceReflections: { maxRayDistance: 1, stride: 0.3 }
+                })
+        ).toThrow(/at least four stride steps/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    temporalAA: {},
+                    screenSpaceReflections: { maxRayDistance: 1, thickness: 0.6 }
+                })
+        ).toThrow(/must not exceed half maxRayDistance/u);
         expect(
             () =>
                 new ClusteredForwardPlusPipelineFactory({
@@ -981,7 +1015,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
     );
 
     it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
-        'integrates GTAO before indirect clustered PBR shading',
+        'integrates GTAO into GPU Scene and Forward fallback SSR reflection data',
         async () => {
             const geometry = new BoxGeometry();
             const material = new PBRMaterial({
@@ -997,9 +1031,12 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 maxLightsPerCluster: 1,
                 maxViewportWidth: 64,
                 maxViewportHeight: 64,
-                hiZ: false,
                 bloomStrength: 0,
                 temporalAA: {},
+                screenSpaceReflections: {
+                    resolutionScale: 0.5,
+                    maxSteps: 8
+                },
                 groundTruthAmbientOcclusion: {
                     directionCount: 4,
                     stepCount: 3,
@@ -1020,6 +1057,19 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             try {
                 const scene = new Node();
                 new Mesh({ geometry, material, frustumTest: false }).addTo(scene);
+                new Mesh({
+                    geometry: new BoxGeometry(),
+                    material: new PBRMaterial({
+                        baseColor: new Color(0.3, 0.45, 0.75),
+                        metallic: 0.35,
+                        roughness: 0.3,
+                        iridescenceFactor: 0.7,
+                        iridescenceThicknessMinimum: 180,
+                        iridescenceThicknessMaximum: 420
+                    }),
+                    x: 1.25,
+                    frustumTest: false
+                }).addTo(scene);
                 new PointLight({ amount: 4, range: 8, z: 3 }).addTo(scene);
                 const camera = new PerspectiveCamera({
                     aspect: 1,
@@ -1036,7 +1086,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
 
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 1,
-                    fallbackObjectCount: 0
+                    fallbackObjectCount: 1
                 });
                 expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
                 const passNames = rendererDiagnostics
@@ -1047,7 +1097,10 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                         'GPU Scene GTAO material attributes',
                         'GTAO rotated horizon search',
                         'GTAO production temporal resolve',
-                        'Clustered PBR buckets'
+                        'Clustered PBR buckets',
+                        'Clustered Forward+ fallback material attributes',
+                        'Screen-space reflections finalize indirect tile dispatch',
+                        'Hierarchical screen-space reflection trace'
                     ])
                 );
             } finally {
@@ -1094,7 +1147,11 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 maxViewportWidth: 128,
                 maxViewportHeight: 128,
                 temporalAA: { renderScale: 0.75 },
-                screenSpaceReflections: { resolutionScale: 0.5, maxSteps: 8 },
+                screenSpaceReflections: {
+                    resolutionScale: 0.5,
+                    maxSteps: 8,
+                    roughnessCutoff: 0.25
+                },
                 volumetricLighting: {
                     quality: 'low',
                     density: 0.018,
@@ -1171,6 +1228,20 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 expect(diagnostics.hiZValid).toBe(true);
                 expect(diagnostics.volumetricFroxelCount).toBeGreaterThan(0);
                 expect(diagnostics.volumetricHistoryUsed).toBe(true);
+                expect(diagnostics.screenSpaceReflectionActiveTileCount).toBeGreaterThan(0);
+                expect(diagnostics.screenSpaceReflectionActivePixelCount).toBeGreaterThan(0);
+                expect(
+                    diagnostics.screenSpaceReflectionHitPixelCount +
+                        diagnostics.screenSpaceReflectionMissPixelCount
+                ).toBe(diagnostics.screenSpaceReflectionActivePixelCount);
+                expect(
+                    diagnostics.screenSpaceReflectionUncertainPixelCount +
+                        diagnostics.screenSpaceReflectionBackfaceRejectedPixelCount
+                ).toBeLessThanOrEqual(diagnostics.screenSpaceReflectionMissPixelCount);
+                expect(
+                    diagnostics.screenSpaceReflectionHistoryAcceptedPixelCount +
+                        diagnostics.screenSpaceReflectionHistoryRejectedPixelCount
+                ).toBeGreaterThan(0);
                 expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
                 const passNames = rendererDiagnostics
                     .snapshot()
@@ -1182,7 +1253,20 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                     passNames?.indexOf('GPU Scene current depth Hi-Z min/max mip zero') ?? -1;
                 expect(fallbackDepthIndex).toBeGreaterThan(-1);
                 expect(currentHiZIndex).toBeGreaterThan(fallbackDepthIndex);
-                expect(passNames).toContain('Screen-space reflections confidence filter step 8');
+                expect(passNames).toContain('Screen-space reflections adaptive confidence filter');
+                expect(passNames).toContain(
+                    'Screen-space reflections variance-guided stability filter'
+                );
+                expect(passNames).toContain(
+                    'Screen-space reflections residual coverage cleanup filter'
+                );
+                expect(passNames).toEqual(
+                    expect.arrayContaining([
+                        'Screen-space reflections active tile classification',
+                        'Screen-space reflections coherent tile compaction',
+                        'Hierarchical screen-space reflection trace'
+                    ])
+                );
                 expect(passNames).toEqual(
                     expect.arrayContaining([
                         'Froxel volumetric light and density injection',
@@ -1192,6 +1276,44 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                         'Volumetric lighting linear HDR composite'
                     ])
                 );
+
+                material.roughness = 1;
+                renderer.render(scene, camera);
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                expect(
+                    (await factory.readDiagnostics()).screenSpaceReflectionActivePixelCount
+                ).toBe(0);
+                material.roughness = 0.28;
+                renderer.render(scene, camera);
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                expect(
+                    (await factory.readDiagnostics()).screenSpaceReflectionActivePixelCount
+                ).toBeGreaterThan(0);
+
+                material.metallic = 0.9;
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                expect(
+                    (await factory.readDiagnostics()).screenSpaceReflectionHistoryRejectedPixelCount
+                ).toBeGreaterThan(0);
+                material.metallic = 0.35;
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+
+                const movingMesh = meshes[0];
+                if (movingMesh === undefined) throw new Error('Expected a moving SSR fixture mesh');
+                movingMesh.x += 0.35;
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
+                const movingDiagnostics = await factory.readDiagnostics();
+                expect(
+                    movingDiagnostics.screenSpaceReflectionHitPixelCount +
+                        movingDiagnostics.screenSpaceReflectionMissPixelCount
+                ).toBe(movingDiagnostics.screenSpaceReflectionActivePixelCount);
+                renderer.render(scene, camera);
+                await renderer.waitForIdle();
 
                 camera.setPosition(0.25, 0, 8).lookAt(new Vector3(0, 0, 0));
                 renderer.render(scene, camera);

--- a/test/spec/renderer/PostProcessing.test.ts
+++ b/test/spec/renderer/PostProcessing.test.ts
@@ -220,7 +220,8 @@ describe('built-in post-processing', () => {
                 { format: 'rgba16float', use: 'filterable-sampled' },
                 { format: 'r32float', use: 'color-attachment' },
                 { format: 'r32float', use: 'sampled' },
-                { format: 'rgba8unorm', use: 'color-attachment' }
+                { format: 'rgba8unorm', use: 'color-attachment' },
+                { format: 'rgba8unorm', use: 'filterable-sampled' }
             ])
         );
     });

--- a/test/ui/screen-space-reflections.spec.ts
+++ b/test/ui/screen-space-reflections.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 import { PNG } from 'pngjs';
 
 interface PixelDifference {
@@ -6,24 +6,42 @@ interface PixelDifference {
     readonly meanChannelDelta: number;
 }
 
-function pixelDifference(referenceBuffer: Buffer, candidateBuffer: Buffer): PixelDifference {
+interface NormalizedPixelRegion {
+    readonly left: number;
+    readonly top: number;
+    readonly right: number;
+    readonly bottom: number;
+}
+
+function pixelDifference(
+    referenceBuffer: Buffer,
+    candidateBuffer: Buffer,
+    region: Readonly<NormalizedPixelRegion> = { left: 0, top: 0, right: 1, bottom: 1 }
+): PixelDifference {
     const reference = PNG.sync.read(referenceBuffer);
     const candidate = PNG.sync.read(candidateBuffer);
     expect(candidate.width).toBe(reference.width);
     expect(candidate.height).toBe(reference.height);
+    const left = Math.floor(reference.width * region.left);
+    const top = Math.floor(reference.height * region.top);
+    const right = Math.ceil(reference.width * region.right);
+    const bottom = Math.ceil(reference.height * region.bottom);
     let changed = 0;
     let totalDelta = 0;
-    const pixelCount = reference.width * reference.height;
-    for (let offset = 0; offset < reference.data.length; offset += 4) {
-        const red = Math.abs((reference.data[offset] ?? 0) - (candidate.data[offset] ?? 0));
-        const green = Math.abs(
-            (reference.data[offset + 1] ?? 0) - (candidate.data[offset + 1] ?? 0)
-        );
-        const blue = Math.abs(
-            (reference.data[offset + 2] ?? 0) - (candidate.data[offset + 2] ?? 0)
-        );
-        totalDelta += red + green + blue;
-        if (Math.max(red, green, blue) > 5) changed++;
+    const pixelCount = (right - left) * (bottom - top);
+    for (let y = top; y < bottom; y += 1) {
+        for (let x = left; x < right; x += 1) {
+            const offset = (y * reference.width + x) * 4;
+            const red = Math.abs((reference.data[offset] ?? 0) - (candidate.data[offset] ?? 0));
+            const green = Math.abs(
+                (reference.data[offset + 1] ?? 0) - (candidate.data[offset + 1] ?? 0)
+            );
+            const blue = Math.abs(
+                (reference.data[offset + 2] ?? 0) - (candidate.data[offset + 2] ?? 0)
+            );
+            totalDelta += red + green + blue;
+            if (Math.max(red, green, blue) > 5) changed++;
+        }
     }
     return {
         changedRatio: changed / pixelCount,
@@ -31,8 +49,31 @@ function pixelDifference(referenceBuffer: Buffer, candidateBuffer: Buffer): Pixe
     };
 }
 
+async function worstConsecutiveDifference(
+    page: Page,
+    canvas: Locator,
+    initialFrame: Buffer,
+    region: Readonly<NormalizedPixelRegion>,
+    frameCount: number
+): Promise<PixelDifference> {
+    let previousFrame = initialFrame;
+    let changedRatio = 0;
+    let meanChannelDelta = 0;
+    for (let frame = 0; frame < frameCount; frame += 1) {
+        await page.evaluate(async () => {
+            await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(1);
+        });
+        const staticFrame = await canvas.screenshot({ animations: 'disabled' });
+        const difference = pixelDifference(previousFrame, staticFrame, region);
+        changedRatio = Math.max(changedRatio, difference.changedRatio);
+        meanChannelDelta = Math.max(meanChannelDelta, difference.meanChannelDelta);
+        previousFrame = staticFrame;
+    }
+    return { changedRatio, meanChannelDelta };
+}
+
 test('renders a stable and visually material SSR contribution in Afterimage', async ({ page }) => {
-    test.setTimeout(120_000);
+    test.setTimeout(180_000);
     const consoleErrors: string[] = [];
     const pageErrors: string[] = [];
     const gpuValidationErrors: string[] = [];
@@ -63,11 +104,24 @@ test('renders a stable and visually material SSR contribution in Afterimage', as
         hiZValid: true,
         screenSpaceReflections: true,
         temporalAA: true,
+        resolutionScale: 0.5,
         surfaceFinish: 'smoked lacquer',
         heroAsset: 'Khronos Car Concept'
     });
     expect(evidence?.objectCount).toBeGreaterThan(0);
     expect(evidence?.fallbackObjectCount).toBeGreaterThan(0);
+    expect(evidence?.activeTileCount).toBeGreaterThan(0);
+    expect(evidence?.activePixelCount).toBeGreaterThan(0);
+    expect(evidence?.hitPixelCount).toBeGreaterThan(0);
+    expect((evidence?.hitPixelCount ?? 0) + (evidence?.missPixelCount ?? 0)).toBe(
+        evidence?.activePixelCount
+    );
+    expect(
+        (evidence?.uncertainPixelCount ?? 0) + (evidence?.backfaceRejectedPixelCount ?? 0)
+    ).toBeLessThanOrEqual(evidence?.missPixelCount ?? 0);
+    expect(
+        (evidence?.historyAcceptedPixelCount ?? 0) + (evidence?.historyRejectedPixelCount ?? 0)
+    ).toBeGreaterThan(0);
 
     const canvas = page.locator('canvas');
     await page.evaluate(async () => {
@@ -81,6 +135,110 @@ test('renders a stable and visually material SSR contribution in Afterimage', as
     const stability = pixelDifference(reflected, nextStaticFrame);
     expect(stability.changedRatio).toBeLessThan(0.16);
     expect(stability.meanChannelDelta).toBeLessThan(3.5);
+    const reflectionRegion = {
+        left: 0.5,
+        top: 0.62,
+        right: 0.88,
+        bottom: 0.9
+    } as const;
+    const initialReflectionStability = pixelDifference(
+        reflected,
+        nextStaticFrame,
+        reflectionRegion
+    );
+    const additionalReflectionStability = await worstConsecutiveDifference(
+        page,
+        canvas,
+        nextStaticFrame,
+        reflectionRegion,
+        4
+    );
+    expect(
+        Math.max(
+            initialReflectionStability.changedRatio,
+            additionalReflectionStability.changedRatio
+        )
+    ).toBeLessThan(0.075);
+    expect(
+        Math.max(
+            initialReflectionStability.meanChannelDelta,
+            additionalReflectionStability.meanChannelDelta
+        )
+    ).toBeLessThan(1.5);
+
+    await page.evaluate(async () => {
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.setGrazingCamera();
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24);
+    });
+    const grazingReflection = await canvas.screenshot({ animations: 'disabled' });
+    const grazingStability = await worstConsecutiveDifference(
+        page,
+        canvas,
+        grazingReflection,
+        { left: 0.2, top: 0.6, right: 0.92, bottom: 0.92 },
+        4
+    );
+    expect(grazingStability.changedRatio).toBeLessThan(0.1);
+    expect(grazingStability.meanChannelDelta).toBeLessThan(2);
+
+    const defaultStochasticActivePixels = evidence?.activePixelCount ?? 0;
+    const deterministicActivePixels = await page.evaluate(async () => {
+        const activePixels =
+            (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(0.08)) ?? -1;
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(12);
+        return activePixels;
+    });
+    expect(deterministicActivePixels).toBeGreaterThan(0);
+    const deterministicReflection = await canvas.screenshot({ animations: 'disabled' });
+    const deterministicStability = await worstConsecutiveDifference(
+        page,
+        canvas,
+        deterministicReflection,
+        reflectionRegion,
+        3
+    );
+    expect(deterministicStability.changedRatio).toBeLessThan(0.1);
+    expect(deterministicStability.meanChannelDelta).toBeLessThan(1.5);
+
+    const stochasticActivePixels = await page.evaluate(async () => {
+        const activePixels =
+            (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(0.24)) ?? -1;
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24);
+        return activePixels;
+    });
+    expect(stochasticActivePixels).toBeGreaterThan(0);
+    const stochasticReflection = await canvas.screenshot({ animations: 'disabled' });
+    const stochasticStability = await worstConsecutiveDifference(
+        page,
+        canvas,
+        stochasticReflection,
+        reflectionRegion,
+        4
+    );
+    expect(stochasticStability.changedRatio).toBeLessThan(0.12);
+    expect(stochasticStability.meanChannelDelta).toBeLessThan(2);
+
+    const roughActivePixels = await page.evaluate(async () => {
+        return (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(1)) ?? -1;
+    });
+    expect(roughActivePixels).toBeGreaterThanOrEqual(0);
+    expect(roughActivePixels).toBeLessThan(defaultStochasticActivePixels);
+    await page.evaluate(async () => {
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(0.16);
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.moveCamera();
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.moveHero();
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(12);
+    });
+    const movedSettled = await canvas.screenshot({ animations: 'disabled' });
+    await page.evaluate(async () => {
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(1);
+    });
+    const movedNextFrame = await canvas.screenshot({ animations: 'disabled' });
+    const movedContribution = pixelDifference(reflected, movedSettled);
+    expect(movedContribution.changedRatio).toBeGreaterThan(0.01);
+    const movedStability = pixelDifference(movedSettled, movedNextFrame);
+    expect(movedStability.changedRatio).toBeLessThan(0.18);
+    expect(movedStability.meanChannelDelta).toBeLessThan(4);
 
     await page.goto(
         `${examplesOrigin}/examples/screen_space_reflections_palace.html?backend=webgpu&test=1&ssr=false`,
@@ -115,6 +273,15 @@ declare global {
             readonly fallbackObjectCount: number;
             readonly visibleObjectCount: number;
             readonly hiZValid: boolean;
+            readonly activeTileCount: number;
+            readonly activePixelCount: number;
+            readonly hitPixelCount: number;
+            readonly missPixelCount: number;
+            readonly uncertainPixelCount: number;
+            readonly backfaceRejectedPixelCount: number;
+            readonly historyAcceptedPixelCount: number;
+            readonly historyRejectedPixelCount: number;
+            readonly resolutionScale: 0.5;
             readonly screenSpaceReflections: boolean;
             readonly temporalAA: true;
             readonly surfaceFinish: 'smoked lacquer';
@@ -122,6 +289,10 @@ declare global {
         };
         __HILO3D_SSR_PALACE_TEST_API__?: {
             settle(frames?: number): Promise<void>;
+            moveCamera(): Promise<void>;
+            setGrazingCamera(): Promise<void>;
+            moveHero(deltaX?: number): Promise<void>;
+            setFloorRoughness(value: number): Promise<number>;
         };
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade the WebGPU high-end SSR path with response-aware tile compaction, stochastic visible-GGX tracing, refined hit validation, temporal rejection, and adaptive spatial filtering.
- Align GPU Scene and ordinary Forward reflection response/fallback data with the main PBR path, including GTAO, anisotropy, clearcoat, and iridescence behavior.
- Harden 4K full-resolution dispatch limits, make miss diagnostics mutually exclusive, retain material/response continuity in history, and update the SSR example, tests, API report, changelog, and architecture documentation.

## Validation

- npm run typecheck
- npm run lint
- npm run format:check
- targeted Vitest: 37 passed
- npm run test:render:architecture: 144 passed
- npm run test:rhi: 213 passed; native 3 passed, 1 skipped
- npm run test:webgpu: 19 passed
- npm run api:check
- npm run docs:check
- git diff --check

Full npm run validate was not run; the renderer, RHI, shader, and real WebGPU lanes affected by this change were covered.