### PR TITLE
feat(render): add GPU virtual shadow maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,15 @@
   receiver-driven local/cascade resolution; deterministic slice budgets and 1/2/4/8-frame CSM
   cadence; and submission-aware 128-pixel page residency with coalesced page-scissored updates that
   avoid replaying the caster queue once per adjacent page. Expose page
-  request/update/defer/residency and budget-overflow counts in frame diagnostics. Arbitrary physical
-  page remapping, GPU receiver/depth requests, and directional clipmaps remain future work.
+  request/update/defer/residency and budget-overflow counts in frame diagnostics.
+- Add opt-in WebGPU Clustered virtual directional shadows through
+  `ClusteredForwardPlusPipelineOptions.virtualShadows`: previous-Hi-Z receiver classification,
+  atomic GPU request deduplication and deterministic ordering, arbitrary logical-to-physical page
+  remapping with LRU eviction, deferred dirty-page retry, per-page GPU caster compact/indirect depth
+  draws, and camera-centered directional clipmaps. Double-buffer page tables, residency, and clipmap
+  epochs commit only after successful submission; failed frames roll back and device recovery
+  reinitializes mappings without CPU request readback. Expose on-demand virtual-shadow diagnostics
+  and retain shared CSM fallback for missing pages and non-GPU caster scenes.
 - Complete the WebGPU high-end Clustered Forward+ P0 closure. Globally sorted compatible transparent
   PBR and direct GPU Scene skin, morph, and layered glTF PBR now consume the native storage light
   list, while mixed Transmission/custom/particle transparent queues fail closed to the shared

--- a/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
+++ b/documentation/MODERN_WEBGPU_RENDERING_ROADMAP.md
@@ -32,14 +32,15 @@ Draw、HDR/PBR、设备丢失恢复、严格帧事务、TAA/TAAU、GTAO、SSR、
 5. **阴影缓存与虚拟页**：共享 Shadow Atlas、CSM、Spot/Point shadow、Clustered surface
    sampling、submission-aware stable-slice 内容缓存、GPU Scene caster cull、receiver-driven
    resolution/update budget、CSM cadence，以及固定 atlas 内的 submission-aware page
-   residency 已完成；GPU receiver/depth request、任意 physical-page remap/page table 与 directional
-   clipmap 仍未完成。
+   residency 已完成；WebGPU Clustered opt-in 路径还具备 GPU receiver/depth
+   request、bitset 去重/确定排序、任意 physical-page remap/page table、LRU eviction 和 directional
+   clipmap。
 6. **现代资源与几何虚拟化**：GPU Scene 已有 projected-radius bucket LOD，但仍没有 meshlet/cluster
    geometry streaming、KTX 2/Basis、mip
-   residency、虚拟纹理或虚拟阴影页系统；SSGI 已覆盖屏幕内漫反射传输，off-screen probe/software-BVH
+   residency 或虚拟纹理；SSGI 已覆盖屏幕内漫反射传输，off-screen probe/software-BVH
    fallback 仍属于 GI0。
 
