### PR TITLE
fix(render): fit 128-joint skinning within WebGL2's 16 KiB limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Breaking changes
 
+- Move skin history validity from the removed `SkinningBlock.u_skinHistoryParams.x` to
+  `ModelBlock.u_modelHistoryParams.y`. The two 128-joint palettes now occupy exactly 16,384 bytes,
+  fitting the WebGL2 minimum uniform-block capacity. Custom shaders and block producers must use the
+  new location; model and skin validity remain independent.
+
 - Integrate typed particle parameters into emission and spawn initialization across CPU, stateless,
   and stateful WebGPU command generation; runtime value changes no longer require recompilation.
   Apply `ParticleBudgetManager` decisions directly to live capacity, spawn rate, sorting, soft

--- a/documentation/ENGINEERING_MODERNIZATION.md
+++ b/documentation/ENGINEERING_MODERNIZATION.md
@@ -656,6 +656,11 @@ layout。
 - joint index/weight 和 morph target 仍是 vertex attribute；joint palette 进入
   `SkinningBlock`，morph weight 进入
   `MorphBlock`。骨骼、形变与实例化组合必须使用各自 revision，不能共享错误 pose。
+- `SkinningBlock` 仅保存 current/previous 各 128 个 mat4，精确占用 16,384
+  bytes，兼容 WebGL2 最低 uniform-block capacity。skin history validity 使用
+  `ModelBlock.u_modelHistoryParams.y`，model validity 仍使用
+  `.x`；两者独立判断，且不依赖 ModelBlock/SkinningBlock 解析顺序。首次使用、motion
+  participation 间断、显式失效与设备恢复均保持无效历史；失败 submission 不提交待定姿态。
 
 ### ShaderMaterial 迁移
 

--- a/src/render/BuiltInUniformBlockManager.ts
+++ b/src/render/BuiltInUniformBlockManager.ts
@@ -145,6 +145,7 @@ const MATERIAL_TEXTURE_BLOCK_FIELD_NAMES = Object.freeze(
 );
 const MODEL_HISTORY_INVALID = new Float32Array(4);
 const MODEL_HISTORY_VALID = new Float32Array([1, 0, 0, 0]);
