### PR TITLE
fix(render): make shadow slice updates atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 
 ### Changes
 
+- Add `Renderer`/`Stage` `shadowUpdateMode: 'paged' | 'full'`. Paged updates now defer complete
+  caster-only shadow slices instead of publishing mixed page revisions; `full` disables page-budget
+  deferral for fully dynamic scenes. This prevents continuously moving or deforming casters from
+  combining old and new poses in one visible shadow slice.
 - Add tag-driven npm releases: the release command creates and pushes an annotated tag matching all
   three package versions, then GitHub Actions validates the tagged commit and publishes `hilo3d`,
   `@hilo/addon-particle`, and `@hilo/addon-physics` under one dist-tag through npm Trusted

--- a/documentation/RENDERING_ARCHITECTURE.md
+++ b/documentation/RENDERING_ARCHITECTURE.md
@@ -91,9 +91,12 @@ recovery 都会明确失效。Clustered GPU Scene 中的 rigid caster 由 comput
 slice 裁剪并写入固定 bucket indirect draw；不满足 GPU Scene 合同的 caster 仍走共享 CPU depth
 path。high-end profile 依据 receiver 覆盖缩放 local
 light 与远级联分辨率，以 1/2/4/8 帧 cadence 更新 CSM，并由确定性 slice/page
-budget 延后 caster-only 失效。每个 slice 再拆为 128 像素固定物理页；同帧相邻 dirty 页先合并为 scissor 矩形再重绘，完整 slice 因此只重复录制一次 caster 队列。页 revision、residency 和失败回滚均在有效 submission 后提交，旧页在缺页期间继续提供确定内容。注册
-`RendererDiagnostics` 后，`caches.shadowAtlas`
-提供累计hit/miss/replacement/live-slice，`frame.shadow*` 提供 slice/page
+budget 延后 caster-only 失效。每个 slice 再拆为 128 像素固定物理页；同帧相邻 dirty 页先合并为 scissor 矩形再重绘，完整 slice 因此只重复录制一次 caster 队列。预算可以延后整个 caster-only
+slice，但一旦选中就原子更新该 slice 的全部旧 revision 页，必要时允许越过软 page
+budget，避免连续运动时新旧姿势混合。`Renderer`/`Stage` 的 `shadowUpdateMode` 默认是
+`paged`；纯动画展示等全动态场景可设为 `full`，让本帧已调度的全部 slice 跳过 page
+budget 延后。页 revision、residency 和失败回滚均在有效 submission 后提交。注册 `RendererDiagnostics`
+后，`caches.shadowAtlas` 提供累计hit/miss/replacement/live-slice，`frame.shadow*` 提供 slice/page
 request、update、defer、resident 和 overflow 观测。
 
 WebGPU high-end `ClusteredForwardPlusPipelineFactory` 还提供显式 opt-in 的

--- a/etc/hilo3d.api.md
+++ b/etc/hilo3d.api.md
@@ -6061,6 +6061,7 @@ export class Renderer<Backend extends RendererBackend = RendererBackend> impleme
     readonly setOffset: RendererContract['setOffset'];
     // (undocumented)
     readonly setRenderTarget: (...args: Parameters<RendererContract['setRenderTarget']>) => this;
+    readonly shadowUpdateMode: RendererContract['shadowUpdateMode'];
     // (undocumented)
     readonly supportsTextureCompression: RendererContract['supportsTextureCompression'];
     // (undocumented)