-最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 P0 功能闭环上登记物理 GPU 性能证据，再进入 S0/A0：
+最值得先做的不是直接复刻 Nanite 或 Lumen，而是在已经完成的 P0/S0 功能闭环上登记物理 GPU 性能证据，再进入 A0：
 
 ```mermaid
 flowchart LR
@@ -52,8 +53,8 @@ flowchart LR
   G --> V["已完成切片：Froxel / Atmosphere / Clouds"]
   G --> P0["已完成：透明 / 变形 / Layered PBR / 时域策略"]
   T --> P0
-  P0 --> PERF["下一步：登记物理 GPU 性能基线"]
-  PERF --> S["S0：Shadow cache / caster cull / pages"]
+  P0 --> S["已完成 opt-in：S0 Shadow cache / caster cull / pages"]
+  S --> PERF["下一步：登记物理 GPU 性能基线"]
   P0 --> A["A0：KTX2 / Mip / Geometry streaming"]
   A --> M["M0：Meshlet / Cluster LOD"]
   Q --> GI["GI0：Probe / Software-BVH off-screen fallback"]
@@ -114,21 +115,21 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 
 ## 2. 当前渲染能力基线
 
-| 领域                                 | 当前状态          | 证据与边界                                                                                                                                                                                                    |
-| ------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Shared Renderer / Render Graph / RHI | 生产可用          | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                                                                                                     |
-| Raster PBR / HDR                     | 生产可用          | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                                                                          |
-| Shadow                               | 生产缓存与固定页  | 统一 atlas、方向光 1–4 级 CSM、Spot/Point shadow、PCF、stable-slice cache、Clustered GPU caster cull、receiver/budget/cadence 与固定物理页 residency；仍缺 GPU page request、任意 page-table remap 和 clipmap |
-| Compute / Storage / Indirect         | 底座生产可用      | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                                                                     |
-| Material architecture                | high-end P0 完成  | Definition/Instance、语义 Pass、共享 PBR GPU record，以及 variant manifest、异步 warmup、预算和诊断已落地；更多 family 按需扩展                                                                               |
-| GPU-driven ordinary scene            | high-end P0 完成  | opaque/alpha-mask 走固定 bucket indirect；skin/morph/layered PBR 走 GPU Scene direct storage lane；兼容透明保留全局排序并消费 clustered light list                                                            |
-| Forward+                             | high-end P0 完成  | 3D cluster、有界预算、storage GGX PBR、共享 shadow/LTC、透明/变形/layered consumer、analytic cookie/IES 与 uint32 light-layer ABI 已闭环                                                                      |
-| Temporal rendering                   | high-end P0 完成  | opaque TAAU、GPU-time dynamic resolution、authored reactive，以及透明/transmission/GPU-particle 独立 short history 与 resurrection 已完成                                                                     |
-| Exposure / display transform         | WebGPU 生产切片   | 独立 Forward `AutoExposure` 与 Clustered 集成都具备 GPU histogram、asymmetric eye adaptation、submission-aware history；`ColorUber` 有参数化 filmic，Clustered 有 compact filmic                              |
-| Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；SSR miss 保留 forward environment/probe baseline，透明/离屏几何不参与 trace，BVH/SDF fallback 待 GI0                               |
-| Volumetrics / atmosphere             | high-end 生产切片 | WebGPU Clustered froxel、height/local fog、screen-space caster visibility、physical atmosphere LUT、aerial perspective、temporal clouds，以及 surface/froxel cloud shadow 已落地                              |
-| Geometry / texture streaming         | 仅 bucket LOD     | GPU Scene 已有 projected-radius geometry bucket LOD；没有 meshlet/cluster streaming、KTX 2/Basis 或 mip residency，KTX loader 仅支持 KTX 1.1 单面 2D 容器                                                     |
-| GPU profiling / graph debugging      | 生产基线          | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 且无内部 timing consumer 时不创建 query                                                                              |
+| 领域                                 | 当前状态          | 证据与边界                                                                                                                                                                                                                                  |
+| ------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared Renderer / Render Graph / RHI | 生产可用          | 单一共享前端、显式 graph、双后端、submission-aware 生命周期和恢复已经完成                                                                                                                                                                   |
+| Raster PBR / HDR                     | 生产可用          | layered glTF PBR、IBL、LTC area light、transmission、`rgba16float`、Bloom、Color Uber 已接入共享路径                                                                                                                                        |
+| Shadow                               | 生产缓存与虚拟页  | 统一 atlas、方向光 CSM、Spot/Point shadow、stable-slice cache 与固定页 residency；WebGPU Clustered opt-in 再提供 GPU request/dedup/order、任意 page-table remap、LRU physical atlas 与 directional clipmap，非 GPU caster 回退 stable atlas |
+| Compute / Storage / Indirect         | 底座生产可用      | Direct WGSL compute、storage buffer/texture、indirect dispatch/draw、readback、恢复和 graph hazard 已闭环                                                                                                                                   |
+| Material architecture                | high-end P0 完成  | Definition/Instance、语义 Pass、共享 PBR GPU record，以及 variant manifest、异步 warmup、预算和诊断已落地；更多 family 按需扩展                                                                                                             |
+| GPU-driven ordinary scene            | high-end P0 完成  | opaque/alpha-mask 走固定 bucket indirect；skin/morph/layered PBR 走 GPU Scene direct storage lane；兼容透明保留全局排序并消费 clustered light list                                                                                          |
+| Forward+                             | high-end P0 完成  | 3D cluster、有界预算、storage GGX PBR、共享 shadow/LTC、透明/变形/layered consumer、analytic cookie/IES 与 uint32 light-layer ABI 已闭环                                                                                                    |
+| Temporal rendering                   | high-end P0 完成  | opaque TAAU、GPU-time dynamic resolution、authored reactive，以及透明/transmission/GPU-particle 独立 short history 与 resurrection 已完成                                                                                                   |
+| Exposure / display transform         | WebGPU 生产切片   | 独立 Forward `AutoExposure` 与 Clustered 集成都具备 GPU histogram、asymmetric eye adaptation、submission-aware history；`ColorUber` 有参数化 filmic，Clustered 有 compact filmic                                                            |
+| Screen-space lighting                | Q0 生产切片完成   | portable Forward/Clustered GTAO 与 SSGI、WebGPU Clustered Hi-Z SSR 已完成；SSR miss 保留 forward environment/probe baseline，透明/离屏几何不参与 trace，BVH/SDF fallback 待 GI0                                                             |
+| Volumetrics / atmosphere             | high-end 生产切片 | WebGPU Clustered froxel、height/local fog、screen-space caster visibility、physical atmosphere LUT、aerial perspective、temporal clouds，以及 surface/froxel cloud shadow 已落地                                                            |
+| Geometry / texture streaming         | 仅 bucket LOD     | GPU Scene 已有 projected-radius geometry bucket LOD；没有 meshlet/cluster streaming、KTX 2/Basis 或 mip residency，KTX loader 仅支持 KTX 1.1 单面 2D 容器                                                                                   |
+| GPU profiling / graph debugging      | 生产基线          | opt-in CPU/GPU Graph timeline、query ring、debug marker、资源 lifetime；关闭 diagnostics 且无内部 timing consumer 时不创建 query                                                                                                            |
 
 ### 2.1 现有实现中最关键的限制
 
@@ -163,10 +164,11 @@ Forward+ 时才值得作为特定 profile 考虑，而不是现代化的默认�
 - RHI 已有 timestamp QuerySet、pass timestamp、debug group/marker 和 Render Graph
   timeline；occlusion query 仍不在当前合同内。
 - 当前 Shadow Atlas 已有跨帧 stable-slice cache、Clustered GPU caster cull、receiver-driven
-  budget/cadence 和固定物理页 residency；但仍不是完整 Virtual Shadow Maps，因为 GPU receiver/depth
-  request、任意 physical-page remap/page table 与 directional
-  clipmap 尚未落地。体积光也只使用 bounded screen-space caster visibility 与 cloud
-  shadow，尚未采样 shared shadow atlas。
+  budget/cadence 和固定物理页 residency；opt-in WebGPU Clustered virtual path 已加入 GPU
+  receiver/depth request、任意 physical-page remap/page table、LRU eviction 与 directional
+  clipmap。首版只接 GPU Scene rigid caster/receiver，其他 caster、Spot/Point 和 WebGL 2 使用 stable
+  atlas。体积光仍只使用 bounded screen-space caster visibility 与 cloud shadow，尚未采样 shared
+  shadow atlas。
 - KTX loader 明确只解析 KTX 1.1、单 face 2D；没有 KTX 2、Basis Universal transcode、mip
   residency 或带宽预算。
 - 110k object / 256 light fixture 已验证 GPU-only 规模正确性、CPU record/GPU
@@ -222,22 +224,22 @@ indirect 建立相同类别的数据驱动系统，并给出 WebGPU 自身的性
 
 ## 5. 缺口优先级矩阵
 
-| ID   | 能力                                                                     | 优先级 | 当前状态                                                | 工作量 | 前置依赖                                      |
-| ---- | ------------------------------------------------------------------------ | ------ | ------------------------------------------------------- | ------ | --------------------------------------------- |
-| F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                                  | L      | 当前 Graph/RHI                                |
-| F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                                  | M      | WebGPU compiler/RHI                           |
-| D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                                  | L      | Camera/shader ABI                             |
-| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续                      | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
-| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                                        | XL     | F0、D0；材质/变形扩展使用 MAT0                |
-| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                                        | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
-| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                                        | XL     | F0、D0、MAT0                                  |
-| E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                                  | M      | F0、compute/storage；可独立于 T0 使用         |
-| Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0                    | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
-| S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | 生产缓存与固定物理页首版完成；page-table/clipmap 未开始 | XL     | MAT0、G0、F0、F1                              |
-| V0   | Froxel volumetric fog/lighting/cloud foundation                          | P1     | 生产切片完成；atlas shadow/透明体积后续                 | XL     | L0、F0；T0 可稳定最终边缘但非创建前置         |
-| A0   | KTX 2/Basis、mip residency、texture/geometry streaming budget            | P1     | 未开始                                                  | XL     | F0、diagnostics                               |
-| M0   | Offline meshlet build、cluster LOD、GPU material bin、geometry streaming | P2     | 未开始；已有 bucket-level LOD 可复用                    | XXL    | MAT0、G0、A0                                  |
-| GI0  | Screen/probe/software-BVH hybrid GI                                      | P2     | 屏幕内 SSGI 已完成；off-screen 层未开始                 | XXL    | T0、Q0、G0、A0                                |
+| ID   | 能力                                                                     | 优先级 | 当前状态                                                                                          | 工作量 | 前置依赖                                      |
+| ---- | ------------------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------- | ------ | --------------------------------------------- |
+| F0   | Graph texture subresource view、persistent texture/history               | P0     | 已完成                                                                                            | L      | 当前 Graph/RHI                                |
+| F1   | `f16`、subgroup、timestamp/query、debug marker 的 capability 与 RHI 闭环 | P0     | 已完成                                                                                            | M      | WebGPU compiler/RHI                           |
+| D0   | Reversed-Z、camera-relative rendering、current/previous frame ABI        | P0     | 已完成                                                                                            | L      | Camera/shader ABI                             |
+| MAT0 | Material Definition/Instance、语义 Pass、稳定 variant、共享 material ABI | P0     | high-end P0 完成；更多 family 后续                                                                | XL     | 当前 Renderer/SRP 与 G0/L0 材质垂直切片       |
+| G0   | GPU Scene、dirty upload、GPU frustum/Hi-Z culling、LOD/compact           | P0     | high-end P0 完成                                                                                  | XL     | F0、D0；材质/变形扩展使用 MAT0                |
+| L0   | 生产级 Clustered Forward+ + 内置 PBR storage lighting                    | P0     | high-end P0 完成                                                                                  | XL     | F0、F1、G0；完整材质接入使用 MAT0             |
+| T0   | Motion Vector、history、TAA/TAAU、dynamic resolution                     | P0     | high-end P0 完成                                                                                  | XL     | F0、D0、MAT0                                  |
+| E0   | Auto exposure、exposure history、参数化 filmic display transform         | P1     | 已完成                                                                                            | M      | F0、compute/storage；可独立于 T0 使用         |
+| Q0   | Material attribute buffer、GTAO、Hi-Z SSR、temporal SSGI                 | P1     | 已完成；off-screen fallback 属于 GI0                                                              | XL     | MAT0、F0；Clustered 集成用 T0，SSR 用 G0 Hi-Z |
+| S0   | Shadow cache/invalidation、GPU caster cull、virtual shadow pages         | P1→P2  | opt-in GPU request/page-table/remap/clipmap 已完成；待登记物理 GPU 压力证据与扩大 caster coverage | XL     | MAT0、G0、F0、F1                              |
+| V0   | Froxel volumetric fog/lighting/cloud foundation                          | P1     | 生产切片完成；atlas shadow/透明体积后续                                                           | XL     | L0、F0；T0 可稳定最终边缘但非创建前置         |
+| A0   | KTX 2/Basis、mip residency、texture/geometry streaming budget            | P1     | 未开始                                                                                            | XL     | F0、diagnostics                               |
+| M0   | Offline meshlet build、cluster LOD、GPU material bin、geometry streaming | P2     | 未开始；已有 bucket-level LOD 可复用                                                              | XXL    | MAT0、G0、A0                                  |
+| GI0  | Screen/probe/software-BVH hybrid GI                                      | P2     | 屏幕内 SSGI 已完成；off-screen 层未开始                                                           | XXL    | T0、Q0、G0、A0                                |
 
 `P0` 是“现代 WebGPU renderer”定义所需能力；`P1` 是高画质生产 profile；`P2`
 是依赖场景规模、内容管线和长期性能投入的虚拟化能力。
@@ -249,8 +251,9 @@ timeline、确定的前后帧坐标 ABI、GPU Scene object/light database、共�
 handle/variant、3D cluster allocator 与现有时域/屏幕空间 controller。P0 的透明、变形、完整 layered
 PBR、analytic cookie/IES、light-layer、variant
 warmup 和透明/粒子时域策略已收口；尚需在登记物理 GPU 上建立不可覆盖的跨提交性能基线。S0 已完成 stable-atlas
-cache、GPU caster cull、receiver budget/cadence 与固定物理页 residency；任意 page-table remap、GPU
-page request 和 clipmap 仍未开始。A0、M0 和 GI0 的 off-screen 层也尚未开始。详见
+cache、GPU caster cull、receiver budget/cadence、固定物理页 residency，以及 opt-in GPU
+request/page-table/remap/directional clipmap；后续是物理 GPU 压力证据和扩展非 rigid caster
+coverage。A0、M0 和 GI0 的 off-screen 层也尚未开始。详见
 [`MATERIAL_SYSTEM_MODERNIZATION.md`](./MATERIAL_SYSTEM_MODERNIZATION.md)。
 
 ## 6. 可落地工作包
@@ -619,7 +622,7 @@ off-screen GI 补偿属于 GI0，而不是未完成的 Q0。实现与上线证�
 这里推荐 GTAO/temporal AO，而不是补传统 SSAO；推荐 hierarchical SSR/temporal
 SSGI，而不是单帧固定步长 ray march。
 
-#### S0：现代阴影（生产缓存完成；固定物理页首版完成）
+#### S0：现代阴影（生产缓存与 opt-in 虚拟方向光已完成）
 
 ![S0：阴影缓存、脏页更新与虚拟阴影 Atlas](./images/modern-webgpu-roadmap/virtual-shadow-cache.jpg)
 
@@ -641,12 +644,20 @@ cadence。静态 slice 不再记录 Shadow Pass；移动 local light 只重绘�
 caster 不回读 visible count，不满足 GPU Scene 合同的 caster 保留共享 CPU fallback。geometry
 bounds 变化、skin/morph 仍保守失效相关全部 slice。
 
-第二层已交付固定 atlas 内的 128 像素页 residency 首版：dirty slice
+第二层先交付固定 atlas 内的 128 像素页 residency：dirty slice
 revision 分页请求，旧页在预算不足时继续有效，page-scissored
 clear/draw 与 residency 只在 submission 后提交，rollback 会确定重试；`RendererDiagnostics.frame.shadow*`
-暴露 request/update/defer/resident/overflow。这不是最终 virtual page table：页目前固定映射到 stable
-atlas，尚无 GPU receiver/depth request、任意 physical-page allocation/remap、directional
-clipmap，GPU caster cull 也仍以 slice frustum 保守生成每页 draw list。
+暴露 request/update/defer/resident/overflow。
+
+WebGPU Clustered opt-in 路径已在其上补齐 virtual page
+table：上一提交帧 Hi-Z 在 GPU 重建 receiver，atomic
+bitset 完成 request 去重，分配器按 light/clipmap/page 确定扫描并把逻辑页任意 remap 到 LRU physical
+depth atlas。每个更新页独立完成 GPU caster cull、bucket prefix/compact 和 indirect clear/depth
+draw；budget 不足的 dirty 页保留 pending 状态且回退 stable CSM。方向光使用 page-snapped
+camera-centered clipmap。page-table history、双 residency buffer 与 light/depth-slab
+epoch 均在有效 submission 后提交，rollback 保留旧映射，device
+recovery 从空 residency 重建。首版限定 GPU Scene rigid opaque/alpha-mask caster 和 Clustered
+receiver；不兼容 caster、Spot/Point 与 WebGL 2 保留 shared atlas。
 
 这里的 virtual shadow
 page 不等同于 SVT/RVT。SVT 是从磁盘按 tile 流送纹理，RVT 是运行时生成并缓存材质或地形 shading 数据；两者可以承载 lightmap 或 shadow
@@ -849,10 +860,11 @@ report、类型消费和 package 验证必须同版本完成。
   atmosphere/cloud/cloud-shadow 场景。**仍缺**：shared shadow-atlas volumetric
   sampling、透明介质参与和对应性能证据；
 - **Streaming 未有**：后续场景需覆盖低带宽冷启动、快速 teleport、取消、内存压力与 device loss；
-- **Shadow cache/固定页已有首版**：单元/生产接线覆盖静态 hit、local-light face 局部失效、GPU caster
+- **Shadow cache/虚拟页已有首版**：单元/生产接线覆盖静态 hit、local-light face 局部失效、GPU caster
   cull、receiver/update budget、CSM cadence、page overflow、失败回滚、atlas
-  detach 与 recovery；**仍缺**快速 camera 物理 GPU 压力证据、GPU receiver/depth
-  request、任意 page-table remap 与 directional clipmap。
+  detach 与 recovery，以及 virtual request/remap/clipmap 的真实 WebGPU
+  rollback/recovery；**仍缺**快速 camera 的登记物理 GPU 压力证据和 non-rigid/direct
+  caster 的虚拟页覆盖。
 
 不能把验收 example 的“算法跑通”当成 production baseline，也不能通过 CPU readback visible
 count 来驱动下一步 draw。功能完成必须同时回答：更少的 CPU work、更稳定的 GPU
@@ -879,9 +891,9 @@ time、确定的资源预算和失败时的可观察行为。
 1. **登记 G0/L0 物理 GPU baseline**：把现有 110k object / 256 light
    fixture 纳入固定 hardware/browser/driver 的不可覆盖跨提交协议，先锁定 CPU record、GPU
    pass、upload 与显存阈值；
-2. **S0 生产缓存层**：stable atlas content cache、static/dynamic exact
-   invalidation 和局部 clear 已完成；继续补 GPU caster
-   cull 与 receiver/budget 更新，只有第一层证明收益后再进入 virtual shadow page；
+2. **S0 物理 GPU 证据与覆盖扩展**：stable cache、GPU caster cull、receiver budget 和 opt-in virtual
+   request/remap/clipmap 已完成；登记快速 camera/高 caster 压力数据后，再决定扩展 skin/morph/direct
+   caster 或 local-light virtual page table；
 3. **A0 资源流送**：KTX 2/Basis + capability-driven transcode、Worker decode、mip
    residency、上传/内存/in-flight budget；随后再增加 geometry page/meshopt；
 4. **M0 meshlet/cluster geometry**：复用 GPU Scene、bucket LOD 与 A0 residency，先限定 static rigid

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -96,9 +96,26 @@ budget 延后 caster-only 失效。每个 slice 再拆为 128 像素固定物理
 提供累计hit/miss/replacement/live-slice，`frame.shadow*` 提供 slice/page
 request、update、defer、resident 和 overflow 观测。
 
-当前页层仍使用 stable atlas 内的固定物理映射；尚未实现 GPU receiver/depth page
-request、任意 physical-page remap/page table 或 directional clipmap，因此不宣称等价于完整 Virtual
-Shadow Maps。
+WebGPU high-end `ClusteredForwardPlusPipelineFactory` 还提供显式 opt-in 的
+`virtualShadows`。这条方向光路径从上一提交帧的 Hi-Z depth 在 compute 中重建 receiver world
+position，以 atomic
+bitset 生成和去重逻辑页请求，再按 light/clipmap/page 的确定顺序扫描；CPU 不读取请求、页数或 indirect 参数。GPU 分配器把逻辑页任意 remap 到有界 physical
+depth atlas，优先复用 exact identity，否则按 last-used frame 驱逐最旧的未选物理页；dirty 页在 update
+budget 不足时保留 pending 状态且不发布 stale page-table entry。随后按物理页进行 caster cull、bucket
+prefix/compact，并用固定上限的 GPU-authored indirect clear/depth draw 更新 atlas。
+
+方向光使用 camera-centered、texel/page-snapped
+clipmap；默认四级，每级覆盖宽度倍增。页 identity 包含 light/map、绝对页坐标与提交感知 epoch，光方向、沿光线方向的 snapped
+depth slab、caster transform/material/coverage 或 geometry bounds 变化都会精确或保守失效。page
+table 使用 renderer-owned 双缓冲 history，physical residency 使用双 `StorageBuffer`；两者和 clipmap
+epoch 只在 `frameSubmitted()` 后轮换，graph/prepare/execute 失败保留上一提交状态，device
+recovery 通过无效 history 清空 residency 并重建 atlas。缺页和 deferred dirty 页回退到同帧 stable
+CSM，不解释为“无遮挡”。
+
+首版虚拟路径只覆盖 GPU Scene rigid opaque/alpha-mask caster 与 Clustered GPU Scene
+receiver；出现 skin、morph、direct/fallback 等非虚拟 caster 时，该帧方向光继续完整使用 shared stable
+atlas。Spot/Point 与 WebGL 2 也始终保持 shared
+atlas 路径。这是明确的渐进边界，不建立第二套后端 shader 树或 CPU page-request fallback。
 
 Sprite 仍是 Mesh：共享单位 quad、按 atlas Texture 共享 SpriteMaterial，先按 Node 级
 `sortingLayer / zIndex / stable scene traversal` 确定显示顺序，再仅对相邻兼容项合批，并把 UV

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -828,6 +828,7 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly screenSpaceReflectionMissPixelCount: number;
     readonly screenSpaceReflectionUncertainPixelCount: number;
     readonly smoothedGPUFrameTimeMs: number | null;
+    readonly virtualShadows: Readonly<VirtualShadowMapDiagnostics> | null;
     readonly visibleObjectCount: number;
     readonly volumetricFroxelCount: number;
     readonly volumetricHistoryUsed: boolean;
@@ -864,6 +865,7 @@ export interface ClusteredForwardPlusPipelineOptions {
     readonly tileSize?: number;
     readonly toneMapping?: 'aces' | 'filmic';
     readonly variantManifest?: Readonly<ClusteredMaterialVariantManifest>;
+    readonly virtualShadows?: Readonly<VirtualShadowMapOptions> | false;
     readonly volumetricLighting?: Readonly<VolumetricLightingOptions> | false;
     readonly zSlices?: number;
 }
@@ -11078,6 +11080,28 @@ export class Vector4 {
 
 // @public (undocumented)
 export const version: string;
+
+// @public
+export interface VirtualShadowMapDiagnostics {
+    readonly deferredPageCount: number;
+    readonly directionalClipmapLevelCount: number;
+    readonly evictionCount: number;
+    readonly invalidatedPageCount: number;
+    readonly physicalPageCapacity: number;
+    readonly renderedPageCount: number;
+    readonly requestedPageCount: number;
+    readonly residentPageCount: number;
+}
+
+// @public
+export interface VirtualShadowMapOptions {
+    readonly directionalClipmapLevels?: number;
+    readonly firstDirectionalClipmapExtent?: number;
+    readonly maxPageUpdatesPerFrame?: number;
+    readonly pageSize?: number;
+    readonly physicalPageCount?: number;
+    readonly virtualResolution?: number;
+}
 
 // @public
 export interface VolumetricBoxFogVolume {

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -177,6 +177,18 @@ import {
     type AutoExposureSettings
 } from '../postprocessing/AutoExposure';
 import {
+    VirtualShadowMapController,
+    snapshotVirtualShadowMapOptions,
+    virtualShadowBucketOffsetRange,
+    virtualShadowClearIndirectOffset,
+    virtualShadowIndirectOffset,
+    virtualShadowPhysicalPageRange,
+    type VirtualShadowFrameResources,
+    type VirtualShadowMapDiagnostics,
+    type VirtualShadowMapOptions,
+    type VirtualShadowMapSettings
+} from './VirtualShadowMaps';
+import {
     ATMOSPHERE_WEATHER_REQUIRED_TEXTURE_FORMATS,
     AtmosphereWeatherController,
     snapshotAtmosphereWeatherOptions,
@@ -223,6 +235,7 @@ const OBJECT_MOTION_HISTORY_FLAG = 8;
 const OBJECT_MOTION_CHANGED_FLAG = 16;
 const OBJECT_RECEIVE_SHADOW_FLAG = 32;
 const OBJECT_CAST_SHADOW_FLAG = 64;
+const OBJECT_SHADOW_DIRTY_FLAG = 128;
 const LIGHT_COOKIE_FLAG = 1;
 const LIGHT_IES_FLAG = 2;
 const CULL_WORKGROUP_SIZE = 64;
@@ -486,6 +499,11 @@ export interface ClusteredForwardPlusPipelineOptions {
     readonly maxViewportHeight?: number;
     /** Enable previous-frame Hi-Z occlusion. Defaults to true. */
     readonly hiZ?: boolean;
+    /**
+     * GPU receiver-driven virtual directional shadows with arbitrary page-table remapping and
+     * camera-centered clipmaps. Requires `hiZ`; disabled by default.
+     */
+    readonly virtualShadows?: Readonly<VirtualShadowMapOptions> | false;
     /** Bloom contribution mixed into the final display transform. Defaults to 0.7. */
     readonly bloomStrength?: number;
     /** Exposure multiplier applied before the ACES display transform. Defaults to 1. */
@@ -589,6 +607,8 @@ export interface ClusteredForwardPlusDiagnostics {
     readonly materialVariantBudget: number;
     /** CPU translation wall time spent in asynchronous warmup. */
     readonly materialVariantWarmupTimeMs: number;
+    /** Latest on-demand virtual-shadow counters, or null when virtual shadows are disabled. */
+    readonly virtualShadows: Readonly<VirtualShadowMapDiagnostics> | null;
 }
 
 interface NormalizedLOD {
@@ -616,6 +636,7 @@ interface NormalizedOptions {
     readonly maxViewportHeight: number;
     readonly hiZ: boolean;
     readonly hiZLevelCount: number;
+    readonly virtualShadows: VirtualShadowMapSettings | null;
     readonly bloomStrength: number;
     readonly exposure: number;
     readonly toneMapping: 'aces' | 'filmic';
@@ -681,8 +702,10 @@ interface PhysicalBucket {
     indexRevision: number;
     depthPass: GPUDrivenRenderPass;
     shadowPass: GPUDrivenRenderPass;
+    virtualShadowPass: GPUDrivenRenderPass | null;
     colorPass: GPUDrivenRenderPass;
     colorShadowed: boolean;
+    colorVirtualShadowed: boolean;
     materialAttributesPass: GPUDrivenRenderPass | null;
     materialVariantKey: string;
     materialVariant: Readonly<PBRMaterialVariant>;
@@ -736,6 +759,10 @@ interface GPUSceneObjectRecord {
     committedOcclusionStable: boolean;
     pendingMotionChanged: boolean;
     committedMotionChanged: boolean;
+    pendingShadowChanged: boolean;
+    committedShadowChanged: boolean;
+    pendingMaterialRevision: number;
+    committedMaterialRevision: number;
     pendingMotionHistoryValid: boolean;
     committedMotionHistoryValid: boolean;
     pendingHistoryRevision: number;
@@ -1073,6 +1100,17 @@ function bufferRequirementPlan(
 ): Readonly<BufferRequirementPlan> {
     const capacity = clusterCapacityPlan(options);
     const materialCount = new Set(options.buckets.map(bucket => bucket.material)).size;
+    const virtualShadows = options.virtualShadows;
+    const virtualPageBitsetBytes =
+        virtualShadows === null
+            ? 0
+            : Math.ceil(
+                  (MAX_DIRECTIONAL_LIGHTS *
+                      virtualShadows.directionalClipmapLevels *
+                      virtualShadows.virtualPageGridSize *
+                      virtualShadows.virtualPageGridSize) /
+                      32
+              ) * 4;
     const storageBufferLengths = [
         FRAME_RECORD_BYTES,
         ...(options.volumetricLighting === null
@@ -1108,7 +1146,46 @@ function bufferRequirementPlan(
         safeProduct('Clustered Forward+ cluster-grid database size', capacity.maxClusters, 8),
         safeProduct('Clustered Forward+ cluster-block database size', capacity.maxClusterBlocks, 4),
         safeProduct('Clustered Forward+ light-index database size', options.maxLightIndices, 4),
-        STATS_BYTES
+        STATS_BYTES,
+        ...(virtualShadows === null
+            ? []
+            : [
+                  safeProduct(
+                      'Virtual shadow clipmap database size',
+                      virtualShadows.clipmapVec4Count,
+                      16
+                  ),
+                  virtualPageBitsetBytes,
+                  safeProduct(
+                      'Virtual shadow physical residency size',
+                      virtualShadows.physicalPageCount,
+                      256
+                  ),
+                  safeProduct(
+                      'Virtual shadow selected caster size',
+                      virtualShadows.physicalPageCount,
+                      options.maxObjects,
+                      4
+                  ),
+                  safeProduct(
+                      'Virtual shadow visible caster size',
+                      virtualShadows.physicalPageCount,
+                      visibleBucketCapacity(options.maxObjects),
+                      4
+                  ),
+                  safeProduct(
+                      'Virtual shadow bucket offset size',
+                      virtualShadows.physicalPageCount,
+                      physicalCount,
+                      BUCKET_OFFSET_STRIDE_BYTES
+                  ),
+                  safeProduct(
+                      'Virtual shadow indirect argument size',
+                      virtualShadows.physicalPageCount,
+                      physicalCount,
+                      INDIRECT_ARGUMENT_BYTES
+                  )
+              ])
     ];
     let maxStorageBufferBindingSize = Math.max(...storageBufferLengths);
     let maxBufferSize = maxStorageBufferBindingSize;
@@ -1149,6 +1226,7 @@ function bufferRequirementPlan(
         Math.ceil(options.maxViewportHeight / 8),
         Math.min(maximumSSRTileCount, 65_535),
         Math.ceil(maximumSSRTileCount / 65_535),
+        virtualShadows?.physicalPageCount ?? 1,
         1
     );
     return Object.freeze({
@@ -1290,6 +1368,13 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         throw new TypeError('Clustered Forward+ hiZ must be a boolean');
     }
     const hiZ = input.hiZ ?? true;
+    const virtualShadows =
+        input.virtualShadows === undefined || input.virtualShadows === false
+            ? null
+            : snapshotVirtualShadowMapOptions(input.virtualShadows);
+    if (virtualShadows !== null && !hiZ) {
+        throw new TypeError('Clustered Forward+ virtual shadows require hiZ');
+    }
     if (
         hiZ &&
         (maxViewportWidth > MAX_HIZ_OCCLUSION_DIAMETER ||
@@ -1441,6 +1526,7 @@ function normalizeOptions(options: unknown): Readonly<NormalizedOptions> {
         hiZLevelCount: hiZ
             ? Math.max(1, Math.ceil(Math.log2(Math.max(maxViewportWidth, maxViewportHeight))))
             : 0,
+        virtualShadows,
         bloomStrength: finiteNonNegative(
             input.bloomStrength ?? 0.7,
             'Clustered Forward+ bloomStrength'
@@ -2815,7 +2901,358 @@ void main() {
     return shader;
 }
 
-function gpuSceneShadowSource(): string {
+const GPU_SCENE_VIRTUAL_SHADOW_SHADER_CACHE = new Map<string, StorageGraphicsShader>();
+
+function virtualShadowVertexTransformSource(settings: Readonly<VirtualShadowMapSettings>): string {
+    return `
+mat4 hiloVirtualShadowMatrix(uint mapIndex) {
+    uint base = 13u + mapIndex * 5u;
+    return mat4(
+        clipmapData.values[base],
+        clipmapData.values[base + 1u],
+        clipmapData.values[base + 2u],
+        clipmapData.values[base + 3u]
+    );
+}
+vec4 hiloVirtualShadowAtlasPosition(vec4 clipPosition, vec2 logicalPage, uint physicalIndex) {
+    vec2 logicalUV = vec2(
+        clipPosition.x / clipPosition.w * 0.5 + 0.5,
+        0.5 - clipPosition.y / clipPosition.w * 0.5
+    );
+    v_virtualPageUV = logicalUV * ${String(settings.virtualPageGridSize)}.0 - logicalPage;
+    vec2 pageNDC = vec2(v_virtualPageUV.x * 2.0 - 1.0, 1.0 - v_virtualPageUV.y * 2.0);
+    uint column = physicalIndex % ${String(settings.physicalPageColumns)}u;
+    uint row = physicalIndex / ${String(settings.physicalPageColumns)}u;
+    vec2 atlasUV = (vec2(float(column), float(row)) + pageNDC * 0.5 + 0.5) /
+        vec2(${String(settings.physicalPageColumns)}.0, ${String(settings.physicalPageRows)}.0);
+    vec2 atlasNDC = vec2(atlasUV.x * 2.0 - 1.0, 1.0 - atlasUV.y * 2.0);
+    return vec4(atlasNDC * clipPosition.w, clipPosition.zw);
+}`;
+}
+
+function gpuSceneVirtualShadowShader(
+    variant: Readonly<PBRMaterialVariant>,
+    settings: Readonly<VirtualShadowMapSettings>
+): StorageGraphicsShader {
+    const cacheKey = `${variant.key}|${String(settings.virtualResolution)}|${String(settings.pageSize)}|${String(settings.physicalPageCount)}`;
+    const cached = GPU_SCENE_VIRTUAL_SHADOW_SHADER_CACHE.get(cacheKey);
+    if (cached !== undefined) return cached;
+    const textures = coverageTextures(variant);
+    const baseColorMap = textures.find(binding => binding.role === 'baseColorMap') ?? null;
+    const opacityMap = textures.find(binding => binding.role === 'opacityMap') ?? null;
+    const usesUV0 = textures.some(binding => binding.uv === 0);
+    const usesUV1 = textures.some(binding => binding.uv === 1);
+    const textureDeclarations = textures
+        .map(binding => `uniform sampler2D ${binding.shaderName};`)
+        .join('\n');
+    const vertexUVDeclarations = [
+        usesUV0 ? 'layout(location=2) in vec2 a_uv0;\nout vec2 v_uv0;' : '',
+        usesUV1 ? 'layout(location=3) in vec2 a_uv1;\nout vec2 v_uv1;' : ''
+    ]
+        .filter(Boolean)
+        .join('\n');
+    const fragmentUVDeclarations = [
+        usesUV0 ? 'in vec2 v_uv0;' : '',
+        usesUV1 ? 'in vec2 v_uv1;' : ''
+    ]
+        .filter(Boolean)
+        .join('\n');
+    const vertexUVWrites = [usesUV0 ? 'v_uv0 = a_uv0;' : '', usesUV1 ? 'v_uv1 = a_uv1;' : '']
+        .filter(Boolean)
+        .join('\n    ');
+    const materialSample = (binding: Readonly<PBRTextureBinding>): string =>
+        `hiloMaterialSample(${binding.shaderName}, materialBase, ${String(binding.slotIndex)}u, ${variantSampleUV(binding)})`;
+    const bindings: ShaderReadBinding[] = [
+        { name: 'clipmapData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+        {
+            name: 'physicalPage',
+            group: 0,
+            binding: 1,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 32
+        },
+        { name: 'objects', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
+        { name: 'visibleIndices', group: 0, binding: 3, kind: 'read-only-storage-buffer' },
+        {
+            name: 'visibleOffset',
+            group: 0,
+            binding: 4,
+            kind: 'read-only-storage-buffer',
+            minBindingSize: 4
+        }
+    ];
+    if (variant.coverageMode === 'mask') {
+        bindings.push({
+            name: 'materials',
+            group: 0,
+            binding: 5,
+            kind: 'read-only-storage-buffer'
+        });
+    }
+    for (let index = 0; index < textures.length; index += 1) {
+        const texture = textures[index];
+        if (texture === undefined) continue;
+        bindings.push(
+            {
+                name: texture.shaderName,
+                group: 1,
+                binding: index * 2,
+                kind: 'sampled-texture',
+                sampleType: 'float'
+            },
+            {
+                name: texture.shaderName,
+                group: 1,
+                binding: index * 2 + 1,
+                kind: 'sampler'
+            }
+        );
+    }
+    const shader = new StorageGraphicsShader({
+        label: `GPU Scene virtual shadow depth (${variant.key})`,
+        vertexSource: `#version 310 es
+precision highp float;
+precision highp int;
+invariant gl_Position;
+layout(std430) readonly buffer ClipmapDataBlock { vec4 values[]; } clipmapData;
+layout(std430) readonly buffer PhysicalPageBlock { uvec4 values[]; } physicalPage;
+layout(std430) readonly buffer ObjectBlock { vec4 values[]; } objects;
+layout(std430) readonly buffer VisibleBlock { uint values[]; } visibleIndices;
+layout(std430) readonly buffer VisibleOffsetBlock { uint value; } visibleOffset;
+layout(location=0) in vec3 a_position;
+${vertexUVDeclarations}
+out vec2 v_virtualPageUV;
+${variant.coverageMode === 'mask' ? 'flat out uint v_materialIndex;' : ''}
+mat4 readObjectMatrix(uint base) {
+    return mat4(
+        objects.values[base],
+        objects.values[base + 1u],
+        objects.values[base + 2u],
+        objects.values[base + 3u]
+    );
+}
+${GPU_SCENE_VISIBLE_INDEX_SOURCE}
+${virtualShadowVertexTransformSource(settings)}
+void main() {
+    uint objectIndex = gpuSceneVisibleObjectIndex();
+    uint objectBase = objectIndex * 13u;
+    uint mapIndex = physicalPage.values[0].x;
+    uint mapBase = 13u + mapIndex * 5u;
+    ivec2 origin = ivec2(floatBitsToInt(clipmapData.values[mapBase + 4u].xy));
+    ivec2 absolutePage = floatBitsToInt(uintBitsToFloat(physicalPage.values[0].yz));
+    vec2 logicalPage = vec2(absolutePage - origin);
+    vec4 worldPosition = readObjectMatrix(objectBase) * vec4(a_position, 1.0);
+    vec4 lightClip = hiloVirtualShadowMatrix(mapIndex) * worldPosition;
+    gl_Position = hiloVirtualShadowAtlasPosition(
+        lightClip,
+        logicalPage,
+        physicalPage.values[1].w
+    );
+    ${variant.coverageMode === 'mask' ? 'v_materialIndex = floatBitsToUint(objects.values[objectBase + 12u].w);' : ''}
+    ${vertexUVWrites}
+}`,
+        fragmentSource: `#version 310 es
+precision highp float;
+precision highp int;
+in vec2 v_virtualPageUV;
+${fragmentUVDeclarations}
+${variant.coverageMode === 'mask' ? 'layout(std430) readonly buffer MaterialDataBlock { vec4 values[]; } materials;\nflat in uint v_materialIndex;' : ''}
+${textureDeclarations}
+${variant.coverageMode === 'mask' ? encodingSource : ''}
+${
+    variant.coverageMode === 'mask'
+        ? `float hiloMaterialChannel(vec4 value, int channel) {
+    if (channel == 0) return value.r;
+    if (channel == 1) return value.g;
+    if (channel == 2) return value.b;
+    if (channel == 3) return value.a;
+    return channel == 5 ? 1.0 : 0.0;
+}
+vec4 hiloMaterialSample(sampler2D source, uint materialBase, uint slotIndex, vec2 uv) {
+    uint slotBase = materialBase + 4u + slotIndex * 5u;
+    mat3 transform = mat3(
+        materials.values[slotBase].xyz,
+        materials.values[slotBase + 1u].xyz,
+        materials.values[slotBase + 2u].xyz
+    );
+    vec4 info = materials.values[slotBase + 3u];
+    vec4 sampled = texture(source, (transform * vec3(uv, 1.0)).xy);
+    if (int(info.y) == 1) sampled = sRGBToLinear(sampled);
+    ivec4 channels = ivec4(materials.values[slotBase + 4u]);
+    return vec4(
+        hiloMaterialChannel(sampled, channels.x),
+        hiloMaterialChannel(sampled, channels.y),
+        hiloMaterialChannel(sampled, channels.z),
+        hiloMaterialChannel(sampled, channels.w)
+    );
+}`
+        : ''
+}
+void main() {
+    if (any(lessThan(v_virtualPageUV, vec2(0.0))) || any(greaterThan(v_virtualPageUV, vec2(1.0)))) discard;
+    ${
+        variant.coverageMode === 'mask'
+            ? `uint materialBase = v_materialIndex * ${String(PBR_GPU_MATERIAL_RECORD_BYTES / 16)}u;
+    float coverageAlpha = materials.values[materialBase + 3u].x;
+    ${baseColorMap === null ? '' : `coverageAlpha *= ${materialSample(baseColorMap)}.a;`}
+    ${opacityMap === null ? '' : `coverageAlpha *= ${materialSample(opacityMap)}.r;`}
+    if (coverageAlpha < ${String(variant.alphaCutoff)}) discard;`
+            : ''
+    }
+}`,
+        bindings
+    });
+    GPU_SCENE_VIRTUAL_SHADOW_SHADER_CACHE.set(cacheKey, shader);
+    return shader;
+}
+
+function virtualShadowClearShader(
+    settings: Readonly<VirtualShadowMapSettings>
+): StorageGraphicsShader {
+    return new StorageGraphicsShader({
+        label: 'Virtual shadow physical page depth clear',
+        vertexSource: `#version 310 es
+precision highp float;
+precision highp int;
+invariant gl_Position;
+layout(std430) readonly buffer ClipmapDataBlock { uvec4 values[]; } clipmapData;
+layout(std430) readonly buffer PhysicalPageBlock { uvec4 values[]; } physicalPage;
+out vec2 v_pageUV;
+void main() {
+    vec2 triangle = gl_VertexID == 0 ? vec2(-1.0, -1.0) :
+        (gl_VertexID == 1 ? vec2(3.0, -1.0) : vec2(-1.0, 3.0));
+    uint physicalIndex = physicalPage.values[1].w;
+    uint column = physicalIndex % ${String(settings.physicalPageColumns)}u;
+    uint row = physicalIndex / ${String(settings.physicalPageColumns)}u;
+    vec2 atlasUV = (vec2(float(column), float(row)) + triangle * 0.5 + 0.5) /
+        vec2(${String(settings.physicalPageColumns)}.0, ${String(settings.physicalPageRows)}.0);
+    vec2 atlasNDC = vec2(atlasUV.x * 2.0 - 1.0, 1.0 - atlasUV.y * 2.0);
+    float farNDC = clipmapData.values[2u].w == 0u ? 1.0 : -1.0;
+    v_pageUV = triangle * 0.5 + 0.5;
+    gl_Position = vec4(atlasNDC, farNDC, 1.0);
+}`,
+        fragmentSource: `#version 310 es
+precision highp float;
+in vec2 v_pageUV;
+void main() {
+    if (any(lessThan(v_pageUV, vec2(0.0))) || any(greaterThan(v_pageUV, vec2(1.0)))) discard;
+}`,
+        bindings: [
+            { name: 'clipmapData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            {
+                name: 'physicalPage',
+                group: 0,
+                binding: 1,
+                kind: 'read-only-storage-buffer',
+                minBindingSize: 32
+            }
+        ]
+    });
+}
+
+function gpuSceneVirtualShadowSource(settings: Readonly<VirtualShadowMapSettings>): string {
+    return `
+vec4 hiloVirtualShadowTableTexel(uint linearIndex) {
+    uint width = ${String(settings.pageTableWidth)}u;
+    return texelFetch(
+        u_virtualShadowPageTable,
+        ivec2(int(linearIndex % width), int(linearIndex / width)),
+        0
+    );
+}
+mat4 hiloVirtualShadowMapMatrix(uint mapIndex) {
+    uint base = 13u + mapIndex * 5u;
+    return mat4(
+        hiloVirtualShadowTableTexel(base),
+        hiloVirtualShadowTableTexel(base + 1u),
+        hiloVirtualShadowTableTexel(base + 2u),
+        hiloVirtualShadowTableTexel(base + 3u)
+    );
+}
+mat4 hiloVirtualShadowInverseView() {
+    return mat4(
+        hiloVirtualShadowTableTexel(5u),
+        hiloVirtualShadowTableTexel(6u),
+        hiloVirtualShadowTableTexel(7u),
+        hiloVirtualShadowTableTexel(8u)
+    );
+}
+float hiloVirtualDirectionalShadow(int lightIndex, float bias, vec3 viewPosition) {
+    vec4 config = hiloVirtualShadowTableTexel(0u);
+    int lightCount = int(config.x + 0.5);
+    int levels = int(config.y + 0.5);
+    int grid = int(config.z + 0.5);
+    if (lightIndex < 0 || lightIndex >= lightCount) return -1.0;
+    vec4 world = hiloVirtualShadowInverseView() * vec4(viewPosition, 1.0);
+    world /= max(abs(world.w), 0.000001) * sign(world.w);
+    for (int level = 0; level < ${String(settings.directionalClipmapLevels)}; level++) {
+        if (level >= levels) break;
+        uint mapIndex = uint(lightIndex * levels + level);
+        vec4 clipPosition = hiloVirtualShadowMapMatrix(mapIndex) * world;
+        if (clipPosition.w <= 0.0) continue;
+        vec3 projection = clipPosition.xyz / clipPosition.w;
+        vec2 logicalUV = vec2(
+            projection.x * 0.5 + 0.5,
+            0.5 - projection.y * 0.5
+        );
+        if (
+            any(lessThan(logicalUV, vec2(0.0))) ||
+            any(greaterThanEqual(logicalUV, vec2(1.0))) ||
+            projection.z < -1.0 || projection.z > 1.0
+        ) continue;
+        ivec2 logicalPage = ivec2(floor(logicalUV * float(grid)));
+        int tableY = ${String(settings.pageTableHeaderRows)} + int(mapIndex) * grid + logicalPage.y;
+        vec4 entry = texelFetch(
+            u_virtualShadowPageTable,
+            ivec2(logicalPage.x, tableY),
+            0
+        );
+        if (entry.x < 0.5) continue;
+        uint mapBase = 13u + mapIndex * 5u;
+        vec4 identity = hiloVirtualShadowTableTexel(mapBase + 4u);
+        ivec2 absolutePage = ivec2(round(identity.xy)) + logicalPage;
+        if (any(notEqual(ivec2(round(entry.yz)), absolutePage))) continue;
+        uint epoch = uint(identity.z + 0.5);
+        if (uint(entry.w + 0.5) != epoch) continue;
+        uint physicalIndex = uint(entry.x - 0.5);
+        uint column = physicalIndex % ${String(settings.physicalPageColumns)}u;
+        uint row = physicalIndex / ${String(settings.physicalPageColumns)}u;
+        vec2 pageUV = fract(logicalUV * float(grid));
+        vec2 atlasSlots = vec2(
+            ${String(settings.physicalPageColumns)}.0,
+            ${String(settings.physicalPageRows)}.0
+        );
+        vec2 atlasUV = (vec2(float(column), float(row)) + pageUV) / atlasSlots;
+        vec2 texel = vec2(
+            1.0 / ${String(settings.physicalAtlasWidth)}.0,
+            1.0 / ${String(settings.physicalAtlasHeight)}.0
+        );
+        vec2 rectMin = vec2(float(column), float(row)) / atlasSlots + texel * 0.5;
+        vec2 rectMax = vec2(float(column + 1u), float(row + 1u)) / atlasSlots - texel * 0.5;
+        bool reversed = hiloVirtualShadowTableTexel(2u).w > 0.5;
+        float depthBias = reversed ? bias : -bias;
+        float visibility = 0.0;
+        for (int y = -1; y <= 1; y++) {
+            for (int x = -1; x <= 1; x++) {
+                vec2 sampleUV = clamp(
+                    atlasUV + vec2(float(x), float(y)) * texel,
+                    rectMin,
+                    rectMax
+                );
+                visibility += textureLod(
+                    u_virtualShadowAtlas,
+                    vec3(hiloRenderTargetUV(sampleUV), projection.z * 0.5 + 0.5 + depthBias),
+                    0.0
+                );
+            }
+        }
+        return visibility / 9.0;
+    }
+    return -1.0;
+}`;
+}
+
+function gpuSceneShadowSource(virtualShadows: Readonly<VirtualShadowMapSettings> | null): string {
     return `
 mat4 hiloShadowMatrix(uint base) {
     return mat4(
@@ -2865,6 +3302,15 @@ float hiloDirectionalShadow(int index, float bias, vec3 viewPosition) {
     vec4 params = frameData.values[${String(SHADOW_DIRECTIONAL_PARAMS_VEC4)}u + uint(index)];
     int cascadeCount = clamp(int(params.x + 0.5), 1, ${String(MAX_DIRECTIONAL_SHADOW_CASCADES)});
     float viewDepth = max(-viewPosition.z, 0.0);
+    ${
+        virtualShadows === null
+            ? ''
+            : `float virtualVisibility = hiloVirtualDirectionalShadow(index, bias, viewPosition);
+    if (virtualVisibility >= 0.0) {
+        float virtualStrength = clamp(params.z, 0.0, 4.0);
+        return clamp(1.0 - (1.0 - virtualVisibility) * virtualStrength, 0.0, 1.0);
+    }`
+    }
     int cascade = 0;
     if (cascadeCount > 1 && viewDepth > splits.x) cascade = 1;
     if (cascadeCount > 2 && viewDepth > splits.y) cascade = 2;
@@ -2969,9 +3415,10 @@ function gpuScenePBRShader(
     withReflectionData: boolean,
     withGroundTruthAmbientOcclusion: boolean,
     withCloudShadow: boolean,
-    withShadows: boolean
+    withShadows: boolean,
+    virtualShadows: Readonly<VirtualShadowMapSettings> | null
 ): StorageGraphicsShader {
-    const cacheKey = `${variant.key}|attributes=${withMaterialAttributes ? '1' : '0'}|reflections=${withReflectionData ? '1' : '0'}|gtao=${withGroundTruthAmbientOcclusion ? '1' : '0'}|cloud-shadow=${withCloudShadow ? '1' : '0'}|shadows=${withShadows ? '1' : '0'}`;
+    const cacheKey = `${variant.key}|attributes=${withMaterialAttributes ? '1' : '0'}|reflections=${withReflectionData ? '1' : '0'}|gtao=${withGroundTruthAmbientOcclusion ? '1' : '0'}|cloud-shadow=${withCloudShadow ? '1' : '0'}|shadows=${withShadows ? '1' : '0'}|virtual-shadows=${virtualShadows === null ? '0' : `${String(virtualShadows.virtualResolution)}:${String(virtualShadows.pageSize)}:${String(virtualShadows.physicalPageCount)}`}`;
     const cached = GPU_SCENE_PBR_SHADER_CACHE.get(cacheKey);
     if (cached !== undefined) return cached;
     const textureDeclarations = variant.textures
@@ -3093,9 +3540,43 @@ function gpuScenePBRShader(
             }
         );
     }
+    if (virtualShadows !== null) {
+        const pageTableTextureIndex = areaTextureIndex + 3;
+        const pageTableBinding = pageTableTextureIndex * 2;
+        bindings.push(
+            {
+                name: 'u_virtualShadowPageTable',
+                group: 1,
+                binding: pageTableBinding,
+                kind: 'sampled-texture',
+                sampleType: 'unfilterable-float'
+            },
+            {
+                name: 'u_virtualShadowPageTable',
+                group: 1,
+                binding: pageTableBinding + 1,
+                kind: 'sampler'
+            },
+            {
+                name: 'u_virtualShadowAtlas',
+                group: 1,
+                binding: pageTableBinding + 2,
+                kind: 'sampled-texture',
+                sampleType: 'depth'
+            },
+            {
+                name: 'u_virtualShadowAtlas',
+                group: 1,
+                binding: pageTableBinding + 3,
+                kind: 'comparison-sampler'
+            }
+        );
+    }
     const shadowTextureCount = withShadows ? 1 : 0;
+    const virtualShadowTextureCount = virtualShadows === null ? 0 : 2;
     if (withCloudShadow) {
-        const cloudTextureIndex = areaTextureIndex + 2 + shadowTextureCount;
+        const cloudTextureIndex =
+            areaTextureIndex + 2 + shadowTextureCount + virtualShadowTextureCount;
         const binding = cloudTextureIndex * 2;
         bindings.push(
             {
@@ -3174,6 +3655,7 @@ ${withCloudShadow ? 'uniform sampler2D u_cloudShadowTexture;' : ''}
 uniform sampler2D u_areaLightsLtcTexture1;
 uniform sampler2D u_areaLightsLtcTexture2;
 ${withShadows ? 'uniform highp sampler2DShadow u_shadowAtlas;' : ''}
+${virtualShadows === null ? '' : 'uniform highp sampler2D u_virtualShadowPageTable;\nuniform highp sampler2DShadow u_virtualShadowAtlas;'}
 in vec3 v_viewPosition;
 in vec3 v_viewNormal;
 ${fragmentUVDeclarations}
@@ -3218,7 +3700,8 @@ vec4 hiloMaterialSample(sampler2D source, uint materialBase, uint slotIndex, vec
 ${pbrSurfaceSource}
 ${pbrBrdfSource}
 ${CLUSTERED_AREA_LIGHT_SOURCE}
-${withShadows ? gpuSceneShadowSource() : ''}
+${virtualShadows === null ? '' : gpuSceneVirtualShadowSource(virtualShadows)}
+${withShadows ? gpuSceneShadowSource(virtualShadows) : ''}
 float hiloClusteredPhotometricAttenuation(
     vec3 viewPosition,
     vec3 lightPosition,
@@ -3984,6 +4467,41 @@ class MutableGPUDrivenParameters implements GPUDrivenRenderPassParameters {
     }
 }
 
+class MutableVirtualShadowClearParameters implements GPUDrivenRenderPassParameters {
+    readonly buffers: MutableBufferBinding[] = [
+        { buffer: INVALID_BUFFER },
+        { buffer: INVALID_BUFFER }
+    ];
+    readonly colorAttachments: RenderPipelineColorAttachment[] = [];
+    draw: {
+        kind: 'draw-indirect';
+        buffer: RenderGraphBufferHandle;
+        byteOffset: number;
+    } = { kind: 'draw-indirect', buffer: INVALID_BUFFER, byteOffset: 0 };
+    depthStencilAttachment?: RenderPipelineDepthStencilAttachment;
+
+    setBuffer(index: number, buffer: RenderGraphBufferHandle): void {
+        const binding = this.buffers[index];
+        if (binding === undefined) throw new RangeError('Virtual shadow clear buffer is missing');
+        binding.buffer = buffer;
+        delete binding.byteOffset;
+        delete binding.byteLength;
+    }
+
+    setBufferRange(
+        index: number,
+        buffer: RenderGraphBufferHandle,
+        byteOffset: number,
+        byteLength: number
+    ): void {
+        const binding = this.buffers[index];
+        if (binding === undefined) throw new RangeError('Virtual shadow clear buffer is missing');
+        binding.buffer = buffer;
+        binding.byteOffset = byteOffset;
+        binding.byteLength = byteLength;
+    }
+}
+
 class MutableGPUDrivenBatchParameters implements GPUDrivenRenderBatchPassParameters {
     readonly passes: GPUDrivenRenderPass[] = [];
     readonly parameters: GPUDrivenRenderPassParameters[] = [];
@@ -4404,6 +4922,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #volumetricLighting: VolumetricLightingController | null;
     readonly #autoExposure: AutoExposureController | null;
     readonly #atmosphere: AtmosphereWeatherController | null;
+    readonly #virtualShadows: VirtualShadowMapController | null;
+    readonly #virtualShadowClearPass: GPUDrivenRenderPass | null;
     readonly #groundTruthAmbientOcclusionSampler = new ComputeSampler({
         label: 'Clustered GTAO linear clamp sampler',
         magFilter: 'linear',
@@ -4431,6 +4951,13 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         mipmapFilter: 'nearest',
         lodMaxClamp: 0,
         compare: depthComparison('reversed')
+    });
+    readonly #virtualShadowPageTableSampler = new ComputeSampler({
+        label: 'Clustered virtual shadow page-table nearest sampler',
+        magFilter: 'nearest',
+        minFilter: 'nearest',
+        mipmapFilter: 'nearest',
+        lodMaxClamp: 0
     });
     readonly #clearPass = new ClearBuffersPass();
     readonly #clearPool = new RenderPassParameterPool(
@@ -4490,6 +5017,18 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             parameters.reset();
         }
     );
+    readonly #virtualShadowDrawPool = new RenderPassParameterPool(
+        () => new MutableGPUDrivenParameters(6, 1)
+    );
+    readonly #virtualShadowClearPool = new RenderPassParameterPool(
+        () => new MutableVirtualShadowClearParameters()
+    );
+    readonly #virtualShadowBatchPool = new RenderPassParameterPool(
+        () => new MutableGPUDrivenBatchParameters(),
+        parameters => {
+            parameters.reset();
+        }
+    );
     readonly #shadowPageScissors: [number, number, number, number][] = [];
     readonly #colorDrawPool = new RenderPassParameterPool(
         () => new MutableGPUDrivenParameters(8, 2)