+const MODEL_AND_SKIN_HISTORY_PARAMS = new Float32Array(4);
 const MODEL_LAYER_PARAMS = new Uint32Array(4);
 
 function fieldNamesOf(layout: Std140Layout): readonly string[] {
@@ -341,7 +342,8 @@ function updateModelTransformBlock(
     current: Float32Array,
     previous: Float32Array,
     normal: Matrix3,
-    historyValid: boolean
+    historyValid: boolean,
+    skinHistoryValid: boolean
 ): void {
     let candidate = semanticBlockScratch.get(buffer);
     if (candidate?.byteLength !== modelBlockLayout.byteLength) {
@@ -362,10 +364,12 @@ function updateModelTransformBlock(
         normal.normalFromMat4(mesh.worldMatrix).elements,
         std140WriteResult
     );
+    MODEL_AND_SKIN_HISTORY_PARAMS[0] = historyValid ? 1 : 0;
+    MODEL_AND_SKIN_HISTORY_PARAMS[1] = skinHistoryValid ? 1 : 0;
     modelBlockLayout.writeInto(
         target,
         'u_modelHistoryParams',
-        historyValid ? MODEL_HISTORY_VALID : MODEL_HISTORY_INVALID,
+        MODEL_AND_SKIN_HISTORY_PARAMS,
         std140WriteResult
     );
     modelBlockLayout.writeInto(
@@ -1026,7 +1030,8 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
                 history.pending,
                 historyValid ? history.committed : history.pending,
                 cached.normal,
-                historyValid
+                historyValid,
+                this.hasValidSkinHistory(mesh)
             );
             cached.frameIndex = this.frameIndex;
             cached.revision = mesh.worldMatrixVersion;
@@ -1103,20 +1108,23 @@ class BuiltInUniformBlockManager implements RHIUploadBatchParticipant {
             history.pendingRevision = getTransformHistoryRevision(mesh);
             history.pendingFrame = this.frameIndex;
             this.stagedSkinning.push(history);
-            const historyValid =
-                history.committedGeneration === this.historyGeneration &&
-                history.committedRevision === history.pendingRevision &&
-                this.hasConsecutiveMotionParticipation(mesh);
+            const historyValid = this.hasValidSkinHistory(mesh);
             cached.buffer
                 .set('u_jointMat', history.pending)
-                .set('u_previousJointMat', historyValid ? history.committed : history.pending)
-                .set(
-                    'u_skinHistoryParams',
-                    historyValid ? MODEL_HISTORY_VALID : MODEL_HISTORY_INVALID
-                );
+                .set('u_previousJointMat', historyValid ? history.committed : history.pending);
             cached.frameIndex = this.frameIndex;
         }
         return cached.buffer;
+    }
+
+    /** Read committed skin history independently of this frame's block resolution order. */
+    private hasValidSkinHistory(mesh: Mesh): boolean {
+        const history = this.skinningHistory.get(mesh);
+        return (
+            history?.committedGeneration === this.historyGeneration &&
+            history.committedRevision === getTransformHistoryRevision(mesh) &&
+            this.hasConsecutiveMotionParticipation(mesh)
+        );
     }
 
     private getMorphBuffer(

--- a/src/render/ubo/BuiltInUniformBlocks.ts
+++ b/src/render/ubo/BuiltInUniformBlocks.ts
@@ -149,8 +149,7 @@ export const geometryBlockLayout = createStd140Layout({
 
 export const skinningBlockLayout = createStd140Layout({
     u_jointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS },
-    u_previousJointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS },
-    u_skinHistoryParams: 'vec4'
+    u_previousJointMat: { type: 'mat4', arrayLength: MAX_SKIN_JOINTS }
 });
 
 export const morphBlockLayout = createStd140Layout({

--- a/src/shader/chunk/uniformBlocks.glsl
+++ b/src/shader/chunk/uniformBlocks.glsl
@@ -152,9 +152,8 @@ layout(std140) uniform GeometryBlock {
     layout(std140) uniform SkinningBlock {
         mat4 u_jointMat[HILO_MAX_SKIN_JOINTS];
         mat4 u_previousJointMat[HILO_MAX_SKIN_JOINTS];
-        vec4 u_skinHistoryParams;
     };
-    #define u_skinHistoryValid u_skinHistoryParams.x
+    #define u_skinHistoryValid u_modelHistoryParams.y
 #endif
 
 #ifdef HILO_MORPH_TARGET_COUNT

--- a/test/spec/renderer/BuiltInUniformBlockManager.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlockManager.test.ts
@@ -666,6 +666,66 @@ describe('BuiltInUniformBlockManager', () => {
         expect(readFloatField(block, 'u_modelHistoryParams', 1)[0]).toBe(0);
     });
 
+    it.each([false, true])(
+        'keeps skin validity independent of model history and resolution order (skin first: %s)',
+        skinFirst => {
+            const manager = new BuiltInUniformBlockManager({ width: 320, height: 180 });
+            const mesh = new SkinnedMesh({
+                geometry: testEnv.geometry,
+                material: testEnv.material
+            });
+            const pose = new Float32Array(new Matrix4().elements);
+            vi.spyOn(mesh, 'getJointMat').mockImplementation(() => pose);
+            const modelBlock = (): UniformBuffer =>
+                manager.resolveUniformBlock('ModelBlock', mesh, testEnv.material);
+            const skinBlock = (): UniformBuffer =>
+                manager.resolveUniformBlock('SkinningBlock', mesh, testEnv.material);
+            // A model-only committed frame must not make uninitialized skin history valid.
+            manager.beginFrame(testEnv.camera);
+            manager.markMotionVectorParticipation(mesh);
+            modelBlock();
+            manager.commit({} as never);
+            const render = (x: number): { model: UniformBuffer; skin: UniformBuffer } => {
+                pose[12] = x;
+                manager.beginFrame(testEnv.camera);
+                manager.markMotionVectorParticipation(mesh);
+                if (skinFirst) {
+                    const skin = skinBlock();
+                    return { skin, model: modelBlock() };
+                }
+                const model = modelBlock();
+                return { model, skin: skinBlock() };
+            };
+            let blocks = render(2);
+            expect(readFloatField(blocks.model, 'u_modelHistoryParams', 2)).toEqual([1, 0]);
+            expect(readFloatField(blocks.skin, 'u_previousJointMat', 16)[12]).toBe(2);
+            expect(blocks.skin.byteLength).toBe(16_384);
+            manager.commit({} as never);
+            blocks = render(3);
+            expect(readFloatField(blocks.model, 'u_modelHistoryParams', 2)).toEqual([1, 1]);
+            expect(readFloatField(blocks.skin, 'u_previousJointMat', 16)[12]).toBe(2);
+            manager.rollback();
+            blocks = render(4);
+            expect(readFloatField(blocks.model, 'u_modelHistoryParams', 2)).toEqual([1, 1]);
+            expect(readFloatField(blocks.skin, 'u_previousJointMat', 16)[12]).toBe(2);
+            manager.commit({} as never);
+            manager.beginFrame(testEnv.camera);
+            manager.commit({} as never);
+            blocks = render(5);
+            expect(readFloatField(blocks.model, 'u_modelHistoryParams', 2)).toEqual([0, 0]);
+            expect(readFloatField(blocks.skin, 'u_previousJointMat', 16)[12]).toBe(5);
+            manager.commit({} as never);
+            mesh.invalidateTransformHistory();
+            blocks = render(6);
+            expect(readFloatField(blocks.model, 'u_modelHistoryParams', 2)).toEqual([0, 0]);
+            manager.commit({} as never);
+            manager.synchronizeAfterRecovery();
+            blocks = render(7);
+            expect(readFloatField(blocks.model, 'u_modelHistoryParams', 2)).toEqual([0, 0]);
+            expect(readFloatField(blocks.skin, 'u_previousJointMat', 16)[12]).toBe(7);
+        }
+    );
+
     it('packs jittered raster matrices beside stable CPU camera matrices', () => {
         const manager = new BuiltInUniformBlockManager({ width: 320, height: 180 });
         const camera = new PerspectiveCamera({ aspect: 16 / 9 });

--- a/test/spec/renderer/BuiltInUniformBlocks.test.ts
+++ b/test/spec/renderer/BuiltInUniformBlocks.test.ts
@@ -37,7 +37,7 @@ describe('built-in std140 ABI', () => {
             MaterialTextureBlock: 1920,
             ModelBlock: 224,
             GeometryBlock: 224,
-            SkinningBlock: 16400,
+            SkinningBlock: 16384,
             MorphBlock: 80,
             InstanceBlock: 26624
         });
@@ -109,7 +109,7 @@ describe('built-in std140 ABI', () => {
 
         expect(skinningBlockLayout.fields.u_jointMat.arrayStride).toBe(64);
         expect(skinningBlockLayout.fields.u_previousJointMat.offset).toBe(8192);
-        expect(skinningBlockLayout.fields.u_skinHistoryParams.offset).toBe(16384);
+        expect(skinningBlockLayout.byteLength).toBeLessThanOrEqual(16_384);
         expect(morphBlockLayout.fields.u_morphWeights1.offset).toBe(16);
         expect(morphBlockLayout.fields.u_previousMorphWeights0.offset).toBe(32);
         expect(morphBlockLayout.fields.u_previousMorphWeights1.offset).toBe(48);


### PR DESCRIPTION
## Summary

Fix GPU skinning on WebGL2 devices whose uniform-block limit is 16,384 bytes. The current and previous 128-joint palettes previously occupied 16,400 bytes with their history flag; move that flag into the unused `ModelBlock.u_modelHistoryParams.y` component so `SkinningBlock` fits exactly within 16 KiB without adding a binding.

Keep model and skin history validity independent and independent of block resolution order. Add regression coverage for missing skin history, discarded frames, skipped motion participation, explicit invalidation, and recovery. Document the shader ABI migration: custom producers/consumers must replace `SkinningBlock.u_skinHistoryParams.x` with `ModelBlock.u_modelHistoryParams.y`.

## Validation

- Passed typecheck, lint, format check, API update/check (no API report changes), package types and package build/validation.
- Passed targeted uniform-block/history and shader tests, render architecture tests, and RHI suites (one native-suite test skipped).
- Passed all 19 tests selected by `test:webgpu` and four glTF loader/clone browser tests across WebGL2/WebGPU.
- Browser tests used a temporary config with an isolated port because the default port was occupied by the Pokemon preview. Browser coverage used Chromium/SwiftShader; the physical-GPU-specific lane and full `validate` were not run.
- [ ] I ran `npm run test:browser` locally and all browser GPU tests passed.

The full browser/visual suite above was not run; the targeted browser coverage is listed explicitly. The Pokemon project's CPU skinning policy is unchanged.
