### PR TITLE
feat(render): harden ground-truth ambient occlusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@
 
 ### Changes
 
+- Rebuild portable GTAO around view-relative dual horizons, projected-normal analytic visible-arc
+  integration, depth-derived or hybrid normals, a separately controlled contact lobe, integrated
+  bent normals, distance/edge fading, and explicit low/medium/high/ultra budgets. Add logarithmic-
+  depth reconstruction, per-camera pass/UBO isolation, closest-depth motion selection, depth/normal
+  confidence, variance clipping, vector-space bent-normal filtering, unblurred rejection depth, and
+  joint bilateral upsampling. Feed color-aware multi-bounce visibility and bent-cone specular
+  visibility into ordinary and Clustered PBR, retune The Silent Dragon, and add a deterministic GTAO
+  Acceptance Lab with corner, thin-card, slab, stair, normal-map, dielectric/metal, moving-occluder,
+  screen-edge, log-depth, on/off, temporal, and WebGL2/WebGPU parity gates.
 - Upgrade WebGPU high-end SSR with response-aware 8×8 tile masks, coherent prefix compaction,
   indirect stochastic visible-GGX tracing, roughness-adaptive ray budgets, refined depth crossings,
   hit-normal facing validation, and explicit uncertain/backface outcomes. Evaluate receiver- and

--- a/documentation/GROUND_TRUTH_AMBIENT_OCCLUSION.md
+++ b/documentation/GROUND_TRUTH_AMBIENT_OCCLUSION.md
@@ -14,15 +14,27 @@ Turnkey Forward/HDR 管线通过 `PostProcessRenderPipelineFactory` 启用：
 ```ts
 new Hilo3d.PostProcessRenderPipelineFactory({
     groundTruthAmbientOcclusion: {
+        quality: 'high',
         resolutionScale: 0.5,
         radius: 2,
         falloffStart: 0.6,
         thickness: 0.05,
-        directionCount: 6,
-        stepCount: 4,
+        thicknessBlend: 0.5,
+        intensity: 1,
         power: 1.2,
+        bias: 0.035,
+        contactRadiusScale: 0.2,
+        contactStrength: 0.35,
+        normalSource: 'hybrid',
+        geometricNormalWeight: 0.65,
+        bentNormalStrength: 1,
+        multiBounce: 1,
+        distanceFadeStart: 100,
+        distanceFadeEnd: 200,
+        edgeFadePixels: 2,
         historyWeight: 0.9,
-        depthThreshold: 0.03
+        depthThreshold: 0.03,
+        normalThreshold: 0.82
     }
 });
 ```
@@ -33,8 +45,10 @@ option；该路径要求同时启用 `temporalAA`，从而复用 GPU
 Scene 已融合的 motion/log-depth 输出及其 camera-cut validity。未配置或显式设为 `false`
 时不创建 depth/attribute、AO transient、history 或额外 shader variant。
 
-所有 option 都在 factory 构造时做有限区间校验。`directionCount` 只接受 4/6/8，`stepCount`
-只接受 3/4/5/6，防止运行时动态循环和未经预算的 shader 变体。
+所有 option 都在 factory 构造时做有限区间和交叉字段校验。`quality` 提供 `low/medium/high/ultra`
+四个 sampling budget；显式 `resolutionScale`、`directionCount` 和 `stepCount`
+会逐项覆盖 preset。方向数只接受 2/3/4/6/8，每侧 step 只接受 3/4/5/6/8/10/12，防止运行时动态循环和未经预算的 shader 变体。`distanceFadeEnd`
+必须大于 `distanceFadeStart`。
 
 ## 帧编排与数据合同
 
@@ -44,11 +58,11 @@ Scene 已融合的 motion/log-depth 输出及其 camera-cut validity。未配置
 opaque depth prepass
   -> material attributes (oct view normal + roughness/metallic flags)
   -> motion + logarithmic view depth