@@ -4531,6 +5070,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     readonly #displayPass: FullscreenRenderPass;
     readonly #depthBatchPass = new GPUDrivenRenderBatchPass('GPU Scene depth buckets');
     readonly #shadowBatchPass = new GPUDrivenRenderBatchPass('GPU Scene shadow caster buckets');
+    readonly #virtualShadowBatchPass = new GPUDrivenRenderBatchPass(
+        'GPU Scene virtual shadow physical page updates'
+    );
     readonly #colorBatchPass = new GPUDrivenRenderBatchPass('Clustered PBR buckets');
     readonly #materialAttributesBatchPass = new GPUDrivenRenderBatchPass(
         'GPU Scene GTAO material attributes'
@@ -4627,6 +5169,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     #directionalLightCount = 0;
     #droppedLightCount = 0;
     #hasShadowLights = false;
+    #hasVirtualIncompatibleShadowCaster = false;
     #lastRecordedFrame = -1;
     #pendingCamera: Camera | null = null;
     #committedCamera: Camera | null = null;
@@ -4836,6 +5379,31 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         });
         const indirectData = new Uint32Array(physicalCount * 5);
         this.#physicalBuckets = Object.freeze(this.createPhysicalBuckets(context, indirectData));
+        this.#virtualShadows =
+            options.virtualShadows === null
+                ? null
+                : new VirtualShadowMapController(
+                      options.virtualShadows,
+                      context,
+                      this.#physicalBuckets.map(bucket =>
+                          Object.freeze({ indexCount: bucket.indexCount })
+                      ),
+                      options.maxObjects,
+                      this.#visibleBucketCapacity
+                  );
+        this.#virtualShadowClearPass =
+            options.virtualShadows === null
+                ? null
+                : new GPUDrivenRenderPass({
+                      name: 'Virtual shadow physical page clear',
+                      shader: virtualShadowClearShader(options.virtualShadows),
+                      pipelineState: Object.freeze({
+                          ...DEFAULT_MATERIAL_PIPELINE_STATE,
+                          cullMode: 'none',
+                          depthWrite: true,
+                          depthCompare: 'always'
+                      })
+                  });
         this.#logicalGPUCompatible.fill(1);
         this.#indirectArguments = create({
             label: 'GPU Scene fixed bucket indirect arguments',
@@ -5002,7 +5570,12 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 this.#clusteredDeformedObjectCount -
                 this.#clusteredTransparentObjectCount
         );
-        this.refreshShadowCompatibility(shadowResources !== null);
+        const virtualShadowsActive =
+            this.#virtualShadows !== null &&
+            shadowResources !== null &&
+            shadowResources.directionalShadowCount > 0 &&
+            !this.#hasVirtualIncompatibleShadowCaster;
+        this.refreshShadowCompatibility(shadowResources !== null, virtualShadowsActive);
         const frame = this.packFrame(context, renderWidth, renderHeight);
         context.writeStorageBuffer(this.#frameData, 0, new Uint8Array(this.#frameBytes));
 
@@ -5122,6 +5695,21 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const clusterStats = context.graph.importStorageBuffer(this.#clusterStats);
 
         const histories = this.acquireHiZ(context);
+        let virtualShadowResources: Readonly<VirtualShadowFrameResources> | null = null;
+        if (virtualShadowsActive && shadowResources !== null) {
+            virtualShadowResources = this.#virtualShadows.record(context, {
+                frameBuffer,
+                objects,
+                bucketData,
+                previousHiZ: histories.previous[0] ?? null,
+                hiZHistoryValid: histories.valid,
+                shadows: shadowResources,
+                activeObjectHighWater: this.#activeObjectHighWater,
+                previousViewMatrix: this.#committedViewMatrix,
+                cameraHistoryValid: frame.historyValid
+            });
+            this.recordVirtualShadowPages(context, virtualShadowResources, objects, materials);
+        }
         const clear = context.acquirePassParameters(this.#clearPool);
         // Reinitialize-policy buffers have undefined contents after device recovery. Clear the
         // complete allocation so the first recovered frame is valid even when the active viewport
@@ -5330,7 +5918,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             fallbackSpecular,
             ambientOcclusion,
             cloudShadow: atmospherePrerequisites?.cloudShadow ?? null,
-            shadowResources
+            shadowResources,
+            virtualShadowResources
         });
         if (fallbackCulling !== null && this.#clusteredDeformedObjectCount !== 0) {
             this.recordClusteredOpaque(
@@ -5569,6 +6158,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 record.committedOcclusionStable = record.pendingOcclusionStable;
                 record.committedMotionChanged = record.pendingMotionChanged;
                 record.committedMotionHistoryValid = record.pendingMotionHistoryValid;
+                record.committedShadowChanged = record.pendingShadowChanged;
+                record.committedMaterialRevision = record.pendingMaterialRevision;
                 record.pendingWorldVersion = -1;
             }
             record.committedHistoryRevision = record.pendingHistoryRevision;
@@ -5593,6 +6184,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#volumetricLighting?.frameSubmitted(frameIndex);
         this.#autoExposure?.frameSubmitted(frameIndex);
         this.#temporal?.frameSubmitted(frameIndex);
+        this.#virtualShadows?.frameSubmitted(frameIndex);
     }
 
     frameDiscarded(frameIndex: number): void {
@@ -5611,6 +6203,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             record.pendingOcclusionStable = false;
             record.pendingMotionChanged = false;
             record.pendingMotionHistoryValid = false;
+            record.pendingShadowChanged = false;
+            record.pendingMaterialRevision = -1;
         }
         this.#pendingCamera = null;
         this.#groundTruthAmbientOcclusion?.frameDiscarded(frameIndex);
@@ -5619,6 +6213,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#volumetricLighting?.frameDiscarded(frameIndex);
         this.#autoExposure?.frameDiscarded(frameIndex);
         this.#temporal?.frameDiscarded(frameIndex);
+        this.#virtualShadows?.frameDiscarded(frameIndex);
     }
 
     async readDiagnostics(): Promise<Readonly<ClusteredForwardPlusDiagnostics>> {
@@ -5647,6 +6242,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                       historyRejectedPixelCount: 0
                   })
                 : await this.#screenSpaceReflections.readDiagnostics();
+        const virtualShadows =
+            this.#virtualShadows === null ? null : await this.#virtualShadows.readDiagnostics();
         const cullValues = new Uint32Array(
             cull.data.buffer,
             cull.data.byteOffset,
@@ -5689,7 +6286,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             activeMaterialVariantCount: this.#activeMaterialVariants.size,
             materialVariantBudgetExceededCount: this.#materialVariantBudgetExceededCount,
             materialVariantBudget: this.#options.variantManifest.maxVariants,
-            materialVariantWarmupTimeMs: this.#materialVariantWarmupTimeMs
+            materialVariantWarmupTimeMs: this.#materialVariantWarmupTimeMs,
+            virtualShadows
         });
     }
 
@@ -5729,6 +6327,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         const failures: unknown[] = [];
         try {
             this.#temporal?.destroy();
+        } catch (error) {
+            failures.push(error);
+        }
+        try {
+            this.#virtualShadows?.destroy();
         } catch (error) {
             failures.push(error);
         }
@@ -5924,14 +6527,22 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                         validated.indexFormat,
                         variant
                     ),
+                    virtualShadowPass: this.createVirtualShadowPass(
+                        logical,
+                        physicalIndex,
+                        validated.indexFormat,
+                        variant
+                    ),
                     colorPass: this.createColorPass(
                         logical,
                         physicalIndex,
                         validated.indexFormat,
                         variant,
+                        false,
                         false
                     ),
                     colorShadowed: false,
+                    colorVirtualShadowed: false,
                     materialAttributesPass: this.createMaterialAttributesPass(
                         logical,
                         physicalIndex,
@@ -5976,12 +6587,30 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         });
     }
 