@@ -6117,6 +6118,7 @@ export interface RendererCommonOptions {
     premultipliedAlpha?: boolean;
     renderingProfile?: RendererRenderingProfile;
     renderPipeline?: RenderPipelineFactory;
+    shadowUpdateMode?: RendererShadowUpdateMode;
     // (undocumented)
     stencil?: boolean;
     // (undocumented)
@@ -6191,6 +6193,7 @@ export interface RendererContract {
     setOffset(x: number, y: number): void;
     // (undocumented)
     setRenderTarget(target: RenderTarget | null, options?: RenderTargetSelectionOptions): this;
+    readonly shadowUpdateMode: 'paged' | 'full';
     // (undocumented)
     supportsTextureCompression(format: TextureCompressionFormat): boolean;
     // (undocumented)
@@ -6291,6 +6294,9 @@ export interface RendererResourceManager {
 export type RendererScene = Node_2 & {
     readonly fog?: Fog | null;
 };
+
+// @public
+export type RendererShadowUpdateMode = 'paged' | 'full';
 
 // @public
 export interface RendererSupportOptions {
@@ -8323,6 +8329,7 @@ export interface StageCommonParameters extends NodeParameters {
     premultipliedAlpha?: boolean;
     renderingProfile?: RendererRenderingProfile;
     renderPipeline?: RenderPipelineFactory;
+    shadowUpdateMode?: RendererShadowUpdateMode;
     // (undocumented)
     stencil?: boolean;
     systems?: readonly StageSystem[];

--- a/examples/shadow_residency_sanctum.ts
+++ b/examples/shadow_residency_sanctum.ts
@@ -11,6 +11,7 @@ interface SanctumEvidence {
     readonly shadowUpdatedPages: number;
     readonly shadowDeferredPages: number;
     readonly shadowResidentPages: number;
+    readonly shadowBudgetOverflowPages: number;
     readonly hiddenLayerEnabled: boolean;
     readonly drawCount: number;
 }
@@ -216,6 +217,7 @@ const stage = await Hilo3d.Stage.create<'webgpu'>({
     clearColor: new Hilo3d.Color(0.0015, 0.002, 0.007),
     useInstanced: true,
     renderingProfile: 'high-end',
+    shadowUpdateMode: 'full',
     renderPipeline: pipeline
 });
 
@@ -488,6 +490,7 @@ function updateMetrics(): SanctumEvidence {
         shadowUpdatedPages: frame.shadowUpdatedPages,
         shadowDeferredPages: frame.shadowDeferredPages,
         shadowResidentPages: frame.shadowResidentPages,
+        shadowBudgetOverflowPages: frame.shadowBudgetOverflowPages,
         hiddenLayerEnabled: veilEnabled,
         drawCount: stage.renderer.renderInfo.drawCount
     };

--- a/src/Hilo3d.ts
+++ b/src/Hilo3d.ts
@@ -244,6 +244,7 @@ export {
     type RendererOptions,
     type RendererOptionsMap,
     type RendererRenderingProfile,
+    type RendererShadowUpdateMode,
     type RendererResourceDiagnostics,
     type RendererResourceManager,
     type RendererScene,

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -5,6 +5,7 @@ import Renderer, {
     type RendererFrame,
     type RendererOptions,
     type RendererRenderingProfile,
+    type RendererShadowUpdateMode,
     type RendererSupportOptions
 } from '../render/Renderer';
 import Ray from '../math/Ray';
@@ -179,6 +180,8 @@ export interface StageCommonParameters extends NodeParameters {
     useLogDepth?: boolean;
     /** Renderer policy bundle. `high-end` enables reversed-Z and camera-relative transforms. */
     renderingProfile?: RendererRenderingProfile;
+    /** Shadow-atlas update policy. Use `full` for scenes whose shadow casters move every frame. */
+    shadowUpdateMode?: RendererShadowUpdateMode;
     alpha?: boolean;
     depth?: boolean;
     stencil?: boolean;

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -21,6 +21,7 @@ import type {
     RendererOptions,
     RendererOptionsMap,
     RendererRenderingProfile,
+    RendererShadowUpdateMode,
     RendererSupportOptions,
     RendererWebGL2Options,
     RendererWebGPUOptions
@@ -45,6 +46,8 @@ export class Renderer<
     declare readonly renderTarget: RendererContract['renderTarget'];
     declare readonly cameraRelative: RendererContract['cameraRelative'];
     declare readonly renderingProfile: RendererContract['renderingProfile'];
+    /** Shadow-atlas page-budget policy selected at creation. */
+    declare readonly shadowUpdateMode: RendererContract['shadowUpdateMode'];
     declare width: RendererContract['width'];
     declare height: RendererContract['height'];
     declare pixelRatio: RendererContract['pixelRatio'];
@@ -120,6 +123,7 @@ export type {
     RendererOptions,
     RendererOptionsMap,
     RendererRenderingProfile,
+    RendererShadowUpdateMode,
     RendererSupportOptions,
     RendererWebGL2Options,
     RendererWebGPUOptions

--- a/src/render/RendererCore.ts
+++ b/src/render/RendererCore.ts
@@ -139,6 +139,8 @@ export interface RendererContract {
     useInstanced: boolean;
     readonly cameraRelative: boolean;
     readonly renderingProfile: 'portable' | 'high-end';
+    /** Shadow-atlas page-budget policy selected when this renderer was created. */
+    readonly shadowUpdateMode: 'paged' | 'full';
     forceMaterial: Material | null;
     clearColor: Color;
     resize(width: number, height: number, force?: boolean): void;
@@ -202,6 +204,8 @@ export abstract class RendererCore extends EventDispatcher implements RendererCo
     /** Use frame-wide camera-relative GPU transforms without changing CPU world coordinates. */
     cameraRelative = false;
     readonly renderingProfile: 'portable' | 'high-end' = 'portable';
+    /** Update complete scheduled shadow slices without page-budget deferral in fully dynamic scenes. */
+    readonly shadowUpdateMode: 'paged' | 'full' = 'paged';
     vertexPrecision: ShaderPrecision = 'highp';
     fragmentPrecision: ShaderPrecision = 'highp';
     fog: Fog | null = null;

--- a/src/render/RendererOptions.ts
+++ b/src/render/RendererOptions.ts
@@ -14,6 +14,9 @@ export type RendererContextPowerPreference = 'default' | RendererAdapterPowerPre
 /** Shared renderer policy bundle. `high-end` enables reversed-Z cameras and camera-relative GPU transforms. */
 export type RendererRenderingProfile = 'portable' | 'high-end';
 
+/** Shadow-atlas update policy. `full` disables page-budget deferral within a renderer frame. */
+export type RendererShadowUpdateMode = 'paged' | 'full';
+
 /** Optional device capabilities that the renderer can request through the portable RHI. */
 export type RendererFeatureName =
     | 'texture-compression-bc'
@@ -47,6 +50,8 @@ export interface RendererCommonOptions {
     cameraRelative?: boolean;
     /** Renderer policy bundle. Defaults to `portable`. */
     renderingProfile?: RendererRenderingProfile;
+    /** Shadow-atlas update policy. Defaults to `paged`; use `full` for fully dynamic scenes. */
+    shadowUpdateMode?: RendererShadowUpdateMode;
     vertexPrecision?: ShaderPrecision;
     fragmentPrecision?: ShaderPrecision;
     fog?: Fog | null;

--- a/src/render/internal/SharedRendererDriver.ts
+++ b/src/render/internal/SharedRendererDriver.ts
@@ -395,6 +395,10 @@ class SharedRendererDriver
         if (renderingProfile !== 'portable' && renderingProfile !== 'high-end') {
             throw new TypeError('Renderer renderingProfile must be "portable" or "high-end"');
         }
+        const shadowUpdateMode: unknown = this.shadowUpdateMode;
+        if (shadowUpdateMode !== 'paged' && shadowUpdateMode !== 'full') {
+            throw new TypeError('Renderer shadowUpdateMode must be "paged" or "full"');
+        }
         if (this.renderingProfile === 'high-end') this.cameraRelative = true;
         const optionRequiredFeatures =
             'requiredFeatures' in options ? options.requiredFeatures : undefined;
@@ -1986,7 +1990,8 @@ class SharedRendererDriver
             plan,
             content,
             updates.scheduledSlices,
-            scope.uploads
+            scope.uploads,
+            this.shadowUpdateMode
         );
         let completedUpdateCount = 0;
         for (let index = 0; index < content.sliceCount; index += 1) {

--- a/src/render/renderer/ShadowAtlasPageResidency.ts
+++ b/src/render/renderer/ShadowAtlasPageResidency.ts
@@ -26,6 +26,8 @@ export interface ShadowAtlasPageResidencyDecision {
     readonly budgetOverflowCount: number;
 }
 
+export type ShadowAtlasPageUpdateMode = 'paged' | 'full';
+
 interface MutablePageRegion {
     slicePhysicalIndex: number;
     pageX: number;
@@ -122,8 +124,8 @@ function copyRegion(target: MutablePageRegion, source: Readonly<MutablePageRegio
 /**
  * Submission-aware fixed-atlas virtual-page residency for shadow updates. Receiver-driven slice
  * sizing determines the requested virtual grid; dirty pages are redrawn through coalesced scissor
- * rectangles and committed only after a valid RHI submission. Missing pages retain the previous
- * slice contents.
+ * rectangles and committed only after a valid RHI submission. A budget may defer a complete
+ * caster-only slice, but it never publishes a mixture of page revisions within that slice.
  */
 export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
     readonly pageSize: number;
@@ -188,9 +190,14 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
         plan: Readonly<ShadowAtlasScenePlan>,
         content: Readonly<ShadowAtlasContentDecision>,
         scheduledSlices: readonly boolean[],
-        uploads: RHIUploadBatch
+        uploads: RHIUploadBatch,
+        updateMode: ShadowAtlasPageUpdateMode = 'paged'
     ): Readonly<ShadowAtlasPageResidencyDecision> {
         this.assertAlive();
+        const selectedUpdateMode: unknown = updateMode;
+        if (selectedUpdateMode !== 'paged' && selectedUpdateMode !== 'full') {
+            throw new TypeError('Shadow page update mode must be "paged" or "full"');
+        }
         const sliceCount = plan.slices.length;
         if (
             content.sliceCount !== sliceCount ||
@@ -223,8 +230,9 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
             const record = this.sliceAt(sliceIndex);
             this.configureSlice(record, slice.viewport);
             const reason = content.reasons[sliceIndex];
-            const forceComplete =
+            const isMandatory =
                 reason === 'allocation' || reason === 'layout' || reason === 'light';
+            const forceComplete = updateMode === 'full' || isMandatory;
             const pageCount = record.columns * record.rows;
             let missing = 0;
             for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
@@ -238,10 +246,10 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
             if (!forceComplete) continue;
             while ((this.#remainingPages[sliceIndex] ?? 0) > 0) {
                 if (!this.scheduleNextPage(sliceIndex, targetUpdateId, record)) {
-                    throw new Error('Mandatory shadow page scheduling made no progress');
+                    throw new Error('Complete shadow slice scheduling made no progress');
                 }
                 this.#remainingPages[sliceIndex] = (this.#remainingPages[sliceIndex] ?? 0) - 1;
-                mandatory++;
+                if (isMandatory) mandatory++;
                 scheduled++;
                 if (budgetRemaining > 0) budgetRemaining--;
             }
@@ -269,18 +277,19 @@ export class ShadowAtlasPageResidency implements RHIUploadBatchParticipant {
             const slice = plan.slices[selectedSlice];
             const record = this.#slices[selectedSlice];
             const targetUpdateId = content.updateIds[selectedSlice] ?? 0;
-            if (
-                slice === undefined ||
-                record === undefined ||
-                targetUpdateId === 0 ||
-                !this.scheduleNextPage(selectedSlice, targetUpdateId, record)
-            ) {
+            if (slice === undefined || record === undefined || targetUpdateId === 0) {
                 throw new Error('Budgeted shadow page scheduling made no progress');
             }
-            this.#remainingPages[selectedSlice] = (this.#remainingPages[selectedSlice] ?? 0) - 1;
-            this.#completedSlices[selectedSlice] = this.#remainingPages[selectedSlice] === 0;
-            scheduled++;
-            budgetRemaining--;
+            const slicePageCount = this.#remainingPages[selectedSlice] ?? 0;
+            for (let pageIndex = 0; pageIndex < slicePageCount; pageIndex += 1) {
+                if (!this.scheduleNextPage(selectedSlice, targetUpdateId, record)) {
+                    throw new Error('Atomic shadow slice scheduling made no progress');
+                }
+            }
+            this.#remainingPages[selectedSlice] = 0;
+            this.#completedSlices[selectedSlice] = true;
+            scheduled += slicePageCount;
+            budgetRemaining = Math.max(0, budgetRemaining - slicePageCount);
             sliceCursor = (selectedSlice + 1) % sliceCount;
             this.#pendingSliceCursor = sliceCursor;
             this.#pendingSliceCursorEpoch = this.#transactionEpoch;

--- a/test/spec/renderer/Renderer.test.ts
+++ b/test/spec/renderer/Renderer.test.ts
@@ -142,7 +142,8 @@ describe('Renderer public entry point', () => {
             width: 12,
             height: 6,
             antialias: false,
-            renderingProfile: 'high-end'
+            renderingProfile: 'high-end',
+            shadowUpdateMode: 'full'
         });
         activeRenderers.push(renderer);
         const camera = new PerspectiveCamera({ near: 0.1, far: null });
@@ -152,6 +153,7 @@ describe('Renderer public entry point', () => {
         renderer.renderToTarget(derivedTarget, stage, camera);
 
         expect(renderer.renderingProfile).toBe('high-end');
+        expect(renderer.shadowUpdateMode).toBe('full');
         expect(renderer.cameraRelative).toBe(true);
         expect(camera.depthMode).toBe('reversed');
 
@@ -165,6 +167,16 @@ describe('Renderer public entry point', () => {
         }).toThrow(/depth mode standard does not match camera depth mode reversed/u);
         derivedTarget.destroy();
         incompatibleTarget.destroy();
+    });
+
+    it('rejects an unsupported shadow update mode before creating resources', async () => {
+        await expect(
+            Renderer.create({
+                backend: 'webgl2',
+                domElement: document.createElement('canvas'),
+                shadowUpdateMode: 'incremental' as 'full'
+            })
+        ).rejects.toThrow('Renderer shadowUpdateMode must be "paged" or "full"');
     });
 
     it('probes auto once and falls back to WebGL2 without a facade', async () => {

--- a/test/spec/renderer/ShadowAtlasPageResidency.test.ts
+++ b/test/spec/renderer/ShadowAtlasPageResidency.test.ts
@@ -28,7 +28,7 @@ function decision(
 }
 
 describe('ShadowAtlasPageResidency', () => {
-    it('commits mandatory pages and advances budgeted replacement pages across submissions', async () => {
+    it('commits mandatory and budgeted replacement slices atomically', async () => {
         const backend = new FakeWebGLRHIBackend();
         const device = backend.createDevice();
         const manager = new LightManager();
@@ -77,20 +77,33 @@ describe('ShadowAtlasPageResidency', () => {
         const failed = pages.stage(plan, replacement, [true], failedBatch);
         expect(failed.updateRegions).toHaveLength(1);
         const failedRegion = { ...failed.updateRegions[0] };
+        expect(failedRegion).toEqual({
+            slicePhysicalIndex: 0,
+            pageX: 0,
+            pageY: 0,
+            x: 0,
+            y: 0,
+            width: 256,
+            height: 256
+        });
+        expect(failed).toMatchObject({
+            requestedPageCount: 4,
+            scheduledPageCount: 4,
+            deferredPageCount: 0,
+            mandatoryPageCount: 0,
+            budgetOverflowCount: 3
+        });
+        expect(failed.completedSlices).toEqual([true]);
         failedBatch.rollback();
 
-        for (let update = 0; update < 4; update += 1) {
-            const batch = new RHIUploadBatch(new FrameArena());
-            const staged = pages.stage(plan, replacement, [true], batch);
-            expect(staged.updateRegions).toHaveLength(1);
-            if (update === 0) expect(staged.updateRegions[0]).toEqual(failedRegion);
-            expect(staged.completedSlices).toEqual([update === 3]);
-            const commands = device.graphicsQueue.beginFrame();
-            batch.flush(commands);
-            const submission = device.graphicsQueue.endFrame(commands);
-            batch.commit(submission);
-            await submission.done;
-        }
+        const replacementBatch = new RHIUploadBatch(new FrameArena());
+        const stagedReplacement = pages.stage(plan, replacement, [true], replacementBatch);
+        expect(stagedReplacement.updateRegions).toEqual([failedRegion]);
+        const replacementCommands = device.graphicsQueue.beginFrame();
+        replacementBatch.flush(replacementCommands);
+        const replacementSubmission = device.graphicsQueue.endFrame(replacementCommands);
+        replacementBatch.commit(replacementSubmission);
+        await replacementSubmission.done;
 
         const stableBatch = new RHIUploadBatch(new FrameArena());
         const stable = pages.stage(plan, replacement, [true], stableBatch);
@@ -122,14 +135,14 @@ describe('ShadowAtlasPageResidency', () => {
             [true],
             groupedReplacementBatch
         );
-        expect(groupedReplacement.scheduledPageCount).toBe(3);
-        expect(groupedReplacement.updateRegions).toHaveLength(2);
-        expect(groupedReplacement.updateRegions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({ x: 0, y: 0, width: 256, height: 128 }),
-                expect.objectContaining({ x: 0, y: 128, width: 128, height: 128 })
-            ])
-        );
+        expect(groupedReplacement).toMatchObject({
+            scheduledPageCount: 4,
+            deferredPageCount: 0,
+            budgetOverflowCount: 1
+        });
+        expect(groupedReplacement.updateRegions).toEqual([
+            expect.objectContaining({ x: 0, y: 0, width: 256, height: 256 })
+        ]);
         groupedReplacementBatch.rollback();
         groupedPages.destroy();
 
@@ -138,7 +151,7 @@ describe('ShadowAtlasPageResidency', () => {
         backend.destroy();
     });
 
-    it('rotates budgeted pages when moving casters produce a new revision every frame', async () => {
+    it('never mixes page revisions when moving casters produce a new revision every frame', async () => {
         const backend = new FakeWebGLRHIBackend();
         const device = backend.createDevice();
         const manager = new LightManager();
@@ -167,18 +180,75 @@ describe('ShadowAtlasPageResidency', () => {
         pages.stage(plan, decision('allocation', 1), [true], allocationBatch);
         await submit(allocationBatch);
 
-        const visited = new Set<string>();
         for (let updateId = 2; updateId <= 5; updateId += 1) {
             const batch = new RHIUploadBatch(new FrameArena());
             const staged = pages.stage(plan, decision('caster-transform', updateId), [true], batch);
             expect(staged.updateRegions).toHaveLength(1);
             const region = staged.updateRegions[0];
-            if (region === undefined) throw new Error('Expected one rotating shadow page');
-            visited.add(`${String(region.pageX)}:${String(region.pageY)}`);
+            expect(region).toEqual({
+                slicePhysicalIndex: 0,
+                pageX: 0,
+                pageY: 0,
+                x: 0,
+                y: 0,
+                width: 256,
+                height: 256
+            });
+            expect(staged).toMatchObject({
+                requestedPageCount: 4,
+                scheduledPageCount: 4,
+                deferredPageCount: 0,
+                budgetOverflowCount: 3
+            });
+            expect(staged.completedSlices).toEqual([true]);
             await submit(batch);
         }
+        pages.destroy();
+        adapter.destroy();
+        backend.destroy();
+    });
 
-        expect(visited).toEqual(new Set(['0:0', '1:0', '0:1', '1:1']));
+    it('lets full mode bypass the page budget for every scheduled slice', () => {
+        const backend = new FakeWebGLRHIBackend();
+        const device = backend.createDevice();
+        const manager = new LightManager();
+        manager.addLight(new DirectionalLight({ shadow: { width: 256, height: 256 } }));
+        manager.addLight(new DirectionalLight({ shadow: { width: 256, height: 256 } }));
+        const camera = new PerspectiveCamera({ near: 0.1, far: 100, aspect: 1 });
+        camera.setPosition(0, 1, 5).lookAt(new Vector3());
+        camera.updateViewProjectionMatrix();
+        const adapter = new ShadowAtlasSceneAdapter();
+        const plan = adapter.prepare(manager, camera, device.capabilities, {
+            width: 512,
+            height: 256
+        });
+        expect(plan.slices).toHaveLength(2);
+        const content: Readonly<ShadowAtlasContentDecision> = {
+            dirtySlices: [true, true],
+            reasons: ['caster-transform', 'caster-transform'],
+            updateIds: [1, 2],
+            sliceCount: 2,
+            dirtySliceCount: 2,
+            cachedSliceCount: 0
+        };
+        const pages = new ShadowAtlasPageResidency({
+            pageSize: 128,
+            maxPageUpdatesPerFrame: 1
+        });
+        const batch = new RHIUploadBatch(new FrameArena());
+        const staged = pages.stage(plan, content, [true, true], batch, 'full');
+
+        expect(staged.completedSlices).toEqual([true, true]);
+        expect(staged.updateRegions).toHaveLength(2);
+        expect(staged).toMatchObject({
+            requestedPageCount: 8,
+            scheduledPageCount: 8,
+            deferredPageCount: 0,
+            mandatoryPageCount: 0,
+            budgetOverflowCount: 7
+        });
+
+        batch.rollback();
         pages.destroy();
         adapter.destroy();
         backend.destroy();

--- a/test/types/package.test.ts
+++ b/test/types/package.test.ts
@@ -55,6 +55,7 @@ import {
     type RendererBackend,
     type RendererResourceDiagnostics,
     type RendererRenderingProfile,
+    type RendererShadowUpdateMode,
     type RendererSupportOptions,
     type RendererWebGL2Options,
     type RendererWebGPUOptions,
@@ -408,9 +409,12 @@ const webgpuRendererParameters = {
     width: 640,
     height: 360,
     pixelRatio: 1,
-    renderingProfile: 'high-end'
+    renderingProfile: 'high-end',
+    shadowUpdateMode: 'full'
 } satisfies RendererWebGPUOptions;
 const renderingProfile: RendererRenderingProfile = webgpuRendererParameters.renderingProfile;
+const shadowUpdateMode: RendererShadowUpdateMode = webgpuRendererParameters.shadowUpdateMode;
+void shadowUpdateMode;
 const webgpuRendererPromise: Promise<Renderer<'webgpu'>> =
     Renderer.create(webgpuRendererParameters);
 const webgpuRenderer = await webgpuRendererPromise;

--- a/test/ui/shadow-residency-sanctum.spec.ts
+++ b/test/ui/shadow-residency-sanctum.spec.ts
@@ -16,6 +16,7 @@ interface SanctumEvidence {
     readonly shadowUpdatedPages: number;
     readonly shadowDeferredPages: number;
     readonly shadowResidentPages: number;
+    readonly shadowBudgetOverflowPages: number;
     readonly hiddenLayerEnabled: boolean;
     readonly drawCount: number;
 }
@@ -79,7 +80,7 @@ function differingPixelRatio(referenceBuffer: Buffer, candidateBuffer: Buffer): 
     return changed / pixelCount;
 }
 
-test('Umbra Sanctum keeps moving shadow pages budgeted and camera layers isolated @webgpu', async ({
+test('Umbra Sanctum updates moving shadow slices atomically and keeps camera layers isolated @webgpu', async ({
     page
 }) => {
     test.setTimeout(120_000);
@@ -108,9 +109,10 @@ test('Umbra Sanctum keeps moving shadow pages budgeted and camera layers isolate
         hiddenLayerEnabled: false
     });
     expect(moving?.shadowRequestedPages).toBeGreaterThan(32);
-    expect(moving?.shadowUpdatedPages).toBeGreaterThan(0);
-    expect(moving?.shadowUpdatedPages).toBeLessThanOrEqual(32);
-    expect(moving?.shadowDeferredPages).toBeGreaterThan(0);
+    expect(moving?.shadowUpdatedPages).toBeGreaterThan(32);
+    expect(moving?.shadowUpdatedPages).toBeLessThanOrEqual(moving?.shadowRequestedPages ?? 0);
+    expect(moving?.shadowDeferredPages).toBeGreaterThanOrEqual(0);
+    expect(moving?.shadowBudgetOverflowPages).toBeGreaterThan(0);
     expect(moving?.shadowResidentPages).toBeGreaterThan(32);
 
     await page.evaluate(async () => window.__HILO3D_SHADOW_SANCTUM_TEST_API__?.setMotion(false));


### PR DESCRIPTION
## Summary
- prevent paged shadow updates from publishing mixed revisions inside one atlas slice
- add the public Renderer/Stage shadowUpdateMode option with paged and full policies
- configure the fully dynamic Umbra Sanctum showcase to use full shadow updates
- update diagnostics coverage, tests, architecture documentation, changelog, and API report

## Validation
- npm run test:types
- npm run typecheck
- npm run lint
- targeted shadow and renderer unit tests: 21 passed
- npm run test:render:architecture: 145 passed
- npm run test:rhi: 216 passed, 1 skipped by environment
- npm run api:check
- npm run test:package
- npm run format:check
- focused WebGPU Umbra Sanctum Playwright test
- focused WebGL2 cascaded-shadow Playwright test

Validation used Node 20.20.2 and npm 10.9.4. The complete npm run validate matrix and formal performance benchmark were not run.