-  -> rotated horizon search at resolutionScale
-  -> submission-aware temporal resolve
-  -> two edge-aware spatial filters
-  -> bounded depth/normal bilateral upsample
-  -> opaque PBR shading with pass-global GTAO
+  -> view-relative dual-horizon search + analytic normal-hemisphere integration
+  -> closest-depth motion resolve + variance-clipped temporal accumulation
+  -> two joint depth/normal bilateral filters (depth remains unfiltered)
+  -> bounded depth/normal bilateral upsample or full-resolution finalize
+  -> color-aware diffuse and bent-cone specular PBR composition
 ```
 
 depth、attribute 与 motion 都由内置 material semantic pass 生成，alpha-mask
@@ -56,17 +70,31 @@ coverage、skinning、morph 和 instancing 仍使用共享材质/几何准备路
 Graph，也不从后端 framebuffer 抓取数据。Forward 与 Clustered 都要求可作为 attachment 且可 filterable
 sample 的 `rgba8unorm` material attributes；bent-normal AO/history 继续使用 `rgba16float`。
 
-AO history/output packing 为：
+内部 current/history packing 为：
 
-| Channel | 内容                                                 |
-| ------- | ---------------------------------------------------- |
-| R, G    | view-space bent normal 的 signed octahedral encoding |
-| B       | 0–1 ambient visibility                               |
-| A       | `log2(1 + viewDepth)`，供 temporal/filter rejection  |
+| Channel | 内容                                                         |
+| ------- | ------------------------------------------------------------ |
+| R, G    | view-space bent normal 的 signed octahedral encoding         |
+| B       | 0–1 ambient visibility                                       |
+| A       | `log2(1 + viewDepth)`，供 temporal/filter/upsample rejection |
 
-horizon pass 在每个 pixel 上旋转 slice 方向，双向搜索屏幕空间 horizon，按 view-space radius、thin
-surface tolerance 与 distance falloff 累积遮挡，同时把未遮挡方向折入 bent
-normal。空间 filter 和最终 upsample 同时限制 normal 与 log-depth 差异；所有指数、深度和累计权重都有显式有限边界，避免 NaN/Inf 传播到 PBR。
+交给 PBR 的 full-resolution texture 仍以 R/G 保存 signed-octahedral bent
+normal、B 保存 visibility，但 A 改为 0–1 的 multi-bounce strength；内部 rejection
+depth 不泄漏到 shading ABI。
+
+horizon pass 不再用 `dot(normal, sampleDirection)` 近似遮挡。它对每条 view-relative
+slice 分别搜索正负 horizon，把材质法线投影到 slice plane，并解析积分法线半球中仍可见的 angular
+arc。bent normal 是可见 arc 方向的一阶矩，而不是 screen tangent 的经验偏移。主 radius 和短程 contact
+radius 分别积分，再通过独立 intensity/strength 合成；angular bias、thin/solid thickness
+blend、distance fade 和 screen-edge fade 有各自语义，不再依赖一个高 `power` 值同时承担所有美术控制。
+
+默认 `hybrid` normal 以 full-resolution
+depth 的最小差分重建几何法线，并与 material-attribute 法线合成；`material` 与 `geometry`
+模式可用于特殊内容或诊断。普通和 reversed depth 直接用 inverse projection；renderer 开启 logarithmic
+depth 时，controller 通过公开的 pipeline depth encoding 状态和相机 far 参数先恢复 view
+depth，再沿 inverse-projection
+ray 重建位置。该路径与 renderer 的既有合同一致：只接受 standard-Z 透视相机和有限、正值的 far
+plane，并在记录阶段 fail-fast。
 
 ## 时域与生命周期
 
@@ -77,15 +105,26 @@ history 按 Camera identity 双缓冲，并且只在成功 submission 后交换�
 - Clustered GPU Scene 报告 camera cut/history invalid；
 - device/context recovery。
 
-resolve 使用 current-to-previous velocity、relative log-depth reject、3×3 visibility neighborhood
-clamp 与随像素速度下降的 history weight。失败帧不提交 projection、transform revision、history
-index 或 eviction；长时间未使用的 Camera history 通过 graph API 回收。
+resolve 在 full-resolution motion texture 的 3×3 邻域选择与当前 AO depth 最接近的 point
+velocity，避免线性采样跨越前后景。reprojection 同时执行 relative log-depth reject、normal
+reject、3×3 visibility mean/variance clip、depth/normal confidence 和随像素速度下降的 history
+weight。history 的 bent normal 先解码为向量再做 bilinear accumulation，避免直接插值 oct
+encoding。空间 filter 同样先解码 bent normal，仅滤 bent/visibility，并把 center
+depth 原样带到下一阶段；最终 upsample 使用未被空间滤波污染的 depth 做 joint bilateral
+reconstruction。
+
+每个 Camera identity 拥有独立 UniformBuffer 和 fullscreen pass binding，避免同一 application
+frame 内多个相机后记录的 inverse projection 覆盖先记录的 command。失败帧不提交 projection、transform
+revision、history index 或 eviction；长时间未使用的 Camera history 通过 graph API 回收。
 
 ## PBR 合成边界
 
-GTAO 只改变内置 opaque PBR 的环境可见度：ambient/diffuse IBL 使用 visibility 与 bent
-normal，现有 specular
-AO 也读取该 visibility。方向光、点光、聚光、面光、阴影结果与 emission 不乘 GTAO，因此不会把 AO 当作全局暗角。结果通过 renderer-owned
+GTAO 只改变内置 opaque PBR 的环境可见度：ambient/diffuse IBL 使用 bent
+normal，并以 visibility 和 base color 计算可调强度的 multi-bounce diffuse
+compensation，减少传统单通道 AO 在高反射率表面产生的无色死黑。specular IBL/SSR
+fallback 使用 visibility、bent-normal cone、view reflection direction 和 roughness 得到 directional
+specular
+visibility。方向光、点光、聚光、面光、阴影结果与 emission 不乘 GTAO，因此不会把 AO 当作全局暗角。结果通过 renderer-owned
 pass-global texture 在 graph prepare 后绑定；WebGPU 使用固定 group 3 binding 0/1，WebGL
 2 使用同一 reflection plan 的 combined sampler。
 
@@ -93,7 +132,8 @@ pass-global texture 在 graph prepare 后绑定；WebGPU 使用固定 group 3 bi
 
 - 只覆盖 opaque/masked surface；透明物体不写入或消费 GTAO；
 - 内置 PBR 自动消费，custom material shader 必须自行定义等价的 effect contract；
-- 当前只接受 full-output viewport；split viewport/multi-camera atlas 需要独立 history region 合同；
+- 每次 invocation 仍要求 full-output viewport；同帧多 Camera 已隔离状态，但 split
+  viewport/atlas 需要独立 history region 合同；
 - 屏幕外几何不会参与 horizon search，这是 screen-space AO 的确定边界，不以随机 fallback 掩盖；
 - Clustered 路径仍是 WebGPU high-end profile；普通 Forward 的 GTAO 明确支持 WebGPU 与 WebGL 2。
 
@@ -108,3 +148,25 @@ Dragon 博物馆展陈。单色烧陶材质让鳞片、趾爪、盘曲空腔、�
 发布覆盖至少包含：option/requirements 单元测试、真实 WebGL 2 与 WebGPU
 graph/pipeline 生命周期、Clustered
 graph 集成，以及双后端非黑屏和 on/off 像素差异的 Playwright 图形健康检查。
+
+[`gtao_acceptance_lab.html`](../examples/gtao_acceptance_lab.html)
+是专用、确定性的验收 fixture，固定曝光并同时放置 90° concavity、薄片、平行窄缝、重复台阶、normal-map
+surface、rough dielectric、glossy
+metal、屏幕边缘对象和移动遮挡体。页面可在不重建 Stage/canvas 的情况下切换 AO、运动和 edge
+view，并通过 `logDepth=true` 进入对数深度路径。Playwright 门禁覆盖 WebGL2/WebGPU health、AO on/off
+material difference、运动进度、edge view、log-depth 以及双后端像素 parity budget。
+
+## 与 Unreal GTAO 的实现对照
+
+实现对照使用用户 fork 中 UE 5.8 的 `Engine/Shaders/Private/PostProcessAmbientOcclusion.usf` 与
+`Engine/Source/Runtime/Renderer/Private/CompositionLighting/PostProcessAmbientOcclusion.cpp`。Hilo3D 现在与其共享的核心原则包括：view-relative 双侧 horizon、projected-normal
+inner integral、distance/thickness heuristic、temporal phase rotation、depth-aware
+upsample，以及可选择 depth-derived normal。Hilo3D 没有复制 Unreal 的 renderer-private
+ABI：它保留 portable GLSL→Naga→WGSL、Render Graph/RHI、signed-oct bent normal、per-Camera
+submission-aware history 和 Forward/Clustered 共享 controller。
+
+当前 sampling 在 256 AO-pixel radius 内使用固定 budget 的 sparse depth
+taps，而不是消费 Unreal 的 HZB
+sampler；这是明确的性能边界，不影响上述解析积分合同。大物体数量的普通 Forward 还会付出 depth、attribute、motion 三次 semantic
+prepass 的 draw cost；专项场景在 WebGL2 上保留该证据，后续若增加 fused visibility
+MRT，必须作为共享 material-pass ABI 完成，不能为 GTAO 私建后端旁路。

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -102,14 +102,19 @@ ray；volume 根据折射方向修正光程，再用 Beer-Lambert attenuation �
 
 `GroundTruthAmbientOcclusion` 是 `before-opaque` feature。普通 Forward 在 WebGPU 与 WebGL
 2 上先记录共享 `depth-only`、`material-attributes` 与 `motion-vector` semantic
-pass，再以可配置的 4/6/8 个旋转 slice、每侧 3–6 个 sample 搜索 view-space
-horizon。半分辨率结果包含 signed-octahedral bent normal、ambient visibility 与 logarithmic view
-depth，随后经过 submission-aware temporal reprojection、relative-depth rejection、neighborhood
-clamp、两级 edge-aware filter 和有界 depth/normal bilateral upsample。
+pass，再以可配置的旋转 slice 和 sparse sample 搜索 view-space horizon。当前 public
+budget 提供 low/medium/high/ultra
+preset、2/3/4/6/8 个 slice 与每侧 3/4/5/6/8/10/12 个 sample。每条 view-relative
+slice 双向搜索 horizon，再对 projected normal hemisphere 做 analytic visible-arc
+integral；主尺度和 contact 尺度独立合成，并输出可见 arc 的 bent-normal 一阶矩。半分辨率结果包含 signed-octahedral
+bent normal、ambient visibility 与 logarithmic view depth，随后经过 closest-depth motion
+selection、depth/normal rejection、variance clip、两级 joint bilateral filter 和有界 depth/normal
+upsample。普通、reversed 与 renderer log-depth 都使用显式 view-position reconstruction 合同。
 
-full-resolution GTAO 通过 graph-prepare 后的 pass-global texture 进入 opaque
-PBR。它只调制 ambient/diffuse IBL 与现有 specular AO，并以 bent normal 查询 diffuse
-environment；direct
+full-resolution GTAO 通过 graph-prepare 后的 pass-global texture 进入 opaque PBR。它以 bent
+normal 查询 diffuse environment，应用 base-color-aware multi-bounce diffuse
+visibility，并以 bent-normal cone、reflection direction 和 roughness 约束 specular IBL/SSR
+fallback；direct
 light、shadow 和 emission 不乘 visibility。默认关闭时不创建 prepass、transient、history 或材质 shader
 variant。Clustered Forward+ 复用同一个 GTAO controller 与 GPU Scene attributes，并要求同时启用
 `temporalAA` 以复用融合的 motion/log-depth 和 camera-cut

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -14,7 +14,7 @@ committed.
 | [Modern WebGPU rendering roadmap](./MODERN_WEBGPU_RENDERING_ROADMAP.md)         | Current rendering gaps and an actionable GPU Scene, temporal, lighting, virtualization, and high-end WebGPU roadmap                 |
 | [Temporal rendering remediation](./TEMPORAL_RENDERING_REMEDIATION.md)           | Production Motion Vector/TAA ABI, history validity, Clustered integration, performance contract, and release evidence               |
 | [Screen-space reflections](./SCREEN_SPACE_REFLECTIONS.md)                       | Production WebGPU Hi-Z SSR, material attribute ABI, temporal rejection, lifecycle rules, limitations, and release evidence          |
-| [Ground-truth ambient occlusion](./GROUND_TRUTH_AMBIENT_OCCLUSION.md)           | Portable Forward GTAO, Clustered integration, bent-normal/visibility packing, temporal lifecycle, and release boundaries            |
+| [Ground-truth ambient occlusion](./GROUND_TRUTH_AMBIENT_OCCLUSION.md)           | Analytic horizon GTAO, bent/multi-bounce PBR integration, log-depth temporal lifecycle, acceptance fixture, and release boundaries  |
 | [Screen-space global illumination](./SCREEN_SPACE_GLOBAL_ILLUMINATION.md)       | Portable Forward/Clustered SSGI, radiance tracing, temporal denoise, lifecycle, quality budgets, and release boundaries             |
 | [Froxel volumetric lighting](./VOLUMETRIC_LIGHTING.md)                          | WebGPU Clustered froxels, height/local fog, light injection, radiative integration, temporal lifecycle, and quality tiers           |
 | [Physical atmosphere and weather](./PHYSICAL_ATMOSPHERE_AND_WEATHER.md)         | GPU histogram exposure, filmic display, atmosphere LUTs, temporal volumetric clouds, cloud shadows, and integration order           |

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -155,8 +155,10 @@ flag；SSR 启用时扩展两个 matching HDR MRT（优先 `rg11b10ufloat`，否
 `rgba16float`），额外输出 view-dependent reflection response 和 forward environment/probe specular
 baseline。portable Forward GTAO 与 Clustered Hi-Z
 SSR/GTAO/SSGI 按需消费它。GTAO 以相同 attributes 和 logarithmic motion depth 执行 horizon
-visibility、temporal rejection、edge-aware filter 与 depth/normal
-upsample；SSGI 在 opaque 后复用或生成 attributes/motion，执行随机 view-space diffuse ray
+visible-arc integral、bent-normal moment、closest-depth/variance-clipped temporal rejection、joint
+depth/normal filter 与 bilateral upsample；full-resolution result 再以 multi-bounce
+diffuse 和 bent-cone specular
+visibility 进入 PBR。SSGI 在 opaque 后复用或生成 attributes/motion，执行随机 view-space diffuse ray
 trace、YCoCg variance-clipped temporal resolve、depth/normal/luminance-aware a-trous
 filter、bilateral upsample 与线性 HDR 合成；SSR 以 response-aware tile mask 和 coherent
 compaction 生成受单维 65,535 上限约束的二维间接 dispatch，执行低粗糙度确定性镜面与每帧四条 32-phase
@@ -245,9 +247,12 @@ transfer。
 texture，再把该 texture 作为 pass-global binding 交给 transparent PBR transmission/volume draw。可选
 `GroundTruthAmbientOcclusion` 在 opaque 前复用共享 culling，记录 depth、material
 attributes 与 motion/log-depth，随后执行 rotated horizon search、submission-aware temporal
-resolve、两级 edge-aware filter 和 bounded bilateral upsample。full-resolution
-bent-normal/visibility 通过 pass-global binding 只进入 opaque
-PBR 的 ambient/IBL；普通 Forward 的同一 portable raster 实现覆盖 WebGPU/WebGL 2，完整合同见
+resolve、两级 joint bilateral filter 和 bounded bilateral upsample。horizon
+search 使用 view-relative 双侧 horizon 与 projected-normal analytic visible-arc
+integral，并显式支持普通、reversed 和 logarithmic depth；per-Camera
+pass/UBO/history 状态互相隔离。full-resolution bent-normal/visibility/multi-bounce
+strength 通过 pass-global binding 只进入 opaque PBR 的 ambient/IBL；普通 Forward 的同一 portable
+raster 实现覆盖 WebGPU/WebGL 2，完整合同见
 [`GROUND_TRUTH_AMBIENT_OCCLUSION.md`](./GROUND_TRUTH_AMBIENT_OCCLUSION.md)。可选 `TemporalAA`
 在 opaque 后记录 `rgba16float` motion/log-depth，并用 `rgba16float` 双缓冲 color history 和
 `r32float` 双缓冲 log-view-depth history 完成 reprojection、relative-depth disocclusion、YCoCg

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -3542,17 +3542,37 @@ export class GroundTruthAmbientOcclusion implements ForwardRenderPipelineFeature
 }
 
 // @public
+export type GroundTruthAmbientOcclusionNormalSource = 'material' | 'geometry' | 'hybrid';
+
+// @public
 export interface GroundTruthAmbientOcclusionOptions {
+    readonly bentNormalStrength?: number;
+    readonly bias?: number;
+    readonly contactRadiusScale?: number;
+    readonly contactStrength?: number;
     readonly depthThreshold?: number;
-    readonly directionCount?: 4 | 6 | 8;
+    readonly directionCount?: 2 | 3 | 4 | 6 | 8;
+    readonly distanceFadeEnd?: number;
+    readonly distanceFadeStart?: number;
+    readonly edgeFadePixels?: number;
     readonly falloffStart?: number;
+    readonly geometricNormalWeight?: number;
     readonly historyWeight?: number;
+    readonly intensity?: number;
+    readonly multiBounce?: number;
+    readonly normalSource?: GroundTruthAmbientOcclusionNormalSource;
+    readonly normalThreshold?: number;
     readonly power?: number;
+    readonly quality?: GroundTruthAmbientOcclusionQuality;
     readonly radius?: number;
     readonly resolutionScale?: number;
-    readonly stepCount?: 3 | 4 | 5 | 6;
+    readonly stepCount?: 3 | 4 | 5 | 6 | 8 | 10 | 12;
     readonly thickness?: number;
+    readonly thicknessBlend?: number;
 }
+
+// @public
+export type GroundTruthAmbientOcclusionQuality = 'low' | 'medium' | 'high' | 'ultra';
 
 // @public (undocumented)
 export class HDRLoader {
@@ -8171,6 +8191,7 @@ export interface RenderPipelineContext {
     prepareScene(): void;
     recordShadows(cullingResults: CullingResultsHandle, options?: Readonly<RenderPipelineShadowOptions>): Readonly<RenderPipelineShadowResources> | null;
     readonly scene: RendererScene;
+    readonly useLogDepth: boolean;
     readonly viewport: RendererViewport;
     writeStorageBuffer(buffer: StorageBuffer, byteOffset: number, data: ArrayBufferView): void;
 }

--- a/examples/ground_truth_ambient_occlusion.ts
+++ b/examples/ground_truth_ambient_occlusion.ts
@@ -382,15 +382,28 @@ class ToggleableGroundTruthAmbientOcclusion implements Hilo3d.ForwardRenderPipel
 }
 
 const gtao = new ToggleableGroundTruthAmbientOcclusion(gtaoEnabled, {
+    quality: testMode ? 'medium' : 'ultra',
     resolutionScale: testMode ? 0.5 : 0.7,
     radius: 1.12,
     falloffStart: 0.66,
-    thickness: 0.065,
-    directionCount: testMode ? 4 : 8,
-    stepCount: testMode ? 3 : 5,
-    power: 3.05,
+    thickness: 0.045,
+    thicknessBlend: 0.58,
+    directionCount: testMode ? 3 : 6,
+    stepCount: testMode ? 5 : 8,
+    intensity: 1.06,
+    power: 1.18,
+    bias: 0.03,
+    contactRadiusScale: 0.18,
+    contactStrength: 0.3,
+    normalSource: 'hybrid',
+    geometricNormalWeight: 0.64,
+    bentNormalStrength: 0.94,
+    multiBounce: 0.92,
+    distanceFadeStart: 36,
+    distanceFadeEnd: 54,
     historyWeight: 0.9,
-    depthThreshold: 0.025
+    depthThreshold: 0.025,
+    normalThreshold: 0.84
 });
 
 const pipeline = new Hilo3d.PostProcessRenderPipelineFactory({
@@ -568,7 +581,7 @@ const searchLabel = requireElement('#gtaoSearchLabel');
 toggle.setAttribute('aria-pressed', String(gtaoEnabled));
 toggleLabel.textContent = gtaoEnabled ? 'GTAO on' : 'GTAO off';
 backendLabel.textContent = BACKEND_LABELS[renderer.backend];
-searchLabel.textContent = testMode ? '4 × 3' : '8 × 5';
+searchLabel.textContent = testMode ? '3 × 5' : '6 × 8';
 toggle.addEventListener('click', () => {
     gtaoEnabled = !gtaoEnabled;
     gtao.enabled = gtaoEnabled;

--- a/examples/ground_truth_ambient_occlusion.ts
+++ b/examples/ground_truth_ambient_occlusion.ts
@@ -433,8 +433,9 @@ const mobileCameraPosition = new Hilo3d.Vector3(11.2, 4.65, 16.4);
 const viewTarget = new Hilo3d.Vector3(1.55, 0.18, -4.62);
 const initialCameraPosition = mobileLayout.matches ? mobileCameraPosition : desktopCameraPosition;
 
-const { stage, renderer, directionLight, ambientLight, orbitControls } = await createExampleContext(
-    {
+const { stage, renderer, directionLight, ambientLight, orbitControls, ticker } =
+    await createExampleContext({
+        autoStart: false,
         camera: {
             fov: 32,
             near: 0.05,
@@ -444,6 +445,8 @@ const { stage, renderer, directionLight, ambientLight, orbitControls } = await c
             z: initialCameraPosition.z
         },
         stage: {
+            width: testMode ? 640 : window.innerWidth,
+            height: testMode ? 360 : window.innerHeight,
             pixelRatio: testMode ? 1 : Math.min(devicePixelRatio, 1.5),
             clearColor: new Hilo3d.Color(0.032, 0.012, 0.011),
             renderPipeline: pipeline
@@ -458,8 +461,7 @@ const { stage, renderer, directionLight, ambientLight, orbitControls } = await c
             rotateSpeed: 0.38,
             zoomSpeed: 0.55
         }
-    }
-);
+    });
 
 renderer.clearColor.set(0.032, 0.012, 0.011, 1);
 directionLight.amount = 0.42;
@@ -589,6 +591,7 @@ toggle.addEventListener('click', () => {
     toggleLabel.textContent = gtaoEnabled ? 'GTAO on' : 'GTAO off';
     document.body.dataset['gtao'] = gtaoEnabled ? 'enabled' : 'disabled';
     history.replaceState(history.state, '', buildUrl(location.href, { gtao: gtaoEnabled }));
+    if (testMode) stage.tick(1000 / 60);
 });
 mobileLayout.addEventListener('change', event => {
     orbitControls.setView(event.matches ? mobileCameraPosition : desktopCameraPosition, viewTarget);
@@ -596,5 +599,8 @@ mobileLayout.addEventListener('change', event => {
 
 document.body.dataset['gtao'] = gtaoEnabled ? 'enabled' : 'disabled';
 document.body.dataset['backend'] = renderer.backend;
-document.body.dataset['gtaoPhase'] = 'ready';
 orbitControls.setView(initialCameraPosition, viewTarget);
+stage.tick(1000 / 60);
+await renderer.waitForIdle();
+if (!testMode) ticker.start();
+document.body.dataset['gtaoPhase'] = 'ready';

--- a/examples/gtao_acceptance_lab.css
+++ b/examples/gtao_acceptance_lab.css
@@ -1,0 +1,207 @@
+:root {
+    color-scheme: dark;
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    background: #0b0d0f;
+    color: #ebe7df;
+}
+
+body {
+    overflow: hidden;
+    margin: 0;
+    background: #0b0d0f;
+}
+
+#container,
+#container canvas {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.labHeader {
+    position: fixed;
+    z-index: 3;
+    top: 28px;
+    right: 34px;
+    left: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid rgb(235 231 223 / 22%);
+    padding-bottom: 13px;
+    color: rgb(235 231 223 / 68%);
+    font:
+        600 10px/1.2 ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        monospace;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    pointer-events: none;
+}
+
+.labHeader a {
+    color: inherit;
+    text-decoration: none;
+    pointer-events: auto;
+}
+
+.labIntro {
+    position: fixed;
+    z-index: 2;
+    top: 88px;
+    left: 34px;
+    width: min(350px, calc(100vw - 68px));
+    pointer-events: none;
+}
+
+.labIntro > p:first-child {
+    margin: 0 0 13px;
+    color: #e5ad72;
+    font:
+        650 10px/1.2 ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        monospace;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+}
+
+.labIntro h1 {
+    margin: 0;
+    font:
+        300 clamp(42px, 5.7vw, 78px) / 0.86 Georgia,
+        serif;
+    letter-spacing: -0.055em;
+}
+
+.labIntro h1 em {
+    color: #e5ad72;
+    font:
+        600 11px/1 ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        monospace;
+    letter-spacing: 0.08em;
+    vertical-align: top;
+}
+
+.labSummary {
+    width: 300px;
+    max-width: 80vw;
+    margin: 22px 0 0;
+    color: rgb(235 231 223 / 58%);
+    font-size: 12px;
+    line-height: 1.65;
+}
+
+.labControls {
+    position: fixed;
+    z-index: 4;
+    right: 34px;
+    bottom: 34px;
+    display: flex;
+    gap: 8px;
+}
+
+.labControls button {
+    min-width: 108px;
+    border: 1px solid rgb(235 231 223 / 24%);
+    border-radius: 999px;
+    padding: 11px 16px;
+    background: rgb(11 13 15 / 72%);
+    color: rgb(235 231 223 / 72%);
+    font:
+        600 9px/1 ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        monospace;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    backdrop-filter: blur(12px);
+    cursor: pointer;
+}
+
+.labControls button[aria-pressed='true'] {
+    border-color: #e5ad72;
+    color: #f5c795;
+}
+
+.labCases {
+    position: fixed;
+    z-index: 2;
+    right: 34px;
+    top: 92px;
+    display: grid;
+    gap: 7px;
+    margin: 0;
+    padding: 0;
+    color: rgb(235 231 223 / 55%);
+    font:
+        500 9px/1.25 ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        monospace;
+    letter-spacing: 0.08em;
+    list-style: none;
+    text-transform: uppercase;
+    pointer-events: none;
+}
+
+.labCases b {
+    display: inline-block;
+    width: 24px;
+    color: #e5ad72;
+    font-weight: 500;
+}
+
+.labHint {
+    position: fixed;
+    z-index: 2;
+    bottom: 38px;
+    left: 34px;
+    margin: 0;
+    color: rgb(235 231 223 / 44%);
+    font:
+        500 9px/1.2 ui-monospace,
+        SFMono-Regular,
+        Menlo,
+        monospace;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    pointer-events: none;
+}
+
+@media (max-width: 760px) {
+    .labHeader,
+    .labIntro,
+    .labHint {
+        left: 18px;
+    }
+
+    .labHeader,
+    .labControls,
+    .labCases {
+        right: 18px;
+    }
+
+    .labCases {
+        display: none;
+    }
+
+    .labControls {
+        bottom: 18px;
+        left: 18px;
+    }
+
+    .labControls button {
+        min-width: 0;
+        flex: 1;
+        padding-inline: 10px;
+    }
+
+    .labHint {
+        display: none;
+    }
+}

--- a/examples/gtao_acceptance_lab.html
+++ b/examples/gtao_acceptance_lab.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0"
+        />
+        <title>Hilo3D GTAO Acceptance Lab</title>
+        <link rel="stylesheet" href="./example.css" />
+        <link rel="stylesheet" href="./gtao_acceptance_lab.css" />
+    </head>
+    <body data-ao-acceptance-phase="loading" data-ao="enabled" data-motion="paused">
+        <div id="container"></div>
+
+        <header class="labHeader">
+            <a href="./index.html" aria-label="Back to Hilo3D examples">Hilo3D / rendering lab</a>
+            <span id="backendLabel">detecting</span>
+        </header>
+
+        <main class="labIntro">
+            <p>Ground-truth ambient occlusion</p>
+            <h1>Acceptance<br />Lab <em>01</em></h1>
+            <p class="labSummary">
+                Deterministic production fixture for contact scale, thin geometry, depth edges,
+                normal detail, material response and temporal rejection.
+            </p>
+        </main>
+
+        <section class="labControls" aria-label="GTAO acceptance controls">
+            <button id="aoToggle" type="button" aria-pressed="true">AO enabled</button>
+            <button id="motionToggle" type="button" aria-pressed="false">start motion</button>
+            <button id="viewToggle" type="button" aria-pressed="false">edge view</button>
+        </section>
+
+        <ol class="labCases" aria-label="Acceptance geometry">
+            <li><b>01</b> perpendicular corner</li>
+            <li><b>02</b> thin cards</li>
+            <li><b>03</b> parallel slabs</li>
+            <li><b>04</b> stair contacts</li>
+            <li><b>05</b> normal detail</li>
+            <li><b>06</b> rough / metal</li>
+            <li><b>07</b> moving occluder</li>
+        </ol>
+
+        <p class="labHint">Drag to orbit · wheel to inspect · fixed exposure</p>
+        <script type="module" src="./gtao_acceptance_lab.ts"></script>
+    </body>
+</html>

--- a/examples/gtao_acceptance_lab.ts
+++ b/examples/gtao_acceptance_lab.ts
@@ -1,0 +1,371 @@
+import * as Hilo3d from '../src/Hilo3d';
+import { createExampleContext } from './shared/init';
+import { createStudioEnvironmentMaps } from './shared/studioEnvironment';
+
+const query = new URLSearchParams(location.search);
+const testMode = query.get('test') === '1';
+let aoEnabled = query.get('ao') !== 'false';
+let motionEnabled = query.get('motion') === 'true';
+let edgeViewEnabled = false;
+
+function requireButton(id: string): HTMLButtonElement {
+    const button = document.querySelector<HTMLButtonElement>(`#${id}`);
+    if (button === null) throw new Error(`GTAO acceptance lab is missing #${id}`);
+    return button;
+}
+
+function createNormalTexture(): Hilo3d.Texture {
+    const size = 96;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const context = canvas.getContext('2d');
+    if (context === null) throw new Error('Unable to create the GTAO normal fixture');
+    const image = context.createImageData(size, size);
+    for (let y = 0; y < size; y += 1) {
+        for (let x = 0; x < size; x += 1) {
+            const u = x / size;
+            const v = y / size;
+            const nx = Math.sin(u * Math.PI * 12) * 0.28;
+            const ny = Math.cos(v * Math.PI * 10 + u * Math.PI * 2) * 0.28;
+            const nz = Math.sqrt(Math.max(1 - nx * nx - ny * ny, 0));
+            const offset = (y * size + x) * 4;
+            image.data[offset] = Math.round((nx * 0.5 + 0.5) * 255);
+            image.data[offset + 1] = Math.round((ny * 0.5 + 0.5) * 255);
+            image.data[offset + 2] = Math.round((nz * 0.5 + 0.5) * 255);
+            image.data[offset + 3] = 255;
+        }
+    }
+    context.putImageData(image, 0, 0);
+    return new Hilo3d.Texture({
+        image: canvas,
+        wrapS: Hilo3d.constants.webgl.REPEAT,
+        wrapT: Hilo3d.constants.webgl.REPEAT,
+        magFilter: Hilo3d.constants.webgl.LINEAR,
+        minFilter: Hilo3d.constants.webgl.LINEAR_MIPMAP_LINEAR
+    });
+}
+
+class ToggleableGTAO implements Hilo3d.ForwardRenderPipelineFeature {
+    readonly name = 'ground-truth-ambient-occlusion';
+    readonly injectionPoint = 'before-opaque' as const;
+    readonly requirements: Readonly<Hilo3d.ForwardRenderFeatureRequirements>;
+    readonly #feature: Hilo3d.GroundTruthAmbientOcclusion;
+    enabled: boolean;
+
+    constructor(enabled: boolean) {
+        this.enabled = enabled;
+        this.#feature = new Hilo3d.GroundTruthAmbientOcclusion({
+            quality: testMode ? 'low' : 'high',
+            radius: 1.65,
+            falloffStart: 0.62,
+            thickness: 0.035,
+            thicknessBlend: 0.58,
+            intensity: 1.08,
+            power: 1.16,
+            bias: 0.032,
+            contactRadiusScale: 0.18,
+            contactStrength: 0.32,
+            normalSource: 'hybrid',
+            geometricNormalWeight: 0.68,
+            bentNormalStrength: 0.92,
+            multiBounce: 0.9,
+            distanceFadeStart: 32,
+            distanceFadeEnd: 52,
+            edgeFadePixels: 2,
+            historyWeight: 0.9,
+            depthThreshold: 0.025,
+            normalThreshold: 0.84
+        });
+        this.requirements = this.#feature.requirements;
+    }
+
+    create(): Hilo3d.ForwardRenderPipelineFeatureRuntime {
+        const runtime = this.#feature.create();
+        return {
+            record: (context: Hilo3d.ForwardRenderFeatureContext): unknown =>
+                this.enabled ? runtime.record(context) : undefined,
+            frameSubmitted(frameIndex: number): void {
+                runtime.frameSubmitted?.(frameIndex);
+            },
+            frameDiscarded(frameIndex: number): void {
+                runtime.frameDiscarded?.(frameIndex);
+            },
+            destroy(): void {
+                runtime.destroy();
+            }
+        };
+    }
+}
+
+const gtao = new ToggleableGTAO(aoEnabled);
+const pipeline = new Hilo3d.PostProcessRenderPipelineFactory({
+    groundTruthAmbientOcclusion: false,
+    bloom: false,
+    colorUber: {
+        toneMapping: 'pbr-neutral',
+        exposure: -0.18,
+        contrast: 0.04,
+        saturation: -0.04,
+        vignetteIntensity: 0.08,
+        vignetteSmoothness: 0.86,
+        vignetteColor: new Hilo3d.Color(0.02, 0.022, 0.024, 0.2)
+    },
+    features: [gtao]
+});
+
+const heroView = new Hilo3d.Vector3(9.8, 5.25, 13.4);
+const heroTarget = new Hilo3d.Vector3(0, -0.05, -1.5);
+const edgeView = new Hilo3d.Vector3(13.6, 3.3, 8.7);
+const edgeTarget = new Hilo3d.Vector3(1.7, -0.15, -2.2);
+const { stage, renderer, camera, directionLight, ambientLight, orbitControls, ticker } =
+    await createExampleContext({
+        autoStart: false,
+        camera: {
+            fov: 39,
+            near: 0.08,
+            far: 80,
+            x: heroView.x,
+            y: heroView.y,
+            z: heroView.z
+        },
+        stage: {
+            width: testMode ? 640 : window.innerWidth,
+            height: testMode ? 360 : window.innerHeight,
+            pixelRatio: testMode ? 1 : Math.min(devicePixelRatio, 1.5),
+            clearColor: new Hilo3d.Color(0.055, 0.06, 0.064),
+            useLogDepth: query.get('logDepth') === 'true',
+            useInstanced: true,
+            renderPipeline: pipeline
+        },
+        controls: {
+            target: heroTarget,
+            enablePan: false,
+            minDistance: 8,
+            maxDistance: 30,
+            minPolarAngle: Math.PI * 0.18,
+            maxPolarAngle: Math.PI * 0.62,
+            rotateSpeed: 0.42,
+            zoomSpeed: 0.62
+        }
+    });
+
+orbitControls.setView(heroView, heroTarget);
+renderer.clearColor.set(0.055, 0.06, 0.064, 1);
+directionLight.amount = 0.38;
+directionLight.color.set(1, 0.9, 0.78, 1);
+directionLight.direction.set(-0.58, -0.82, -0.42);
+ambientLight.amount = 1.72;
+ambientLight.color.set(0.76, 0.81, 0.88, 1);
+
+const { diffuseEnvMap, specularEnvMap } = createStudioEnvironmentMaps();
+const brdfLUT = await new Hilo3d.TextureLoader().load({
+    src: new URL('./image/brdfLUT.png', import.meta.url).href,
+    wrapS: Hilo3d.constants.webgl.CLAMP_TO_EDGE,
+    wrapT: Hilo3d.constants.webgl.CLAMP_TO_EDGE
+});
+const materialDefaults = Object.freeze({
+    brdfLUT,
+    diffuseEnvMap: Object.freeze({ texture: diffuseEnvMap, encoding: 'srgb' as const }),
+    specularEnvMap: Object.freeze({ texture: specularEnvMap, encoding: 'srgb' as const }),
+    diffuseEnvIntensity: 1.05,
+    specularEnvIntensity: 0.42
+});
+const material = (
+    color: Readonly<[number, number, number]>,
+    roughness: number,
+    metallic = 0
+): Hilo3d.PBRMaterial =>
+    new Hilo3d.PBRMaterial({
+        ...materialDefaults,
+        baseColor: new Hilo3d.Color(color[0], color[1], color[2]),
+        roughness,
+        metallic
+    });
+
+const plaster = material([0.67, 0.65, 0.6], 0.94);
+const pale = material([0.82, 0.79, 0.72], 0.88);
+const dark = material([0.14, 0.16, 0.17], 0.76);
+const copper = material([0.62, 0.26, 0.095], 0.24, 0.82);
+const normalMaterial = new Hilo3d.PBRMaterial({
+    ...materialDefaults,
+    baseColor: new Hilo3d.Color(0.42, 0.54, 0.58),
+    roughness: 0.62,
+    metallic: 0,
+    normalMap: createNormalTexture(),
+    normalScale: 1
+});
+const sharedBoxGeometry = new Hilo3d.BoxGeometry();
+
+const addBox = (
+    size: Readonly<[number, number, number]>,
+    position: Readonly<[number, number, number]>,
+    surface: Hilo3d.PBRMaterial,
+    rotation: Readonly<[number, number, number]> = [0, 0, 0]
+): Hilo3d.Mesh => {
+    const mesh = new Hilo3d.Mesh({
+        geometry: sharedBoxGeometry,
+        material: surface,
+        x: position[0],
+        y: position[1],
+        z: position[2],
+        rotationX: rotation[0],
+        rotationY: rotation[1],
+        rotationZ: rotation[2],
+        frustumTest: false
+    });
+    mesh.setScale(size[0], size[1], size[2]);
+    mesh.addTo(stage);
+    return mesh;
+};
+
+addBox([15, 0.22, 11], [0, -1.62, -1.1], plaster);
+addBox([15, 6.2, 0.22], [0, 1.38, -6.45], plaster);
+addBox([0.22, 5.2, 4.4], [-5.8, 0.88, -4.25], plaster);
+
+// 01: a clean ninety-degree concavity and a sphere-to-floor contact.
+addBox([0.28, 3.2, 3.4], [-4.15, -0.01, -4.72], pale);
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.SphereGeometry({ radius: 0.72, widthSegments: 32, heightSegments: 18 }),
+    material: dark,
+    x: -4.55,
+    y: -0.78,
+    z: -3.68,
+    frustumTest: false
+}).addTo(stage);
+
+// 02: sub-radius cards exercise thickness handling without growing black halos.
+for (let index = 0; index < 4; index += 1) {
+    addBox(
+        [0.055, 1.7 - index * 0.15, 1.65],
+        [-2.65 + index * 0.42, -0.72 + index * 0.03, -3.45 - index * 0.2],
+        index % 2 === 0 ? pale : dark,
+        [0, -18 + index * 12, 0]
+    );
+}
+
+// 03: parallel gaps verify depth-aware filtering and medium-scale visibility.
+for (let index = 0; index < 3; index += 1) {
+    addBox([2.2, 0.13, 1.35], [0.15, -0.82 + index * 0.54, -4.72], pale);
+}
+
+// 04: repeated contacts make over-blur and leaking immediately visible.
+for (let index = 0; index < 5; index += 1) {
+    addBox(
+        [0.92, 0.28 + index * 0.22, 1.42],
+        [2.15 + index * 0.72, -1.48 + (0.28 + index * 0.22) * 0.5, -4.75],
+        plaster
+    );
+}
+
+// 05/06: material normal detail plus rough dielectric and glossy metal response.
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.SphereGeometry({ radius: 0.78, widthSegments: 40, heightSegments: 22 }),
+    material: normalMaterial,
+    x: -1.62,
+    y: -0.82,
+    z: -1.42,
+    rotationY: -8,
+    frustumTest: false
+}).addTo(stage);
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.SphereGeometry({ radius: 0.76, widthSegments: 32, heightSegments: 18 }),
+    material: pale,
+    x: 0.48,
+    y: -0.82,
+    z: -1.35,
+    frustumTest: false
+}).addTo(stage);
+new Hilo3d.Mesh({
+    geometry: new Hilo3d.SphereGeometry({ radius: 0.76, widthSegments: 32, heightSegments: 18 }),
+    material: copper,
+    x: 2.32,
+    y: -0.82,
+    z: -1.28,
+    frustumTest: false
+}).addTo(stage);
+
+// 07: closest-depth motion selection and history rejection around a moving occluder.
+const movingOccluder = addBox([0.34, 2.25, 1.4], [4.45, -0.38, -1.92], dark, [0, -12, 0]);
+addBox([2.65, 0.12, 1.65], [4.45, -1.05, -2.02], pale);
+
+let elapsedSeconds = 0;
+const motionDriver: Hilo3d.Tickable = {
+    tick(deltaTime: number): void {
+        if (!motionEnabled) return;
+        elapsedSeconds += Math.min(deltaTime, 50) * 0.001;
+        movingOccluder.x = 4.45 + Math.sin(elapsedSeconds * 1.15) * 0.92;
+        movingOccluder.rotationY = -12 + Math.sin(elapsedSeconds * 0.73) * 20;
+    }
+};
+ticker.addTick(motionDriver);
+
+const aoToggle = requireButton('aoToggle');
+const motionToggle = requireButton('motionToggle');
+const viewToggle = requireButton('viewToggle');
+const backendLabel = document.querySelector<HTMLElement>('#backendLabel');
+if (backendLabel === null) throw new Error('GTAO acceptance lab is missing #backendLabel');
+
+function reflectState(): void {
+    aoToggle.setAttribute('aria-pressed', String(aoEnabled));
+    aoToggle.textContent = aoEnabled ? 'AO enabled' : 'AO disabled';
+    motionToggle.setAttribute('aria-pressed', String(motionEnabled));
+    motionToggle.textContent = motionEnabled ? 'pause motion' : 'start motion';
+    viewToggle.setAttribute('aria-pressed', String(edgeViewEnabled));
+    viewToggle.textContent = edgeViewEnabled ? 'hero view' : 'edge view';
+    document.body.dataset['ao'] = aoEnabled ? 'enabled' : 'disabled';
+    document.body.dataset['motion'] = motionEnabled ? 'running' : 'paused';
+}
+
+function renderStaticTestFrame(): void {
+    if (testMode && !motionEnabled) stage.tick(1000 / 60);
+}
+
+aoToggle.addEventListener('click', () => {
+    aoEnabled = !aoEnabled;
+    gtao.enabled = aoEnabled;
+    reflectState();
+    renderStaticTestFrame();
+});
+motionToggle.addEventListener('click', () => {
+    motionEnabled = !motionEnabled;
+    reflectState();
+    if (testMode) {
+        if (motionEnabled) ticker.start();
+        else ticker.stop();
+    }
+});
+viewToggle.addEventListener('click', () => {
+    edgeViewEnabled = !edgeViewEnabled;
+    orbitControls.setView(
+        edgeViewEnabled ? edgeView : heroView,
+        edgeViewEnabled ? edgeTarget : heroTarget
+    );
+    camera.invalidateTransformHistory();
+    reflectState();
+    renderStaticTestFrame();
+});
+
+const backendNames = Object.freeze({ webgl2: 'WebGL 2', webgpu: 'WebGPU' });
+backendLabel.textContent = `${backendNames[renderer.backend]} · ${
+    query.get('logDepth') === 'true' ? 'log depth' : 'linear depth'
+}`;
+reflectState();
+
+function errorChain(error: unknown): string {
+    if (!(error instanceof Error)) return String(error);
+    const cause = error.cause;
+    return cause === undefined ? error.message : `${error.message}: ${errorChain(cause)}`;
+}
+
+const warmupFrameCount = testMode ? 1 : 12;
+for (let frame = 0; frame < warmupFrameCount; frame += 1) {
+    try {
+        stage.tick(1000 / 60);
+        await renderer.waitForIdle();
+    } catch (error) {
+        throw new Error(`GTAO acceptance warmup failed: ${errorChain(error)}`, { cause: error });
+    }
+}
+if (!testMode || motionEnabled) ticker.start();
+document.body.dataset['aoAcceptancePhase'] = 'ready';

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -112,6 +112,7 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'screen_space_global_illumination_chapel.html':
         'Prismatic Vespers — Screen-space Global Illumination',
     'ground_truth_ambient_occlusion.html': 'The Silent Dragon — Ground-truth Ambient Occlusion',