+    private createVirtualShadowPass(
+        logical: Readonly<NormalizedBucket>,
+        physicalIndex: number,
+        indexFormat: 'uint16' | 'uint32',
+        variant: Readonly<PBRMaterialVariant>
+    ): GPUDrivenRenderPass | null {
+        const settings = this.#options.virtualShadows;
+        if (settings === null) return null;
+        return new GPUDrivenRenderPass({
+            name: `GPU Scene virtual shadow bucket ${String(physicalIndex)}`,
+            shader: gpuSceneVirtualShadowShader(variant, settings),
+            pipelineState: requireBucketPassState(logical.material, 'depth-only'),
+            vertexLayouts: gpuSceneDepthVertexLayouts(variant),
+            indexFormat
+        });
+    }
+
     private createColorPass(
         logical: Readonly<NormalizedBucket>,
         physicalIndex: number,
         indexFormat: 'uint16' | 'uint32',
         variant: Readonly<PBRMaterialVariant>,
-        withShadows: boolean
+        withShadows: boolean,
+        withVirtualShadows: boolean
     ): GPUDrivenRenderPass {
         return new GPUDrivenRenderPass({
             name: `Clustered PBR bucket ${String(physicalIndex)}`,
@@ -5993,7 +6622,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 this.#options.screenSpaceReflections !== null,
                 this.#options.groundTruthAmbientOcclusion !== null,
                 this.#options.atmosphere !== null && this.#options.atmosphere.clouds !== null,
-                withShadows
+                withShadows,
+                withVirtualShadows ? this.#options.virtualShadows : null
             ),
             pipelineState: Object.freeze({
                 ...requireBucketPassState(logical.material, 'forward'),
@@ -6086,12 +6716,19 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 bucket.indexFormat,
                 variant
             );
+            bucket.virtualShadowPass = this.createVirtualShadowPass(
+                logical,
+                bucket.physicalIndex,
+                bucket.indexFormat,
+                variant
+            );
             bucket.colorPass = this.createColorPass(
                 logical,
                 bucket.physicalIndex,
                 bucket.indexFormat,
                 variant,
-                bucket.colorShadowed
+                bucket.colorShadowed,
+                bucket.colorVirtualShadowed
             );
             bucket.materialAttributesPass = this.createMaterialAttributesPass(
                 logical,
@@ -6104,10 +6741,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         }
     }
 
-    private refreshShadowCompatibility(withShadows: boolean): void {
+    private refreshShadowCompatibility(withShadows: boolean, withVirtualShadows: boolean): void {
         for (const bucket of this.#physicalBuckets) {
             if (
-                bucket.colorShadowed === withShadows ||
+                (bucket.colorShadowed === withShadows &&
+                    bucket.colorVirtualShadowed === withVirtualShadows) ||
                 this.#logicalGPUCompatible[bucket.logicalIndex] !== 1
             ) {
                 continue;
@@ -6119,9 +6757,11 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                 bucket.physicalIndex,
                 bucket.indexFormat,
                 bucket.materialVariant,
-                withShadows
+                withShadows,
+                withVirtualShadows
             );
             bucket.colorShadowed = withShadows;
+            bucket.colorVirtualShadowed = withVirtualShadows;
         }
     }
 
@@ -6163,6 +6803,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         this.#directionalLightCount = 0;
         this.#droppedLightCount = 0;
         this.#hasShadowLights = false;
+        this.#hasVirtualIncompatibleShadowCaster = false;
         const temporalEnabled = this.#temporal !== null;
 
         context.scene.traverse(node => {
@@ -6200,6 +6841,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                                 committedOcclusionStable: false,
                                 pendingMotionChanged: false,
                                 committedMotionChanged: false,
+                                pendingShadowChanged: false,
+                                committedShadowChanged: false,
+                                pendingMaterialRevision: -1,
+                                committedMaterialRevision: -1,
                                 pendingMotionHistoryValid: false,
                                 committedMotionHistoryValid: false,
                                 pendingHistoryRevision: temporalEnabled
@@ -6237,6 +6882,17 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                             record.committedSubmission === this.#submissionIndex &&
                             record.committedHistoryRevision === historyRevision;
                         const boundsStable = record.committedBoundsRevision === bounds.revision;
+                        if (!boundsStable && record.committedBoundsRevision >= 0) {
+                            this.#virtualShadows?.invalidateAll();
+                        }
+                        const materialRevision =
+                            this.#options.buckets[logicalIndex]?.material.revision ?? -1;
+                        const shadowChanged =
+                            record.logicalBucket !== logicalIndex ||
+                            !transformStable ||
+                            !boundsStable ||
+                            record.committedCastShadows !== node.castShadows ||
+                            record.committedMaterialRevision !== materialRevision;
                         const occlusionStable = transformStable && boundsStable;
                         const dirty =
                             record.logicalBucket !== logicalIndex ||
@@ -6247,7 +6903,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                             !boundsStable ||
                             record.committedOcclusionStable !== occlusionStable ||
                             record.committedMotionChanged !== motionChanged ||
-                            record.committedMotionHistoryValid !== motionHistoryValid;
+                            record.committedMotionHistoryValid !== motionHistoryValid ||
+                            record.committedShadowChanged !== shadowChanged ||
+                            record.committedMaterialRevision !== materialRevision;
                         record.logicalBucket = logicalIndex;
                         record.pendingHistoryRevision = historyRevision;
                         if (dirty) {
@@ -6257,7 +6915,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                                 logicalIndex,
                                 occlusionStable,
                                 motionHistoryValid,
-                                motionChanged
+                                motionChanged,
+                                shadowChanged,
+                                materialRevision
                             );
                             dirtyStart = Math.min(dirtyStart, record.slot);
                             dirtyEnd = Math.max(dirtyEnd, record.slot + 1);
@@ -6295,6 +6955,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
 
         for (const [mesh, record] of this.#objectByMesh) {
             if (record.seenFrame === this.#frameSerial) continue;
+            if (record.committedCastShadows) this.#virtualShadows?.invalidateAll();
             const metaOffset = record.slot * (OBJECT_RECORD_BYTES / 4) + 48;
             this.#objectUInts[metaOffset + 2] = 0;
             dirtyStart = Math.min(dirtyStart, record.slot);
@@ -6326,6 +6987,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
     private trackFallbackMesh(mesh: Mesh): void {
         const material = mesh.material;
         if (material === null) return;
+        if (mesh.castShadows) {
+            this.#hasVirtualIncompatibleShadowCaster = true;
+            this.#virtualShadows?.invalidateAll();
+        }
         if (this.#temporal !== null && !this.#pendingFallbackTemporalMeshes.has(mesh)) {
             const previousSubmission = this.#fallbackTemporalParticipation.get(mesh);
             if (previousSubmission !== undefined && previousSubmission !== this.#submissionIndex) {
@@ -6592,7 +7257,9 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         logicalIndex: number,
         occlusionStable: boolean,
         motionHistoryValid: boolean,
-        motionChanged: boolean
+        motionChanged: boolean,
+        shadowChanged: boolean,
+        materialRevision: number
     ): void {
         const bucket = this.#options.buckets[logicalIndex];
         if (bucket === undefined) throw new Error('GPU Scene logical bucket is unavailable');
@@ -6600,7 +7267,10 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         if (sphere === undefined) throw new Error('GPU Scene logical bounds are unavailable');
         const floatOffset = record.slot * (OBJECT_RECORD_BYTES / 4);
         matrixElements(mesh.worldMatrix, this.#objectFloats, floatOffset);
-        const previous = motionHistoryValid ? record.committedMatrix : mesh.worldMatrix.elements;
+        const previous =
+            motionHistoryValid || shadowChanged
+                ? record.committedMatrix
+                : mesh.worldMatrix.elements;
         for (let index = 0; index < 16; index += 1) {
             this.#objectFloats[floatOffset + 16 + index] = previous[index] ?? 0;
         }
@@ -6637,7 +7307,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             (motionHistoryValid ? OBJECT_MOTION_HISTORY_FLAG : 0) |
             (motionChanged ? OBJECT_MOTION_CHANGED_FLAG : 0) |
             (mesh.receiveShadows ? OBJECT_RECEIVE_SHADOW_FLAG : 0) |
-            (mesh.castShadows ? OBJECT_CAST_SHADOW_FLAG : 0);
+            (mesh.castShadows ? OBJECT_CAST_SHADOW_FLAG : 0) |
+            (shadowChanged ? OBJECT_SHADOW_DIRTY_FLAG : 0);
         this.#objectUInts[floatOffset + 51] = this.#materialDatabase.getHandle(
             bucket.material
         ).recordIndex;
@@ -6650,6 +7321,8 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
         record.pendingOcclusionStable = occlusionStable;
         record.pendingMotionHistoryValid = motionHistoryValid;
         record.pendingMotionChanged = motionChanged;
+        record.pendingShadowChanged = shadowChanged;
+        record.pendingMaterialRevision = materialRevision;
     }
 
     private packLights(
@@ -7054,6 +7727,111 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             previous: Object.freeze(previous),
             current: Object.freeze(current)
         });
+    }
+
+    private recordVirtualShadowPages(
+        context: RenderPipelineContext,
+        resources: Readonly<VirtualShadowFrameResources>,
+        objects: RenderGraphBufferHandle,
+        materials: RenderGraphBufferHandle
+    ): void {
+        const settings = this.#options.virtualShadows;
+        const clearPass = this.#virtualShadowClearPass;
+        if (settings === null || clearPass === null) return;
+        const batch = context.acquirePassParameters(this.#virtualShadowBatchPool);
+        const depthAttachment: RenderPipelineDepthStencilAttachment = {
+            texture: resources.atlas,
+            depthLoadOp: resources.clearAtlas ? 'clear' : 'load',
+            depthStoreOp: 'store',
+            depthClearValue: depthClearValue(context.camera.depthMode)
+        };
+        batch.depthStencilAttachment = depthAttachment;
+        for (let page = 0; page < settings.physicalPageCount; page += 1) {
+            const physicalRange = virtualShadowPhysicalPageRange(page);
+            const clear = context.acquirePassParameters(this.#virtualShadowClearPool);
+            clear.setBuffer(0, resources.clipmapData);
+            clear.setBufferRange(
+                1,
+                resources.physicalPages,
+                physicalRange.byteOffset,
+                physicalRange.byteLength
+            );
+            clear.draw.buffer = resources.clearIndirectArguments;
+            clear.draw.byteOffset = virtualShadowClearIndirectOffset(page);
+            clear.depthStencilAttachment = depthAttachment;
+            batch.add(clearPass, clear);
+            for (
+                let bucketIndex = 0;
+                bucketIndex < this.#physicalBuckets.length;
+                bucketIndex += 1
+            ) {
+                const bucket = this.#physicalBuckets[bucketIndex];
+                const virtualShadowPass = bucket?.virtualShadowPass ?? null;
+                if (bucket === undefined || virtualShadowPass === null) continue;
+                const variant = bucket.materialVariant;
+                const coverage = coverageTextures(variant);
+                const parameters = context.acquirePassParameters(this.#virtualShadowDrawPool);
+                parameters.configure(virtualShadowPass.vertexLayouts.length, coverage.length);
+                parameters.configureStorageBufferCount(variant.coverageMode === 'mask' ? 6 : 5);
+                parameters.setBuffer(0, resources.clipmapData);
+                parameters.setBufferRange(
+                    1,
+                    resources.physicalPages,
+                    physicalRange.byteOffset,
+                    physicalRange.byteLength
+                );
+                parameters.setBuffer(2, objects);
+                parameters.setBuffer(3, resources.visibleIndices);
+                const offsetRange = virtualShadowBucketOffsetRange(
+                    page,
+                    bucketIndex,
+                    this.#physicalBuckets.length
+                );
+                parameters.setBufferRange(
+                    4,
+                    resources.visibleBucketOffsets,
+                    offsetRange.byteOffset,
+                    offsetRange.byteLength
+                );
+                if (variant.coverageMode === 'mask') parameters.setBuffer(5, materials);
+                parameters.setVertexBuffer(0, context.graph.importStorageBuffer(bucket.position));
+                let vertexSlot = 1;
+                if (coverage.some(binding => binding.uv === 0)) {
+                    if (bucket.uv0 === null) {
+                        throw new Error('Virtual shadow UV0 buffer is unavailable');
+                    }
+                    parameters.setVertexBuffer(
+                        vertexSlot++,
+                        context.graph.importStorageBuffer(bucket.uv0)
+                    );
+                }
+                if (coverage.some(binding => binding.uv === 1)) {
+                    if (bucket.uv1 === null) {
+                        throw new Error('Virtual shadow UV1 buffer is unavailable');
+                    }
+                    parameters.setVertexBuffer(
+                        vertexSlot,
+                        context.graph.importStorageBuffer(bucket.uv1)
+                    );
+                }
+                for (let textureIndex = 0; textureIndex < coverage.length; textureIndex += 1) {
+                    const texture = coverage[textureIndex]?.texture;
+                    if (texture === undefined) continue;
+                    parameters.setTexture(textureIndex, context.graph.importTexture(texture));
+                    parameters.samplers[textureIndex] = this.samplerFor(texture);
+                }
+                parameters.indexBuffer.buffer = context.graph.importStorageBuffer(bucket.index);
+                parameters.draw.buffer = resources.shadowIndirectArguments;
+                parameters.draw.byteOffset = virtualShadowIndirectOffset(
+                    page,
+                    bucketIndex,
+                    this.#physicalBuckets.length
+                );
+                parameters.depthStencilAttachment = depthAttachment;
+                batch.add(virtualShadowPass, parameters);
+            }
+        }
+        context.graph.addPass(this.#virtualShadowBatchPass, batch);
     }
 
     /**
@@ -7573,6 +8351,7 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             ambientOcclusion: RenderGraphTextureHandle | null;
             cloudShadow: RenderGraphTextureHandle | null;
             shadowResources: Readonly<RenderPipelineShadowResources> | null;
+            virtualShadowResources: Readonly<VirtualShadowFrameResources> | null;
         }>
     ): void {
         const batch = context.acquirePassParameters(this.#colorBatchPool);
@@ -7642,12 +8421,14 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
             const gtaoTextureCount = resources.ambientOcclusion === null ? 0 : 1;
             const cloudShadowTextureCount = resources.cloudShadow === null ? 0 : 1;
             const shadowTextureCount = resources.shadowResources === null ? 0 : 1;
+            const virtualShadowTextureCount = resources.virtualShadowResources === null ? 0 : 2;
             parameters.configure(
                 bucket.colorPass.vertexLayouts.length,
                 variant.textures.length +
                     gtaoTextureCount +
                     2 +
                     shadowTextureCount +
+                    virtualShadowTextureCount +
                     cloudShadowTextureCount
             );
             parameters.setBuffer(0, resources.frameBuffer);
@@ -7714,8 +8495,19 @@ class ClusteredForwardPlusPipeline implements RenderPipeline {
                         ? this.#reversedShadowSampler
                         : this.#standardShadowSampler;
             }
+            if (resources.virtualShadowResources !== null) {
+                const pageTableIndex = areaTextureIndex + 2 + shadowTextureCount;
+                parameters.setTexture(pageTableIndex, resources.virtualShadowResources.pageTable);
+                parameters.samplers[pageTableIndex] = this.#virtualShadowPageTableSampler;
+                parameters.setTexture(pageTableIndex + 1, resources.virtualShadowResources.atlas);
+                parameters.samplers[pageTableIndex + 1] =
+                    resources.shadowResources?.depthMode === 'reversed'
+                        ? this.#reversedShadowSampler
+                        : this.#standardShadowSampler;
+            }
             if (resources.cloudShadow !== null) {
-                const cloudShadowIndex = areaTextureIndex + 2 + shadowTextureCount;
+                const cloudShadowIndex =
+                    areaTextureIndex + 2 + shadowTextureCount + virtualShadowTextureCount;
                 parameters.setTexture(cloudShadowIndex, resources.cloudShadow);
                 parameters.samplers[cloudShadowIndex] = this.#cloudShadowSampler;
             }
@@ -8152,6 +8944,7 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
         );
         const requirements = bufferRequirementPlan(this.#options, physicalCount);
         const hiZ = this.#options.hiZ;
+        const virtualShadows = this.#options.virtualShadows !== null;
         const screenSpaceReflections = this.#options.screenSpaceReflections !== null;
         const screenSpaceGlobalIllumination = this.#options.screenSpaceGlobalIllumination !== null;
         const groundTruthAmbientOcclusion = this.#options.groundTruthAmbientOcclusion !== null;
@@ -8166,7 +8959,7 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
         this.requirements = snapshotRenderPipelineRequirements({
             requiredCapabilities: Object.freeze([
                 'storage-buffer' as const,
-                ...(hiZ || volumetricLighting || autoExposure || atmosphere
+                ...(hiZ || volumetricLighting || autoExposure || atmosphere || virtualShadows
                     ? (['storage-texture' as const] as const)
                     : []),
                 'compute-pass' as const,
@@ -8190,6 +8983,18 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                           }),
                           Object.freeze({
                               format: 'rg32float' as const,
+                              use: 'storage' as const
+                          })
+                      ]
+                    : []),
+                ...(virtualShadows
+                    ? [
+                          Object.freeze({
+                              format: 'rgba32float' as const,
+                              use: 'sampled' as const
+                          }),
+                          Object.freeze({
+                              format: 'rgba32float' as const,
                               use: 'storage' as const
                           })
                       ]
@@ -8251,7 +9056,9 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     PBR_TEXTURE_ROLES.length * 2 +
                         (groundTruthAmbientOcclusion ? 2 : 0) +
                         6 +
+                        (virtualShadows ? 4 : 0) +
                         (cloudShadows ? 2 : 0),
+                    virtualShadows ? 9 : 0,
                     screenSpaceReflections
                         ? 3 + SCREEN_SPACE_REFLECTION_COLOR_LEVELS + 4 + reflectionHiZLevels + 1 + 2
                         : 0,
@@ -8265,6 +9072,7 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     PBR_TEXTURE_ROLES.length +
                         (groundTruthAmbientOcclusion ? 1 : 0) +
                         3 +
+                        (virtualShadows ? 2 : 0) +
                         (cloudShadows ? 1 : 0),
                     screenSpaceReflections
                         ? SCREEN_SPACE_REFLECTION_COLOR_LEVELS + 4 + reflectionHiZLevels
@@ -8277,8 +9085,9 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     PBR_TEXTURE_ROLES.length +
                     (groundTruthAmbientOcclusion ? 1 : 0) +
                     3 +
+                    (virtualShadows ? 2 : 0) +
                     (cloudShadows ? 1 : 0),
-                ...(hiZ || volumetricLighting || autoExposure || atmosphere
+                ...(hiZ || volumetricLighting || autoExposure || atmosphere || virtualShadows
                     ? {
                           maxStorageTexturesPerShaderStage: screenSpaceReflections
                               ? 4
@@ -8289,8 +9098,16 @@ export class ClusteredForwardPlusPipelineFactory implements RenderPipelineFactor
                     : {}),
                 maxStorageBufferBindingSize: requirements.maxStorageBufferBindingSize,
                 maxBufferSize: requirements.maxBufferSize,
-                ...(volumetricLighting
-                    ? { maxTextureDimension2D: volumetricAtlasMaxDimension(this.#options) }
+                ...(volumetricLighting || virtualShadows
+                    ? {
+                          maxTextureDimension2D: Math.max(
+                              volumetricAtlasMaxDimension(this.#options),
+                              this.#options.virtualShadows?.physicalAtlasWidth ?? 1,
+                              this.#options.virtualShadows?.physicalAtlasHeight ?? 1,
+                              this.#options.virtualShadows?.pageTableWidth ?? 1,
+                              this.#options.virtualShadows?.pageTableHeight ?? 1
+                          )
+                      }
                     : {}),
                 maxComputeInvocationsPerWorkgroup: PREFIX_WORKGROUP_SIZE,
                 maxComputeWorkgroupsPerDimension: requirements.maxComputeWorkgroupsPerDimension,

--- a/src/render/pipeline/VirtualShadowMaps.ts
+++ b/src/render/pipeline/VirtualShadowMaps.ts
@@ -1,0 +1,1664 @@
+import type Camera from '../../camera/Camera';
+import type DirectionalLight from '../../light/DirectionalLight';
+import Matrix4 from '../../math/Matrix4';
+import Vector3 from '../../math/Vector3';
+import ComputeKernel from '../compute/ComputeKernel';
+import ComputeShader from '../compute/ComputeShader';
+import type ComputeSampler from '../compute/ComputeSampler';
+import type { StorageBuffer } from '../StorageBuffer';
+import type {
+    RenderPipelineContext,
+    RenderPipelineCreateContext,
+    RenderPipelineShadowResources
+} from './RenderPipeline';
+import { RenderPassParameterPool } from './RenderPassParameterPool';
+import { ComputeRenderPass, type ComputeRenderPassParameters } from './passes/ComputeRenderPass';
+import type {
+    RenderGraphBufferHandle,
+    RenderGraphTextureAccessHandle,
+    RenderGraphTextureHandle,
+    RenderPipelineTargetResources,
+    ScriptableRenderPass,
+    ScriptableRenderPassBuilder,
+    ScriptableRenderPassContext
+} from './ScriptableRenderGraph';
+
+const INVALID_BUFFER = 0 as RenderGraphBufferHandle;
+const INVALID_TEXTURE = 0 as RenderGraphTextureHandle;
+const MAX_DIRECTIONAL_VIRTUAL_LIGHTS = 4;
+const CLIPMAP_HEADER_VEC4_COUNT = 13;
+const CLIPMAP_MAP_VEC4_COUNT = 5;
+const PHYSICAL_PAGE_STRIDE_BYTES = 256;
+const PHYSICAL_PAGE_BINDING_BYTES = 32;
+const SHADOW_INDIRECT_ARGUMENT_BYTES = 20;
+const DRAW_INDIRECT_ARGUMENT_BYTES = 16;
+const BUCKET_OFFSET_STRIDE_BYTES = 256;
+const CULL_WORKGROUP_SIZE = 64;
+const REQUEST_WORKGROUP_SIZE = 8;
+const VIRTUAL_SHADOW_STATS_BYTES = 32;
+
+/** GPU receiver-driven shadow-page allocation and directional clipmap controls. */
+export interface VirtualShadowMapOptions {
+    /** Square virtual resolution for every directional clipmap level. Defaults to 4096. */
+    readonly virtualResolution?: number;
+    /** Square physical page edge in pixels. Defaults to 128. */
+    readonly pageSize?: number;
+    /** Shared physical depth-page capacity. Defaults to 32. */
+    readonly physicalPageCount?: number;
+    /** Maximum missing or invalidated pages rendered by one frame. Defaults to 16. */
+    readonly maxPageUpdatesPerFrame?: number;
+    /** Camera-centered directional clipmap levels. Defaults to 4. */
+    readonly directionalClipmapLevels?: number;
+    /** Full world-space width covered by the finest clipmap. Defaults to 64. */
+    readonly firstDirectionalClipmapExtent?: number;
+}
+
+/** Validated immutable virtual-shadow configuration used by one pipeline runtime. */
+export interface VirtualShadowMapSettings {
+    readonly virtualResolution: number;
+    readonly pageSize: number;
+    readonly virtualPageGridSize: number;
+    readonly physicalPageCount: number;
+    readonly physicalPageColumns: number;
+    readonly physicalPageRows: number;
+    readonly physicalAtlasWidth: number;
+    readonly physicalAtlasHeight: number;
+    readonly maxPageUpdatesPerFrame: number;
+    readonly directionalClipmapLevels: number;
+    readonly firstDirectionalClipmapExtent: number;
+    readonly pageTableWidth: number;
+    readonly pageTableHeaderRows: number;
+    readonly pageTableHeight: number;
+    readonly clipmapVec4Count: number;
+}
+
+/** On-demand counters copied only when diagnostics are explicitly requested. */
+export interface VirtualShadowMapDiagnostics {
+    /** Unique logical pages requested by the latest submitted receiver pass. */
+    readonly requestedPageCount: number;
+    /** Physical pages whose depth contents were refreshed by the latest submitted frame. */
+    readonly renderedPageCount: number;
+    /** Requested or dirty pages postponed by the configured update/physical-page budgets. */
+    readonly deferredPageCount: number;
+    /** Valid physical residency records retained after the latest submitted allocation. */
+    readonly residentPageCount: number;
+    /** Resident physical pages remapped to another logical identity. */
+    readonly evictionCount: number;
+    /** Unique logical pages touched by changed caster coverage. */
+    readonly invalidatedPageCount: number;
+    /** Configured physical depth-page capacity. */
+    readonly physicalPageCapacity: number;
+    /** Configured camera-centered clipmap levels per directional light. */
+    readonly directionalClipmapLevelCount: number;
+}
+
+export interface VirtualShadowBucketDescriptor {
+    readonly indexCount: number;
+}
+
+export interface VirtualShadowFrameResources {
+    readonly atlas: RenderGraphTextureHandle;
+    readonly pageTable: RenderGraphTextureHandle;
+    readonly clipmapData: RenderGraphBufferHandle;
+    readonly physicalPages: RenderGraphBufferHandle;
+    readonly visibleIndices: RenderGraphBufferHandle;
+    readonly visibleBucketOffsets: RenderGraphBufferHandle;
+    readonly shadowIndirectArguments: RenderGraphBufferHandle;
+    readonly clearIndirectArguments: RenderGraphBufferHandle;
+    readonly clearAtlas: boolean;
+    readonly directionalLightCount: number;
+}
+
+interface MutableBufferBinding {
+    buffer: RenderGraphBufferHandle;
+    byteOffset?: number;
+    byteLength?: number;
+}
+
+interface MutableTextureBinding {
+    texture: RenderGraphTextureAccessHandle;
+}
+
+class MutableComputeParameters implements ComputeRenderPassParameters {
+    readonly buffers: MutableBufferBinding[];
+    readonly textures: MutableTextureBinding[];
+    readonly samplers: ComputeSampler[] = [];
+    dispatch: { x: number; y: number; z: number } = { x: 1, y: 1, z: 1 };
+
+    constructor(bufferCount: number, textureCount: number) {
+        this.buffers = Array.from({ length: bufferCount }, () => ({ buffer: INVALID_BUFFER }));
+        this.textures = Array.from({ length: textureCount }, () => ({ texture: INVALID_TEXTURE }));
+    }
+
+    setBuffer(index: number, buffer: RenderGraphBufferHandle): void {
+        const binding = this.buffers[index];
+        if (binding === undefined) throw new RangeError('Virtual-shadow compute buffer is missing');
+        binding.buffer = buffer;
+        delete binding.byteOffset;
+        delete binding.byteLength;
+    }
+
+    setTexture(index: number, texture: RenderGraphTextureAccessHandle): void {
+        const binding = this.textures[index];
+        if (binding === undefined)
+            throw new RangeError('Virtual-shadow compute texture is missing');
+        binding.texture = texture;
+    }
+
+    setDispatch(x: number, y = 1, z = 1): void {
+        this.dispatch.x = x;
+        this.dispatch.y = y;
+        this.dispatch.z = z;
+    }
+}
+
+interface BufferClearRange {
+    buffer: RenderGraphBufferHandle;
+    byteOffset: number;
+    byteLength: number;
+}
+
+class BufferClearParameters {
+    readonly ranges: BufferClearRange[] = [];
+
+    add(buffer: RenderGraphBufferHandle, byteOffset: number, byteLength: number): void {
+        let range = this.ranges[this.ranges.length];
+        if (range === undefined) {
+            range = { buffer, byteOffset, byteLength };
+            this.ranges.push(range);
+        } else {
+            range.buffer = buffer;
+            range.byteOffset = byteOffset;
+            range.byteLength = byteLength;
+        }
+    }
+
+    reset(): void {
+        this.ranges.length = 0;
+    }
+}
+
+class BufferClearPass implements ScriptableRenderPass<BufferClearParameters> {
+    readonly name = 'Virtual shadow request and invalidation reset';
+
+    setup(builder: ScriptableRenderPassBuilder, parameters: BufferClearParameters): void {
+        for (const range of parameters.ranges) {
+            builder.clearBuffer(range.buffer, range.byteOffset, range.byteLength);
+        }
+    }
+
+    execute(context: ScriptableRenderPassContext, parameters: BufferClearParameters): void {
+        for (const range of parameters.ranges) {
+            context.commands.clearBuffer(range.buffer, range.byteOffset, range.byteLength);
+        }
+    }
+}
+
+function positiveInteger(value: unknown, label: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new RangeError(`${label} must be a positive safe integer`);
+    }
+    return value as number;
+}
+
+function finitePositive(value: unknown, label: string): number {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        throw new RangeError(`${label} must be finite and positive`);
+    }
+    return value;
+}
+
+function powerOfTwo(value: number): boolean {
+    return (value & (value - 1)) === 0;
+}
+
+/** Validate and snapshot public virtual-shadow options. */
+export function snapshotVirtualShadowMapOptions(
+    value: unknown
+): Readonly<VirtualShadowMapSettings> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new TypeError('Virtual shadow map options must be an object');
+    }
+    const input = value as Readonly<VirtualShadowMapOptions>;
+    const virtualResolution = positiveInteger(
+        input.virtualResolution ?? 4096,
+        'Virtual shadow virtualResolution'
+    );
+    const pageSize = positiveInteger(input.pageSize ?? 128, 'Virtual shadow pageSize');
+    if (!powerOfTwo(virtualResolution) || !powerOfTwo(pageSize)) {
+        throw new RangeError('Virtual shadow virtualResolution and pageSize must be powers of two');
+    }
+    if (pageSize < 64 || pageSize > 256) {
+        throw new RangeError('Virtual shadow pageSize must be between 64 and 256');
+    }
+    if (virtualResolution < pageSize || virtualResolution % pageSize !== 0) {
+        throw new RangeError('Virtual shadow virtualResolution must contain complete pages');
+    }
+    const virtualPageGridSize = virtualResolution / pageSize;
+    if (virtualPageGridSize < 8 || virtualPageGridSize > 128) {
+        throw new RangeError('Virtual shadow page grid must contain between 8 and 128 pages');
+    }
+    const physicalPageCount = positiveInteger(
+        input.physicalPageCount ?? 32,
+        'Virtual shadow physicalPageCount'
+    );
+    if (physicalPageCount > 256) {
+        throw new RangeError('Virtual shadow physicalPageCount cannot exceed 256');
+    }
+    const maxPageUpdatesPerFrame = positiveInteger(
+        input.maxPageUpdatesPerFrame ?? 16,
+        'Virtual shadow maxPageUpdatesPerFrame'
+    );
+    if (maxPageUpdatesPerFrame > physicalPageCount) {
+        throw new RangeError(
+            'Virtual shadow maxPageUpdatesPerFrame cannot exceed physicalPageCount'
+        );
+    }
+    const directionalClipmapLevels = positiveInteger(
+        input.directionalClipmapLevels ?? 4,
+        'Virtual shadow directionalClipmapLevels'
+    );
+    if (directionalClipmapLevels > 4) {
+        throw new RangeError('Virtual shadow directionalClipmapLevels cannot exceed four');
+    }
+    const firstDirectionalClipmapExtent = finitePositive(
+        input.firstDirectionalClipmapExtent ?? 64,
+        'Virtual shadow firstDirectionalClipmapExtent'
+    );
+    const physicalPageColumns = Math.ceil(Math.sqrt(physicalPageCount));
+    const physicalPageRows = Math.ceil(physicalPageCount / physicalPageColumns);
+    const clipmapVec4Count =
+        CLIPMAP_HEADER_VEC4_COUNT +
+        MAX_DIRECTIONAL_VIRTUAL_LIGHTS * directionalClipmapLevels * CLIPMAP_MAP_VEC4_COUNT;
+    const pageTableWidth = Math.max(virtualPageGridSize, 32);
+    const pageTableHeaderRows = Math.ceil(clipmapVec4Count / pageTableWidth);
+    const pageTableHeight =
+        pageTableHeaderRows +
+        MAX_DIRECTIONAL_VIRTUAL_LIGHTS * directionalClipmapLevels * virtualPageGridSize;
+    return Object.freeze({
+        virtualResolution,
+        pageSize,
+        virtualPageGridSize,
+        physicalPageCount,
+        physicalPageColumns,
+        physicalPageRows,
+        physicalAtlasWidth: physicalPageColumns * pageSize,
+        physicalAtlasHeight: physicalPageRows * pageSize,
+        maxPageUpdatesPerFrame,
+        directionalClipmapLevels,
+        firstDirectionalClipmapExtent,
+        pageTableWidth,
+        pageTableHeaderRows,
+        pageTableHeight,
+        clipmapVec4Count
+    });
+}
+
+function computePass(shader: ComputeShader): ComputeRenderPass {
+    return new ComputeRenderPass(new ComputeKernel({ label: shader.label, shader }), shader.label);
+}
+
+function matrixToArray(matrix: Matrix4, target: Float32Array, offset: number): void {
+    for (let index = 0; index < 16; index += 1) {
+        target[offset + index] = matrix.elements[index] ?? 0;
+    }
+}
+
+class DirectionalClipmapState {
+    readonly data: ArrayBuffer;
+    readonly floats: Float32Array;
+    readonly uints: Uint32Array;
+    readonly #view = new Matrix4();
+    readonly #projection = new Matrix4();
+    readonly #viewProjection = new Matrix4();
+    readonly #inverseView = new Matrix4();
+    readonly #previousView = new Matrix4();
+    readonly #previousInverseView = new Matrix4();
+    readonly #eye = new Vector3();
+    readonly #target = new Vector3();
+    readonly #up = new Vector3();
+    readonly #committedLights: (DirectionalLight | null)[] = Array.from(
+        { length: MAX_DIRECTIONAL_VIRTUAL_LIGHTS },
+        () => null
+    );
+    readonly #pendingLights: (DirectionalLight | null)[] = Array.from(
+        { length: MAX_DIRECTIONAL_VIRTUAL_LIGHTS },
+        () => null
+    );
+    readonly #committedDirections = new Float32Array(MAX_DIRECTIONAL_VIRTUAL_LIGHTS * 3);
+    readonly #pendingDirections = new Float32Array(MAX_DIRECTIONAL_VIRTUAL_LIGHTS * 3);
+    readonly #committedEpochs = new Uint32Array(MAX_DIRECTIONAL_VIRTUAL_LIGHTS);
+    readonly #pendingEpochs = new Uint32Array(MAX_DIRECTIONAL_VIRTUAL_LIGHTS);
+    readonly #committedDepthCells = new Int32Array(MAX_DIRECTIONAL_VIRTUAL_LIGHTS);
+    readonly #pendingDepthCells = new Int32Array(MAX_DIRECTIONAL_VIRTUAL_LIGHTS);
+    #pendingFrame = -1;
+
+    constructor(readonly settings: Readonly<VirtualShadowMapSettings>) {
+        this.data = new ArrayBuffer(settings.clipmapVec4Count * 16);
+        this.floats = new Float32Array(this.data);
+        this.uints = new Uint32Array(this.data);
+    }
+
+    stage(
+        frameIndex: number,
+        camera: Camera,
+        shadows: Readonly<RenderPipelineShadowResources>,
+        cameraHistoryValid: boolean,
+        previousViewMatrix: ArrayLike<number>,
+        stateValid: boolean,
+        bucketCount: number,
+        visibleBucketCapacity: number
+    ): number {
+        const settings = this.settings;
+        const lightCount = Math.min(shadows.directionalShadowCount, MAX_DIRECTIONAL_VIRTUAL_LIGHTS);
+        this.floats.fill(0);
+        this.floats[0] = lightCount;
+        this.floats[1] = settings.directionalClipmapLevels;
+        this.floats[2] = settings.virtualPageGridSize;
+        this.floats[3] = settings.pageSize;
+        this.floats[4] = settings.physicalAtlasWidth;
+        this.floats[5] = settings.physicalAtlasHeight;
+        this.floats[6] = settings.physicalPageColumns;
+        this.floats[7] = settings.physicalPageRows;
+        this.uints[8] = frameIndex >>> 0;
+        this.uints[9] = settings.maxPageUpdatesPerFrame;
+        this.uints[10] = cameraHistoryValid ? 1 : 0;
+        this.uints[11] = shadows.depthMode === 'reversed' ? 1 : 0;
+        this.uints[12] = settings.pageTableHeaderRows;
+        this.uints[13] = bucketCount;
+        this.uints[14] = visibleBucketCapacity;
+        this.uints[15] = settings.physicalPageCount;
+        this.uints[16] = stateValid ? 1 : 0;
+        this.uints[17] = lightCount * settings.directionalClipmapLevels;
+        this.uints[18] = settings.pageTableWidth;
+        this.uints[19] = settings.pageTableHeight;
+
+        this.#inverseView.invert(camera.viewMatrix);
+        matrixToArray(this.#inverseView, this.floats, 20);
+        this.#previousView.fromArray(
+            cameraHistoryValid ? previousViewMatrix : camera.viewMatrix.elements
+        );
+        this.#previousInverseView.invert(this.#previousView);
+        matrixToArray(this.#previousInverseView, this.floats, 36);
+
+        const cameraX = camera.worldMatrix.elements[12];
+        const cameraY = camera.worldMatrix.elements[13];
+        const cameraZ = camera.worldMatrix.elements[14];
+        const cameraFar = Math.max(
+            settings.firstDirectionalClipmapExtent,
+            typeof Reflect.get(camera, 'far') === 'number'
+                ? (Reflect.get(camera, 'far') as number)
+                : settings.firstDirectionalClipmapExtent * 16
+        );
+
+        for (let lightIndex = 0; lightIndex < MAX_DIRECTIONAL_VIRTUAL_LIGHTS; lightIndex += 1) {
+            const light =
+                lightIndex < lightCount ? shadows.directionalLights[lightIndex] : undefined;
+            this.#pendingLights[lightIndex] = light ?? null;
+            if (light === undefined) {
+                this.#pendingEpochs[lightIndex] = this.#committedEpochs[lightIndex] ?? 0;
+                this.#pendingDepthCells[lightIndex] = this.#committedDepthCells[lightIndex] ?? 0;
+                continue;
+            }
+            const direction = light.getWorldDirection();
+            const directionOffset = lightIndex * 3;
+            this.#pendingDirections[directionOffset] = direction.x;
+            this.#pendingDirections[directionOffset + 1] = direction.y;
+            this.#pendingDirections[directionOffset + 2] = direction.z;
+            const dzX = -direction.x;
+            const dzY = -direction.y;
+            const dzZ = -direction.z;
+            const useXAxis = Math.abs(dzY) > 0.95;
+            const upX = useXAxis ? 1 : 0;
+            const upY = useXAxis ? 0 : 1;
+            const upZ = 0;
+            let rightX = upY * dzZ - upZ * dzY;
+            let rightY = upZ * dzX - upX * dzZ;
+            let rightZ = upX * dzY - upY * dzX;
+            const rightLength = Math.hypot(rightX, rightY, rightZ);
+            rightX /= rightLength;
+            rightY /= rightLength;
+            rightZ /= rightLength;
+            const planeUpX = dzY * rightZ - dzZ * rightY;
+            const planeUpY = dzZ * rightX - dzX * rightZ;
+            const planeUpZ = dzX * rightY - dzY * rightX;
+            const cameraPlaneX = cameraX * rightX + cameraY * rightY + cameraZ * rightZ;
+            const cameraPlaneY = cameraX * planeUpX + cameraY * planeUpY + cameraZ * planeUpZ;
+            const cameraPlaneZ = cameraX * dzX + cameraY * dzY + cameraZ * dzZ;
+            const depthWorldSize =
+                settings.firstDirectionalClipmapExtent / settings.virtualPageGridSize;
+            const depthCell = Math.round(cameraPlaneZ / depthWorldSize);
+            const snappedPlaneZ = depthCell * depthWorldSize;
+            this.#pendingDepthCells[lightIndex] = depthCell;
+            const changed =
+                this.#committedLights[lightIndex] !== light ||
+                this.#committedDirections[directionOffset] !== direction.x ||
+                this.#committedDirections[directionOffset + 1] !== direction.y ||
+                this.#committedDirections[directionOffset + 2] !== direction.z ||
+                this.#committedDepthCells[lightIndex] !== depthCell;
+            const previousEpoch = this.#committedEpochs[lightIndex] ?? 0;
+            this.#pendingEpochs[lightIndex] = changed ? (previousEpoch + 1) >>> 0 : previousEpoch;
+
+            for (let level = 0; level < settings.directionalClipmapLevels; level += 1) {
+                const extent = settings.firstDirectionalClipmapExtent * 2 ** level;
+                const pageWorldSize = extent / settings.virtualPageGridSize;
+                const snappedX = Math.round(cameraPlaneX / pageWorldSize) * pageWorldSize;
+                const snappedY = Math.round(cameraPlaneY / pageWorldSize) * pageWorldSize;
+                const centerX = rightX * snappedX + planeUpX * snappedY + dzX * snappedPlaneZ;
+                const centerY = rightY * snappedX + planeUpY * snappedY + dzY * snappedPlaneZ;
+                const centerZ = rightZ * snappedX + planeUpZ * snappedY + dzZ * snappedPlaneZ;
+                const depthHalf = Math.max(cameraFar, extent) * 1.25;
+                this.#eye.set(
+                    centerX - direction.x * depthHalf,
+                    centerY - direction.y * depthHalf,
+                    centerZ - direction.z * depthHalf
+                );
+                this.#target.set(centerX, centerY, centerZ);
+                this.#up.set(planeUpX, planeUpY, planeUpZ);
+                this.#view.lookAt(this.#eye, this.#target, this.#up);
+                const halfExtent = extent * 0.5;
+                const near = 0.1;
+                const far = depthHalf * 2 + near;
+                this.#projection.ortho(
+                    -halfExtent,
+                    halfExtent,
+                    -halfExtent,
+                    halfExtent,
+                    shadows.depthMode === 'reversed' ? far : near,
+                    shadows.depthMode === 'reversed' ? near : far
+                );
+                this.#viewProjection.multiply(this.#projection, this.#view);
+                const mapIndex = lightIndex * settings.directionalClipmapLevels + level;
+                const mapVec4 = CLIPMAP_HEADER_VEC4_COUNT + mapIndex * CLIPMAP_MAP_VEC4_COUNT;
+                matrixToArray(this.#viewProjection, this.floats, mapVec4 * 4);
+                const params = (mapVec4 + 4) * 4;
+                this.uints[params] =
+                    (Math.round(snappedX / pageWorldSize) - settings.virtualPageGridSize / 2) >>> 0;
+                this.uints[params + 1] =
+                    (-Math.round(snappedY / pageWorldSize) - settings.virtualPageGridSize / 2) >>>
+                    0;
+                this.uints[params + 2] = this.#pendingEpochs[lightIndex] ?? 0;
+                this.uints[params + 3] = mapIndex;
+            }
+        }
+        this.#pendingFrame = frameIndex;
+        return lightCount;
+    }
+
+    frameSubmitted(frameIndex: number): void {
+        if (frameIndex !== this.#pendingFrame) return;
+        for (let index = 0; index < MAX_DIRECTIONAL_VIRTUAL_LIGHTS; index += 1) {
+            this.#committedLights[index] = this.#pendingLights[index] ?? null;
+            this.#committedEpochs[index] = this.#pendingEpochs[index] ?? 0;
+        }
+        this.#committedDirections.set(this.#pendingDirections);
+        this.#committedDepthCells.set(this.#pendingDepthCells);
+        this.#pendingFrame = -1;
+    }
+
+    frameDiscarded(frameIndex: number): void {
+        if (frameIndex === this.#pendingFrame) this.#pendingFrame = -1;
+    }
+}
+
+const FRAME_WGSL = `
+struct FrameData {
+    currentViewProjection: mat4x4<f32>,
+    previousViewProjection: mat4x4<f32>,
+    view: mat4x4<f32>,
+    projection: mat4x4<f32>,
+    previousView: mat4x4<f32>,
+    previousProjection: mat4x4<f32>,
+    viewport: vec4<f32>,
+    depth: vec4<f32>,
+    previousDepth: vec4<f32>,
+    cluster: vec4<u32>,
+    counts: vec4<u32>,
+    budgets: vec4<u32>,
+    directional: vec4<u32>,
+    ambient: vec4<f32>,
+};
+struct ObjectRecord {
+    model0: vec4<f32>, model1: vec4<f32>, model2: vec4<f32>, model3: vec4<f32>,
+    previous0: vec4<f32>, previous1: vec4<f32>, previous2: vec4<f32>, previous3: vec4<f32>,
+    normal0: vec4<f32>, normal1: vec4<f32>, normal2: vec4<f32>,
+    bounds: vec4<f32>,
+    metadata: vec4<u32>,
+};
+struct BucketRecord {
+    indices0: vec4<u32>,
+    indices1: vec4<u32>,
+    thresholds: vec4<f32>,
+};
+fn objectModel(object: ObjectRecord) -> mat4x4<f32> {
+    return mat4x4<f32>(object.model0, object.model1, object.model2, object.model3);
+}
+fn objectPreviousModel(object: ObjectRecord) -> mat4x4<f32> {
+    return mat4x4<f32>(
+        object.previous0, object.previous1, object.previous2, object.previous3
+    );
+}
+fn maximumScale(model: mat4x4<f32>) -> f32 {
+    return max(length(model[0].xyz), max(length(model[1].xyz), length(model[2].xyz)));
+}
+`;
+
+const CLIPMAP_WGSL = `
+fn clipmapFloat(index: u32) -> vec4<f32> {
+    return bitcast<vec4<f32>>(clipmapData[index]);
+}
+fn clipmapMatrix(mapIndex: u32) -> mat4x4<f32> {
+    let base = ${String(CLIPMAP_HEADER_VEC4_COUNT)}u + mapIndex * ${String(CLIPMAP_MAP_VEC4_COUNT)}u;
+    return mat4x4<f32>(
+        clipmapFloat(base), clipmapFloat(base + 1u),
+        clipmapFloat(base + 2u), clipmapFloat(base + 3u)
+    );
+}
+fn clipmapIdentity(mapIndex: u32) -> vec4<u32> {
+    return clipmapData[${String(CLIPMAP_HEADER_VEC4_COUNT)}u + mapIndex * ${String(CLIPMAP_MAP_VEC4_COUNT)}u + 4u];
+}
+fn clipmapInversePreviousView() -> mat4x4<f32> {
+    return mat4x4<f32>(
+        clipmapFloat(9u), clipmapFloat(10u), clipmapFloat(11u), clipmapFloat(12u)
+    );
+}
+fn virtualPageBitIndex(mapIndex: u32, page: vec2<u32>) -> u32 {
+    let grid = u32(clipmapFloat(0u).z + 0.5);
+    return mapIndex * grid * grid + page.y * grid + page.x;
+}
+`;
+
+function requestPass(): ComputeRenderPass {
+    return computePass(
+        new ComputeShader({
+            label: 'Virtual shadow receiver depth page requests',
+            source: `${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read> clipmapData: array<vec4<u32>>;
+@group(0) @binding(2) var<storage, read_write> requestBits: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read_write> statistics: array<atomic<u32>>;
+@group(0) @binding(4) var previousHiZ: texture_2d<f32>;
+${CLIPMAP_WGSL}
+fn markRequested(mapIndex: u32, page: vec2<i32>) {
+    let grid = i32(clipmapFloat(0u).z + 0.5);
+    if (any(page < vec2<i32>(0)) || any(page >= vec2<i32>(grid))) { return; }
+    let bitIndex = virtualPageBitIndex(mapIndex, vec2<u32>(page));
+    let word = bitIndex >> 5u;
+    let mask = 1u << (bitIndex & 31u);
+    let previous = atomicOr(&requestBits[word], mask);
+    if ((previous & mask) == 0u) { _ = atomicAdd(&statistics[0], 1u); }
+}
+fn reconstructPreviousWorld(uv: vec2<f32>, deviceDepth: f32) -> vec3<f32> {
+    let ndc = vec3<f32>(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0, deviceDepth * 2.0 - 1.0);
+    let viewZ = -frameData.previousProjection[3][2] /
+        (ndc.z + frameData.previousProjection[2][2]);
+    let viewX = -(ndc.x + frameData.previousProjection[2][0]) * viewZ /
+        frameData.previousProjection[0][0];
+    let viewY = -(ndc.y + frameData.previousProjection[2][1]) * viewZ /
+        frameData.previousProjection[1][1];
+    let world = clipmapInversePreviousView() * vec4<f32>(viewX, viewY, viewZ, 1.0);
+    return world.xyz / max(abs(world.w), 0.000001) * sign(world.w);
+}
+@compute @workgroup_size(${String(REQUEST_WORKGROUP_SIZE)}, ${String(REQUEST_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let size = textureDimensions(previousHiZ);
+    if (any(id.xy >= size) || clipmapData[2u].z == 0u) { return; }
+    let bounds = textureLoad(previousHiZ, vec2<i32>(id.xy), 0).xy;
+    let reversed = clipmapData[2u].w != 0u;
+    let depth = select(bounds.x, bounds.y, reversed);
+    let empty = select(depth >= 0.999999, depth <= 0.000001, reversed);
+    if (empty) { return; }
+    let uv = (vec2<f32>(id.xy) + vec2<f32>(0.5)) / vec2<f32>(size);
+    let world = reconstructPreviousWorld(uv, depth);
+    let lightCount = u32(clipmapFloat(0u).x + 0.5);
+    let levels = u32(clipmapFloat(0u).y + 0.5);
+    let grid = u32(clipmapFloat(0u).z + 0.5);
+    for (var light = 0u; light < lightCount; light += 1u) {
+        var selected = 0xffffffffu;
+        var selectedPage = vec2<i32>(0);
+        for (var level = 0u; level < levels; level += 1u) {
+            let mapIndex = light * levels + level;
+            let clip = clipmapMatrix(mapIndex) * vec4<f32>(world, 1.0);
+            if (clip.w <= 0.0) { continue; }
+            let logicalUv = vec2<f32>(
+                clip.x / clip.w * 0.5 + 0.5,
+                0.5 - clip.y / clip.w * 0.5
+            );
+            if (all(logicalUv >= vec2<f32>(0.0)) && all(logicalUv < vec2<f32>(1.0))) {
+                selected = mapIndex;
+                selectedPage = vec2<i32>(logicalUv * f32(grid));
+                break;
+            }
+        }
+        if (selected == 0xffffffffu) { continue; }
+        for (var y = -1; y <= 1; y += 1) {
+            for (var x = -1; x <= 1; x += 1) {
+                markRequested(selected, selectedPage + vec2<i32>(x, y));
+            }
+        }
+        let coarse = selected + 1u;
+        if ((coarse % levels) != 0u) {
+            let clip = clipmapMatrix(coarse) * vec4<f32>(world, 1.0);
+            let logicalUv = vec2<f32>(
+                clip.x / clip.w * 0.5 + 0.5,
+                0.5 - clip.y / clip.w * 0.5
+            );
+            markRequested(coarse, vec2<i32>(logicalUv * f32(grid)));
+        }
+    }
+}`,
+            workgroupSize: [REQUEST_WORKGROUP_SIZE, REQUEST_WORKGROUP_SIZE],
+            bindings: [
+                { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+                { name: 'clipmapData', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+                {
+                    name: 'requestBits',
+                    group: 0,
+                    binding: 2,
+                    kind: 'storage-buffer',
+                    access: 'read-write'
+                },
+                {
+                    name: 'statistics',
+                    group: 0,
+                    binding: 3,
+                    kind: 'storage-buffer',
+                    access: 'read-write'
+                },
+                {
+                    name: 'previousHiZ',
+                    group: 0,
+                    binding: 4,
+                    kind: 'sampled-texture',
+                    sampleType: 'unfilterable-float'
+                }
+            ]
+        })
+    );
+}
+
+const INVALIDATION_PASS = computePass(
+    new ComputeShader({
+        label: 'Virtual shadow changed-caster page invalidation',
+        source: `${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read> clipmapData: array<vec4<u32>>;
+@group(0) @binding(2) var<storage, read> objects: array<ObjectRecord>;
+@group(0) @binding(3) var<storage, read_write> dirtyBits: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> statistics: array<atomic<u32>>;
+${CLIPMAP_WGSL}
+fn markDirty(mapIndex: u32, page: vec2<u32>) {
+    let bitIndex = virtualPageBitIndex(mapIndex, page);
+    let word = bitIndex >> 5u;
+    let mask = 1u << (bitIndex & 31u);
+    let previous = atomicOr(&dirtyBits[word], mask);
+    if ((previous & mask) == 0u) { _ = atomicAdd(&statistics[5], 1u); }
+}
+@compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= frameData.counts.x || id.x >= frameData.budgets.x) { return; }
+    let object = objects[id.x];
+    let flags = object.metadata.z;
+    if ((flags & 129u) != 129u) { return; }
+    let currentModel = objectModel(object);
+    let previousModel = objectPreviousModel(object);
+    let currentWorld = currentModel * vec4<f32>(object.bounds.xyz, 1.0);
+    let previousWorld = previousModel * vec4<f32>(object.bounds.xyz, 1.0);
+    let currentRadius = object.bounds.w * maximumScale(currentModel);
+    let previousRadius = object.bounds.w * maximumScale(previousModel);
+    let mapCount = clipmapData[4u].y;
+    let grid = u32(clipmapFloat(0u).z + 0.5);
+    for (var mapIndex = 0u; mapIndex < mapCount; mapIndex += 1u) {
+        let matrix = clipmapMatrix(mapIndex);
+        let currentClip = matrix * currentWorld;
+        let previousClip = matrix * previousWorld;
+        if (currentClip.w <= 0.0 && previousClip.w <= 0.0) { continue; }
+        let rowX = vec3<f32>(matrix[0].x, matrix[1].x, matrix[2].x);
+        let rowY = vec3<f32>(matrix[0].y, matrix[1].y, matrix[2].y);
+        let axisScale = vec2<f32>(length(rowX), length(rowY)) * 0.5;
+        let currentRadiusUv = axisScale * currentRadius;
+        let previousRadiusUv = axisScale * previousRadius;
+        let currentCenterUv = vec2<f32>(
+            currentClip.x / currentClip.w * 0.5 + 0.5,
+            0.5 - currentClip.y / currentClip.w * 0.5
+        );
+        let previousCenterUv = vec2<f32>(
+            previousClip.x / previousClip.w * 0.5 + 0.5,
+            0.5 - previousClip.y / previousClip.w * 0.5
+        );
+        let minimumUv = min(
+            currentCenterUv - currentRadiusUv,
+            previousCenterUv - previousRadiusUv
+        );
+        let maximumUv = max(
+            currentCenterUv + currentRadiusUv,
+            previousCenterUv + previousRadiusUv
+        );
+        if (any(maximumUv < vec2<f32>(0.0)) || any(minimumUv >= vec2<f32>(1.0))) { continue; }
+        let minimum = clamp(floor(minimumUv * f32(grid)), vec2<f32>(0.0), vec2<f32>(f32(grid - 1u)));
+        let maximum = clamp(floor(maximumUv * f32(grid)), vec2<f32>(0.0), vec2<f32>(f32(grid - 1u)));
+        for (var y = u32(minimum.y); y <= u32(maximum.y); y += 1u) {
+            for (var x = u32(minimum.x); x <= u32(maximum.x); x += 1u) {
+                markDirty(mapIndex, vec2<u32>(x, y));
+            }
+        }
+    }
+}`,
+        workgroupSize: [CULL_WORKGROUP_SIZE],
+        bindings: [
+            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            { name: 'clipmapData', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+            { name: 'objects', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
+            {
+                name: 'dirtyBits',
+                group: 0,
+                binding: 3,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'statistics',
+                group: 0,
+                binding: 4,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            }
+        ]
+    })
+);
+
+function allocatorPass(settings: Readonly<VirtualShadowMapSettings>): ComputeRenderPass {
+    const recordWords = PHYSICAL_PAGE_STRIDE_BYTES / 4;
+    return computePass(
+        new ComputeShader({
+            label: 'Virtual shadow deterministic page-table allocation and remap',
+            source: `
+@group(0) @binding(0) var<storage, read> clipmapData: array<vec4<u32>>;
+@group(0) @binding(1) var<storage, read> requestBits: array<u32>;
+@group(0) @binding(2) var<storage, read> dirtyBits: array<u32>;
+@group(0) @binding(3) var<storage, read> previousPhysical: array<u32>;
+@group(0) @binding(4) var<storage, read_write> currentPhysical: array<u32>;
+@group(0) @binding(5) var<storage, read_write> clearArguments: array<u32>;
+@group(0) @binding(6) var<storage, read_write> shadowArguments: array<u32>;
+@group(0) @binding(7) var<storage, read_write> statistics: array<u32>;
+@group(0) @binding(8) var pageTable: texture_storage_2d<rgba32float, write>;
+fn clipmapFloat(index: u32) -> vec4<f32> { return bitcast<vec4<f32>>(clipmapData[index]); }
+fn requested(bitIndex: u32) -> bool {
+    return (requestBits[bitIndex >> 5u] & (1u << (bitIndex & 31u))) != 0u;
+}
+fn dirty(bitIndex: u32) -> bool {
+    return (dirtyBits[bitIndex >> 5u] & (1u << (bitIndex & 31u))) != 0u;
+}
+fn physicalBase(index: u32) -> u32 { return index * ${String(recordWords)}u; }
+fn previousBitIndex(base: u32) -> u32 {
+    if (previousPhysical[base + 5u] == 0u) { return 0xffffffffu; }
+    let mapIndex = previousPhysical[base];
+    if (mapIndex >= clipmapData[4u].y) { return 0xffffffffu; }
+    let identity = clipmapData[${String(CLIPMAP_HEADER_VEC4_COUNT)}u + mapIndex * ${String(CLIPMAP_MAP_VEC4_COUNT)}u + 4u];
+    if (previousPhysical[base + 3u] != identity.z) { return 0xffffffffu; }
+    let grid = i32(clipmapFloat(0u).z + 0.5);
+    let page = vec2<i32>(
+        bitcast<i32>(previousPhysical[base + 1u]) - bitcast<i32>(identity.x),
+        bitcast<i32>(previousPhysical[base + 2u]) - bitcast<i32>(identity.y)
+    );
+    if (any(page < vec2<i32>(0)) || any(page >= vec2<i32>(grid))) {
+        return 0xffffffffu;
+    }
+    let unsignedGrid = u32(grid);
+    return mapIndex * unsignedGrid * unsignedGrid +
+        u32(page.y) * unsignedGrid + u32(page.x);
+}
+fn sameIdentity(base: u32, mapIndex: u32, absolutePage: vec2<i32>, epoch: u32) -> bool {
+    return previousPhysical[base + 5u] != 0u &&
+        previousPhysical[base] == mapIndex &&
+        bitcast<i32>(previousPhysical[base + 1u]) == absolutePage.x &&
+        bitcast<i32>(previousPhysical[base + 2u]) == absolutePage.y &&
+        previousPhysical[base + 3u] == epoch;
+}
+@compute @workgroup_size(1)
+fn main() {
+    let tableSize = textureDimensions(pageTable);
+    for (var y = 0u; y < tableSize.y; y += 1u) {
+        for (var x = 0u; x < tableSize.x; x += 1u) {
+            textureStore(pageTable, vec2<i32>(i32(x), i32(y)), vec4<f32>(0.0));
+        }
+    }
+    let headerCount = ${String(settings.clipmapVec4Count)}u;
+    for (var index = 0u; index < headerCount; index += 1u) {
+        let x = index % tableSize.x;
+        let y = index / tableSize.x;
+        var value = bitcast<vec4<f32>>(clipmapData[index]);
+        if (index >= 2u && index <= 4u) {
+            value = vec4<f32>(clipmapData[index]);
+        } else if (
+            index >= ${String(CLIPMAP_HEADER_VEC4_COUNT)}u &&
+            ((index - ${String(CLIPMAP_HEADER_VEC4_COUNT)}u) % ${String(CLIPMAP_MAP_VEC4_COUNT)}u) == 4u
+        ) {
+            let identity = clipmapData[index];
+            value = vec4<f32>(
+                f32(bitcast<i32>(identity.x)),
+                f32(bitcast<i32>(identity.y)),
+                f32(identity.z),
+                f32(identity.w)
+            );
+        }
+        textureStore(pageTable, vec2<i32>(i32(x), i32(y)), value);
+    }
+    let physicalCount = clipmapData[3u].w;
+    let bucketCount = clipmapData[3u].y;
+    let stateValid = clipmapData[4u].x != 0u;
+    for (var physical = 0u; physical < physicalCount; physical += 1u) {
+        let base = physicalBase(physical);
+        for (var word = 0u; word < ${String(recordWords)}u; word += 1u) {
+            currentPhysical[base + word] = select(0u, previousPhysical[base + word], stateValid);
+        }
+        currentPhysical[base + 6u] = 0u;
+        currentPhysical[base + 7u] = 0u;
+        let previousBit = previousBitIndex(base);
+        if (stateValid && previousBit != 0xffffffffu && dirty(previousBit)) {
+            currentPhysical[base + 8u] = 1u;
+        }
+        let clearBase = physical * 4u;
+        clearArguments[clearBase] = 3u;
+        clearArguments[clearBase + 1u] = 0u;
+        clearArguments[clearBase + 2u] = 0u;
+        clearArguments[clearBase + 3u] = 0u;
+        for (var bucket = 0u; bucket < bucketCount; bucket += 1u) {
+            shadowArguments[(physical * bucketCount + bucket) * 5u + 1u] = 0u;
+        }
+    }
+    let lightCount = u32(clipmapFloat(0u).x + 0.5);
+    let levels = u32(clipmapFloat(0u).y + 0.5);
+    let grid = u32(clipmapFloat(0u).z + 0.5);
+    let headerRows = clipmapData[3u].x;
+    let frameIndex = clipmapData[2u].x;
+    let updateBudget = clipmapData[2u].y;
+    var rendered = 0u;
+    var deferred = 0u;
+    var evictions = 0u;
+    var resident = 0u;
+    for (var mapIndex = 0u; mapIndex < lightCount * levels; mapIndex += 1u) {
+        let identity = clipmapData[${String(CLIPMAP_HEADER_VEC4_COUNT)}u + mapIndex * ${String(CLIPMAP_MAP_VEC4_COUNT)}u + 4u];
+        let origin = vec2<i32>(bitcast<i32>(identity.x), bitcast<i32>(identity.y));
+        let epoch = identity.z;
+        for (var y = 0u; y < grid; y += 1u) {
+            for (var x = 0u; x < grid; x += 1u) {
+                let bitIndex = mapIndex * grid * grid + y * grid + x;
+                if (!requested(bitIndex)) { continue; }
+                let absolutePage = origin + vec2<i32>(i32(x), i32(y));
+                var selected = 0xffffffffu;
+                for (var physical = 0u; physical < physicalCount; physical += 1u) {
+                    let base = physicalBase(physical);
+                    if (
+                        currentPhysical[base + 7u] == 0u &&
+                        sameIdentity(base, mapIndex, absolutePage, epoch)
+                    ) {
+                        selected = physical;
+                        break;
+                    }
+                }
+                var needsUpdate = dirty(bitIndex);
+                if (selected != 0xffffffffu) {
+                    needsUpdate = needsUpdate || previousPhysical[physicalBase(selected) + 8u] != 0u;
+                }
+                if (selected == 0xffffffffu) {
+                    var candidate = 0xffffffffu;
+                    var oldest = 0xffffffffu;
+                    for (var physical = 0u; physical < physicalCount; physical += 1u) {
+                        let base = physicalBase(physical);
+                        if (currentPhysical[base + 7u] != 0u) { continue; }
+                        if (currentPhysical[base + 5u] == 0u) {
+                            candidate = physical;
+                            break;
+                        }
+                        let age = currentPhysical[base + 4u];
+                        if (age <= oldest) {
+                            oldest = age;
+                            candidate = physical;
+                        }
+                    }
+                    if (candidate != 0xffffffffu && rendered < updateBudget) {
+                        selected = candidate;
+                        let base = physicalBase(selected);
+                        if (currentPhysical[base + 5u] != 0u) { evictions += 1u; }
+                        currentPhysical[base] = mapIndex;
+                        currentPhysical[base + 1u] = bitcast<u32>(absolutePage.x);
+                        currentPhysical[base + 2u] = bitcast<u32>(absolutePage.y);
+                        currentPhysical[base + 3u] = epoch;
+                        currentPhysical[base + 5u] = 1u;
+                        needsUpdate = true;
+                    }
+                }
+                if (selected == 0xffffffffu) {
+                    deferred += 1u;
+                    continue;
+                }
+                let base = physicalBase(selected);
+                currentPhysical[base + 4u] = frameIndex;
+                currentPhysical[base + 7u] = 1u;
+                if (needsUpdate) {
+                    if (rendered < updateBudget) {
+                        currentPhysical[base + 6u] = 1u;
+                        currentPhysical[base + 8u] = 0u;
+                        clearArguments[selected * 4u + 1u] = 1u;
+                        rendered += 1u;
+                    } else {
+                        currentPhysical[base + 8u] = 1u;
+                        deferred += 1u;
+                        continue;
+                    }
+                }
+                let tableY = headerRows + mapIndex * grid + y;
+                textureStore(
+                    pageTable,
+                    vec2<i32>(i32(x), i32(tableY)),
+                    vec4<f32>(f32(selected + 1u), f32(absolutePage.x), f32(absolutePage.y), f32(epoch))
+                );
+            }
+        }
+    }
+    for (var physical = 0u; physical < physicalCount; physical += 1u) {
+        let base = physicalBase(physical);
+        if (currentPhysical[base + 5u] != 0u) { resident += 1u; }
+        currentPhysical[base + 7u] = physical;
+    }
+    statistics[1] = rendered;
+    statistics[2] = deferred;
+    statistics[3] = resident;
+    statistics[4] = evictions;
+    statistics[6] = physicalCount;
+    statistics[7] = levels;
+}`,
+            workgroupSize: [1],
+            bindings: [
+                { name: 'clipmapData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+                { name: 'requestBits', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+                { name: 'dirtyBits', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
+                {
+                    name: 'previousPhysical',
+                    group: 0,
+                    binding: 3,
+                    kind: 'read-only-storage-buffer'
+                },
+                {
+                    name: 'currentPhysical',
+                    group: 0,
+                    binding: 4,
+                    kind: 'storage-buffer',
+                    access: 'write-discard'
+                },
+                {
+                    name: 'clearArguments',
+                    group: 0,
+                    binding: 5,
+                    kind: 'storage-buffer',
+                    access: 'write-discard'
+                },
+                {
+                    name: 'shadowArguments',
+                    group: 0,
+                    binding: 6,
+                    kind: 'storage-buffer',
+                    access: 'read-write'
+                },
+                {
+                    name: 'statistics',
+                    group: 0,
+                    binding: 7,
+                    kind: 'storage-buffer',
+                    access: 'read-write'
+                },
+                {
+                    name: 'pageTable',
+                    group: 0,
+                    binding: 8,
+                    kind: 'storage-texture',
+                    access: 'write-only',
+                    format: 'rgba32float'
+                }
+            ]
+        })
+    );
+}
+
+const PAGE_CULL_PASS = computePass(
+    new ComputeShader({
+        label: 'Virtual shadow per-page caster culling',
+        source: `${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read> clipmapData: array<vec4<u32>>;
+@group(0) @binding(2) var<storage, read> physicalPages: array<u32>;
+@group(0) @binding(3) var<storage, read> objects: array<ObjectRecord>;
+@group(0) @binding(4) var<storage, read> buckets: array<BucketRecord>;
+@group(0) @binding(5) var<storage, read_write> selectedBuckets: array<u32>;
+@group(0) @binding(6) var<storage, read_write> shadowArguments: array<atomic<u32>>;
+${CLIPMAP_WGSL}
+fn physicalBase(index: u32) -> u32 {
+    return index * ${String(PHYSICAL_PAGE_STRIDE_BYTES / 4)}u;
+}
+@compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let objectIndex = id.x;
+    let physicalIndex = id.y;
+    let objectCount = frameData.counts.x;
+    let maximumObjects = frameData.budgets.x;
+    if (objectIndex >= objectCount || objectIndex >= maximumObjects) { return; }
+    let base = physicalBase(physicalIndex);
+    let selectedIndex = physicalIndex * maximumObjects + objectIndex;
+    selectedBuckets[selectedIndex] = 0xffffffffu;
+    if (physicalPages[base + 6u] == 0u) { return; }
+    let object = objects[objectIndex];
+    let flags = object.metadata.z;
+    if ((flags & 65u) != 65u || (object.metadata.y & frameData.budgets.w) == 0u) { return; }
+    let mapIndex = physicalPages[base];
+    let identity = clipmapIdentity(mapIndex);
+    let page = vec2<i32>(
+        bitcast<i32>(physicalPages[base + 1u]) - bitcast<i32>(identity.x),
+        bitcast<i32>(physicalPages[base + 2u]) - bitcast<i32>(identity.y)
+    );
+    let grid = u32(clipmapFloat(0u).z + 0.5);
+    if (any(page < vec2<i32>(0)) || any(page >= vec2<i32>(i32(grid)))) { return; }
+    let model = objectModel(object);
+    let center = model * vec4<f32>(object.bounds.xyz, 1.0);
+    let radius = object.bounds.w * maximumScale(model);
+    let matrix = clipmapMatrix(mapIndex);
+    let clip = matrix * center;
+    if (clip.w <= 0.0) { return; }
+    let rowX = vec3<f32>(matrix[0].x, matrix[1].x, matrix[2].x);
+    let rowY = vec3<f32>(matrix[0].y, matrix[1].y, matrix[2].y);
+    let rowZ = vec3<f32>(matrix[0].z, matrix[1].z, matrix[2].z);
+    let radiusNdc = vec3<f32>(length(rowX), length(rowY), length(rowZ)) * radius / clip.w;
+    let centerNdc = clip.xyz / clip.w;
+    let pageMinimum = vec2<f32>(page) / f32(grid) * 2.0 - vec2<f32>(1.0);
+    let pageMaximum = vec2<f32>(page + vec2<i32>(1)) / f32(grid) * 2.0 - vec2<f32>(1.0);
+    let yMinimum = -pageMaximum.y;
+    let yMaximum = -pageMinimum.y;
+    if (
+        centerNdc.x + radiusNdc.x < pageMinimum.x ||
+        centerNdc.x - radiusNdc.x > pageMaximum.x ||
+        centerNdc.y + radiusNdc.y < yMinimum ||
+        centerNdc.y - radiusNdc.y > yMaximum ||
+        centerNdc.z + radiusNdc.z < -1.0 ||
+        centerNdc.z - radiusNdc.z > 1.0
+    ) { return; }
+    let bucket = buckets[object.metadata.x].indices0.x;
+    let bucketCount = clipmapData[3u].y;
+    let indirectIndex = (physicalIndex * bucketCount + bucket) * 5u;
+    _ = atomicAdd(&shadowArguments[indirectIndex + 1u], 1u);
+    selectedBuckets[selectedIndex] = bucket;
+}`,
+        workgroupSize: [CULL_WORKGROUP_SIZE],
+        bindings: [
+            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            { name: 'clipmapData', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+            { name: 'physicalPages', group: 0, binding: 2, kind: 'read-only-storage-buffer' },
+            { name: 'objects', group: 0, binding: 3, kind: 'read-only-storage-buffer' },
+            { name: 'buckets', group: 0, binding: 4, kind: 'read-only-storage-buffer' },
+            {
+                name: 'selectedBuckets',
+                group: 0,
+                binding: 5,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            },
+            {
+                name: 'shadowArguments',
+                group: 0,
+                binding: 6,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            }
+        ]
+    })
+);
+
+const PAGE_BUCKET_PREFIX_PASS = computePass(
+    new ComputeShader({
+        label: 'Virtual shadow per-page bucket prefix',
+        source: `
+@group(0) @binding(0) var<storage, read> clipmapData: array<vec4<u32>>;
+@group(0) @binding(1) var<storage, read> physicalPages: array<u32>;
+@group(0) @binding(2) var<storage, read_write> shadowArguments: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bucketOffsets: array<u32>;
+fn physicalBase(index: u32) -> u32 {
+    return index * ${String(PHYSICAL_PAGE_STRIDE_BYTES / 4)}u;
+}
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let physicalIndex = id.x;
+    let bucketCount = clipmapData[3u].y;
+    let visibleCapacity = clipmapData[3u].z;
+    var offset = physicalIndex * visibleCapacity;
+    for (var bucket = 0u; bucket < bucketCount; bucket += 1u) {
+        let entry = physicalIndex * bucketCount + bucket;
+        atomicStore(&bucketCursors[entry], 0u);
+        bucketOffsets[entry * ${String(BUCKET_OFFSET_STRIDE_BYTES / 4)}u] = offset;
+        let indirect = entry * 5u;
+        let count = select(0u, atomicLoad(&shadowArguments[indirect + 1u]), physicalPages[physicalBase(physicalIndex) + 6u] != 0u);
+        atomicStore(&shadowArguments[indirect + 4u], offset);
+        offset += count;
+    }
+}`,
+        workgroupSize: [1],
+        bindings: [
+            { name: 'clipmapData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            { name: 'physicalPages', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+            {
+                name: 'shadowArguments',
+                group: 0,
+                binding: 2,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'bucketCursors',
+                group: 0,
+                binding: 3,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            },
+            {
+                name: 'bucketOffsets',
+                group: 0,
+                binding: 4,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            }
+        ]
+    })
+);
+
+const PAGE_VISIBLE_COMPACT_PASS = computePass(
+    new ComputeShader({
+        label: 'Virtual shadow per-page visible caster compact',
+        source: `
+${FRAME_WGSL}
+@group(0) @binding(0) var<storage, read> frameData: FrameData;
+@group(0) @binding(1) var<storage, read> clipmapData: array<vec4<u32>>;
+@group(0) @binding(2) var<storage, read> selectedBuckets: array<u32>;
+@group(0) @binding(3) var<storage, read_write> bucketCursors: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read> bucketOffsets: array<u32>;
+@group(0) @binding(5) var<storage, read_write> visibleIndices: array<u32>;
+@compute @workgroup_size(${String(CULL_WORKGROUP_SIZE)})
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let objectIndex = id.x;
+    let physicalIndex = id.y;
+    let maximumObjects = frameData.budgets.x;
+    if (objectIndex >= frameData.counts.x || objectIndex >= maximumObjects) { return; }
+    let bucket = selectedBuckets[physicalIndex * maximumObjects + objectIndex];
+    if (bucket == 0xffffffffu) { return; }
+    let bucketCount = clipmapData[3u].y;
+    let entry = physicalIndex * bucketCount + bucket;
+    let localIndex = atomicAdd(&bucketCursors[entry], 1u);
+    let offset = bucketOffsets[entry * ${String(BUCKET_OFFSET_STRIDE_BYTES / 4)}u];
+    visibleIndices[offset + localIndex] = objectIndex;
+}`,
+        workgroupSize: [CULL_WORKGROUP_SIZE],
+        bindings: [
+            { name: 'frameData', group: 0, binding: 0, kind: 'read-only-storage-buffer' },
+            { name: 'clipmapData', group: 0, binding: 1, kind: 'read-only-storage-buffer' },
+            {
+                name: 'selectedBuckets',
+                group: 0,
+                binding: 2,
+                kind: 'read-only-storage-buffer'
+            },
+            {
+                name: 'bucketCursors',
+                group: 0,
+                binding: 3,
+                kind: 'storage-buffer',
+                access: 'read-write'
+            },
+            {
+                name: 'bucketOffsets',
+                group: 0,
+                binding: 4,
+                kind: 'read-only-storage-buffer'
+            },
+            {
+                name: 'visibleIndices',
+                group: 0,
+                binding: 5,
+                kind: 'storage-buffer',
+                access: 'write-discard'
+            }
+        ]
+    })
+);
+
+/** Return the aligned storage-binding range for one physical-page record. */
+export function virtualShadowPhysicalPageRange(
+    physicalPageIndex: number
+): Readonly<{ byteOffset: number; byteLength: number }> {
+    return Object.freeze({
+        byteOffset: physicalPageIndex * PHYSICAL_PAGE_STRIDE_BYTES,
+        byteLength: PHYSICAL_PAGE_BINDING_BYTES
+    });
+}
+
+/** Return the aligned storage-binding range containing one page/bucket visible offset. */
+export function virtualShadowBucketOffsetRange(
+    physicalPageIndex: number,
+    bucketIndex: number,
+    bucketCount: number
+): Readonly<{ byteOffset: number; byteLength: number }> {
+    return Object.freeze({
+        byteOffset: (physicalPageIndex * bucketCount + bucketIndex) * BUCKET_OFFSET_STRIDE_BYTES,
+        byteLength: 4
+    });
+}
+
+/** Return one page/bucket indexed indirect-draw argument offset. */
+export function virtualShadowIndirectOffset(
+    physicalPageIndex: number,
+    bucketIndex: number,
+    bucketCount: number
+): number {
+    return (physicalPageIndex * bucketCount + bucketIndex) * SHADOW_INDIRECT_ARGUMENT_BYTES;
+}
+
+/** Return one physical-page non-indexed clear-draw argument offset. */
+export function virtualShadowClearIndirectOffset(physicalPageIndex: number): number {
+    return physicalPageIndex * DRAW_INDIRECT_ARGUMENT_BYTES;
+}
+
+export interface VirtualShadowRecordInputs {
+    readonly frameBuffer: RenderGraphBufferHandle;
+    readonly objects: RenderGraphBufferHandle;
+    readonly bucketData: RenderGraphBufferHandle;
+    readonly previousHiZ: RenderGraphTextureHandle | null;
+    readonly hiZHistoryValid: boolean;
+    readonly shadows: Readonly<RenderPipelineShadowResources>;
+    readonly activeObjectHighWater: number;
+    readonly previousViewMatrix: ArrayLike<number>;
+    readonly cameraHistoryValid: boolean;
+}
+
+/** Renderer-local WebGPU virtual-shadow state and graph recorder. */
+export class VirtualShadowMapController {
+    readonly settings: Readonly<VirtualShadowMapSettings>;
+    readonly #clipmaps: DirectionalClipmapState;
+    readonly #clipmapData: StorageBuffer;
+    readonly #requestBits: StorageBuffer;
+    readonly #dirtyBits: StorageBuffer;
+    readonly #physicalPages: readonly [StorageBuffer, StorageBuffer];
+    readonly #selectedBuckets: StorageBuffer;
+    readonly #visibleIndices: StorageBuffer;
+    readonly #bucketCursors: StorageBuffer;
+    readonly #bucketOffsets: StorageBuffer;
+    readonly #shadowArguments: StorageBuffer;
+    readonly #clearArguments: StorageBuffer;
+    readonly #statistics: StorageBuffer;
+    readonly #pageTableKey = {};
+    readonly #atlasKey = {};
+    readonly #requestPass = requestPass();
+    readonly #allocatorPass: ComputeRenderPass;
+    readonly #clearPass = new BufferClearPass();
+    readonly #clearPool = new RenderPassParameterPool(
+        () => new BufferClearParameters(),
+        value => {
+            value.reset();
+        }
+    );
+    readonly #requestPool = new RenderPassParameterPool(() => new MutableComputeParameters(4, 1));
+    readonly #invalidationPool = new RenderPassParameterPool(
+        () => new MutableComputeParameters(5, 0)
+    );
+    readonly #allocatorPool = new RenderPassParameterPool(() => new MutableComputeParameters(8, 1));
+    readonly #cullPool = new RenderPassParameterPool(() => new MutableComputeParameters(7, 0));
+    readonly #prefixPool = new RenderPassParameterPool(() => new MutableComputeParameters(5, 0));
+    readonly #compactPool = new RenderPassParameterPool(() => new MutableComputeParameters(6, 0));
+    readonly #bucketCount: number;
+    readonly #visibleBucketCapacity: number;
+    #physicalPageIndex = 0;
+    #pendingFrame = -1;
+    #pendingPhysicalPageIndex = 0;
+    #stateValid = false;
+    #invalidateRequested = false;
+    #destroyed = false;
+
+    constructor(
+        settings: Readonly<VirtualShadowMapSettings>,
+        context: RenderPipelineCreateContext,
+        buckets: readonly Readonly<VirtualShadowBucketDescriptor>[],
+        maximumObjects: number,
+        visibleBucketCapacity: number
+    ) {
+        this.settings = settings;
+        this.#clipmaps = new DirectionalClipmapState(settings);
+        this.#allocatorPass = allocatorPass(settings);
+        this.#bucketCount = buckets.length;
+        this.#visibleBucketCapacity = visibleBucketCapacity;
+        const create = (
+            descriptor: Parameters<RenderPipelineCreateContext['createStorageBuffer']>[0]
+        ): StorageBuffer => context.createStorageBuffer(descriptor);
+        const virtualPageCount =
+            MAX_DIRECTIONAL_VIRTUAL_LIGHTS *
+            settings.directionalClipmapLevels *
+            settings.virtualPageGridSize *
+            settings.virtualPageGridSize;
+        const bitsetByteLength = Math.ceil(virtualPageCount / 32) * 4;
+        this.#clipmapData = create({
+            label: 'Virtual shadow directional clipmap database',
+            byteLength: this.#clipmaps.data.byteLength,
+            usage: ['storage', 'copy-destination'],
+            recovery: 'cpu-shadow'
+        });
+        this.#requestBits = create({
+            label: 'Virtual shadow receiver request bitset',
+            byteLength: bitsetByteLength,
+            usage: ['storage', 'copy-destination'],
+            recovery: 'reinitialize'
+        });
+        this.#dirtyBits = create({
+            label: 'Virtual shadow changed-caster invalidation bitset',
+            byteLength: bitsetByteLength,
+            usage: ['storage', 'copy-destination'],
+            recovery: 'reinitialize'
+        });
+        const physicalByteLength = settings.physicalPageCount * PHYSICAL_PAGE_STRIDE_BYTES;
+        this.#physicalPages = Object.freeze([
+            create({
+                label: 'Virtual shadow physical residency state A',
+                byteLength: physicalByteLength,
+                usage: ['storage', 'copy-destination'],
+                recovery: 'reinitialize'
+            }),
+            create({
+                label: 'Virtual shadow physical residency state B',
+                byteLength: physicalByteLength,
+                usage: ['storage', 'copy-destination'],
+                recovery: 'reinitialize'
+            })
+        ]);
+        this.#selectedBuckets = create({
+            label: 'Virtual shadow per-page selected caster buckets',
+            byteLength: settings.physicalPageCount * maximumObjects * 4,
+            usage: ['storage'],
+            recovery: 'reinitialize'
+        });
+        this.#visibleIndices = create({
+            label: 'Virtual shadow per-page visible caster indices',
+            byteLength: settings.physicalPageCount * visibleBucketCapacity * 4,
+            usage: ['storage'],
+            recovery: 'reinitialize'
+        });
+        const pageBucketCount = settings.physicalPageCount * buckets.length;
+        this.#bucketCursors = create({
+            label: 'Virtual shadow page bucket compact cursors',
+            byteLength: pageBucketCount * 4,
+            usage: ['storage'],
+            recovery: 'reinitialize'
+        });
+        this.#bucketOffsets = create({
+            label: 'Virtual shadow aligned page bucket offsets',
+            byteLength: pageBucketCount * BUCKET_OFFSET_STRIDE_BYTES,
+            usage: ['storage'],
+            recovery: 'reinitialize'
+        });
+        const shadowArguments = new Uint32Array(pageBucketCount * 5);
+        for (let page = 0; page < settings.physicalPageCount; page += 1) {
+            for (let bucket = 0; bucket < buckets.length; bucket += 1) {
+                const descriptor = buckets[bucket];
+                if (descriptor === undefined) {
+                    throw new Error('Virtual shadow bucket plan is incomplete');
+                }
+                shadowArguments[(page * buckets.length + bucket) * 5] = descriptor.indexCount;
+            }
+        }
+        this.#shadowArguments = create({
+            label: 'Virtual shadow page bucket indirect arguments',
+            byteLength: shadowArguments.byteLength,
+            usage: ['storage', 'indirect'],
+            initialData: shadowArguments,
+            recovery: 'cpu-shadow'
+        });
+        this.#clearArguments = create({
+            label: 'Virtual shadow physical-page clear indirect arguments',
+            byteLength: settings.physicalPageCount * DRAW_INDIRECT_ARGUMENT_BYTES,
+            usage: ['storage', 'indirect'],
+            recovery: 'reinitialize'
+        });
+        this.#statistics = create({
+            label: 'Virtual shadow request, residency, and update counters',
+            byteLength: VIRTUAL_SHADOW_STATS_BYTES,
+            usage: ['storage', 'copy-source', 'copy-destination'],
+            recovery: 'reinitialize'
+        });
+    }
+
+    record(
+        context: RenderPipelineContext,
+        inputs: Readonly<VirtualShadowRecordInputs>
+    ): Readonly<VirtualShadowFrameResources> {
+        if (this.#destroyed) throw new Error('Virtual shadow controller is destroyed');
+        const settings = this.settings;
+        const pageTableHistory = context.graph.acquireHistoryTexture(this.#pageTableKey, {
+            label: 'Virtual shadow logical-to-physical page table',
+            format: 'rgba32float',
+            extent: { width: settings.pageTableWidth, height: settings.pageTableHeight },
+            usage: ['sampled', 'storage'],
+            bufferCount: 2
+        });
+        const atlasTarget: RenderPipelineTargetResources = context.graph.acquirePersistentTarget(
+            this.#atlasKey,
+            {
+                label: 'Virtual shadow physical depth atlas',
+                extent: {
+                    width: settings.physicalAtlasWidth,
+                    height: settings.physicalAtlasHeight
+                },
+                colorFormats: [],
+                depthStencilFormat: 'depth32float',
+                depthStencilSampled: true,
+                sampleCount: 1
+            }
+        );
+        if (atlasTarget.depthStencil === null) {
+            throw new Error('Virtual shadow physical atlas has no depth attachment');
+        }
+        const stateValid = this.#stateValid && pageTableHistory.valid && !this.#invalidateRequested;
+        const directionalLightCount = this.#clipmaps.stage(
+            context.frameIndex,
+            context.camera,
+            inputs.shadows,
+            inputs.cameraHistoryValid,
+            inputs.previousViewMatrix,
+            stateValid,
+            this.#bucketCount,
+            this.#visibleBucketCapacity
+        );
+        context.writeStorageBuffer(this.#clipmapData, 0, new Uint8Array(this.#clipmaps.data));
+        const clipmapData = context.graph.importStorageBuffer(this.#clipmapData);
+        const requestBits = context.graph.importStorageBuffer(this.#requestBits);
+        const dirtyBits = context.graph.importStorageBuffer(this.#dirtyBits);
+        const previousPhysicalBuffer =
+            this.#physicalPageIndex === 0 ? this.#physicalPages[0] : this.#physicalPages[1];
+        const currentPhysicalPageIndex = this.#physicalPageIndex === 0 ? 1 : 0;
+        const currentPhysicalBuffer =
+            currentPhysicalPageIndex === 0 ? this.#physicalPages[0] : this.#physicalPages[1];
+        const previousPhysical = context.graph.importStorageBuffer(previousPhysicalBuffer);
+        const currentPhysical = context.graph.importStorageBuffer(currentPhysicalBuffer);
+        const selectedBuckets = context.graph.importStorageBuffer(this.#selectedBuckets);
+        const visibleIndices = context.graph.importStorageBuffer(this.#visibleIndices);
+        const bucketCursors = context.graph.importStorageBuffer(this.#bucketCursors);
+        const bucketOffsets = context.graph.importStorageBuffer(this.#bucketOffsets);
+        const shadowArguments = context.graph.importStorageBuffer(this.#shadowArguments);
+        const clearArguments = context.graph.importStorageBuffer(this.#clearArguments);
+        const statistics = context.graph.importStorageBuffer(this.#statistics);
+
+        const clear = context.acquirePassParameters(this.#clearPool);
+        clear.add(requestBits, 0, this.#requestBits.byteLength);
+        clear.add(dirtyBits, 0, this.#dirtyBits.byteLength);
+        clear.add(statistics, 0, this.#statistics.byteLength);
+        if (!stateValid) {
+            clear.add(previousPhysical, 0, previousPhysicalBuffer.byteLength);
+        }
+        context.graph.addPass(this.#clearPass, clear);
+
+        if (inputs.hiZHistoryValid && inputs.previousHiZ !== null && directionalLightCount > 0) {
+            const request = context.acquirePassParameters(this.#requestPool);
+            request.setBuffer(0, inputs.frameBuffer);
+            request.setBuffer(1, clipmapData);
+            request.setBuffer(2, requestBits);
+            request.setBuffer(3, statistics);
+            request.setTexture(0, inputs.previousHiZ);
+            request.setDispatch(
+                Math.max(1, Math.ceil(context.viewport[2] / 2 / REQUEST_WORKGROUP_SIZE)),
+                Math.max(1, Math.ceil(context.viewport[3] / 2 / REQUEST_WORKGROUP_SIZE))
+            );
+            context.graph.addPass(this.#requestPass, request);
+        }
+
+        if (directionalLightCount > 0 && inputs.activeObjectHighWater > 0) {
+            const invalidation = context.acquirePassParameters(this.#invalidationPool);
+            invalidation.setBuffer(0, inputs.frameBuffer);
+            invalidation.setBuffer(1, clipmapData);
+            invalidation.setBuffer(2, inputs.objects);
+            invalidation.setBuffer(3, dirtyBits);
+            invalidation.setBuffer(4, statistics);
+            invalidation.setDispatch(
+                Math.max(1, Math.ceil(inputs.activeObjectHighWater / CULL_WORKGROUP_SIZE))
+            );
+            context.graph.addPass(INVALIDATION_PASS, invalidation);
+        }
+
+        const allocation = context.acquirePassParameters(this.#allocatorPool);
+        allocation.setBuffer(0, clipmapData);
+        allocation.setBuffer(1, requestBits);
+        allocation.setBuffer(2, dirtyBits);
+        allocation.setBuffer(3, previousPhysical);
+        allocation.setBuffer(4, currentPhysical);
+        allocation.setBuffer(5, clearArguments);
+        allocation.setBuffer(6, shadowArguments);
+        allocation.setBuffer(7, statistics);
+        allocation.setTexture(0, pageTableHistory.current);
+        allocation.setDispatch(1);
+        context.graph.addPass(this.#allocatorPass, allocation);
+
+        const cull = context.acquirePassParameters(this.#cullPool);
+        cull.setBuffer(0, inputs.frameBuffer);
+        cull.setBuffer(1, clipmapData);
+        cull.setBuffer(2, currentPhysical);
+        cull.setBuffer(3, inputs.objects);
+        cull.setBuffer(4, inputs.bucketData);
+        cull.setBuffer(5, selectedBuckets);
+        cull.setBuffer(6, shadowArguments);
+        cull.setDispatch(
+            Math.max(1, Math.ceil(inputs.activeObjectHighWater / CULL_WORKGROUP_SIZE)),
+            settings.physicalPageCount
+        );
+        context.graph.addPass(PAGE_CULL_PASS, cull);
+
+        const prefix = context.acquirePassParameters(this.#prefixPool);
+        prefix.setBuffer(0, clipmapData);
+        prefix.setBuffer(1, currentPhysical);
+        prefix.setBuffer(2, shadowArguments);
+        prefix.setBuffer(3, bucketCursors);
+        prefix.setBuffer(4, bucketOffsets);
+        prefix.setDispatch(settings.physicalPageCount);
+        context.graph.addPass(PAGE_BUCKET_PREFIX_PASS, prefix);
+
+        const compact = context.acquirePassParameters(this.#compactPool);
+        compact.setBuffer(0, inputs.frameBuffer);
+        compact.setBuffer(1, clipmapData);
+        compact.setBuffer(2, selectedBuckets);
+        compact.setBuffer(3, bucketCursors);
+        compact.setBuffer(4, bucketOffsets);
+        compact.setBuffer(5, visibleIndices);
+        compact.setDispatch(
+            Math.max(1, Math.ceil(inputs.activeObjectHighWater / CULL_WORKGROUP_SIZE)),
+            settings.physicalPageCount
+        );
+        context.graph.addPass(PAGE_VISIBLE_COMPACT_PASS, compact);
+
+        this.#pendingFrame = context.frameIndex;
+        this.#pendingPhysicalPageIndex = currentPhysicalPageIndex;
+        return Object.freeze({
+            atlas: atlasTarget.depthStencil,
+            pageTable: pageTableHistory.current,
+            clipmapData,
+            physicalPages: currentPhysical,
+            visibleIndices,
+            visibleBucketOffsets: bucketOffsets,
+            shadowIndirectArguments: shadowArguments,
+            clearIndirectArguments: clearArguments,
+            clearAtlas: !stateValid,
+            directionalLightCount
+        });
+    }
+
+    frameSubmitted(frameIndex: number): void {
+        if (frameIndex !== this.#pendingFrame) return;
+        this.#physicalPageIndex = this.#pendingPhysicalPageIndex;
+        this.#stateValid = true;
+        this.#invalidateRequested = false;
+        this.#clipmaps.frameSubmitted(frameIndex);
+        this.#pendingFrame = -1;
+    }
+
+    frameDiscarded(frameIndex: number): void {
+        if (frameIndex !== this.#pendingFrame) return;
+        this.#clipmaps.frameDiscarded(frameIndex);
+        this.#pendingFrame = -1;
+    }
+
+    async readDiagnostics(): Promise<Readonly<VirtualShadowMapDiagnostics>> {
+        if (this.#destroyed) throw new Error('Virtual shadow controller is destroyed');
+        const result = await this.#statistics.read();
+        const values = new Uint32Array(
+            result.data.buffer,
+            result.data.byteOffset,
+            result.data.byteLength / 4
+        );
+        return Object.freeze({
+            requestedPageCount: values[0] ?? 0,
+            renderedPageCount: values[1] ?? 0,
+            deferredPageCount: values[2] ?? 0,
+            residentPageCount: values[3] ?? 0,
+            evictionCount: values[4] ?? 0,
+            invalidatedPageCount: values[5] ?? 0,
+            physicalPageCapacity: this.settings.physicalPageCount,
+            directionalClipmapLevelCount: this.settings.directionalClipmapLevels
+        });
+    }
+
+    /** Invalidate all submitted mappings on the next recorded virtual-shadow frame. */
+    invalidateAll(): void {
+        if (this.#destroyed) throw new Error('Virtual shadow controller is destroyed');
+        this.#invalidateRequested = true;
+    }
+
+    destroy(): void {
+        if (this.#destroyed) return;
+        this.#destroyed = true;
+        const buffers: readonly StorageBuffer[] = [
+            this.#clipmapData,
+            this.#requestBits,
+            this.#dirtyBits,
+            ...this.#physicalPages,
+            this.#selectedBuckets,
+            this.#visibleIndices,
+            this.#bucketCursors,
+            this.#bucketOffsets,
+            this.#shadowArguments,
+            this.#clearArguments,
+            this.#statistics
+        ];
+        const failures: unknown[] = [];
+        for (const buffer of buffers) {
+            try {
+                buffer.destroy();
+            } catch (error) {
+                failures.push(error);
+            }
+        }
+        if (failures.length !== 0) {
+            throw new AggregateError(failures, 'Virtual shadow resource destruction failed', {
+                cause: failures[0]
+            });
+        }
+    }
+}

--- a/src/render/pipeline/index.ts
+++ b/src/render/pipeline/index.ts
@@ -7,6 +7,7 @@ export {
     type GPUSceneBucket,
     type GPUSceneLOD
 } from './ClusteredForwardPlus';
+export type { VirtualShadowMapDiagnostics, VirtualShadowMapOptions } from './VirtualShadowMaps';
 export {
     ForwardRenderPipelineFactory,
     type ForwardRenderFeatureContext,

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -27,7 +27,25 @@ import {
     unregisterRendererDiagnostics
 } from '../../../src/render/diagnostics/RendererDiagnosticsRegistry';
 import { ClusteredForwardPlusPipelineFactory } from '../../../src/render/pipeline/ClusteredForwardPlus';
-import type { RenderPipelineCreateContext } from '../../../src/render/pipeline/RenderPipeline';
+import {
+    acquireRenderPassParameters,
+    type RenderPassParameterPool
+} from '../../../src/render/pipeline/RenderPassParameterPool';
+import type {
+    RenderPipelineContext,
+    RenderPipelineCreateContext,
+    RenderPipelineShadowResources
+} from '../../../src/render/pipeline/RenderPipeline';
+import {
+    snapshotVirtualShadowMapOptions,
+    VirtualShadowMapController,
+    virtualShadowBucketOffsetRange,
+    virtualShadowClearIndirectOffset,
+    virtualShadowIndirectOffset,
+    virtualShadowPhysicalPageRange,
+    type VirtualShadowFrameResources,
+    type VirtualShadowRecordInputs
+} from '../../../src/render/pipeline/VirtualShadowMaps';
 import { ComputeRenderPass, FullscreenRenderPass } from '../../../src/render/pipeline/passes';
 import {
     ScreenSpaceReflectionsController,
@@ -311,6 +329,252 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
         controller.destroy();
         expect(destroy).toHaveBeenCalledOnce();
         await expect(controller.readDiagnostics()).rejects.toThrow(/is destroyed/u);
+    });
+
+    it('records and transactionally owns virtual-shadow page state without GPU readback', async () => {
+        const settings = snapshotVirtualShadowMapOptions({
+            virtualResolution: 512,
+            pageSize: 64,
+            physicalPageCount: 4,
+            maxPageUpdatesPerFrame: 2,
+            directionalClipmapLevels: 2,
+            firstDirectionalClipmapExtent: 16
+        });
+        const counters = new Uint32Array([9, 8, 7, 6, 5, 4, 3, 2]);
+        const created: {
+            readonly label: string;
+            readonly destroy: ReturnType<typeof vi.fn>;
+        }[] = [];
+        type StorageDescriptor = Parameters<RenderPipelineCreateContext['createStorageBuffer']>[0];
+        const createStorageBuffer = vi.fn((descriptor: StorageDescriptor): StorageBuffer => {
+            const destroy = vi.fn();
+            const data =
+                descriptor.label === 'Virtual shadow request, residency, and update counters'
+                    ? new Uint8Array(counters.buffer)
+                    : new Uint8Array(descriptor.byteLength);
+            created.push({ label: descriptor.label ?? '', destroy });
+            return {
+                byteLength: descriptor.byteLength,
+                destroy,
+                read: vi.fn(() =>
+                    Promise.resolve({
+                        data,
+                        byteOffset: data.byteOffset,
+                        byteLength: data.byteLength
+                    })
+                )
+            } as unknown as StorageBuffer;
+        });
+        const createContext = { createStorageBuffer } as unknown as RenderPipelineCreateContext;
+        const controller = new VirtualShadowMapController(
+            settings,
+            createContext,
+            [{ indexCount: 36 }, { indexCount: 12 }],
+            3,
+            64
+        );
+
+        expect(createStorageBuffer).toHaveBeenCalledTimes(12);
+        expect(created.map(entry => entry.label)).toEqual(
+            expect.arrayContaining([
+                'Virtual shadow directional clipmap database',
+                'Virtual shadow physical residency state A',
+                'Virtual shadow physical residency state B',
+                'Virtual shadow page bucket indirect arguments'
+            ])
+        );
+        expect(virtualShadowPhysicalPageRange(2)).toEqual({
+            byteOffset: 512,
+            byteLength: 32
+        });
+        expect(virtualShadowBucketOffsetRange(2, 1, 3)).toEqual({
+            byteOffset: 1_792,
+            byteLength: 4
+        });
+        expect(virtualShadowIndirectOffset(2, 1, 3)).toBe(140);
+        expect(virtualShadowClearIndirectOffset(2)).toBe(32);
+
+        const light = new DirectionalLight({ direction: new Vector3(1, -2, 1) });
+        const camera = new PerspectiveCamera({ aspect: 1, near: 0.1, far: 30 });
+        camera.setPosition(4, 3, 6).lookAt(new Vector3()).updateViewProjectionMatrix();
+        const shadows = {
+            depthMode: 'standard',
+            directionalLights: [light],
+            directionalShadowCount: 1
+        } as unknown as Readonly<RenderPipelineShadowResources>;
+        const noDirectionalShadows = {
+            depthMode: 'reversed',
+            directionalLights: [],
+            directionalShadowCount: 0
+        } as unknown as Readonly<RenderPipelineShadowResources>;
+        const owner = {};
+        const passNames: string[] = [];
+        let nextHandle = 10;
+        const makeContext = (frameIndex: number, historyValid: boolean): RenderPipelineContext => {
+            const graph = {
+                acquireHistoryTexture: vi.fn(() => ({
+                    current: 1,
+                    valid: historyValid,
+                    generation: 0,
+                    historyCount: historyValid ? 1 : 0,
+                    history: vi.fn(() => 2)
+                })),
+                acquirePersistentTarget: vi.fn(() => ({
+                    width: settings.physicalAtlasWidth,
+                    height: settings.physicalAtlasHeight,
+                    sampleCount: 1,
+                    colorAttachmentCount: 0,
+                    color: vi.fn(),
+                    depthStencil: 3
+                })),
+                importStorageBuffer: vi.fn(() => nextHandle++),
+                addPass: vi.fn((pass: { readonly name: string }) => {
+                    passNames.push(pass.name);
+                    return nextHandle++;
+                })
+            };
+            return {
+                frameIndex,
+                camera,
+                viewport: [0, 0, 64, 64],
+                graph,
+                writeStorageBuffer: vi.fn(),
+                acquirePassParameters: (pool: RenderPassParameterPool<object>): object =>
+                    acquireRenderPassParameters(pool, owner, frameIndex)
+            } as unknown as RenderPipelineContext;
+        };
+        const makeInputs = (
+            shadowResources: Readonly<RenderPipelineShadowResources>,
+            activeObjectHighWater: number,
+            hiZHistoryValid: boolean
+        ): Readonly<VirtualShadowRecordInputs> =>
+            ({
+                frameBuffer: 20,
+                objects: 21,
+                bucketData: 22,
+                previousHiZ: hiZHistoryValid ? 23 : null,
+                hiZHistoryValid,
+                shadows: shadowResources,
+                activeObjectHighWater,
+                previousViewMatrix: camera.viewMatrix.elements,
+                cameraHistoryValid: hiZHistoryValid
+            }) as unknown as Readonly<VirtualShadowRecordInputs>;
+
+        const first = controller.record(
+            makeContext(1, false),
+            makeInputs(noDirectionalShadows, 0, false)
+        );
+        expect(first).toMatchObject<Partial<VirtualShadowFrameResources>>({
+            clearAtlas: true,
+            directionalLightCount: 0
+        });
+        expect(passNames).not.toContain('Virtual shadow receiver depth page requests');
+        controller.frameDiscarded(0);
+        controller.frameDiscarded(1);
+
+        passNames.length = 0;
+        const second = controller.record(makeContext(2, true), makeInputs(shadows, 3, true));
+        expect(second.clearAtlas).toBe(true);
+        expect(passNames).toEqual(
+            expect.arrayContaining([
+                'Virtual shadow receiver depth page requests',
+                'Virtual shadow changed-caster page invalidation',
+                'Virtual shadow deterministic page-table allocation and remap',
+                'Virtual shadow per-page caster culling',
+                'Virtual shadow per-page bucket prefix',
+                'Virtual shadow per-page visible caster compact'
+            ])
+        );
+        controller.frameSubmitted(1);
+        controller.frameSubmitted(2);
+
+        const third = controller.record(makeContext(3, true), makeInputs(shadows, 3, true));
+        expect(third.clearAtlas).toBe(false);
+        controller.frameSubmitted(3);
+        controller.invalidateAll();
+        const invalidated = controller.record(makeContext(4, true), makeInputs(shadows, 3, false));
+        expect(invalidated.clearAtlas).toBe(true);
+        controller.frameDiscarded(4);
+
+        await expect(controller.readDiagnostics()).resolves.toEqual({
+            requestedPageCount: 9,
+            renderedPageCount: 8,
+            deferredPageCount: 7,
+            residentPageCount: 6,
+            evictionCount: 5,
+            invalidatedPageCount: 4,
+            physicalPageCapacity: 4,
+            directionalClipmapLevelCount: 2
+        });
+        controller.destroy();
+        controller.destroy();
+        expect(created.every(entry => entry.destroy.mock.calls.length === 1)).toBe(true);
+        expect(() => {
+            controller.invalidateAll();
+        }).toThrow(/is destroyed/u);
+        expect(() => controller.record(makeContext(5, true), makeInputs(shadows, 3, true))).toThrow(
+            /is destroyed/u
+        );
+        await expect(controller.readDiagnostics()).rejects.toThrow(/is destroyed/u);
+
+        const failingCreateStorageBuffer = vi.fn(
+            (descriptor: StorageDescriptor): StorageBuffer =>
+                ({
+                    byteLength: descriptor.byteLength,
+                    destroy: vi.fn(() => {
+                        if (descriptor.label === 'Virtual shadow receiver request bitset') {
+                            throw new Error('injected destroy failure');
+                        }
+                    })
+                }) as unknown as StorageBuffer
+        );
+        const failingController = new VirtualShadowMapController(
+            settings,
+            {
+                createStorageBuffer: failingCreateStorageBuffer
+            } as unknown as RenderPipelineCreateContext,
+            [{ indexCount: 3 }],
+            1,
+            64
+        );
+        expect(() => {
+            failingController.destroy();
+        }).toThrow(/resource destruction failed/u);
+        expect(() => {
+            failingController.destroy();
+        }).not.toThrow();
+    });
+
+    it('validates every virtual-shadow option boundary', () => {
+        expect(() => snapshotVirtualShadowMapOptions(null)).toThrow(/must be an object/u);
+        expect(() => snapshotVirtualShadowMapOptions([])).toThrow(/must be an object/u);
+        expect(() => snapshotVirtualShadowMapOptions({ virtualResolution: 511 })).toThrow(
+            /powers of two/u
+        );
+        expect(() => snapshotVirtualShadowMapOptions({ pageSize: 32 })).toThrow(
+            /between 64 and 256/u
+        );
+        expect(() => snapshotVirtualShadowMapOptions({ pageSize: 512 })).toThrow(
+            /between 64 and 256/u
+        );
+        expect(() =>
+            snapshotVirtualShadowMapOptions({ virtualResolution: 64, pageSize: 64 })
+        ).toThrow(/between 8 and 128 pages/u);
+        expect(() =>
+            snapshotVirtualShadowMapOptions({ virtualResolution: 65_536, pageSize: 64 })
+        ).toThrow(/between 8 and 128 pages/u);
+        expect(() => snapshotVirtualShadowMapOptions({ physicalPageCount: 257 })).toThrow(
+            /cannot exceed 256/u
+        );
+        expect(() => snapshotVirtualShadowMapOptions({ directionalClipmapLevels: 5 })).toThrow(
+            /cannot exceed four/u
+        );
+        expect(() => snapshotVirtualShadowMapOptions({ firstDirectionalClipmapExtent: 0 })).toThrow(
+            /finite and positive/u
+        );
+        expect(() => snapshotVirtualShadowMapOptions({ maxPageUpdatesPerFrame: 0 })).toThrow(
+            /positive safe integer/u
+        );
     });
 
     it('validates bucket identities, opaque materials, and unique LOD thresholds', () => {

--- a/test/spec/renderer/ClusteredForwardPlus.test.ts
+++ b/test/spec/renderer/ClusteredForwardPlus.test.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../src/render/diagnostics/RendererDiagnosticsRegistry';
 import { ClusteredForwardPlusPipelineFactory } from '../../../src/render/pipeline/ClusteredForwardPlus';
 import type { RenderPipelineCreateContext } from '../../../src/render/pipeline/RenderPipeline';
-import { FullscreenRenderPass } from '../../../src/render/pipeline/passes';
+import { ComputeRenderPass, FullscreenRenderPass } from '../../../src/render/pipeline/passes';
 import {
     ScreenSpaceReflectionsController,
     snapshotScreenSpaceReflectionsOptions
@@ -139,6 +139,31 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             maxBindingsPerBindGroup: 22,
             maxSampledTexturesPerShaderStage: 13
         });
+
+        const withVirtualShadows = new ClusteredForwardPlusPipelineFactory({
+            buckets: [{ geometry, material }],
+            maxObjects: 64,
+            virtualShadows: {
+                virtualResolution: 1_024,
+                pageSize: 128,
+                physicalPageCount: 16,
+                maxPageUpdatesPerFrame: 8,
+                directionalClipmapLevels: 3
+            }
+        });
+        expect(withVirtualShadows.requirements.requiredLimits).toMatchObject({
+            maxBindingsPerBindGroup: 26,
+            maxSampledTexturesPerShaderStage: 13,
+            maxSamplersPerShaderStage: 13,
+            maxTextureDimension2D: 512
+        });
+        expect(withVirtualShadows.requirements.requiredTextureFormats).toEqual(
+            expect.arrayContaining([
+                { format: 'rgba32float', use: 'sampled' },
+                { format: 'rgba32float', use: 'storage' },
+                { format: 'depth32float', use: 'sampled' }
+            ])
+        );
 
         const withReflections = new ClusteredForwardPlusPipelineFactory({
             buckets: [{ geometry, material }],
@@ -377,6 +402,28 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                     typeof ClusteredForwardPlusPipelineFactory
                 >[0])
         ).toThrow(/hiZ must be a boolean/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    hiZ: false,
+                    virtualShadows: {}
+                })
+        ).toThrow(/virtual shadows require hiZ/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    virtualShadows: { pageSize: 96 }
+                })
+        ).toThrow(/powers of two/u);
+        expect(
+            () =>
+                new ClusteredForwardPlusPipelineFactory({
+                    buckets: [{ geometry, material }],
+                    virtualShadows: { physicalPageCount: 4, maxPageUpdatesPerFrame: 5 }
+                })
+        ).toThrow(/cannot exceed physicalPageCount/u);
         expect(
             () =>
                 new ClusteredForwardPlusPipelineFactory({
@@ -1761,7 +1808,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
     );
 
     it.skipIf(__HILO3D_GITHUB_ACTIONS_COVERAGE__)(
-        'samples the shared shadow atlas in clustered storage PBR pixels',
+        'samples GPU-requested virtual pages with stable shadow-atlas fallback',
         async () => {
             const geometry = new BoxGeometry();
             const material = new PBRMaterial({
@@ -1777,7 +1824,14 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 maxLightsPerCluster: 1,
                 maxViewportWidth: 64,
                 maxViewportHeight: 64,
-                hiZ: false,
+                virtualShadows: {
+                    virtualResolution: 512,
+                    pageSize: 64,
+                    physicalPageCount: 16,
+                    maxPageUpdatesPerFrame: 16,
+                    directionalClipmapLevels: 2,
+                    firstDirectionalClipmapExtent: 16
+                },
                 bloomStrength: 0
             });
             const canvas = document.createElement('canvas');
@@ -1799,7 +1853,7 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
             });
             try {
                 const scene = new Node();
-                new Mesh({
+                const floor = new Mesh({
                     geometry,
                     material,
                     y: -1,
@@ -1808,7 +1862,12 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                     scaleZ: 5,
                     frustumTest: false
                 }).addTo(scene);
-                new Mesh({ geometry, material, y: 0, frustumTest: false }).addTo(scene);
+                const caster = new Mesh({
+                    geometry,
+                    material,
+                    y: 0,
+                    frustumTest: false
+                }).addTo(scene);
                 new AmbientLight({ amount: 0.05 }).addTo(scene);
                 const light = new DirectionalLight({
                     amount: 4,
@@ -1842,14 +1901,102 @@ describe('ClusteredForwardPlusPipelineFactory', () => {
                 expect(await factory.readDiagnostics()).toMatchObject({
                     objectCount: 2,
                     fallbackObjectCount: 0,
-                    lightCount: 1
+                    lightCount: 1,
+                    virtualShadows: {
+                        physicalPageCapacity: 16,
+                        directionalClipmapLevelCount: 2
+                    }
                 });
+                const originalComputeExecute = Object.getOwnPropertyDescriptor(
+                    ComputeRenderPass.prototype,
+                    'execute'
+                )?.value as (
+                    this: ComputeRenderPass,
+                    ...parameters: Parameters<ComputeRenderPass['execute']>
+                ) => void;
+                let injectedFailure = false;
+                const computeFailure = vi
+                    .spyOn(ComputeRenderPass.prototype, 'execute')
+                    .mockImplementation(function (
+                        this: ComputeRenderPass,
+                        ...parameters: Parameters<typeof originalComputeExecute>
+                    ): void {
+                        if (
+                            !injectedFailure &&
+                            this.name ===
+                                'Virtual shadow deterministic page-table allocation and remap'
+                        ) {
+                            injectedFailure = true;
+                            throw new Error('injected virtual-shadow submission failure');
+                        }
+                        originalComputeExecute.apply(this, parameters);
+                    });
+                try {
+                    expect(() => {
+                        renderer.renderToTarget(target, scene, camera);
+                    }).toThrow(/injected virtual-shadow submission failure/u);
+                } finally {
+                    computeFailure.mockRestore();
+                }
+                expect(injectedFailure).toBe(true);
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+
+                const extension = renderer.getExtension('rhi') as {
+                    readonly device: RHIDevice;
+                } | null;
+                if (extension === null) throw new Error('Expected the public RHI extension');
+                const deviceLost = new Promise<void>(resolve => {
+                    renderer.on(
+                        'webgpuDeviceLost',
+                        () => {
+                            resolve();
+                        },
+                        true
+                    );
+                });
+                const deviceRestored = new Promise<void>(resolve => {
+                    renderer.on(
+                        'webgpuDeviceRestored',
+                        () => {
+                            resolve();
+                        },
+                        true
+                    );
+                });
+                extension.device.destroy();
+                await deviceLost;
+                await Promise.all([renderer.waitForIdle(), deviceRestored]);
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                const recoveredDiagnostics = await factory.readDiagnostics();
+                expect(recoveredDiagnostics).toMatchObject({
+                    virtualShadows: {
+                        physicalPageCapacity: 16,
+                        directionalClipmapLevelCount: 2
+                    }
+                });
+                expect(recoveredDiagnostics.virtualShadows?.requestedPageCount).toBeGreaterThan(0);
+                expect(recoveredDiagnostics.virtualShadows?.renderedPageCount).toBeGreaterThan(0);
+
+                floor.x = 8;
+                caster.x = 8;
+                camera.setPosition(12, 3, 6).lookAt(new Vector3(8, -0.5, 0));
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+                const remappedDiagnostics = await factory.readDiagnostics();
+                expect(remappedDiagnostics.virtualShadows?.evictionCount).toBeGreaterThan(0);
                 expect(
                     rendererDiagnostics.snapshot().renderGraph?.passes.map(pass => pass.name)
                 ).toEqual(
                     expect.arrayContaining([
-                        'GPU Scene shadow caster frustum culling',
-                        'GPU Scene shadow caster buckets'
+                        'Virtual shadow receiver depth page requests',
+                        'Virtual shadow deterministic page-table allocation and remap',
+                        'GPU Scene virtual shadow physical page updates'
                     ])
                 );
             } finally {


### PR DESCRIPTION
## Summary

- generate directional shadow-page requests from previous-frame Hi-Z entirely on the GPU, with atomic bitset deduplication, deterministic ordering, and GPU-authored indirect page draws
- add arbitrary logical-to-physical page-table remapping with bounded LRU eviction, deferred dirty-page retry, submission rollback, and device-loss recovery
- add camera-centered directional clipmaps, virtual-depth sampling, stable CSM fallback, public configuration/diagnostics, API reports, and architecture documentation

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx vitest run test/spec/renderer/ClusteredForwardPlus.test.ts` — 12 passed
- `npm run test:render:architecture` — 144 passed
- `npm run test:rhi` — 213 portable passed; 3 native passed, 1 environment skip
- `npm run test:webgpu` — 19 passed
- `npm run test:types`
- `npm run test:package`
- `npm run api:check`
- `npm run format:check`
- `npm run docs:check`

## Compatibility boundary

The virtual path is opt-in and WebGPU Clustered Forward+ only. It currently virtualizes rigid GPU Scene opaque/alpha-mask casters. Skin, morph, direct/fallback casters, Spot/Point lights, and WebGL2 continue to use the shared stable shadow atlas. Missing or deferred virtual pages fall back to stable directional CSM.

A registered physical-GPU stress baseline and `npm run test:webgpu:native` were not run.