+    'gtao_acceptance_lab.html': 'GTAO Acceptance Lab',
     'temporal_aa_observatory.html': 'Temporal Observatory — Signals in Deep Time',
     'compute_eclipse_shrine.html': 'Eclipse Shrine — WebGPU Compute Installation',
     'compute_particles.html': 'Hilo3D Compute Particle Field',
@@ -154,6 +155,8 @@ const DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
         'Enter a procedural brutalist chapel where portable stochastic SSGI transports cyan, vermilion, violet, and warm emissive radiance across pale stone.',
     'ground_truth_ambient_occlusion.html':
         'Read scales, claws, coils, layered stone contacts, and a deep architectural niche through portable temporal GTAO.',
+    'gtao_acceptance_lab.html':
+        'Validate contact scale, thin geometry, depth edges, normal detail, material response, and temporal rejection in a deterministic dual-backend GTAO fixture.',
     'temporal_aa_observatory.html':
         'Stress fused motion vectors, visibility-aware history, logarithmic depth rejection, and fixed-scale TAAU in a kinetic WebGPU constellation.',
     'compute_eclipse_shrine.html':
@@ -243,6 +246,7 @@ const FEATURED_PATHS = new Set([
     'screen_space_reflections_palace.html',
     'screen_space_global_illumination_chapel.html',
     'ground_truth_ambient_occlusion.html',
+    'gtao_acceptance_lab.html',
     'temporal_aa_observatory.html',
     'compute_eclipse_shrine.html',
     'compute_particles.html',
@@ -280,7 +284,7 @@ function categoryForPath(path: string): ExampleCategoryId {
         return 'textures';
     }
     if (
-        /(?:post_process|bloom|temporal_aa|ground_truth_ambient_occlusion|screen_space_|volumetric|rendertarget|drawbuffers|depthtexture|stencil|multisampled|scriptable_pipeline|clustered_forward_plus|compute_gpu_driven|compute_eclipse_shrine|compute_particles)/u.test(
+        /(?:post_process|bloom|temporal_aa|ground_truth_ambient_occlusion|gtao_acceptance|screen_space_|volumetric|rendertarget|drawbuffers|depthtexture|stencil|multisampled|scriptable_pipeline|clustered_forward_plus|compute_gpu_driven|compute_eclipse_shrine|compute_particles)/u.test(
             normalized
         )
     ) {

--- a/src/render/internal/ScriptableRenderPipelineContext.ts
+++ b/src/render/internal/ScriptableRenderPipelineContext.ts
@@ -3965,6 +3965,11 @@ class RenderPipelineContextLease implements RenderPipelineContext, ScriptableRen
         return this.#owner.capabilities;
     }
 
+    get useLogDepth(): boolean {
+        this.#owner.assertLeaseActive(this.#lease);
+        return this.#owner.services.renderer.useLogDepth;
+    }
+
     get graph(): ScriptableRenderGraph {
         this.#owner.assertLeaseActive(this.#lease);
         return this;

--- a/src/render/pipeline/ClusteredForwardPlus.ts
+++ b/src/render/pipeline/ClusteredForwardPlus.ts
@@ -3651,6 +3651,48 @@ layout(std430) readonly buffer ClusterGridBlock { uvec2 values[]; } clusterGrid;
 layout(std430) readonly buffer ClusterIndexBlock { uint values[]; } clusterIndices;
 ${textureDeclarations}
 ${withGroundTruthAmbientOcclusion ? 'uniform sampler2D u_gtaoTexture;' : ''}
+${
+    withGroundTruthAmbientOcclusion
+        ? `vec3 hiloDecodeGTAOBentNormal(vec2 encoded) {
+    vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
+    if (normal.z < 0.0) {
+        vec2 original = normal.xy;
+        normal.xy = (1.0 - abs(original.yx)) * vec2(
+            original.x >= 0.0 ? 1.0 : -1.0,
+            original.y >= 0.0 ? 1.0 : -1.0
+        );
+    }
+    return normalize(normal);
+}
+vec3 hiloGTAOMultiBounceVisibility(float visibility, vec3 albedo, float strength) {
+    vec3 a = 2.0404 * albedo - 0.3324;
+    vec3 b = -4.7951 * albedo + 0.6417;
+    vec3 c = 2.7552 * albedo + 0.6903;
+    vec3 multiBounce = max(
+        vec3(visibility),
+        ((visibility * a + b) * visibility + c) * visibility
+    );
+    return mix(vec3(visibility), clamp(multiBounce, 0.0, 1.0), strength);
+}
+float hiloGTAOSpecularVisibility(
+    float visibility,
+    vec3 bentNormal,
+    vec3 normal,
+    vec3 viewDirection,
+    float perceptualRoughness
+) {
+    vec3 reflectionDirection = -normalize(reflect(viewDirection, normal));
+    float coneCosine = clamp(1.0 - visibility, 0.0, 1.0);
+    float lobeWidth = max(perceptualRoughness * perceptualRoughness, 0.04);
+    float directionalVisibility = smoothstep(
+        coneCosine - lobeWidth,
+        coneCosine + lobeWidth,
+        dot(reflectionDirection, bentNormal)
+    );
+    return mix(max(visibility, directionalVisibility), visibility, perceptualRoughness);
+}`
+        : ''
+}
 ${withCloudShadow ? 'uniform sampler2D u_cloudShadowTexture;' : ''}
 uniform sampler2D u_areaLightsLtcTexture1;
 uniform sampler2D u_areaLightsLtcTexture2;
@@ -3907,14 +3949,32 @@ void main() {
     uint clusterIndex = slice * cluster.x * cluster.y + tileY * cluster.x + tileX;
     uvec2 allocation = clusterGrid.values[clusterIndex];
     uvec4 directional = floatBitsToUint(frameData.values[30u]);
-    float ambientOcclusion = surface.occlusion;
+    vec3 ambientDiffuseOcclusion = vec3(surface.occlusion);
+    float ambientSpecularOcclusion = surface.occlusion;
     ${
         withGroundTruthAmbientOcclusion
-            ? 'ambientOcclusion *= clamp(texture(u_gtaoTexture, gl_FragCoord.xy / frameData.values[24u].zw).b, 0.0, 1.0);'
+            ? `vec4 gtaoSample = texture(
+        u_gtaoTexture,
+        gl_FragCoord.xy / frameData.values[24u].zw
+    );
+    float gtaoVisibility = clamp(gtaoSample.b, 0.0, 1.0);
+    vec3 gtaoBentNormal = hiloDecodeGTAOBentNormal(gtaoSample.xy);
+    ambientDiffuseOcclusion *= hiloGTAOMultiBounceVisibility(
+        gtaoVisibility,
+        clamp(surface.baseColor.rgb, 0.0, 1.0),
+        clamp(gtaoSample.a, 0.0, 1.0)
+    );
+    ambientSpecularOcclusion *= hiloGTAOSpecularVisibility(
+        gtaoVisibility,
+        gtaoBentNormal,
+        normal,
+        viewDirection,
+        surface.roughness
+    );`
             : ''
     }
     vec3 lighting = frameData.values[31u].rgb * surface.iblDiffuseColor *
-        ambientOcclusion * HILO_INVERSE_PI;
+        ambientDiffuseOcclusion * HILO_INVERSE_PI;
     ${
         withReflectionData
             ? `float reflectionNdotV = max(abs(dot(normal, viewDirection)), 0.0001);
@@ -3924,7 +3984,7 @@ void main() {
     );
     vec3 ssrFallbackSpecular = frameData.values[31u].rgb *
         ssrReflectionResponse *
-        mix(1.0, 0.35, surface.roughness) * ambientOcclusion;
+        mix(1.0, 0.35, surface.roughness) * ambientSpecularOcclusion;
     lighting += ssrFallbackSpecular;
     reflectionResponse = vec4(ssrReflectionResponse, 1.0);
     reflectionFallbackSpecular = vec4(ssrFallbackSpecular, 1.0);`

--- a/src/render/pipeline/RenderPipeline.ts
+++ b/src/render/pipeline/RenderPipeline.ts
@@ -306,6 +306,8 @@ export interface RenderPipelineContext {
     readonly output: RenderPipelineOutput;
     /** Effective capabilities for the current device generation. */
     readonly capabilities: RenderPipelineCapabilities;
+    /** Whether scene depth uses the renderer's logarithmic depth encoding. */
+    readonly useLogDepth: boolean;
     /** Backend-neutral graph facade for this invocation. */
     readonly graph: ScriptableRenderGraph;
 

--- a/src/render/postprocessing/GroundTruthAmbientOcclusion.ts
+++ b/src/render/postprocessing/GroundTruthAmbientOcclusion.ts
@@ -36,40 +36,107 @@ const INVALID_CULLING_RESULTS = 0 as CullingResultsHandle;
 const INVALID_RENDERER_LIST = 0 as RendererListHandle;
 const CAMERA_HISTORY_RETENTION_FRAMES = 120;
 
+/** Quality preset used when an individual GTAO sampling control is omitted. */
+export type GroundTruthAmbientOcclusionQuality = 'low' | 'medium' | 'high' | 'ultra';
+
+/** Normal source used for GTAO horizon integration and edge rejection. */
+export type GroundTruthAmbientOcclusionNormalSource = 'material' | 'geometry' | 'hybrid';
+
 /** Production controls for ground-truth ambient occlusion. */
 export interface GroundTruthAmbientOcclusionOptions {
-    /** Internal AO resolution relative to opaque rendering. Defaults to 0.5. */
+    /** Sampling preset. Individual resolution/direction/step controls override it. Defaults to high. */
+    readonly quality?: GroundTruthAmbientOcclusionQuality;
+    /** Internal AO resolution relative to opaque rendering. Defaults to the quality preset. */
     readonly resolutionScale?: number;
     /** View-space horizon-search radius. Defaults to 2. */
     readonly radius?: number;
     /** Fraction of the radius at which distance falloff begins. Defaults to 0.6. */
     readonly falloffStart?: number;
-    /** Thin-surface tolerance in view-space units. Defaults to 0.05. */
+    /** View-space self-intersection rejection distance. Defaults to 0.05. */
     readonly thickness?: number;
-    /** Number of rotated horizon slices per pixel. Defaults to 6. */
-    readonly directionCount?: 4 | 6 | 8;
-    /** Samples evaluated on each side of a horizon slice. Defaults to 4. */
-    readonly stepCount?: 3 | 4 | 5 | 6;
+    /** Blend between a thin depth field and a solid occluder. Defaults to 0.5. */
+    readonly thicknessBlend?: number;
+    /** Number of rotated horizon slices per pixel. Defaults to the quality preset. */
+    readonly directionCount?: 2 | 3 | 4 | 6 | 8;
+    /** Samples evaluated on each side of a horizon slice. Defaults to the quality preset. */
+    readonly stepCount?: 3 | 4 | 5 | 6 | 8 | 10 | 12;
     /** Contrast applied to the physically normalized visibility. Defaults to 1.2. */
     readonly power?: number;
+    /** Occlusion intensity before contrast. Defaults to 1. */
+    readonly intensity?: number;
+    /** Angular self-occlusion bias in radians. Defaults to 0.035. */
+    readonly bias?: number;
+    /** Radius of the additional contact-occlusion lobe, relative to radius. Defaults to 0.2. */
+    readonly contactRadiusScale?: number;
+    /** Strength of the contact-occlusion lobe. Defaults to 0.35. */
+    readonly contactStrength?: number;
+    /** Normal source used by the horizon search. Defaults to hybrid. */
+    readonly normalSource?: GroundTruthAmbientOcclusionNormalSource;
+    /** Geometric-normal contribution in hybrid mode. Defaults to 0.65. */
+    readonly geometricNormalWeight?: number;
+    /** Strength of bent-normal redirection. Defaults to 1. */
+    readonly bentNormalStrength?: number;
+    /** Strength of color-aware multi-bounce diffuse AO. Defaults to 1. */
+    readonly multiBounce?: number;
+    /** View distance where AO starts fading. Defaults to 100. */
+    readonly distanceFadeStart?: number;
+    /** View distance where AO is fully disabled. Defaults to 200. */
+    readonly distanceFadeEnd?: number;
+    /** Screen-edge fade width in AO pixels. Defaults to 2. */
+    readonly edgeFadePixels?: number;
     /** Maximum accepted temporal contribution. Defaults to 0.9. */
     readonly historyWeight?: number;
     /** Maximum relative reprojected view-depth error. Defaults to 0.03. */
     readonly depthThreshold?: number;
+    /** Minimum normal agreement accepted by temporal reprojection. Defaults to 0.82. */
+    readonly normalThreshold?: number;
 }
 
 /** @internal Immutable validated GTAO configuration. */
 export interface GroundTruthAmbientOcclusionSettings {
+    readonly quality: GroundTruthAmbientOcclusionQuality;
     readonly resolutionScale: number;
     readonly radius: number;
     readonly falloffStart: number;
     readonly thickness: number;
-    readonly directionCount: 4 | 6 | 8;
-    readonly stepCount: 3 | 4 | 5 | 6;
+    readonly thicknessBlend: number;
+    readonly directionCount: 2 | 3 | 4 | 6 | 8;
+    readonly stepCount: 3 | 4 | 5 | 6 | 8 | 10 | 12;
     readonly power: number;
+    readonly intensity: number;
+    readonly bias: number;
+    readonly contactRadiusScale: number;
+    readonly contactStrength: number;
+    readonly normalSource: GroundTruthAmbientOcclusionNormalSource;
+    readonly geometricNormalWeight: number;
+    readonly bentNormalStrength: number;
+    readonly multiBounce: number;
+    readonly distanceFadeStart: number;
+    readonly distanceFadeEnd: number;
+    readonly edgeFadePixels: number;
     readonly historyWeight: number;
     readonly depthThreshold: number;
+    readonly normalThreshold: number;
 }
+
+const GTAO_QUALITY_DEFAULTS = Object.freeze({
+    low: Object.freeze({ resolutionScale: 0.5, directionCount: 2 as const, stepCount: 4 as const }),
+    medium: Object.freeze({
+        resolutionScale: 0.5,
+        directionCount: 3 as const,
+        stepCount: 5 as const
+    }),
+    high: Object.freeze({
+        resolutionScale: 0.5,
+        directionCount: 4 as const,
+        stepCount: 6 as const
+    }),
+    ultra: Object.freeze({
+        resolutionScale: 0.75,
+        directionCount: 6 as const,
+        stepCount: 8 as const
+    })
+});
 
 function finiteRange(value: number, minimum: number, maximum: number, label: string): number {
     if (!Number.isFinite(value) || value < minimum || value > maximum) {
@@ -87,13 +154,44 @@ function member<T extends number>(value: T, values: readonly T[], label: string)
     return value;
 }
 
+function stringMember<T extends string>(value: T, values: readonly T[], label: string): T {
+    if (!values.includes(value)) {
+        throw new TypeError(`${label} must be one of ${values.join(', ')}`);
+    }
+    return value;
+}
+
 /** @internal Validate and freeze public GTAO options. */
 export function snapshotGroundTruthAmbientOcclusionOptions(
     options: Readonly<GroundTruthAmbientOcclusionOptions>
 ): Readonly<GroundTruthAmbientOcclusionSettings> {
+    const quality = stringMember(
+        options.quality ?? 'high',
+        ['low', 'medium', 'high', 'ultra'] as const,
+        'GroundTruthAmbientOcclusion quality'
+    );
+    const defaults = GTAO_QUALITY_DEFAULTS[quality];
+    const distanceFadeStart = finiteRange(
+        options.distanceFadeStart ?? 100,
+        0,
+        1_000_000,
+        'GroundTruthAmbientOcclusion distanceFadeStart'
+    );
+    const distanceFadeEnd = finiteRange(
+        options.distanceFadeEnd ?? 200,
+        0.001,
+        1_000_000,
+        'GroundTruthAmbientOcclusion distanceFadeEnd'
+    );
+    if (distanceFadeEnd <= distanceFadeStart) {
+        throw new RangeError(
+            'GroundTruthAmbientOcclusion distanceFadeEnd must be greater than distanceFadeStart'
+        );
+    }
     return Object.freeze({
+        quality,
         resolutionScale: finiteRange(
-            options.resolutionScale ?? 0.5,
+            options.resolutionScale ?? defaults.resolutionScale,
             0.25,
             1,
             'GroundTruthAmbientOcclusion resolutionScale'
@@ -111,17 +209,73 @@ export function snapshotGroundTruthAmbientOcclusionOptions(
             10,
             'GroundTruthAmbientOcclusion thickness'
         ),
+        thicknessBlend: finiteRange(
+            options.thicknessBlend ?? 0.5,
+            0,
+            1,
+            'GroundTruthAmbientOcclusion thicknessBlend'
+        ),
         directionCount: member(
-            options.directionCount ?? 6,
-            [4, 6, 8] as const,
+            options.directionCount ?? defaults.directionCount,
+            [2, 3, 4, 6, 8] as const,
             'GroundTruthAmbientOcclusion directionCount'
         ),
         stepCount: member(
-            options.stepCount ?? 4,
-            [3, 4, 5, 6] as const,
+            options.stepCount ?? defaults.stepCount,
+            [3, 4, 5, 6, 8, 10, 12] as const,
             'GroundTruthAmbientOcclusion stepCount'
         ),
         power: finiteRange(options.power ?? 1.2, 0.25, 4, 'GroundTruthAmbientOcclusion power'),
+        intensity: finiteRange(
+            options.intensity ?? 1,
+            0,
+            4,
+            'GroundTruthAmbientOcclusion intensity'
+        ),
+        bias: finiteRange(options.bias ?? 0.035, 0, 0.5, 'GroundTruthAmbientOcclusion bias'),
+        contactRadiusScale: finiteRange(
+            options.contactRadiusScale ?? 0.2,
+            0.02,
+            1,
+            'GroundTruthAmbientOcclusion contactRadiusScale'
+        ),
+        contactStrength: finiteRange(
+            options.contactStrength ?? 0.35,
+            0,
+            2,
+            'GroundTruthAmbientOcclusion contactStrength'
+        ),
+        normalSource: stringMember(
+            options.normalSource ?? 'hybrid',
+            ['material', 'geometry', 'hybrid'] as const,
+            'GroundTruthAmbientOcclusion normalSource'
+        ),
+        geometricNormalWeight: finiteRange(
+            options.geometricNormalWeight ?? 0.65,
+            0,
+            1,
+            'GroundTruthAmbientOcclusion geometricNormalWeight'
+        ),
+        bentNormalStrength: finiteRange(
+            options.bentNormalStrength ?? 1,
+            0,
+            1,
+            'GroundTruthAmbientOcclusion bentNormalStrength'
+        ),
+        multiBounce: finiteRange(
+            options.multiBounce ?? 1,
+            0,
+            1,
+            'GroundTruthAmbientOcclusion multiBounce'
+        ),
+        distanceFadeStart,
+        distanceFadeEnd,
+        edgeFadePixels: finiteRange(
+            options.edgeFadePixels ?? 2,
+            0,
+            32,
+            'GroundTruthAmbientOcclusion edgeFadePixels'
+        ),
         historyWeight: finiteRange(
             options.historyWeight ?? 0.9,
             0,
@@ -133,6 +287,12 @@ export function snapshotGroundTruthAmbientOcclusionOptions(
             0,
             1,
             'GroundTruthAmbientOcclusion depthThreshold'
+        ),
+        normalThreshold: finiteRange(
+            options.normalThreshold ?? 0.82,
+            0,
+            1,
+            'GroundTruthAmbientOcclusion normalThreshold'
         )
     });
 }
@@ -152,6 +312,9 @@ const GTAO_BLOCK = `layout(std140) uniform GroundTruthAmbientOcclusionBlock {
     vec4 u_gtaoProjection;
     vec4 u_gtaoSearch;
     vec4 u_gtaoTemporal;
+    vec4 u_gtaoEffects;
+    vec4 u_gtaoContact;
+    vec4 u_gtaoFade;
 };`;
 
 registerUniformBlockBinding('GroundTruthAmbientOcclusionBlock');
@@ -160,7 +323,10 @@ const gtaoLayout = createStd140Layout({
     u_gtaoInverseProjection: 'mat4',
     u_gtaoProjection: 'vec4',
     u_gtaoSearch: 'vec4',
-    u_gtaoTemporal: 'vec4'
+    u_gtaoTemporal: 'vec4',
+    u_gtaoEffects: 'vec4',
+    u_gtaoContact: 'vec4',
+    u_gtaoFade: 'vec4'
 });
 
 function horizonFragment(settings: Readonly<GroundTruthAmbientOcclusionSettings>): string {
@@ -173,6 +339,7 @@ uniform sampler2D u_materialAttributes;
 ${GTAO_BLOCK}
 layout(location = 0) out vec4 gtaoResult;
 const float PI = 3.141592653589793;
+const float HALF_PI = 1.570796326794897;
 
 vec3 decodeOctahedralNormal(vec2 encoded) {
     encoded = encoded * 2.0 - 1.0;
@@ -209,6 +376,12 @@ vec2 ndcForUV(vec2 uv) {
 }
 
 vec3 reconstructViewPosition(vec2 uv, float deviceDepth) {
+    if (u_gtaoProjection.w > 0.5) {
+        vec4 rayPoint = u_gtaoInverseProjection * vec4(ndcForUV(uv), 0.0, 1.0);
+        vec3 ray = rayPoint.xyz / max(abs(rayPoint.w), 1e-6) * sign(rayPoint.w);
+        float viewDepth = exp2(deviceDepth * u_gtaoFade.z) - 1.0;
+        return ray * (viewDepth / max(-ray.z, 1e-6));
+    }
     vec4 homogeneous = u_gtaoInverseProjection * vec4(
         ndcForUV(uv),
         deviceDepth * 2.0 - 1.0,
@@ -225,45 +398,131 @@ float interleavedGradientNoise(vec2 pixel) {
     return fract(52.9829189 * fract(dot(pixel, vec2(0.06711056, 0.00583715))));
 }
 
+ivec2 pixelForUV(vec2 uv, ivec2 size) {
+    return clamp(ivec2(uv * vec2(size)), ivec2(0), size - ivec2(1));
+}
+
+vec3 positionAt(ivec2 pixel, ivec2 size, vec3 fallback) {
+    float depth = texelFetch(u_sceneDepth, pixel, 0).r;
+    if (isBackground(depth)) return fallback;
+    return reconstructViewPosition((vec2(pixel) + 0.5) / vec2(size), depth);
+}
+
+vec3 geometricNormalAt(ivec2 pixel, ivec2 size, vec3 center, vec3 referenceNormal) {
+    ivec2 leftPixel = max(pixel - ivec2(1, 0), ivec2(0));
+    ivec2 rightPixel = min(pixel + ivec2(1, 0), size - ivec2(1));
+    ivec2 topPixel = max(pixel - ivec2(0, 1), ivec2(0));
+    ivec2 bottomPixel = min(pixel + ivec2(0, 1), size - ivec2(1));
+    vec3 left = positionAt(leftPixel, size, center);
+    vec3 right = positionAt(rightPixel, size, center);
+    vec3 top = positionAt(topPixel, size, center);
+    vec3 bottom = positionAt(bottomPixel, size, center);
+    vec3 dx = abs(left.z - center.z) < abs(right.z - center.z)
+        ? center - left
+        : right - center;
+    vec3 dy = abs(top.z - center.z) < abs(bottom.z - center.z)
+        ? center - top
+        : bottom - center;
+    vec3 geometric = cross(dx, dy);
+    if (dot(geometric, geometric) < 1e-10) return referenceNormal;
+    geometric = normalize(geometric);
+    return dot(geometric, referenceNormal) < 0.0 ? -geometric : geometric;
+}
+
+float horizonCandidate(float cosine, float distanceToSample, float distanceWeight) {
+    float angle = acos(clamp(cosine, -1.0, 1.0));
+    float thinSurfaceAngle = min(
+        angle + u_gtaoSearch.z / max(distanceToSample, u_gtaoSearch.z + 1e-5),
+        PI
+    );
+    float thicknessAdjusted = mix(cos(thinSurfaceAngle), cosine, u_gtaoEffects.z);
+    float biased = cos(min(acos(clamp(thicknessAdjusted, -1.0, 1.0)) + u_gtaoEffects.y, PI));
+    return mix(-1.0, biased, distanceWeight);
+}
+
+float integrateVisibility(vec2 horizonCosine, float normalAngle, float projectedLength) {
+    vec2 horizonAngle = acos(clamp(horizonCosine, vec2(-1.0), vec2(1.0)));
+    float lower = max(-horizonAngle.x, normalAngle - HALF_PI);
+    float upper = min(horizonAngle.y, normalAngle + HALF_PI);
+    if (upper <= lower) return 0.0;
+    return projectedLength * 0.5 * (
+        sin(upper - normalAngle) - sin(lower - normalAngle)
+    );
+}
+
+vec3 integrateBentDirection(
+    vec2 horizonCosine,
+    float normalAngle,
+    vec3 viewDirection,
+    vec3 sliceDirection
+) {
+    vec2 horizonAngle = acos(clamp(horizonCosine, vec2(-1.0), vec2(1.0)));
+    float lower = max(-horizonAngle.x, normalAngle - HALF_PI);
+    float upper = min(horizonAngle.y, normalAngle + HALF_PI);
+    if (upper <= lower) return vec3(0.0);
+    return viewDirection * (sin(upper) - sin(lower)) +
+        sliceDirection * (cos(lower) - cos(upper));
+}
+
 void main() {
     ivec2 depthSize = textureSize(u_sceneDepth, 0);
-    ivec2 pixel = clamp(ivec2(v_uv * vec2(depthSize)), ivec2(0), depthSize - ivec2(1));
+    ivec2 pixel = pixelForUV(v_uv, depthSize);
+    vec2 centerUV = (vec2(pixel) + 0.5) / vec2(depthSize);
     float centerDepth = texelFetch(u_sceneDepth, pixel, 0).r;
     if (isBackground(centerDepth)) {
         gtaoResult = vec4(0.0, 0.0, 1.0, 0.0);
         return;
     }
-    vec3 center = reconstructViewPosition(v_uv, centerDepth);
+    vec3 center = reconstructViewPosition(centerUV, centerDepth);
     vec4 attributes = texelFetch(u_materialAttributes, pixel, 0);
-    vec3 normal = decodeOctahedralNormal(attributes.xy);
+    vec3 materialNormal = decodeOctahedralNormal(attributes.xy);
+    vec3 geometryNormal = geometricNormalAt(pixel, depthSize, center, materialNormal);
+    vec3 normal = ${
+        settings.normalSource === 'material'
+            ? 'materialNormal'
+            : settings.normalSource === 'geometry'
+              ? 'geometryNormal'
+              : 'normalize(mix(materialNormal, geometryNormal, u_gtaoFade.w))'
+    };
     float viewDepth = max(-center.z, 1e-4);
     float radiusPixels = u_gtaoProjection.y > 0.5
         ? u_gtaoSearch.x * u_gtaoProjection.x * float(depthSize.y) * 0.5 / viewDepth
         : u_gtaoSearch.x * float(depthSize.y) * 0.5 / max(abs(u_gtaoInverseProjection[1][1]), 1e-5);
     radiusPixels = clamp(radiusPixels, 1.0, 256.0);
-    float noise = interleavedGradientNoise(vec2(pixel) + u_gtaoTemporal.w * 17.0);
-    float occlusion = 0.0;
-    vec3 bent = normal;
+    float phase = u_gtaoTemporal.w;
+    float noise = interleavedGradientNoise(vec2(pixel) + vec2(phase * 17.0, phase * 29.0));
+    float visibilitySum = 0.0;
+    float contactVisibilitySum = 0.0;
+    vec3 bentSum = vec3(0.0);
+    vec3 viewDirection = normalize(-center);
     for (int directionIndex = 0; directionIndex < ${String(settings.directionCount)}; directionIndex++) {
         float angle = (float(directionIndex) + noise) * PI / float(${String(settings.directionCount)});
         vec2 screenDirection = vec2(cos(angle), sin(angle));
-        float directionOcclusion = 0.0;
-        vec3 directionBend = vec3(0.0);
+        vec3 sliceDirection = normalize(
+            reconstructViewPosition(centerUV + screenDirection / vec2(depthSize), centerDepth) -
+            center
+        );
+        vec3 sliceNormal = normalize(cross(sliceDirection, viewDirection));
+        vec3 projectedNormal = normal - sliceNormal * dot(normal, sliceNormal);
+        float projectedLength = max(length(projectedNormal), 1e-5);
+        projectedNormal /= projectedLength;
+        float normalCosine = clamp(dot(projectedNormal, viewDirection), -1.0, 1.0);
+        float normalAngle = acos(normalCosine) *
+            (dot(projectedNormal, sliceDirection) < 0.0 ? -1.0 : 1.0);
+        vec2 horizons = vec2(-1.0);
+        vec2 contactHorizons = vec2(-1.0);
         for (int side = -1; side <= 1; side += 2) {
-            float horizon = 0.0;
             for (int stepIndex = 0; stepIndex < ${String(settings.stepCount)}; stepIndex++) {
-                float stepFraction = (float(stepIndex) + 1.0 + noise * 0.35) /
+                float stepNoise = fract(noise + float(stepIndex) * 0.61803398875);
+                float stepFraction = (float(stepIndex) + 0.65 + stepNoise * 0.7) /
                     float(${String(settings.stepCount)});
                 float pixelDistance = max(1.0, radiusPixels * stepFraction * stepFraction);
-                vec2 sampleUV = v_uv + screenDirection * float(side) * pixelDistance /
+                vec2 sampleUV = centerUV + screenDirection * float(side) * pixelDistance /
                     vec2(depthSize);
                 if (any(lessThanEqual(sampleUV, vec2(0.0))) ||
                     any(greaterThanEqual(sampleUV, vec2(1.0)))) continue;
-                ivec2 samplePixel = clamp(
-                    ivec2(sampleUV * vec2(depthSize)),
-                    ivec2(0),
-                    depthSize - ivec2(1)
-                );
+                ivec2 samplePixel = pixelForUV(sampleUV, depthSize);
+                sampleUV = (vec2(samplePixel) + 0.5) / vec2(depthSize);
                 float sampleDepth = texelFetch(u_sceneDepth, samplePixel, 0).r;
                 if (isBackground(sampleDepth)) continue;
                 vec3 delta = reconstructViewPosition(sampleUV, sampleDepth) - center;
@@ -274,25 +533,63 @@ void main() {
                     u_gtaoSearch.x,
                     distanceToSample
                 );
-                float sampleHorizon = max(dot(normal, delta / distanceToSample), 0.0) *
-                    distanceWeight;
-                horizon = max(horizon, sampleHorizon);
+                float candidate = horizonCandidate(
+                    dot(delta / distanceToSample, viewDirection),
+                    distanceToSample,
+                    distanceWeight
+                );
+                int component = side < 0 ? 0 : 1;
+                horizons[component] = max(horizons[component], candidate);
+                float contactWeight = 1.0 - smoothstep(
+                    u_gtaoSearch.x * u_gtaoContact.x * 0.7,
+                    u_gtaoSearch.x * u_gtaoContact.x,
+                    distanceToSample
+                );
+                contactHorizons[component] = max(
+                    contactHorizons[component],
+                    horizonCandidate(
+                        dot(delta / distanceToSample, viewDirection),
+                        distanceToSample,
+                        contactWeight
+                    )
+                );
             }
-            directionOcclusion += horizon;
-            vec2 away = -screenDirection * float(side);
-            vec3 tangent = normalize(
-                reconstructViewPosition(v_uv + away * 0.01, centerDepth) - center
-            );
-            directionBend += tangent * horizon;
         }
-        occlusion += min(directionOcclusion * 0.5, 1.0);
-        bent += directionBend / float(${String(settings.directionCount)});
+        visibilitySum += clamp(
+            integrateVisibility(horizons, normalAngle, projectedLength),
+            0.0,
+            1.0
+        );
+        contactVisibilitySum += clamp(
+            integrateVisibility(contactHorizons, normalAngle, projectedLength),
+            0.0,
+            1.0
+        );
+        bentSum += integrateBentDirection(horizons, normalAngle, viewDirection, sliceDirection);
     }
-    float visibility = pow(
-        clamp(1.0 - occlusion / float(${String(settings.directionCount)}), 0.0, 1.0),
-        u_gtaoSearch.w
+    float inverseDirectionCount = 1.0 / float(${String(settings.directionCount)});
+    float baseVisibility = clamp(visibilitySum * inverseDirectionCount, 0.0, 1.0);
+    float contactVisibility = clamp(contactVisibilitySum * inverseDirectionCount, 0.0, 1.0);
+    float combinedOcclusion = (1.0 - baseVisibility) * u_gtaoEffects.x +
+        (1.0 - contactVisibility) * u_gtaoContact.y;
+    float visibility = pow(clamp(1.0 - combinedOcclusion, 0.0, 1.0), u_gtaoSearch.w);
+    float distanceFade = 1.0 - smoothstep(u_gtaoFade.x, u_gtaoFade.y, viewDepth);
+    float edgeDistance = min(
+        min(float(pixel.x), float(pixel.y)),
+        min(float(depthSize.x - 1 - pixel.x), float(depthSize.y - 1 - pixel.y))
     );
-    vec3 bentNormal = normalize(mix(normal, normalize(bent), 1.0 - visibility));
+    float edgeFade = u_gtaoContact.z <= 0.0
+        ? 1.0
+        : smoothstep(0.0, u_gtaoContact.z, edgeDistance);
+    float fade = distanceFade * edgeFade;
+    visibility = mix(1.0, visibility, fade);
+    vec3 integratedBent = dot(bentSum, bentSum) > 1e-8 ? normalize(bentSum) : normal;
+    if (dot(integratedBent, normal) < 0.0) integratedBent = normal;
+    vec3 bentNormal = normalize(mix(
+        normal,
+        integratedBent,
+        (1.0 - visibility) * u_gtaoEffects.w * fade
+    ));
     gtaoResult = vec4(encodeOctahedralNormal(bentNormal), visibility, log2(1.0 + viewDepth));
 }`;
 }
@@ -306,10 +603,12 @@ void main() { historyOutput = texture(u_current, v_uv); }`;
 
 const TEMPORAL_RESOLVE_FRAGMENT = `#version 300 es
 precision highp float;
+precision highp int;
 in vec2 v_uv;
 uniform sampler2D u_current;
 uniform sampler2D u_history;
 uniform sampler2D u_motionDepth;
+uniform sampler2D u_materialAttributes;
 ${GTAO_BLOCK}
 layout(location = 0) out vec4 historyOutput;
 
@@ -336,38 +635,102 @@ vec2 encodeOctahedralNormal(vec3 value) {
     }
     return encoded;
 }
+ivec2 pixelForUV(vec2 uv, ivec2 size) {
+    return clamp(ivec2(uv * vec2(size)), ivec2(0), size - ivec2(1));
+}
+vec3 materialNormalAt(vec2 uv) {
+    ivec2 size = textureSize(u_materialAttributes, 0);
+    vec2 encoded = texelFetch(u_materialAttributes, pixelForUV(uv, size), 0).xy * 2.0 - 1.0;
+    return decodeOctahedralNormal(encoded);
+}
 float relativeDepthError(float previousLog, float expectedLog) {
     float previous = exp2(max(previousLog, 0.0)) - 1.0;
     float expected = exp2(max(expectedLog, 0.0)) - 1.0;
     return abs(previous - expected) / max(expected, 1e-3);
 }
+vec4 closestMotion(vec2 uv, float currentLogDepth) {
+    ivec2 size = textureSize(u_motionDepth, 0);
+    ivec2 center = pixelForUV(uv, size);
+    vec4 closest = texelFetch(u_motionDepth, center, 0);
+    float closestError = abs(closest.w - currentLogDepth);
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            ivec2 coordinate = clamp(center + ivec2(x, y), ivec2(0), size - ivec2(1));
+            vec4 candidate = texelFetch(u_motionDepth, coordinate, 0);
+            float error = abs(candidate.w - currentLogDepth);
+            if (error < closestError) {
+                closest = candidate;
+                closestError = error;
+            }
+        }
+    }
+    return closest;
+}
+vec4 sampleHistory(vec2 uv) {
+    ivec2 size = textureSize(u_history, 0);
+    vec2 position = uv * vec2(size) - 0.5;
+    ivec2 base = ivec2(floor(position));
+    vec2 fraction = fract(position);
+    vec3 bent = vec3(0.0);
+    float visibility = 0.0;
+    float depth = 0.0;
+    float totalWeight = 0.0;
+    for (int y = 0; y <= 1; y++) {
+        for (int x = 0; x <= 1; x++) {
+            ivec2 coordinate = clamp(base + ivec2(x, y), ivec2(0), size - ivec2(1));
+            vec2 axisWeight = mix(vec2(1.0) - fraction, fraction, vec2(float(x), float(y)));
+            float weight = axisWeight.x * axisWeight.y;
+            vec4 sampleValue = texelFetch(u_history, coordinate, 0);
+            bent += decodeOctahedralNormal(sampleValue.xy) * weight;
+            visibility += sampleValue.z * weight;
+            depth += sampleValue.w * weight;
+            totalWeight += weight;
+        }
+    }
+    return vec4(
+        encodeOctahedralNormal(normalize(bent / max(totalWeight, 1e-5))),
+        visibility / max(totalWeight, 1e-5),
+        depth / max(totalWeight, 1e-5)
+    );
+}
 void main() {
     ivec2 currentSize = textureSize(u_current, 0);
     ivec2 currentPixel = clamp(ivec2(v_uv * vec2(currentSize)), ivec2(0), currentSize - ivec2(1));
     vec4 current = texelFetch(u_current, currentPixel, 0);
-    vec4 motion = texture(u_motionDepth, v_uv);
+    vec4 motion = closestMotion(v_uv, current.w);
     vec2 historyUV = v_uv - motion.xy;
     vec2 halfTexel = 0.5 / vec2(textureSize(u_history, 0));
     bool inside = all(greaterThanEqual(historyUV, halfTexel)) &&
         all(lessThanEqual(historyUV, vec2(1.0) - halfTexel));
-    vec4 previous = texture(u_history, clamp(historyUV, halfTexel, vec2(1.0) - halfTexel));
-    float minimumVisibility = current.z;
-    float maximumVisibility = current.z;
+    vec4 previous = sampleHistory(clamp(historyUV, halfTexel, vec2(1.0) - halfTexel));
+    float mean = 0.0;
+    float meanSquare = 0.0;
     for (int y = -1; y <= 1; y++) {
         for (int x = -1; x <= 1; x++) {
             ivec2 coordinate = clamp(currentPixel + ivec2(x, y), ivec2(0), currentSize - ivec2(1));
             float value = texelFetch(u_current, coordinate, 0).z;
-            minimumVisibility = min(minimumVisibility, value);
-            maximumVisibility = max(maximumVisibility, value);
+            mean += value;
+            meanSquare += value * value;
         }
     }
-    previous.z = clamp(previous.z, minimumVisibility, maximumVisibility);
-    bool accepted = inside && motion.z >= 0.0 &&
-        relativeDepthError(previous.w, motion.z) <= u_gtaoTemporal.y;
+    mean /= 9.0;
+    meanSquare /= 9.0;
+    float standardDeviation = sqrt(max(meanSquare - mean * mean, 0.0));
+    float clipRadius = max(standardDeviation * 1.5, 0.018);
+    previous.z = clamp(previous.z, mean - clipRadius, mean + clipRadius);
+    float depthError = relativeDepthError(previous.w, motion.z);
+    float normalAgreement = dot(materialNormalAt(v_uv), materialNormalAt(historyUV));
+    bool accepted = inside && motion.z >= 0.0 && depthError <= u_gtaoTemporal.y &&
+        normalAgreement >= u_gtaoTemporal.z;
     float velocityPixels = length(motion.xy * vec2(textureSize(u_motionDepth, 0)));
-    float weight = accepted
-        ? mix(u_gtaoTemporal.x, min(u_gtaoTemporal.x, 0.55), clamp(velocityPixels / 24.0, 0.0, 1.0))
-        : 0.0;
+    float confidence = (1.0 - smoothstep(0.0, u_gtaoTemporal.y, depthError)) *
+        smoothstep(u_gtaoTemporal.z, 1.0, normalAgreement);
+    float stableWeight = u_gtaoTemporal.x * confidence;
+    float weight = accepted ? mix(
+        stableWeight,
+        min(stableWeight, 0.5),
+        clamp(velocityPixels / 16.0, 0.0, 1.0)
+    ) : 0.0;
     vec3 bent = normalize(mix(
         decodeOctahedralNormal(current.xy),
         decodeOctahedralNormal(previous.xy),
@@ -386,10 +749,8 @@ precision highp float;
 in vec2 v_uv;
 uniform sampler2D u_source;
 uniform sampler2D u_materialAttributes;
-uniform sampler2D u_motionDepth;
 layout(location = 0) out vec4 filtered;
 vec3 decodeOctahedralNormal(vec2 encoded) {
-    encoded = encoded * 2.0 - 1.0;
     vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
     if (normal.z < 0.0) {
         vec2 original = normal.xy;
@@ -399,47 +760,75 @@ vec3 decodeOctahedralNormal(vec2 encoded) {
         );
     }
     return normalize(normal);
+}
+vec2 encodeOctahedralNormal(vec3 value) {
+    vec3 normal = normalize(value);
+    normal /= max(abs(normal.x) + abs(normal.y) + abs(normal.z), 1e-6);
+    vec2 encoded = normal.xy;
+    if (normal.z < 0.0) {
+        encoded = (1.0 - abs(encoded.yx)) * vec2(
+            encoded.x >= 0.0 ? 1.0 : -1.0,
+            encoded.y >= 0.0 ? 1.0 : -1.0
+        );
+    }
+    return encoded;
+}
+ivec2 pixelForUV(vec2 uv, ivec2 size) {
+    return clamp(ivec2(uv * vec2(size)), ivec2(0), size - ivec2(1));
+}
+vec3 materialNormalAt(vec2 uv) {
+    ivec2 size = textureSize(u_materialAttributes, 0);
+    vec2 encoded = texelFetch(u_materialAttributes, pixelForUV(uv, size), 0).xy * 2.0 - 1.0;
+    return decodeOctahedralNormal(encoded);
+}
+float viewDepth(float logarithmicDepth) {
+    return exp2(max(logarithmicDepth, 0.0)) - 1.0;
 }
 void main() {
     ivec2 size = textureSize(u_source, 0);
     ivec2 pixel = clamp(ivec2(v_uv * vec2(size)), ivec2(0), size - ivec2(1));
     vec4 center = texelFetch(u_source, pixel, 0);
-    vec3 centerNormal = decodeOctahedralNormal(texture(u_materialAttributes, v_uv).xy);
-    float centerDepth = texture(u_motionDepth, v_uv).w;
-    vec4 sum = center * 0.4;
-    float totalWeight = 0.4;
-    const ivec2 offsets[8] = ivec2[8](
-        ivec2(1, 0), ivec2(-1, 0), ivec2(0, 1), ivec2(0, -1),
-        ivec2(1, 1), ivec2(-1, 1), ivec2(1, -1), ivec2(-1, -1)
+    vec3 centerNormal = materialNormalAt(v_uv);
+    float centerDepth = viewDepth(center.w);
+    vec3 bentSum = decodeOctahedralNormal(center.xy);
+    float visibilitySum = center.z;
+    float totalWeight = 1.0;
+    const ivec2 offsets[4] = ivec2[4](
+        ivec2(1, 0), ivec2(-1, 0), ivec2(0, 1), ivec2(0, -1)
     );
-    for (int index = 0; index < 8; index++) {
+    for (int index = 0; index < 4; index++) {
         ivec2 coordinate = clamp(pixel + offsets[index] * ${String(step)}, ivec2(0), size - ivec2(1));
         vec2 sampleUV = (vec2(coordinate) + 0.5) / vec2(size);
         vec4 sampleValue = texelFetch(u_source, coordinate, 0);
-        vec3 sampleNormal = decodeOctahedralNormal(texture(u_materialAttributes, sampleUV).xy);
-        float sampleDepth = texture(u_motionDepth, sampleUV).w;
-        float normalWeight = pow(max(dot(centerNormal, sampleNormal), 0.0), 16.0);
-        float relativeDepth = abs((exp2(centerDepth) - 1.0) - (exp2(sampleDepth) - 1.0)) /
-            max(exp2(centerDepth) - 1.0, 1e-3);
-        float depthWeight = exp(-relativeDepth * 48.0);
-        float spatialWeight = index < 4 ? 0.075 : 0.0375;
+        vec3 sampleNormal = materialNormalAt(sampleUV);
+        float sampleDepth = viewDepth(sampleValue.w);
+        float normalWeight = pow(max(dot(centerNormal, sampleNormal), 0.0), 24.0);
+        float relativeDepth = abs(centerDepth - sampleDepth) / max(centerDepth, 1e-3);
+        float depthWeight = exp(-relativeDepth * 64.0);
+        float spatialWeight = 0.42;
         float weight = normalWeight * depthWeight * spatialWeight;
-        sum += sampleValue * weight;
+        bentSum += decodeOctahedralNormal(sampleValue.xy) * weight;
+        visibilitySum += sampleValue.z * weight;
         totalWeight += weight;
     }
-    filtered = sum / max(totalWeight, 1e-5);
+    filtered = vec4(
+        encodeOctahedralNormal(normalize(bentSum / max(totalWeight, 1e-5))),
+        clamp(visibilitySum / max(totalWeight, 1e-5), 0.0, 1.0),
+        center.w
+    );
 }`;
 }
 
 const UPSAMPLE_FRAGMENT = `#version 300 es
 precision highp float;
+precision highp int;
 in vec2 v_uv;
 uniform sampler2D u_lowResolutionAO;
 uniform sampler2D u_materialAttributes;
 uniform sampler2D u_motionDepth;
+${GTAO_BLOCK}
 layout(location = 0) out vec4 fullResolutionAO;
 vec3 decodeOctahedralNormal(vec2 encoded) {
-    encoded = encoded * 2.0 - 1.0;
     vec3 normal = vec3(encoded, 1.0 - abs(encoded.x) - abs(encoded.y));
     if (normal.z < 0.0) {
         vec2 original = normal.xy;
@@ -450,33 +839,84 @@ vec3 decodeOctahedralNormal(vec2 encoded) {
     }
     return normalize(normal);
 }
+vec2 encodeOctahedralNormal(vec3 value) {
+    vec3 normal = normalize(value);
+    normal /= max(abs(normal.x) + abs(normal.y) + abs(normal.z), 1e-6);
+    vec2 encoded = normal.xy;
+    if (normal.z < 0.0) {
+        encoded = (1.0 - abs(encoded.yx)) * vec2(
+            encoded.x >= 0.0 ? 1.0 : -1.0,
+            encoded.y >= 0.0 ? 1.0 : -1.0
+        );
+    }
+    return encoded;
+}
+ivec2 pixelForUV(vec2 uv, ivec2 size) {
+    return clamp(ivec2(uv * vec2(size)), ivec2(0), size - ivec2(1));
+}
+vec3 materialNormalAt(vec2 uv) {
+    ivec2 size = textureSize(u_materialAttributes, 0);
+    vec2 encoded = texelFetch(u_materialAttributes, pixelForUV(uv, size), 0).xy * 2.0 - 1.0;
+    return decodeOctahedralNormal(encoded);
+}
 void main() {
     ivec2 lowSize = textureSize(u_lowResolutionAO, 0);
     vec2 lowPosition = v_uv * vec2(lowSize) - 0.5;
     ivec2 base = ivec2(floor(lowPosition));
-    vec3 centerNormal = decodeOctahedralNormal(texture(u_materialAttributes, v_uv).xy);
-    float centerDepth = clamp(texture(u_motionDepth, v_uv).w, 0.0, 32.0);
-    vec4 fallback = texture(u_lowResolutionAO, v_uv);
-    vec4 sum = fallback * 1e-4;
-    float totalWeight = 1e-4;
+    vec3 centerNormal = materialNormalAt(v_uv);
+    ivec2 motionSize = textureSize(u_motionDepth, 0);
+    float centerDepth = texelFetch(u_motionDepth, pixelForUV(v_uv, motionSize), 0).w;
+    ivec2 fallbackCoordinate = clamp(
+        ivec2(floor(lowPosition + 0.5)),
+        ivec2(0),
+        lowSize - ivec2(1)
+    );
+    vec4 fallback = texelFetch(u_lowResolutionAO, fallbackCoordinate, 0);
+    vec3 bentSum = vec3(0.0);
+    float visibilitySum = 0.0;
+    float totalWeight = 0.0;
     for (int y = 0; y <= 1; y++) {
         for (int x = 0; x <= 1; x++) {
             ivec2 coordinate = clamp(base + ivec2(x, y), ivec2(0), lowSize - ivec2(1));
             vec2 sampleUV = (vec2(coordinate) + 0.5) / vec2(lowSize);
             vec4 sampleValue = texelFetch(u_lowResolutionAO, coordinate, 0);
-            vec3 sampleNormal = decodeOctahedralNormal(texture(u_materialAttributes, sampleUV).xy);
+            vec3 sampleNormal = materialNormalAt(sampleUV);
             vec2 bilinear = 1.0 - abs(vec2(coordinate) - lowPosition);
             float spatialWeight = max(bilinear.x, 0.001) * max(bilinear.y, 0.001);
-            float normalWeight = pow(clamp(dot(centerNormal, sampleNormal), 0.0, 1.0), 12.0);
-            float sampleDepth = clamp(sampleValue.w, 0.0, 32.0);
-            float depthWeight = exp(-abs(sampleDepth - centerDepth) * 24.0);
+            float normalWeight = pow(clamp(dot(centerNormal, sampleNormal), 0.0, 1.0), 24.0);
+            float sampleDepth = sampleValue.w;
+            float relativeDepth = abs(
+                (exp2(sampleDepth) - 1.0) - (exp2(centerDepth) - 1.0)
+            ) / max(exp2(centerDepth) - 1.0, 1e-3);
+            float depthWeight = exp(-relativeDepth * 64.0);
             float weight = spatialWeight * normalWeight * depthWeight;
-            sum += sampleValue * weight;
+            bentSum += decodeOctahedralNormal(sampleValue.xy) * weight;
+            visibilitySum += sampleValue.z * weight;
             totalWeight += weight;
         }
     }
-    fullResolutionAO = sum / max(totalWeight, 1e-4);
-    fullResolutionAO.z = clamp(fullResolutionAO.z, 0.0, 1.0);
+    vec3 bent = totalWeight > 1e-5
+        ? normalize(bentSum / totalWeight)
+        : decodeOctahedralNormal(fallback.xy);
+    float visibility = totalWeight > 1e-5 ? visibilitySum / totalWeight : fallback.z;
+    fullResolutionAO = vec4(
+        encodeOctahedralNormal(bent),
+        clamp(visibility, 0.0, 1.0),
+        u_gtaoContact.w
+    );
+}`;
+
+const FINALIZE_FRAGMENT = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_source;
+${GTAO_BLOCK}
+layout(location = 0) out vec4 finalAO;
+void main() {
+    ivec2 size = textureSize(u_source, 0);
+    ivec2 pixel = clamp(ivec2(v_uv * vec2(size)), ivec2(0), size - ivec2(1));
+    vec4 sourceValue = texelFetch(u_source, pixel, 0);
+    finalAO = vec4(sourceValue.xy, clamp(sourceValue.z, 0.0, 1.0), u_gtaoContact.w);
 }`;
 
 function fullscreenPass(
@@ -516,6 +956,12 @@ class MutableFullscreenParameters implements FullscreenRenderPassParameters {
 interface GTAOCameraState {
     readonly camera: Camera;
     readonly historyKey: object;
+    readonly inverseProjection: Matrix4;
+    readonly block: UniformBuffer<typeof gtaoLayout.schema>;
+    readonly horizonPass: FullscreenRenderPass;
+    readonly resolvePass: FullscreenRenderPass;
+    readonly upsamplePass: FullscreenRenderPass;
+    readonly finalizePass: FullscreenRenderPass;
     readonly committedProjection: Float32Array;
     committedTransformRevision: number;
     committedSubmission: number;
@@ -548,22 +994,14 @@ export interface GroundTruthAmbientOcclusionResources {
 /** @internal Portable raster GTAO, temporal accumulation, denoise, and bilateral upsample. */
 export class GroundTruthAmbientOcclusionController {
     readonly #settings: Readonly<GroundTruthAmbientOcclusionSettings>;
-    readonly #block: UniformBuffer<typeof gtaoLayout.schema>;
-    readonly #inverseProjection = new Matrix4();
-    readonly #horizonPass: FullscreenRenderPass;
     readonly #initializePass = fullscreenPass(
         'GTAO initialize temporal history',
         TEMPORAL_INITIALIZE_FRAGMENT
     );
-    readonly #resolvePass: FullscreenRenderPass;
     readonly #filterPasses = Object.freeze([
         fullscreenPass('GTAO edge-aware filter 1', spatialFilterFragment(1)),
         fullscreenPass('GTAO edge-aware filter 2', spatialFilterFragment(2))
     ]);
-    readonly #upsamplePass = fullscreenPass(
-        'GTAO bilateral full-resolution upsample',
-        UPSAMPLE_FRAGMENT
-    );
     readonly #parameters = new RenderPassParameterPool(
         () => new MutableFullscreenParameters(),
         parameters => {
@@ -602,27 +1040,6 @@ export class GroundTruthAmbientOcclusionController {
 
     constructor(settings: Readonly<GroundTruthAmbientOcclusionSettings>) {
         this.#settings = settings;
-        this.#block = UniformBuffer.fromSchema(gtaoLayout, {
-            u_gtaoInverseProjection: this.#inverseProjection.elements,
-            u_gtaoProjection: [1, 1, 0, 0],
-            u_gtaoSearch: [
-                settings.radius,
-                settings.falloffStart,
-                settings.thickness,
-                settings.power
-            ],
-            u_gtaoTemporal: [settings.historyWeight, settings.depthThreshold, 0, 0]
-        });
-        this.#horizonPass = fullscreenPass(
-            'GTAO rotated horizon search',
-            horizonFragment(settings),
-            [this.#block]
-        );
-        this.#resolvePass = fullscreenPass(
-            'GTAO production temporal resolve',
-            TEMPORAL_RESOLVE_FRAGMENT,
-            [this.#block]
-        );
     }
 
     record(
@@ -653,22 +1070,42 @@ export class GroundTruthAmbientOcclusionController {
         this.#fullResolutionDescriptor.extent.height = sceneHeight;
 
         const camera = context.camera;
-        this.#inverseProjection.invert(camera.jitteredProjectionMatrix);
+        const farValue: unknown = Reflect.get(camera, 'far');
+        if (
+            context.useLogDepth &&
+            (!camera.isPerspectiveCamera ||
+                camera.depthMode === 'reversed' ||
+                typeof farValue !== 'number' ||
+                !Number.isFinite(farValue) ||
+                farValue <= 0)
+        ) {
+            throw new Error(
+                'GroundTruthAmbientOcclusion logarithmic depth requires a standard-Z perspective camera with a finite positive far plane'
+            );
+        }
+        const far = typeof farValue === 'number' && Number.isFinite(farValue) ? farValue : 1;
         const projection = camera.jitteredProjectionMatrix.elements;
         const state = this.stageCamera(context, camera);
-        this.#block
-            .set('u_gtaoInverseProjection', this.#inverseProjection.elements)
+        state.inverseProjection.invert(camera.jitteredProjectionMatrix);
+        state.block
+            .set('u_gtaoInverseProjection', state.inverseProjection.elements)
             .set('u_gtaoProjection', [
                 Math.abs(projection[5]),
                 camera.isPerspectiveCamera ? 1 : 0,
                 camera.depthMode === 'reversed' ? 1 : 0,
-                0
+                context.useLogDepth ? 1 : 0
             ])
             .set('u_gtaoTemporal', [
                 this.#settings.historyWeight,
                 this.#settings.depthThreshold,
-                0,
-                this.#submissionIndex % 8
+                this.#settings.normalThreshold,
+                this.#submissionIndex % 24
+            ])
+            .set('u_gtaoFade', [
+                this.#settings.distanceFadeStart,
+                this.#settings.distanceFadeEnd,
+                Math.log2(far + 1),
+                this.#settings.geometricNormalWeight
             ]);
 
         const discontinuous =
@@ -688,7 +1125,7 @@ export class GroundTruthAmbientOcclusionController {
         );
         this.addFullscreen(
             context,
-            this.#horizonPass,
+            state.horizonPass,
             [resources.sceneDepth, resources.materialAttributes],
             current
         );
@@ -696,8 +1133,10 @@ export class GroundTruthAmbientOcclusionController {
         const historyAccepted = !discontinuous && (resources.historyValid ?? true) && history.valid;
         this.addFullscreen(
             context,
-            historyAccepted ? this.#resolvePass : this.#initializePass,
-            historyAccepted ? [current, history.history(), resources.motionDepth] : [current],
+            historyAccepted ? state.resolvePass : this.#initializePass,
+            historyAccepted
+                ? [current, history.history(), resources.motionDepth, resources.materialAttributes]
+                : [current],
             history.current
         );
 
@@ -712,23 +1151,26 @@ export class GroundTruthAmbientOcclusionController {
             this.addFullscreen(
                 context,
                 pass,
-                [filtered, resources.materialAttributes, resources.motionDepth],
+                [filtered, resources.materialAttributes],
                 destination
             );
             filtered = destination;
         }
 
-        if (aoWidth === sceneWidth && aoHeight === sceneHeight) return filtered;
         const fullResolution = context.graph.createTexture(
             'GTAO full-resolution bent normal and visibility',
             this.#fullResolutionDescriptor
         );
-        this.addFullscreen(
-            context,
-            this.#upsamplePass,
-            [filtered, resources.materialAttributes, resources.motionDepth],
-            fullResolution
-        );
+        if (aoWidth === sceneWidth && aoHeight === sceneHeight) {
+            this.addFullscreen(context, state.finalizePass, [filtered], fullResolution);
+        } else {
+            this.addFullscreen(
+                context,
+                state.upsamplePass,
+                [filtered, resources.materialAttributes, resources.motionDepth],
+                fullResolution
+            );
+        }
         return fullResolution;
     }
 
@@ -792,17 +1234,7 @@ export class GroundTruthAmbientOcclusionController {
         this.sweepInactiveStates(context, camera);
         let state = this.#states.get(camera);
         if (state === undefined) {
-            state = {
-                camera,
-                historyKey: Object.freeze({}),
-                committedProjection: new Float32Array(16),
-                committedTransformRevision: -1,
-                committedSubmission: -1,
-                pendingFrame: -1,
-                pendingTransformRevision: -1,
-                pendingProjection: new Float32Array(16),
-                lastTouchedFrame: frameIndex
-            };
+            state = this.createCameraState(camera, frameIndex);
             this.#states.set(camera, state);
             this.#ownedStates.add(state);
         }
@@ -817,6 +1249,74 @@ export class GroundTruthAmbientOcclusionController {
         state.lastTouchedFrame = frameIndex;
         this.#stagedStates.push(state);
         return state;
+    }
+
+    private createCameraState(camera: Camera, frameIndex: number): GTAOCameraState {
+        const inverseProjection = new Matrix4();
+        const settings = this.#settings;
+        const block = UniformBuffer.fromSchema(gtaoLayout, {
+            u_gtaoInverseProjection: inverseProjection.elements,
+            u_gtaoProjection: [1, 1, 0, 0],
+            u_gtaoSearch: [
+                settings.radius,
+                settings.falloffStart,
+                settings.thickness,
+                settings.power
+            ],
+            u_gtaoTemporal: [
+                settings.historyWeight,
+                settings.depthThreshold,
+                settings.normalThreshold,
+                0
+            ],
+            u_gtaoEffects: [
+                settings.intensity,
+                settings.bias,
+                settings.thicknessBlend,
+                settings.bentNormalStrength
+            ],
+            u_gtaoContact: [
+                settings.contactRadiusScale,
+                settings.contactStrength,
+                settings.edgeFadePixels,
+                settings.multiBounce
+            ],
+            u_gtaoFade: [
+                settings.distanceFadeStart,
+                settings.distanceFadeEnd,
+                1,
+                settings.geometricNormalWeight
+            ]
+        });
+        return {
+            camera,
+            historyKey: Object.freeze({}),
+            inverseProjection,
+            block,
+            horizonPass: fullscreenPass('GTAO rotated horizon search', horizonFragment(settings), [
+                block
+            ]),
+            resolvePass: fullscreenPass(
+                'GTAO production temporal resolve',
+                TEMPORAL_RESOLVE_FRAGMENT,
+                [block]
+            ),
+            upsamplePass: fullscreenPass(
+                'GTAO bilateral full-resolution upsample',
+                UPSAMPLE_FRAGMENT,
+                [block]
+            ),
+            finalizePass: fullscreenPass('GTAO full-resolution finalize', FINALIZE_FRAGMENT, [
+                block
+            ]),
+            committedProjection: new Float32Array(16),
+            committedTransformRevision: -1,
+            committedSubmission: -1,
+            pendingFrame: -1,
+            pendingTransformRevision: -1,
+            pendingProjection: new Float32Array(16),
+            lastTouchedFrame: frameIndex
+        };
     }
 
     private sweepInactiveStates(context: RenderPipelineContext, activeCamera: Camera): void {

--- a/src/render/postprocessing/index.ts
+++ b/src/render/postprocessing/index.ts
@@ -22,7 +22,9 @@ export {
 } from './TemporalAA';
 export {
     GroundTruthAmbientOcclusion,
-    type GroundTruthAmbientOcclusionOptions
+    type GroundTruthAmbientOcclusionNormalSource,
+    type GroundTruthAmbientOcclusionOptions,
+    type GroundTruthAmbientOcclusionQuality
 } from './GroundTruthAmbientOcclusion';
 export {
     ScreenSpaceGlobalIllumination,

--- a/src/shader/chunk/pbr.frag
+++ b/src/shader/chunk/pbr.frag
@@ -87,6 +87,39 @@ uniform sampler2D u_baseColorMap;
         }
         return normalize(normal);
     }
+
+    vec3 hiloGTAOMultiBounceVisibility(float visibility, vec3 albedo, float strength) {
+        vec3 a = 2.0404 * albedo - 0.3324;
+        vec3 b = -4.7951 * albedo + 0.6417;
+        vec3 c = 2.7552 * albedo + 0.6903;
+        vec3 multiBounce = max(
+            vec3(visibility),
+            ((visibility * a + b) * visibility + c) * visibility
+        );
+        return mix(vec3(visibility), clamp(multiBounce, 0.0, 1.0), strength);
+    }
+
+    float hiloGTAOSpecularVisibility(
+        float visibility,
+        vec3 bentNormal,
+        vec3 normal,
+        vec3 viewDirection,
+        float perceptualRoughness
+    ) {
+        vec3 reflectionDirection = -normalize(reflect(viewDirection, normal));
+        float coneCosine = clamp(1.0 - visibility, 0.0, 1.0);
+        float lobeWidth = max(perceptualRoughness * perceptualRoughness, 0.04);
+        float directionalVisibility = smoothstep(
+            coneCosine - lobeWidth,
+            coneCosine + lobeWidth,
+            dot(reflectionDirection, bentNormal)
+        );
+        return mix(
+            max(visibility, directionalVisibility),
+            visibility,
+            perceptualRoughness
+        );
+    }
     #endif
     #ifdef HILO_HAS_IRIDESCENCE
         #ifdef HILO_IRIDESCENCE_MAP

--- a/src/shader/chunk/pbr_main.frag
+++ b/src/shader/chunk/pbr_main.frag
@@ -137,13 +137,27 @@ vec3 areaSpecularColor = specularColor;
 ao = hiloEvaluatePBROcclusion(ao, u_occlusionStrength);
 #endif
 
+float materialAmbientOcclusion = ao;
 vec3 indirectDiffuseNormal = N;
+vec3 gtaoDiffuseVisibility = vec3(1.0);
+float gtaoSpecularVisibility = 1.0;
 #ifdef HILO_GTAO
 vec2 gtaoUV = (gl_FragCoord.xy - u_viewport.xy) / max(u_viewport.zw, vec2(1.0));
 vec4 gtaoSample = texture(u_gtaoTexture, gtaoUV);
 float gtaoVisibility = clamp(gtaoSample.b, 0.0, 1.0);
-ao *= gtaoVisibility;
 indirectDiffuseNormal = hiloDecodeGTAOBentNormal(gtaoSample.xy);
+gtaoDiffuseVisibility = hiloGTAOMultiBounceVisibility(
+    gtaoVisibility,
+    clamp(baseColor.rgb, 0.0, 1.0),
+    clamp(gtaoSample.a, 0.0, 1.0)
+);
+gtaoSpecularVisibility = hiloGTAOSpecularVisibility(
+    gtaoVisibility,
+    indirectDiffuseNormal,
+    N,
+    V,
+    roughness
+);
 #endif
 
 vec3 anisotropyT = N;
@@ -458,7 +472,11 @@ for (uint clusteredIndex = 0u; clusteredIndex < clusteredLocalLightCount; cluste
 }
 #endif
 
-vec3 indirectDiffuse = hiloGetIBLDiffuse(indirectDiffuseNormal, iblDiffuseColor, ao);
+vec3 indirectDiffuse = hiloGetIBLDiffuse(
+    indirectDiffuseNormal,
+    iblDiffuseColor,
+    materialAmbientOcclusion
+) * gtaoDiffuseVisibility;
 vec3 indirectSpecular = hiloGetIBLSpecular(
     N,
     V,
@@ -469,13 +487,15 @@ vec3 indirectSpecular = hiloGetIBLSpecular(
     iridescenceFactor,
     iridescenceIor,
     iridescenceThickness,
-    ao
+    materialAmbientOcclusion * gtaoSpecularVisibility
 );
 
 #if defined(HILO_CLUSTERED_FORWARD) && (defined(HILO_IS_DIFFUSE_ENV_AND_AMBIENT_LIGHT_WORK_TOGETHER) || (!defined(HILO_DIFFUSE_ENV_MAP) && !defined(HILO_DIFFUSE_ENV_SPHERE_HARMONICS3)))
-indirectDiffuse += clusterFrameData.values[31u].rgb * iblDiffuseColor * ao * HILO_INVERSE_PI;
+indirectDiffuse += clusterFrameData.values[31u].rgb * iblDiffuseColor *
+    materialAmbientOcclusion * gtaoDiffuseVisibility * HILO_INVERSE_PI;
 #elif defined(HILO_AMBIENT_LIGHTS) && (defined(HILO_IS_DIFFUSE_ENV_AND_AMBIENT_LIGHT_WORK_TOGETHER) || (!defined(HILO_DIFFUSE_ENV_MAP) && !defined(HILO_DIFFUSE_ENV_SPHERE_HARMONICS3)))
-indirectDiffuse += u_ambientLightsColor * iblDiffuseColor * ao * HILO_INVERSE_PI;
+indirectDiffuse += u_ambientLightsColor * iblDiffuseColor *
+    materialAmbientOcclusion * gtaoDiffuseVisibility * HILO_INVERSE_PI;
 #endif
 
 #ifdef HILO_LIGHT_MAP

--- a/src/shader/pbr.frag
+++ b/src/shader/pbr.frag
@@ -212,10 +212,21 @@ void main(void) {
                         vec2 reflectionGTAOUV =
                             (gl_FragCoord.xy - u_viewport.xy) /
                             max(u_viewport.zw, vec2(1.0));
-                        reflectionAO *= clamp(
-                            texture(u_gtaoTexture, reflectionGTAOUV).b,
+                        vec4 reflectionGTAOSample = texture(
+                            u_gtaoTexture,
+                            reflectionGTAOUV
+                        );
+                        float reflectionGTAOVisibility = clamp(
+                            reflectionGTAOSample.b,
                             0.0,
                             1.0
+                        );
+                        reflectionAO *= hiloGTAOSpecularVisibility(
+                            reflectionGTAOVisibility,
+                            hiloDecodeGTAOBentNormal(reflectionGTAOSample.xy),
+                            normal,
+                            reflectionView,
+                            reflectionTraceRoughness
                         );
                     #endif
                     #ifdef HILO_PBR_SPECULAR_GLOSSINESS

--- a/test/spec/renderer/PostProcessing.test.ts
+++ b/test/spec/renderer/PostProcessing.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import OrthographicCamera from '../../../src/camera/OrthographicCamera';
 import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
 import Mesh from '../../../src/core/Mesh';
 import Node from '../../../src/core/Node';
+import Stage from '../../../src/core/Stage';
 import BoxGeometry from '../../../src/geometry/BoxGeometry';
 import BasicMaterial from '../../../src/material/BasicMaterial';
 import PBRMaterial from '../../../src/material/PBRMaterial';
@@ -50,6 +52,7 @@ import {
     AtmosphereWeatherController,
     snapshotAtmosphereWeatherOptions
 } from '../../../src/render/postprocessing/AtmosphereWeather';
+import { snapshotGroundTruthAmbientOcclusionOptions } from '../../../src/render/postprocessing/GroundTruthAmbientOcclusion';
 import type { RenderGraphTimelineSnapshot } from '../../../src/render/graph/RenderGraphTimeline';
 import Shader from '../../../src/shader/Shader';
 import type { RHIDevice } from '../../../src/render/rhi/core';
@@ -162,6 +165,40 @@ describe('built-in post-processing', () => {
         expect(source).toContain('uv = hiloRenderTargetUV(uv);');
     });
 
+    it('exposes color-aware diffuse and bent-cone specular GTAO integration', () => {
+        const pbr = Shader.shaders['chunk/pbr.frag'];
+        const pbrMain = Shader.shaders['chunk/pbr_main.frag'];
+        expect(pbr).toContain('hiloGTAOMultiBounceVisibility');
+        expect(pbr).toContain('hiloGTAOSpecularVisibility');
+        expect(pbrMain).toContain('gtaoDiffuseVisibility');
+        expect(pbrMain).toContain('gtaoSpecularVisibility');
+        expect(pbrMain).not.toContain('ao *= gtaoVisibility');
+    });
+
+    it('normalizes GTAO quality presets while preserving explicit sampling overrides', () => {
+        expect(snapshotGroundTruthAmbientOcclusionOptions({ quality: 'ultra' })).toMatchObject({
+            quality: 'ultra',
+            resolutionScale: 0.75,
+            directionCount: 6,
+            stepCount: 8,
+            normalSource: 'hybrid',
+            multiBounce: 1
+        });
+        expect(
+            snapshotGroundTruthAmbientOcclusionOptions({
+                quality: 'low',
+                resolutionScale: 1,
+                directionCount: 8,
+                stepCount: 12
+            })
+        ).toMatchObject({
+            quality: 'low',
+            resolutionScale: 1,
+            directionCount: 8,
+            stepCount: 12
+        });
+    });
+
     it('normalizes managed 2D, cube, BRDF, and LTC texture coordinates centrally', () => {
         const coordinates = Shader.shaders['method/portableCoordinates.glsl'];
         const uv = Shader.shaders['chunk/uv.frag'];
@@ -251,6 +288,16 @@ describe('built-in post-processing', () => {
             /directionCount/u
         );
         expect(() => new GroundTruthAmbientOcclusion({ radius: 0 })).toThrow(/radius/u);
+        expect(
+            () =>
+                new GroundTruthAmbientOcclusion({
+                    distanceFadeStart: 20,
+                    distanceFadeEnd: 20
+                })
+        ).toThrow(/distanceFadeEnd/u);
+        expect(
+            () => new GroundTruthAmbientOcclusion({ normalSource: 'invalid' as 'hybrid' })
+        ).toThrow(/normalSource/u);
         expect(() => new ScreenSpaceGlobalIllumination({ resolutionScale: 0.2 })).toThrow(
             /resolutionScale/u
         );
@@ -659,6 +706,102 @@ describe('built-in post-processing', () => {
             expect(renderer.renderInfo.drawCount).toBeGreaterThan(0);
         }
     );
+
+    it.each(taaIntegrationBackends)(
+        'isolates per-camera GTAO uniforms while decoding logarithmic depth on %s',
+        async backend => {
+            const first = new PerspectiveCamera({
+                aspect: 1,
+                near: 0.1,
+                far: 80,
+                z: 5,
+                priority: -1
+            });
+            const second = new PerspectiveCamera({
+                aspect: 1,
+                near: 0.2,
+                far: 160,
+                x: 1,
+                z: 6,
+                priority: 1,
+                clearColor: false
+            });
+            const stage = await Stage.create({
+                backend,
+                width: 40,
+                height: 40,
+                pixelRatio: 1,
+                antialias: false,
+                useLogDepth: true,
+                cameras: [second, first],
+                renderPipeline: new PostProcessRenderPipelineFactory({
+                    groundTruthAmbientOcclusion: {
+                        quality: 'low',
+                        resolutionScale: 1
+                    },
+                    bloom: false
+                })
+            });
+            try {
+                new Mesh({
+                    geometry: new BoxGeometry(),
+                    material: new PBRMaterial({
+                        baseColor: new Color(0.7, 0.6, 0.5),
+                        roughness: 0.8
+                    }),
+                    frustumTest: false
+                }).addTo(stage);
+                const observed = observePassLabels(rhiDevice(stage.renderer));
+                stage.tick(16);
+                await stage.renderer.waitForIdle();
+                expect(
+                    observed.labels.filter(label => label === 'GTAO rotated horizon search')
+                ).toHaveLength(2);
+                observed.restore();
+            } finally {
+                stage.destroy();
+            }
+        }
+    );
+
+    it('rejects incompatible GTAO logarithmic-depth camera contracts while recording', async () => {
+        const camera = new OrthographicCamera({
+            left: -1,
+            right: 1,
+            top: 1,
+            bottom: -1,
+            near: 0.1,
+            far: 80,
+            z: 5
+        });
+        const stage = await Stage.create({
+            backend: 'webgl2',
+            width: 24,
+            height: 24,
+            pixelRatio: 1,
+            antialias: false,
+            useLogDepth: true,
+            cameras: [camera],
+            renderPipeline: new PostProcessRenderPipelineFactory({
+                groundTruthAmbientOcclusion: { quality: 'low' },
+                bloom: false
+            })
+        });
+        try {
+            let causeMessage = '';
+            try {
+                stage.tick(16);
+                throw new Error('Expected GTAO logarithmic-depth validation to reject the camera');
+            } catch (error) {
+                if (error instanceof Error && error.cause instanceof Error) {
+                    causeMessage = error.cause.message;
+                }
+            }
+            expect(causeMessage).toMatch(/standard-Z perspective camera/u);
+        } finally {
+            stage.destroy();
+        }
+    });
 
     it.each(taaIntegrationBackends)(
         'renders fixed-scale TAAU, HDR bloom, and transmissive composition on %s',

--- a/test/ui/example-paths.contract.ts
+++ b/test/ui/example-paths.contract.ts
@@ -67,11 +67,11 @@ describe('example release matrix contract', () => {
     it('discovers every HTML entry recursively with no hand-maintained gallery omissions', () => {
         expect(examplePaths).toEqual(independentlyDiscoverHtml());
         expect(new Set(examplePaths).size).toBe(examplePaths.length);
-        expect(examplePaths).toHaveLength(88);
+        expect(examplePaths).toHaveLength(89);
     });
 
-    it('expands 88 pages into the complete 163-case backend matrix', () => {
-        expect(exampleCases).toHaveLength(163);
+    it('expands 89 pages into the complete 165-case backend matrix', () => {
+        expect(exampleCases).toHaveLength(165);
         expect(new Set(exampleCases.map(item => `${item.path}:${item.backend}`)).size).toBe(
             exampleCases.length
         );
@@ -103,7 +103,7 @@ describe('example release matrix contract', () => {
 
     it('builds complete, categorized gallery metadata with valid source links', () => {
         const catalog = createExampleCatalog(examplePaths);
-        expect(catalog).toHaveLength(86);
+        expect(catalog).toHaveLength(87);
         expect(new Set(catalog.map(entry => entry.id)).size).toBe(catalog.length);
         expect(new Set(catalog.map(entry => entry.path))).toEqual(
             new Set(examplePaths.filter(path => path !== 'index.html' && path !== 'list.html'))
@@ -112,8 +112,8 @@ describe('example release matrix contract', () => {
             new Set(EXAMPLE_CATEGORIES.map(category => category.id))
         );
         expect(catalog[0]?.id).toBe('quickStart');
-        expect(examplesForBackend(catalog, 'webgl2')).toHaveLength(74);
-        expect(examplesForBackend(catalog, 'webgpu')).toHaveLength(85);
+        expect(examplesForBackend(catalog, 'webgl2')).toHaveLength(75);
+        expect(examplesForBackend(catalog, 'webgpu')).toHaveLength(86);
         expect(catalog.filter(entry => entry.featured).length).toBeGreaterThan(12);
         expect(catalog.filter(entry => entry.featured).length).toBeLessThan(catalog.length);
         expect(
@@ -258,7 +258,7 @@ describe('example release matrix contract', () => {
         const dedicatedCases = DEDICATED_RELEASE_TEST_EXAMPLE_PATHS.flatMap(path =>
             backendsForExample(path).map(backend => ({ path, backend }))
         );
-        expect(genericCases).toHaveLength(155);
+        expect(genericCases).toHaveLength(157);
         expect(
             [...genericCases, ...dedicatedCases].map(item => `${item.path}:${item.backend}`).sort()
         ).toEqual(exampleCases.map(item => `${item.path}:${item.backend}`).sort());
@@ -289,6 +289,7 @@ describe('example release matrix contract', () => {
             'compute_eclipse_shrine.html': { test: '1' },
             'glTFViewer/index.html': { url: '/examples/models/Tmall/Tmall.gltf' },
             'ground_truth_ambient_occlusion.html': { test: '1' },
+            'gtao_acceptance_lab.html': { test: '1' },
             'particle_gpu_nebula.html': { test: '1' },
             'screen_space_global_illumination_chapel.html': { test: '1' },
             'screen_space_reflections_palace.html': { test: '1' },

--- a/test/ui/example-paths.ts
+++ b/test/ui/example-paths.ts
@@ -43,6 +43,7 @@ export const EXAMPLE_QUERY_PARAMETERS: Readonly<
     'compute_eclipse_shrine.html': { test: '1' },
     'particle_gpu_nebula.html': { test: '1' },
     'ground_truth_ambient_occlusion.html': { test: '1' },
+    'gtao_acceptance_lab.html': { test: '1' },
     'screen_space_global_illumination_chapel.html': { test: '1' },
     'screen_space_reflections_palace.html': { test: '1' },
     'stormfront_observatory.html': { test: '1' },

--- a/test/ui/post-processing.spec.ts
+++ b/test/ui/post-processing.spec.ts
@@ -87,6 +87,45 @@ async function assertFinalGraphicsHealth(
     });
 }
 
+test('GTAO acceptance lab keeps WebGL2 and WebGPU output within the parity budget', async ({
+    page
+}) => {
+    test.setTimeout(240_000);
+    await installRenderHealthProbe(page);
+    const failures = await installPageFailureMonitor(page);
+    try {
+        const captures: Buffer[] = [];
+        for (const backend of backends) {
+            await page.goto(`/examples/gtao_acceptance_lab.html?backend=${backend}&test=1`, {
+                waitUntil: 'domcontentloaded'
+            });
+            await expect(page.locator('body')).toHaveAttribute(
+                'data-ao-acceptance-phase',
+                'ready',
+                { timeout: 45_000 }
+            );
+            await waitForStableAnimationFrames(page);
+            await awaitTrackedGPUQueues(page);
+            const canvas = page.locator(`canvas[data-hilo3d-backend="${backend}"]`);
+            captures.push(await canvas.screenshot({ type: 'png' }));
+            await assertFinalGraphicsHealth(page, backend, `GTAO acceptance parity on ${backend}`);
+        }
+        const webgl2Capture = captures[0];
+        const webgpuCapture = captures[1];
+        if (webgl2Capture === undefined || webgpuCapture === undefined) {
+            throw new Error('GTAO acceptance parity captures are incomplete');
+        }
+        const parity = compareCanvasPixels(webgpuCapture, webgl2Capture);
+        expect(parity.changedPixelCount).toBeLessThan(parity.pixelCount * 0.2);
+        expect(parity.meanChannelDelta).toBeLessThan(3);
+
+        await page.goto('about:blank');
+        failures.assertEmpty('GTAO acceptance backend-parity failures');
+    } finally {
+        await failures.dispose();
+    }
+});
+
 for (const backend of backends) {
     test(`GTAO produces stable non-black contact visibility on ${backend} @${backend}`, async ({
         page
@@ -158,6 +197,83 @@ for (const backend of backends) {
 
             await page.goto('about:blank');
             failures.assertEmpty(`GTAO browser failures on ${backend}`);
+        } finally {
+            await failures.dispose();
+        }
+    });
+
+    test(`GTAO acceptance lab covers spatial, temporal, edge, and log-depth cases on ${backend} @${backend}`, async ({
+        page
+    }) => {
+        test.setTimeout(240_000);
+        await installRenderHealthProbe(page);
+        const failures = await installPageFailureMonitor(page);
+        try {
+            const canvasSelector = `canvas[data-hilo3d-backend="${backend}"]`;
+            await page.goto(`/examples/gtao_acceptance_lab.html?backend=${backend}&test=1`, {
+                waitUntil: 'domcontentloaded'
+            });
+            await expect(page.locator('body')).toHaveAttribute(
+                'data-ao-acceptance-phase',
+                'ready',
+                { timeout: 45_000 }
+            );
+            const canvas = page.locator(canvasSelector);
+            await expect(canvas).toBeVisible();
+            await waitForStableAnimationFrames(page);
+            await awaitTrackedGPUQueues(page);
+            const enabled = await canvas.screenshot({ type: 'png' });
+            await assertFinalGraphicsHealth(page, backend, `GTAO acceptance enabled on ${backend}`);
+
+            await page.getByRole('button', { name: 'AO enabled' }).click();
+            await expect(page.locator('body')).toHaveAttribute('data-ao', 'disabled');
+            await waitForStableAnimationFrames(page);
+            await awaitTrackedGPUQueues(page);
+            const disabled = await canvas.screenshot({ type: 'png' });
+            const aoDifference = compareCanvasPixels(enabled, disabled);
+            expect(aoDifference.changedPixelCount).toBeGreaterThan(aoDifference.pixelCount * 0.03);
+            expect(aoDifference.darkenedPixelCount).toBeGreaterThan(aoDifference.pixelCount * 0.02);
+            expect(aoDifference.meanChannelDelta).toBeGreaterThan(0.75);
+
+            await page.getByRole('button', { name: 'AO disabled' }).click();
+            const beforeMotion = await currentProgress(page, backend);
+            await page.getByRole('button', { name: 'start motion' }).click();
+            await expect(page.locator('body')).toHaveAttribute('data-motion', 'running');
+            await expectActionProgress(
+                page,
+                backend,
+                beforeMotion,
+                `GTAO moving-occluder progress on ${backend}`
+            );
+            await waitForStableAnimationFrames(page);
+            await awaitTrackedGPUQueues(page);
+            await assertFinalGraphicsHealth(page, backend, `GTAO moving occluder on ${backend}`);
+
+            await page.getByRole('button', { name: 'edge view' }).click();
+            await expect(page.getByRole('button', { name: 'hero view' })).toHaveAttribute(
+                'aria-pressed',
+                'true'
+            );
+            await waitForStableAnimationFrames(page);
+            await awaitTrackedGPUQueues(page);
+            await assertFinalGraphicsHealth(page, backend, `GTAO screen-edge view on ${backend}`);
+
+            await page.goto(
+                `/examples/gtao_acceptance_lab.html?backend=${backend}&test=1&logDepth=true`,
+                { waitUntil: 'domcontentloaded' }
+            );
+            await expect(page.locator('body')).toHaveAttribute(
+                'data-ao-acceptance-phase',
+                'ready',
+                { timeout: 45_000 }
+            );
+            await expect(page.locator('#backendLabel')).toContainText('log depth');
+            await waitForStableAnimationFrames(page);
+            await awaitTrackedGPUQueues(page);
+            await assertFinalGraphicsHealth(page, backend, `GTAO logarithmic depth on ${backend}`);
+
+            await page.goto('about:blank');
+            failures.assertEmpty(`GTAO acceptance browser failures on ${backend}`);
         } finally {
             await failures.dispose();
         }


### PR DESCRIPTION
## Summary

- Rebuild portable GTAO around dual horizon search, projected-normal visible-arc integration, contact occlusion, hybrid material/geometry normals, quality presets, and per-camera temporal history.
- Add variance-guided temporal accumulation, edge-aware filtering, depth/normal-aware upsampling, multibounce diffuse AO, and bent-cone specular occlusion across Forward and Clustered Forward+.
- Add a dedicated GTAO acceptance lab plus strict WebGL2/WebGPU visual, parity, material-difference, motion, edge-view, and camera-contract coverage.
- Document the Unreal 5.8 source comparison, architecture contracts, tuning guidance, and the explicit sparse-depth/HZB and semantic-prepass performance boundaries.

## Validation

- [x] I ran `npm run test:browser` locally and all browser GPU tests passed.
- [x] `npm run validate` passed: 1870 unit/coverage tests, portable and native RHI suites, WebGPU 19/19, UI 200/200, visual 3/3, examples build, docs, API, package, and pack checks.

## Evidence limitations

- Native RHI completed with 3 passing and 1 environment-gated skip. The separate physical-GPU `npm run test:webgpu:native` lane was not run on this host.