### PR TITLE
feat(examples): redesign particle studies and orbital trails

### DIFF
--- a/documentation/PARTICLE_SYSTEM.md
+++ b/documentation/PARTICLE_SYSTEM.md
@@ -268,16 +268,16 @@ on the normal Render Graph path.
 ## Maintained visual examples
 
 The example gallery groups particle coverage by the behavior an author is trying to learn rather
-than by implementation phase. Together the five pages exercise the complete P0-P5 rendering and
-interaction surface while keeping each source file readable:
+than by implementation phase. Together the five pages demonstrate representative P0-P5 rendering and
+interaction features while keeping each source file readable:
 
 | Example                                                                      | Primary coverage                                                                                                                                                                                                                                                                                                               |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`particle_elemental_forge.ts`](../examples/particle_elemental_forge.ts)     | Point/line/box/disc/sphere/hemisphere/cone/torus distributions, time and burst emission, lifetime curves, gradients, by-speed values, SubUV animation, sprite alignments, sorting, blending, camera modifiers, custom channels, and kill conditions.                                                                           |
-| [`particle_noise_fields.ts`](../examples/particle_noise_fields.ts)           | Vector and curl noise, position-offset and force modes, one to four octaves, frequency, lacunarity, persistence, scroll velocity, damping, deterministic seeds, and stateless versus CPU stateful execution.                                                                                                                   |
-| [`particle_orbital_weave.ts`](../examples/particle_orbital_weave.ts)         | Mesh buckets, opaque motion-vector eligibility, coherent world-space ribbon/trail sampling, view/world-up facing, repeat UVs, topology-safe ordering, conform/orbit motion, and portable instanced draws.                                                                                                                      |
+| [`particle_elemental_forge.ts`](../examples/particle_elemental_forge.ts)     | Point/line/box/disc/sphere/hemisphere/cone/torus distributions, continuous emission, gravity and orbital forces, noise, lifetime curves, gradients, SubUV animation, sprite alignments, sorting, and blending.                                                                                                                 |
+| [`particle_noise_fields.ts`](../examples/particle_noise_fields.ts)           | Vector and curl noise, position-offset and force modes, deterministic coherent manual emission, tangent velocities, soft grains and mist, and bounded fixed-step CPU simulation.                                                                                                                                               |
+| [`particle_orbital_weave.ts`](../examples/particle_orbital_weave.ts)         | Mesh buckets, opaque motion-vector eligibility, coherent world-space ribbon/trail sampling, view facing, repeat UVs, topology-safe ordering, two scripted comet orbits, and portable instanced draws.                                                                                                                          |
 | [`particle_collision_theatre.ts`](../examples/particle_collision_theatre.ts) | Four color-coded, staggered low-frequency plane/sphere/box/capsule streams, slender projectile trails, short rebounds, dense fire-spark impacts, triggers, bounded event aggregates, batched sub-emitters, typed application channels, and click-triggered full-field meteor rain that collides with every analytic primitive. |
-| [`particle_gpu_nebula.ts`](../examples/particle_gpu_nebula.ts)               | Explicit WebGPU stateful simulation, stateless reconstruction, large capacities, distance sorting, soft particles, scene-depth and analytic collision, GPU-resident sub-emitter routing, fixed bounds, and readback-free runtime diagnostics.                                                                                  |
+| [`particle_gpu_nebula.ts`](../examples/particle_gpu_nebula.ts)               | Explicit WebGPU stateful simulation, stateless reconstruction, large capacities, distance sorting, soft particles, scene-depth and analytic collision, GPU-resident sub-emitter routing, fixed bounds, and a readback-free production loop.                                                                                    |
 
 The pages use procedural textures so their presentation does not depend on a network service or an
 unreviewed binary asset. They are part of the recursively discovered WebGL 2/WebGPU example release
@@ -490,6 +490,28 @@ routing; application-visible GPU diagnostics remain aggregate and asynchronous r
 production-loop particle readback. The public fixed module union rejects arbitrary simulation
 callbacks and arbitrary shader source by design; the offline flipbook capture callback operates only
 at bounded frame/readback boundaries.
+
+## Example collection: Studies in motion
+
+The particle pages share a restrained gallery frame, serif titles, numbered navigation, and short
+exhibit captions. The scene remains the primary surface; rendering statistics are hidden in this
+collection. All artwork uses local procedural geometry and textures with the existing renderer and
+particle materials.
+
+| Exhibit                                                          | Art direction                                                                                       | Runtime boundary                                                                                          |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [Elemental Forge](../examples/particle_elemental_forge.html)     | Molten-gold particles inside a brass instrument, with cold mineral dust and a circular plinth       | Portable sprite shapes, curves, gradients and SubUV                                                       |
+| [Turbulence Atlas](../examples/particle_noise_fields.html)       | Four currents of fine grains and softly fading mist, with camera-projected exhibit labels           | Live CPU particles use coherent manual emission and vector/curl noise in force/offset modes               |
+| [Orbital Weave](../examples/particle_orbital_weave.html)         | Blue-white and ember comets, plus three independent luminous ribbons on differently inclined orbits | Portable sprite dust, gas, tiny mesh buckets, and independently moving world-space ribbon/trail particles |
+| [Collision Theatre](../examples/particle_collision_theatre.html) | Falling light, polished surfaces and delicate architectural arches                                  | Portable analytic collisions, events, triggers and interactive rain                                       |
+| [Event Horizon](../examples/particle_gpu_nebula.html)            | Copper gas veil, dark core, thin photon ring and glacial dust                                       | WebGPU stateful simulation and resident events; torus/noise stateless stars reconstruct on CPU            |
+| [Luminous Tides](../examples/compute_particles.html)             | An interactive star landscape presented in the shared gallery frame                                 | The specialized compute simulation and raster remain unchanged                                            |
+
+The first four exhibits support WebGL2 and WebGPU. Event Horizon and Luminous Tides require WebGPU.
+Orbitable exhibits use public `OrbitControls`; the flow atlas rearranges its four studies into a
+vertical composition on narrow portrait displays. Fine particles use a bounded 1.5 pixel ratio for
+presentation, which is a visual-quality choice rather than a performance benchmark configuration. No
+additional raster shaders or external model dependencies are introduced.
 
 The existing [`compute_particles.ts`](../examples/compute_particles.ts) showcase intentionally keeps
 its specialized implementation for now. It will be migrated only after the remaining particle

--- a/examples/compute_particles.html
+++ b/examples/compute_particles.html
@@ -2,186 +2,92 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-        <title>Hilo3D Compute Particle Field</title>
-        <link rel="stylesheet" type="text/css" href="./example.css" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+            name="description"
+            content="An interactive landscape of luminous particles, meteor wakes and aurora dunes, simulated with WebGPU."
+        />
+        <title>Luminous Tides — Hilo3D Particle Studies</title>
+        <link rel="stylesheet" href="./example.css" />
+        <link rel="stylesheet" href="./particle_showcase.css" />
         <style>
-            :root {
-                color-scheme: dark;
-                font-family:
-                    Inter,
-                    ui-sans-serif,
-                    system-ui,
-                    -apple-system,
-                    BlinkMacSystemFont,
-                    sans-serif;
-                background: #02050c;
+            .compute-particle-page {
+                --particle-accent: #adc6c3;
+                background: #030810;
             }
-
-            * {
-                box-sizing: border-box;
-            }
-
-            body {
-                margin: 0;
-                overflow: hidden;
-                background:
-                    radial-gradient(circle at 50% 38%, rgb(13 32 66 / 72%), transparent 42%),
-                    #02050c;
-                color: #dbf8ff;
-            }
-
-            #container {
+            .compute-particle-page #container {
                 position: fixed;
                 inset: 0;
                 display: grid;
                 place-items: center;
-                padding: 22px;
             }
-
-            canvas {
-                width: min(96vw, 1280px) !important;
+            .compute-particle-page canvas {
+                width: min(calc(100vw - 84px), calc((100vh - 300px) * 16 / 9), 1440px) !important;
                 height: auto !important;
-                max-height: 94vh;
-                border: 1px solid rgb(88 214 255 / 32%);
-                border-radius: 12px;
-                box-shadow:
-                    0 0 0 1px rgb(122 71 255 / 16%),
-                    0 0 80px rgb(25 120 255 / 22%),
-                    0 32px 100px rgb(0 0 0 / 72%);
                 touch-action: none;
                 cursor: crosshair;
             }
-
-            #hud {
-                position: fixed;
-                inset: 28px 30px;
-                pointer-events: none;
-                display: flex;
-                flex-direction: column;
-                justify-content: space-between;
-                text-transform: uppercase;
-                letter-spacing: 0.12em;
-                text-shadow: 0 0 16px rgb(66 216 255 / 55%);
+            .compute-particle-page .particle-hero {
+                width: 600px;
             }
-
-            .topline,
-            .bottomline {
+            .compute-particle-page .particle-hero h1 {
+                font-size: 48px;
+            }
+            .compute-particle-page .particle-hero p {
+                max-width: 410px;
+            }
+            .compute-particle-page .particle-hint {
                 display: flex;
-                align-items: flex-start;
-                justify-content: space-between;
                 gap: 24px;
             }
-
-            .brand {
-                display: grid;
-                gap: 4px;
+            .compute-particle-page .particle-hint b {
+                color: #b9cac9;
+                font-weight: 400;
             }
-
-            .brand strong {
-                font-size: clamp(17px, 2vw, 28px);
-                font-weight: 760;
-                letter-spacing: 0.22em;
-                background: linear-gradient(90deg, #8ef7ff, #6ba8ff 48%, #c684ff);
-                background-clip: text;
-                color: transparent;
-            }
-
-            .brand small,
-            .readout,
-            .controls {
-                color: rgb(160 214 232 / 72%);
-                font-size: 10px;
-                line-height: 1.75;
-            }
-
-            .readout {
-                padding: 8px 11px;
-                border-left: 1px solid rgb(93 231 255 / 52%);
-                text-align: right;
-            }
-
-            .online {
-                color: #91ffd4;
-            }
-
-            .online::before {
-                content: '';
-                display: inline-block;
-                width: 6px;
-                height: 6px;
-                margin-right: 7px;
-                border-radius: 50%;
-                background: currentColor;
-                box-shadow: 0 0 12px currentColor;
-            }
-
-            .controls {
-                display: flex;
-                gap: 18px;
-                flex-wrap: wrap;
-            }
-
-            .controls b {
-                color: #d9f9ff;
-                font-weight: 650;
-            }
-
-            .signature {
-                color: rgb(170 151 255 / 68%);
-                font-size: 9px;
-                text-align: right;
-            }
-
-            @media (max-width: 700px) {
-                #container {
-                    padding: 0;
+            @media (max-width: 720px) {
+                .compute-particle-page .particle-hero {
+                    width: calc(100vw - 52px);
                 }
-
-                canvas {
-                    width: 100vw !important;
-                    border: 0;
-                    border-radius: 0;
+                .compute-particle-page .particle-hero h1 {
+                    font-size: 42px;
                 }
-
-                #hud {
-                    inset: 16px;
+                .compute-particle-page .particle-hero p {
+                    max-width: 260px;
                 }
-
-                .readout span:not(.online),
-                .signature {
-                    display: none;
+                .compute-particle-page canvas {
+                    width: calc(100vw - 20px) !important;
                 }
-
-                .controls {
-                    gap: 9px 14px;
+                .compute-particle-page .particle-hint {
+                    flex-wrap: wrap;
+                    gap: 8px 18px;
+                    right: 26px;
                 }
             }
         </style>
     </head>
-    <body>
+    <body class="particle-gallery compute-particle-page">
         <div id="container"></div>
-        <div id="hud" aria-label="Hilo3D compute particle field controls">
-            <div class="topline">
-                <div class="brand">
-                    <strong>Hilo3D</strong>
-                    <small>Compute particle field / WebGPU</small>
-                </div>
-                <div class="readout">
-                    <span class="online">Field online</span><br />
-                    <span>65,536 bodies · word lattice + aurora field</span><br />
-                    <span>GPU simulation · 3× indirect raster</span>
-                </div>
-            </div>
-            <div class="bottomline">
-                <div class="controls">
-                    <span><b>Move</b> magnetic lens</span>
-                    <span><b>Hold</b> shockwave</span>
-                    <span><b>Right drag</b> vortex</span>
-                </div>
-                <div class="signature">Word lattice / meteor wakes / aurora dunes</div>
-            </div>
+        <header class="particle-hero">
+            <div class="particle-kicker">Studies in motion · 06 / landscape</div>
+            <h1>Luminous Tides</h1>
+            <p>A field of distant stars. Trace the light, disturb the stillness.</p>
+        </header>
+        <aside class="particle-readout">
+            65,536 points of light<br />An interactive WebGPU landscape
+        </aside>
+        <div class="particle-hint" aria-label="Particle field controls">
+            <span><b>MOVE</b> · MAGNETIC LENS</span>
+            <span><b>HOLD</b> · SHOCKWAVE</span>
+            <span><b>RIGHT DRAG</b> · VORTEX</span>
         </div>
+        <nav class="particle-nav" aria-label="Particle example collection">
+            <a href="./particle_elemental_forge.html">Elemental</a>
+            <a href="./particle_noise_fields.html">Flow</a>
+            <a href="./particle_orbital_weave.html">Orbit</a>
+            <a href="./particle_collision_theatre.html">Impact</a>
+            <a href="./particle_gpu_nebula.html?backend=webgpu">Horizon</a>
+            <a aria-current="page" href="./compute_particles.html?backend=webgpu">Tides</a>
+        </nav>
         <script type="module" src="./compute_particles.ts"></script>
     </body>
 </html>

--- a/examples/particle_collision_theatre.html
+++ b/examples/particle_collision_theatre.html
@@ -11,16 +11,14 @@
         <link rel="stylesheet" href="./example.css" />
         <link rel="stylesheet" href="./particle_showcase.css" />
     </head>
-    <body class="collision-theatre-page">
+    <body class="particle-gallery collision-theatre-page">
         <div id="container"></div>
         <header class="particle-hero">
-            <div class="particle-kicker">Hilo3D · Particle Study 03</div>
+            <div class="particle-kicker">Studies in motion · 04 / impact</div>
             <h1><span>Collision</span> Theatre</h1>
-            <p>A study of momentum, material and light across four analytic bodies.</p>
+            <p>Falling light meets polished matter. Four surfaces, four ways to scatter a spark.</p>
         </header>
-        <output class="particle-readout" id="particle-readout" aria-live="polite"
-            >events warming up…</output
-        >
+        <output class="particle-readout" id="particle-readout">Awaiting the first impact…</output>
         <div class="particle-controls">
             <button id="burst-button" type="button">Release rain</button>
             <button id="pause-button" type="button">Pause</button>
@@ -28,10 +26,11 @@
         </div>
         <nav class="particle-nav" aria-label="Particle example collection">
             <a href="./particle_elemental_forge.html">Elemental</a>
-            <a href="./particle_noise_fields.html">Noise</a>
-            <a href="./particle_orbital_weave.html">Topology</a>
-            <a aria-current="page" href="./particle_collision_theatre.html">Interaction</a>
-            <a href="./particle_gpu_nebula.html?backend=webgpu">GPU nebula</a>
+            <a href="./particle_noise_fields.html">Flow</a>
+            <a href="./particle_orbital_weave.html">Orbit</a>
+            <a aria-current="page" href="./particle_collision_theatre.html">Impact</a>
+            <a href="./particle_gpu_nebula.html?backend=webgpu">Horizon</a>
+            <a href="./compute_particles.html?backend=webgpu">Tides</a>
         </nav>
         <script type="module" src="./particle_collision_theatre.ts"></script>
     </body>

--- a/examples/particle_collision_theatre.ts
+++ b/examples/particle_collision_theatre.ts
@@ -1,6 +1,7 @@
 import * as Hilo3d from '../src/Hilo3d';
 import * as Particle from '@hilo/addon-particle';
-import { createExampleContext, loadEnvironmentMaps } from './shared/init';
+import { createExampleContext } from './shared/init';
+import { createStudioEnvironmentMaps } from './shared/studioEnvironment';
 import {
     createParticleTexture,
     installExampleDisposal,
@@ -32,15 +33,16 @@ const context = await createExampleContext({
         far: 60,
         x: 0.1,
         y: compactViewport ? 3.8 : 2.7,
-        z: compactViewport ? 22.5 : 12.6
+        z: compactViewport ? 25 : 12.6
     },
     stage: {
+        pixelRatio: 1.5,
         renderPipeline: new Hilo3d.PostProcessRenderPipelineFactory({
-            bloom: { threshold: 0.82, knee: 0.24, intensity: 0.26, scatter: 0.36, maxLevels: 4 },
+            bloom: { threshold: 0.94, knee: 0.3, intensity: 0.3, scatter: 0.48, maxLevels: 5 },
             colorUber: {
-                exposure: -0.12,
-                contrast: 0.14,
-                saturation: 0.04,
+                exposure: 0.18,
+                contrast: 0.08,
+                saturation: -0.08,
                 toneMapping: 'pbr-neutral',
                 vignetteIntensity: 0.34,
                 vignetteSmoothness: 0.78,
@@ -58,15 +60,16 @@ const context = await createExampleContext({
 });
 const { stage, renderer, directionLight, ambientLight } = context;
 
-renderer.clearColor.set(0.016, 0.014, 0.019, 1);
-directionLight.amount = 1.8;
-directionLight.color.set(1, 0.88, 0.74, 1);
+renderer.clearColor.set(0.018, 0.026, 0.036, 1);
+directionLight.amount = 2.2;
+directionLight.color.set(0.92, 0.94, 1, 1);
 directionLight.direction.set(-0.65, -1, -0.4);
-ambientLight.amount = 0.08;
+ambientLight.amount = 0.24;
+ambientLight.color.set(0.48, 0.6, 0.7, 1);
 
 const areaLight = new Hilo3d.AreaLight({
-    color: new Hilo3d.Color(1, 0.55, 0.3),
-    amount: 3.6,
+    color: new Hilo3d.Color(1, 0.82, 0.62),
+    amount: 2.8,
     width: 4.5,
     height: 2.5,
     x: -1.5,
@@ -75,47 +78,38 @@ const areaLight = new Hilo3d.AreaLight({
 }).addTo(stage);
 areaLight.lookAt(new Hilo3d.Vector3(0, 0.2, 0));
 new Hilo3d.PointLight({
-    color: new Hilo3d.Color(0.2, 0.75, 1),
-    amount: 5,
+    color: new Hilo3d.Color(0.52, 0.76, 1),
+    amount: 3.8,
     range: 10,
     x: 3.2,
     y: 1.6,
     z: 2.4
 }).addTo(stage);
 
-const environmentMaps = await loadEnvironmentMaps();
-const { brdfLUT, diffuseEnvMap, specularEnvMap } = environmentMaps;
+const { diffuseEnvMap, specularEnvMap } = createStudioEnvironmentMaps();
+const brdfLUT = await new Hilo3d.TextureLoader().load({
+    src: new URL('./image/brdfLUT.png', import.meta.url).href,
+    wrapS: Hilo3d.constants.CLAMP_TO_EDGE,
+    wrapT: Hilo3d.constants.CLAMP_TO_EDGE
+});
 const studioEnvironment = Object.freeze({
     brdfLUT,
     diffuseEnvMap: Object.freeze({ texture: diffuseEnvMap, encoding: 'srgb' as const }),
     specularEnvMap: Object.freeze({ texture: specularEnvMap, encoding: 'srgb' as const }),
     diffuseEnvIntensity: 1,
-    specularEnvIntensity: 1
+    specularEnvIntensity: 0.6
 });
 
 const floorY = -1.24;
 const planeY = floorY + 0.32;
 new Hilo3d.Mesh({
-    y: floorY - 0.18,
-    geometry: new Hilo3d.BoxGeometry({ width: 9.5, height: 0.36, depth: 6.1 }),
+    y: floorY - 0.08,
+    geometry: new Hilo3d.BoxGeometry({ width: 8.8, height: 0.16, depth: 2.75 }),
     material: new Hilo3d.PBRMaterial({
         ...studioEnvironment,
-        baseColor: new Hilo3d.Color(0.038, 0.036, 0.043),
+        baseColor: new Hilo3d.Color(0.022, 0.032, 0.04),
         metallic: 0.2,
         roughness: 0.48
-    }),
-    receiveShadows: true
-}).addTo(stage);
-
-new Hilo3d.Mesh({
-    y: 0.78,
-    z: -2.72,
-    geometry: new Hilo3d.BoxGeometry({ width: 9.5, height: 4.35, depth: 0.12 }),
-    material: new Hilo3d.PBRMaterial({
-        ...studioEnvironment,
-        baseColor: new Hilo3d.Color(0.038, 0.038, 0.047),
-        metallic: 0.12,
-        roughness: 0.78
     }),
     receiveShadows: true
 }).addTo(stage);
@@ -127,7 +121,7 @@ const lanes: readonly CollisionLane[] = Object.freeze([
         x: -2.7,
         phase: 0.15,
         burstCounts: [1, 3, 1],
-        color: [0.08, 0.88, 1],
+        color: [0.26, 0.65, 0.67],
         collider: { type: 'sphere', center: [-2.7, -0.4, 0], radius: 0.68 }
     },
     {
@@ -136,7 +130,7 @@ const lanes: readonly CollisionLane[] = Object.freeze([
         x: -0.88,
         phase: 0.65,
         burstCounts: [2, 1, 4],
-        color: [0.92, 0.16, 1],
+        color: [0.49, 0.56, 0.73],
         collider: { type: 'box', center: [-0.88, -0.5, 0], size: [1.08, 1.08, 1.08] }
     },
     {
@@ -145,7 +139,7 @@ const lanes: readonly CollisionLane[] = Object.freeze([
         x: 1.12,
         phase: 1.1,
         burstCounts: [1, 2, 1],
-        color: [1, 0.42, 0.06],
+        color: [1, 0.68, 0.32],
         collider: {
             type: 'capsule',
             start: [0.68, -0.92, 0],
@@ -159,7 +153,7 @@ const lanes: readonly CollisionLane[] = Object.freeze([
         x: 3,
         phase: 1.6,
         burstCounts: [3, 1, 2],
-        color: [0.34, 1, 0.46],
+        color: [0.6, 0.69, 0.5],
         collider: { type: 'plane', normal: [0, 1, 0], offset: planeY }
     }
 ]);
@@ -231,12 +225,6 @@ function accentMaterial(
     });
 }
 
-const nicheMaterial = new Hilo3d.PBRMaterial({
-    ...studioEnvironment,
-    baseColor: new Hilo3d.Color(0.048, 0.047, 0.058),
-    metallic: 0.1,
-    roughness: 0.82
-});
 const plinthMaterial = new Hilo3d.PBRMaterial({
     ...studioEnvironment,
     baseColor: new Hilo3d.Color(0.075, 0.072, 0.084),
@@ -266,20 +254,35 @@ const colliderTrimMaterial = new Hilo3d.PBRMaterial({
 
 new Hilo3d.Mesh({
     y: floorY - 0.01,
-    z: 3.035,
-    geometry: new Hilo3d.BoxGeometry({ width: 9.2, height: 0.028, depth: 0.035 }),
+    z: 1.37,
+    geometry: new Hilo3d.BoxGeometry({ width: 8.65, height: 0.012, depth: 0.012 }),
     material: stageEdgeMaterial,
     castShadows: false
 }).addTo(stage);
 
 function addLaneArchitecture(lane: CollisionLane): void {
+    const arch = new Hilo3d.Geometry({ mode: Hilo3d.constants.LINES });
+    arch.addPoints([-0.68, -1.18, 0], [-0.68, 1.82, 0]);
+    arch.addPoints([0.68, -1.18, 0], [0.68, 1.82, 0]);
+    for (let segment = 0; segment < 64; segment += 1) {
+        const angle = (segment / 64) * Math.PI;
+        const next = ((segment + 1) / 64) * Math.PI;
+        arch.addPoints(
+            [Math.cos(angle) * 0.68, 1.82 + Math.sin(angle) * 0.68, 0],
+            [Math.cos(next) * 0.68, 1.82 + Math.sin(next) * 0.68, 0]
+        );
+    }
     new Hilo3d.Mesh({
         x: lane.x,
-        y: 0.52,
-        z: -2.63,
-        geometry: new Hilo3d.BoxGeometry({ width: 1.28, height: 3.28, depth: 0.1 }),
-        material: nicheMaterial,
-        receiveShadows: true
+        z: -1.18,
+        geometry: arch,
+        material: new Hilo3d.BasicMaterial({
+            lightType: 'NONE',
+            diffuse: new Hilo3d.Color(lane.color[0], lane.color[1], lane.color[2]),
+            opacity: 0.22,
+            compositing: { mode: 'alpha-blend', premultiplied: false }
+        }),
+        castShadows: false
     }).addTo(stage);
     new Hilo3d.Mesh({
         x: lane.x,
@@ -312,7 +315,7 @@ function addLaneArchitecture(lane: CollisionLane): void {
         x: lane.x,
         y: 2.94,
         z: -0.04,
-        geometry: new Hilo3d.BoxGeometry({ width: 0.64, height: 0.1, depth: 0.36 }),
+        geometry: new Hilo3d.BoxGeometry({ width: 0.38, height: 0.055, depth: 0.24 }),
         material: sourceHousingMaterial,
         castShadows: false
     }).addTo(stage);
@@ -336,8 +339,8 @@ for (const lane of lanes) addLaneArchitecture(lane);
 const stageAccent = accentMaterial([0.96, 0.62, 0.28], 0.035);
 new Hilo3d.Mesh({
     y: floorY + 0.06,
-    z: -2.63,
-    geometry: new Hilo3d.BoxGeometry({ width: 9.05, height: 0.02, depth: 0.035 }),
+    z: -1.35,
+    geometry: new Hilo3d.BoxGeometry({ width: 8.6, height: 0.015, depth: 0.02 }),
     material: stageAccent,
     castShadows: false
 }).addTo(stage);
@@ -636,7 +639,7 @@ new Hilo3d.Mesh({
     geometry: new Hilo3d.BoxGeometry({ width: 1.08, height: 0.022, depth: 1.08 }),
     material: new Hilo3d.PBRMaterial({
         ...studioEnvironment,
-        baseColor: new Hilo3d.Color(0.048, 0.25, 0.13),
+        baseColor: new Hilo3d.Color(0.13, 0.17, 0.11),
         metallic: 0.12,
         roughness: 0.17,
         clearcoatFactor: 1,
@@ -709,7 +712,7 @@ function collisionEmitter(lane: CollisionLane): Particle.ParticleEmitterDefiniti
         eventOverflow: 'drop-oldest',
         bounds: { mode: 'dynamic' },
         emission: {
-            rateOverTime: { min: 0.12, max: 0.45 },
+            rateOverTime: { min: 2.4, max: 3.6 },
             bursts: lane.burstCounts.map((count, index) => ({
                 time: lane.phase + index * 3.1,
                 count
@@ -721,7 +724,7 @@ function collisionEmitter(lane: CollisionLane): Particle.ParticleEmitterDefiniti
             direction: { min: [-0.08, -1, -0.04], max: [0.08, -0.96, 0.04] },
             speed: { min: 1.4, max: 2.05 },
             lifetime: { min: 3.8, max: 5.2 },
-            size: { min: 0.11, max: 0.145 },
+            size: { min: 0.055, max: 0.095 },
             mass: { min: 0.8, max: 1.25 }
         },
         modules: [
@@ -741,7 +744,7 @@ function collisionEmitter(lane: CollisionLane): Particle.ParticleEmitterDefiniti
                 type: 'sub-emitter',
                 event: lane.event,
                 emitter: 'impact-sparks',
-                count: 72,
+                count: 48,
                 inheritVelocity: false
             },
             {
@@ -878,7 +881,7 @@ const definition = Particle.ParticleSystemDefinition.create({
             initialize: {
                 lifetime: { min: 0.42, max: 0.92 },
                 speed: { min: 0.35, max: 2.45 },
-                size: { min: 0.025, max: 0.06 }
+                size: { min: 0.014, max: 0.04 }
             },
             modules: [
                 { type: 'gravity', force: [0, -1.35, 0] },
@@ -1068,17 +1071,11 @@ particles.onUpdate = () => {
             lanes.reduce((sum, lane) => sum + (totals[lane.event] ?? 0), 0) +
             (totals['impact-rain'] ?? 0);
         readout.textContent = [
-            `alive      ${String(particles.aliveCount).padStart(5)}`,
-            `collisions ${String(impactCount).padStart(5)}`,
-            `sphere     ${String(totals['impact-sphere'] ?? 0).padStart(5)}`,
-            `box        ${String(totals['impact-box'] ?? 0).padStart(5)}`,
-            `capsule    ${String(totals['impact-capsule'] ?? 0).padStart(5)}`,
-            `plane      ${String(totals['impact-plane'] ?? 0).padStart(5)}`,
-            `rain       ${String(totals['impact-rain'] ?? 0).padStart(5)}`,
-            `trigger    ${String(totals['gate-enter'] ?? 0).padStart(5)}`,
-            `dropped    ${String(aggregate.droppedCount + rainChannel.droppedCount).padStart(5)}`,
+            'THE IMPACT REGISTER',
+            `${String(impactCount).padStart(6, '0')}  encounters`,
+            `${String(particles.aliveCount).padStart(6, '0')}  sparks in motion`,
             '',
-            'click field · four-body meteor rain'
+            'Click the field to release rain'
         ].join('\n');
         readingEvents = false;
     });
@@ -1089,6 +1086,5 @@ installExampleDisposal(() => {
     brdfLUT.destroy();
     diffuseEnvMap.destroy();
     specularEnvMap.destroy();
-    environmentMaps.skyboxMap.destroy();
     context.dispose();
 });

--- a/examples/particle_elemental_forge.html
+++ b/examples/particle_elemental_forge.html
@@ -5,33 +5,30 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
             name="description"
-            content="A portable gallery of elemental Hilo3D particle emitters, curves, gradients, sprite alignments, and texture sheets."
+            content="An alchemical study in molten light, burnished brass, and suspended ash."
         />
         <title>Hilo3D Particle Elemental Forge</title>
         <link rel="stylesheet" href="./example.css" />
         <link rel="stylesheet" href="./particle_showcase.css" />
     </head>
-    <body>
+    <body class="particle-gallery elemental-page">
         <div id="container"></div>
         <header class="particle-hero">
-            <div class="particle-kicker">Particle studies · 01 / portable</div>
+            <div class="particle-kicker">Studies in motion · 01 / alchemy</div>
             <h1>Elemental Forge</h1>
             <p>
-                Fire, frost, plasma and embers built from immutable definitions. Orbit to read how
-                shape, lifetime and alignment change each silhouette.
+                A quiet furnace. Molten light rises through brass orbits, leaving a constellation of
+                ash.
             </p>
-            <div class="particle-chips">
-                <span>8 shapes</span><span>curves + gradients</span><span>SubUV atlas</span
-                ><span>4 alignments</span><span>WebGL2 + WebGPU</span>
-            </div>
         </header>
         <div class="particle-hint">DRAG TO ORBIT · SCROLL TO DOLLY</div>
         <nav class="particle-nav" aria-label="Particle example collection">
             <a aria-current="page" href="./particle_elemental_forge.html">Elemental</a>
-            <a href="./particle_noise_fields.html">Noise</a>
-            <a href="./particle_orbital_weave.html">Topology</a>
-            <a href="./particle_collision_theatre.html">Interaction</a>
-            <a href="./particle_gpu_nebula.html?backend=webgpu">GPU nebula</a>
+            <a href="./particle_noise_fields.html">Flow</a>
+            <a href="./particle_orbital_weave.html">Orbit</a>
+            <a href="./particle_collision_theatre.html">Impact</a>
+            <a href="./particle_gpu_nebula.html?backend=webgpu">Horizon</a>
+            <a href="./compute_particles.html?backend=webgpu">Tides</a>
         </nav>
         <script type="module" src="./particle_elemental_forge.ts"></script>
     </body>

--- a/examples/particle_elemental_forge.ts
+++ b/examples/particle_elemental_forge.ts
@@ -2,7 +2,6 @@ import * as Hilo3d from '../src/Hilo3d';
 import * as Particle from '@hilo/addon-particle';
 import { createExampleContext } from './shared/init';
 import {
-    addParticlePedestal,
     createParticleAtlas,
     createParticleTexture,
     installExampleDisposal
@@ -10,67 +9,204 @@ import {
 
 const particleSystem = Particle.createParticleStageSystem({ budget: false });
 const context = await createExampleContext({
-    camera: { fov: 44, near: 0.1, far: 80, x: 0, y: 1.15, z: 9.2 },
+    camera: { fov: 38, near: 0.1, far: 80, x: 3.6, y: 2.1, z: 9.3 },
     stage: {
         systems: [particleSystem],
+        useInstanced: true,
         renderPipeline: new Hilo3d.PostProcessRenderPipelineFactory({
-            bloom: { threshold: 0.72, knee: 0.5, intensity: 0.66, scatter: 0.7, maxLevels: 6 },
+            bloom: { threshold: 0.94, knee: 0.35, intensity: 0.3, scatter: 0.56, maxLevels: 5 },
             colorUber: {
-                exposure: -0.2,
+                exposure: 0.05,
                 contrast: 0.08,
-                saturation: 0.12,
+                saturation: -0.08,
                 toneMapping: 'pbr-neutral',
-                vignetteIntensity: 0.58,
-                vignetteSmoothness: 0.62,
-                vignetteColor: new Hilo3d.Color(0.002, 0.004, 0.016, 0.62)
+                vignetteIntensity: 0.34,
+                vignetteSmoothness: 0.72,
+                vignetteColor: new Hilo3d.Color(0.007, 0.009, 0.011, 0.5)
             }
         })
     },
     controls: {
-        target: new Hilo3d.Vector3(0, 0.35, 0),
-        minDistance: 6.4,
-        maxDistance: 15,
-        minPolarAngle: 0.7,
-        maxPolarAngle: 2.15
+        target: new Hilo3d.Vector3(-0.45, 0.1, 0),
+        minDistance: 6,
+        maxDistance: 14,
+        minPolarAngle: 0.6,
+        maxPolarAngle: 1.82
     }
 });
 const { stage, renderer, directionLight, ambientLight } = context;
 const particles = stage.systems.get(Particle.PARTICLE_STAGE_SERVICE);
 
-renderer.clearColor.set(0.002, 0.004, 0.014, 1);
-directionLight.amount = 2.2;
-directionLight.color.set(0.65, 0.78, 1, 1);
-ambientLight.amount = 0.2;
-addParticlePedestal(stage, new Hilo3d.Color(0.025, 0.055, 0.12));
+renderer.clearColor.set(0.012, 0.016, 0.018, 1);
+directionLight.amount = 3.8;
+directionLight.color.set(1, 0.8, 0.57, 1);
+directionLight.direction.set(-0.5, -0.85, -0.6);
+ambientLight.amount = 0.55;
+ambientLight.color.set(0.5, 0.57, 0.62, 1);
+new Hilo3d.PointLight({
+    x: 0,
+    y: -0.4,
+    z: 0.2,
+    amount: 4.5,
+    range: 5,
+    color: new Hilo3d.Color(1, 0.37, 0.07)
+}).addTo(stage);
+new Hilo3d.PointLight({
+    x: -2.3,
+    y: 1.8,
+    z: -1.6,
+    amount: 12,
+    range: 7,
+    color: new Hilo3d.Color(0.25, 0.58, 0.63)
+}).addTo(stage);
+
+const bronze = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.3, 0.17, 0.08),
+    metallic: 0.72,
+    roughness: 0.41
+});
+const darkMetal = new Hilo3d.PBRMaterial({
+    baseColor: new Hilo3d.Color(0.027, 0.037, 0.041),
+    metallic: 0.55,
+    roughness: 0.38
+});
+const goldLine = new Hilo3d.BasicMaterial({
+    lightType: 'NONE',
+    diffuse: new Hilo3d.Color(1.05, 0.61, 0.23)
+});
+const coolLine = new Hilo3d.BasicMaterial({
+    lightType: 'NONE',
+    diffuse: new Hilo3d.Color(0.19, 0.4, 0.41)
+});
+
+/** Small, smooth metal rings keep the apparatus legible behind the much finer moving sparks. */
+function createHoopGeometry(radius: number, tube: number, arc = Math.PI * 2): Hilo3d.Geometry {
+    const segments = 144;
+    const sides = 8;
+    const vertices: number[] = [];
+    const normals: number[] = [];
+    const indices: number[] = [];
+    for (let segment = 0; segment <= segments; segment += 1) {
+        const angle = (segment / segments) * arc;
+        const cosine = Math.cos(angle);
+        const sine = Math.sin(angle);
+        for (let side = 0; side <= sides; side += 1) {
+            const section = (side / sides) * Math.PI * 2;
+            const radial = Math.cos(section);
+            const vertical = Math.sin(section);
+            vertices.push(
+                (radius + tube * radial) * cosine,
+                tube * vertical,
+                (radius + tube * radial) * sine
+            );
+            normals.push(radial * cosine, vertical, radial * sine);
+            if (segment < segments && side < sides) {
+                const a = segment * (sides + 1) + side;
+                const b = a + sides + 1;
+                indices.push(a, a + 1, b, b, a + 1, b + 1);
+            }
+        }
+    }
+    return new Hilo3d.Geometry({
+        vertices: new Hilo3d.GeometryData(new Float32Array(vertices), 3),
+        normals: new Hilo3d.GeometryData(new Float32Array(normals), 3),
+        indices: new Hilo3d.GeometryData(new Uint16Array(indices), 1)
+    });
+}
+
+function addHoop(
+    radius: number,
+    tube: number,
+    height: number,
+    material: Hilo3d.MaterialInstance,
+    parent: Hilo3d.Node = stage
+): Hilo3d.Mesh {
+    return new Hilo3d.Mesh({
+        y: height,
+        geometry: createHoopGeometry(radius, tube),
+        material,
+        castShadows: false
+    }).addTo(parent);
+}
+
+const base = new Hilo3d.Mesh({
+    y: -1.58,
+    scaleY: 0.12,
+    geometry: new Hilo3d.SphereGeometry({ radius: 2.32, widthSegments: 96, heightSegments: 24 }),
+    material: darkMetal
+}).addTo(stage);
+addHoop(2.1, 0.012, -1.39, bronze);
+addHoop(2.28, 0.012, -1.55, bronze);
+addHoop(1.98, 0.006, -1.38, coolLine);
+
+const crucible = new Hilo3d.Mesh({
+    y: -1.22,
+    scaleY: 0.23,
+    geometry: new Hilo3d.SphereGeometry({ radius: 1.16, widthSegments: 72, heightSegments: 32 }),
+    material: bronze
+}).addTo(stage);
+new Hilo3d.Mesh({
+    y: -1.05,
+    scaleY: 0.025,
+    geometry: new Hilo3d.SphereGeometry({ radius: 1.02, widthSegments: 72, heightSegments: 16 }),
+    material: darkMetal
+}).addTo(stage);
+addHoop(1.055, 0.022, -1.03, bronze);
+addHoop(0.96, 0.008, -1.012, goldLine);
+addHoop(0.81, 0.006, -1.003, goldLine);
+
+const apparatus = new Hilo3d.Node({ y: 0.43, rotationY: 12 }).addTo(stage);
+const outerHoop = addHoop(1.85, 0.023, 0, bronze, apparatus);
+outerHoop.rotationX = 72;
+outerHoop.rotationZ = -19;
+const innerHoop = addHoop(1.68, 0.016, 0, bronze, apparatus);
+innerHoop.rotationX = 42;
+innerHoop.rotationZ = -32;
+const fineHoop = addHoop(1.88, 0.0045, 0, goldLine, apparatus);
+fineHoop.rotationX = outerHoop.rotationX;
+fineHoop.rotationZ = outerHoop.rotationZ;
+
+const tickGeometry = new Hilo3d.BoxGeometry({ width: 0.007, height: 0.014, depth: 0.07 });
+for (let index = 0; index < 72; index += 1) {
+    const angle = (index / 72) * Math.PI * 2;
+    new Hilo3d.Mesh({
+        x: Math.cos(angle) * 2.06,
+        y: -1.375,
+        z: Math.sin(angle) * 2.06,
+        rotationY: 90 - (angle * 180) / Math.PI,
+        scaleZ: index % 6 === 0 ? 1.65 : 0.7,
+        geometry: tickGeometry,
+        material: index % 6 === 0 ? goldLine : bronze,
+        castShadows: false
+    }).addTo(stage);
+}
 
 const discTexture = createParticleTexture({ style: 'disc' });
-const sparkTexture = createParticleTexture({ style: 'spark' });
-const ringTexture = createParticleTexture({ style: 'ring' });
+const sparkTexture = createParticleTexture({ style: 'comet' });
 const smokeTexture = createParticleTexture({ style: 'smoke' });
 const atlasTexture = createParticleAtlas();
-
-const growThenFade = new Particle.ParticleCurve(
+const fade = new Particle.ParticleCurve(
     [
-        { time: 0, value: 0.05 },
-        { time: 0.18, value: 1 },
-        { time: 0.72, value: 0.62 },
+        { time: 0, value: 0 },
+        { time: 0.12, value: 1 },
+        { time: 0.64, value: 0.75 },
         { time: 1, value: 0 }
     ],
     { interpolation: 'smooth' }
 );
 const emberSize = new Particle.ParticleCurve([
-    { time: 0, value: 0.25 },
-    { time: 0.12, value: 1 },
-    { time: 1, value: 0.08 }
+    { time: 0, value: 0.5 },
+    { time: 0.16, value: 1 },
+    { time: 0.68, value: 0.72 },
+    { time: 1, value: 0.1 }
 ]);
-const spinCurve = new Particle.ParticleCurve(
-    [
-        { time: 0, value: -1.2 },
-        { time: 0.5, value: 1.4 },
-        { time: 1, value: -1.2 }
-    ],
-    { wrap: 'ping-pong', interpolation: 'smooth' }
-);
+const fireColor = new Particle.ParticleGradient([
+    { time: 0, color: [1.4, 0.76, 0.28, 0] },
+    { time: 0.08, color: [1.45, 0.83, 0.38, 0.95] },
+    { time: 0.45, color: [1.1, 0.42, 0.095, 0.82] },
+    { time: 0.78, color: [0.66, 0.2, 0.038, 0.55] },
+    { time: 1, color: [0.4, 0.095, 0.025, 0] }
+]);
 
 function createSystem(
     definition: Readonly<Particle.ParticleEmitterDefinitionInput>,
@@ -89,323 +225,244 @@ function createSystem(
     );
 }
 
-const fire = createSystem(
+// Eight emitter shapes share one visual vocabulary: molten gold, oxidation, and suspended ash.
+createSystem(
     {
-        name: 'solar-fire',
-        capacity: 720,
+        name: 'molten-column',
+        capacity: 2400,
         execution: 'cpu',
-        duration: 6,
+        duration: 8,
         prewarm: true,
-        emission: { rateOverTime: { min: 150, max: 190 }, bursts: [{ time: 0, count: 64 }] },
-        shape: { type: 'cone', radius: 0.38, angle: 14, length: 0.5, distribution: 'volume' },
+        emission: { rateOverTime: 850 },
+        shape: { type: 'cone', radius: 0.36, angle: 12, length: 0.28, distribution: 'volume' },
         initialize: {
-            lifetime: { min: 0.8, max: 1.65 },
-            speed: { min: 1.25, max: 2.5 },
-            size: { min: 0.16, max: 0.4 },
-            color: { min: [1, 0.12, 0.015, 0.95], max: [1, 0.8, 0.15, 1] }
+            lifetime: { min: 1.7, max: 2.75 },
+            speed: { min: 0.85, max: 1.48 },
+            size: { min: 0.012, max: 0.028 }
         },
         modules: [
-            { type: 'wind', force: [0.15, 0.38, 0.04] },
-            { type: 'drag', coefficient: 0.34 },
+            { type: 'vortex-force', center: [0, 0.8, 0], strength: 0.72, axis: [0, 1, 0] },
+            { type: 'point-attraction', point: [0, 2.35, 0], strength: 0.9 },
             {
                 type: 'noise',
                 mode: 'force',
                 field: 'curl',
-                strength: [0.72, 0.3, 0.72],
-                frequency: 1.8,
-                octaves: 3,
-                scrollVelocity: [0.08, 0.4, -0.05],
-                damping: 0.22
+                strength: [0.28, 0.12, 0.28],
+                frequency: 1.65,
+                octaves: 2,
+                scrollVelocity: [0.03, 0.16, -0.02],
+                damping: 0.2
             },
-            { type: 'size-over-lifetime', curve: growThenFade },
-            {
-                type: 'color-over-lifetime',
-                gradient: new Particle.ParticleGradient([
-                    { time: 0, color: [1, 0.96, 0.72, 1] },
-                    { time: 0.22, color: [1, 0.32, 0.025, 0.95] },
-                    { time: 0.72, color: [0.72, 0.03, 0.018, 0.55] },
-                    { time: 1, color: [0.1, 0.004, 0.01, 0] }
-                ])
-            },
-            { type: 'texture-sheet', mode: 'lifetime', rows: 4, columns: 4, cycles: 1 }
-        ],
-        renderers: [
-            {
-                type: 'sprite',
-                texture: atlasTexture,
-                alignment: 'view',
-                blend: 'additive',
-                depthWrite: false,
-                sort: 'oldest',
-                renderOrder: 3
-            }
-        ]
-    },
-    [0, -1.25, 0],
-    301
-);
-
-createSystem(
-    {
-        name: 'forge-heart',
-        capacity: 180,
-        execution: 'cpu',
-        emission: {
-            rateOverTime: 12,
-            bursts: [{ time: 0, count: 28, cycles: 4, interval: 1.1 }]
-        },
-        shape: { type: 'point' },
-        initialize: {
-            lifetime: { min: 0.45, max: 0.9 },
-            direction: { min: [-1, -0.1, -1], max: [1, 1, 1] },
-            speed: { min: 0.35, max: 1.2 },
-            size: { min: 0.08, max: 0.22 }
-        },
-        modules: [
-            { type: 'radial-force', center: [0, 0, 0], strength: 0.8 },
-            { type: 'drag', coefficient: 0.42 },
-            { type: 'size-over-lifetime', curve: growThenFade },
-            {
-                type: 'color-over-lifetime',
-                gradient: new Particle.ParticleGradient([
-                    { time: 0, color: [1, 1, 0.8, 1] },
-                    { time: 0.35, color: [1, 0.3, 0.04, 0.92] },
-                    { time: 1, color: [0.8, 0.02, 0.12, 0] }
-                ])
-            }
-        ],
-        renderers: [
-            {
-                type: 'sprite',
-                texture: sparkTexture,
-                alignment: 'velocity',
-                blend: 'additive',
-                depthWrite: false,
-                renderOrder: 5
-            }
-        ]
-    },
-    [0, -0.45, 0.05],
-    191
-);
-
-createSystem(
-    {
-        name: 'frost-disc',
-        capacity: 460,
-        execution: 'cpu',
-        prewarm: true,
-        emission: { rateOverTime: 105, bursts: [{ time: 0, count: 48 }] },
-        shape: { type: 'disc', radius: 0.82, arc: (Math.PI * 5) / 3, distribution: 'surface' },
-        initialize: {
-            lifetime: { min: 1.3, max: 2.5 },
-            direction: { min: [-0.18, 0.5, -0.18], max: [0.18, 1, 0.18] },
-            speed: { min: 0.15, max: 0.65 },
-            size: { min: 0.06, max: 0.14 },
-            rotation: { min: -3.14, max: 3.14 }
-        },
-        modules: [
-            { type: 'orbital-force', center: [0, 0.5, 0], strength: 0.72, axis: [0, 1, 0] },
-            { type: 'gravity', force: [0, 0.1, 0] },
-            { type: 'rotation-over-lifetime', curve: spinCurve, cycles: 2 },
-            { type: 'size-over-lifetime', curve: growThenFade },
-            {
-                type: 'color-over-lifetime',
-                gradient: new Particle.ParticleGradient([
-                    { time: 0, color: [0.92, 1, 1, 0] },
-                    { time: 0.18, color: [0.35, 0.92, 1, 0.9] },
-                    { time: 0.72, color: [0.25, 0.42, 1, 0.48] },
-                    { time: 1, color: [0.12, 0.18, 0.5, 0] }
-                ])
-            }
-        ],
-        renderers: [
-            {
-                type: 'sprite',
-                texture: sparkTexture,
-                blend: 'additive',
-                alignment: 'world-up',
-                sort: 'distance'
-            }
-        ]
-    },
-    [-2.35, -1.05, 0.35],
-    77
-);
-
-createSystem(
-    {
-        name: 'plasma-torus',
-        capacity: 520,
-        execution: 'cpu',
-        prewarm: true,
-        emission: { rateOverTime: 125 },
-        shape: { type: 'torus', radius: 0.74, tubeRadius: 0.12, arc: Math.PI * 2 },
-        initialize: {
-            lifetime: { min: 1.4, max: 2.3 },
-            direction: [0, 0.35, 0],
-            speed: { min: 0.08, max: 0.32 },
-            size: { min: 0.08, max: 0.18 }
-        },
-        modules: [
-            { type: 'vortex-force', center: [0, 0, 0], strength: 1.45, axis: [0.1, 1, 0.2] },
-            { type: 'point-attraction', point: [0, 0.52, 0], strength: 0.28 },
-            { type: 'drag', coefficient: 0.18 },
-            { type: 'size-by-speed', speedRange: [0, 2], curve: growThenFade },
-            {
-                type: 'color-by-speed',
-                speedRange: [0, 2],
-                gradient: new Particle.ParticleGradient([
-                    { time: 0, color: [0.2, 0.12, 1, 0.5] },
-                    { time: 0.55, color: [0.7, 0.18, 1, 0.9] },
-                    { time: 1, color: [0.2, 0.92, 1, 1] }
-                ])
-            },
-            { type: 'alpha-over-lifetime', curve: growThenFade }
-        ],
-        renderers: [
-            {
-                type: 'sprite',
-                texture: ringTexture,
-                blend: 'additive',
-                alignment: 'velocity',
-                sort: 'youngest'
-            }
-        ]
-    },
-    [2.35, -0.95, 0.2],
-    909
-);
-
-createSystem(
-    {
-        name: 'ember-box',
-        capacity: 260,
-        execution: 'cpu',
-        prewarm: true,
-        emission: { rateOverTime: 46, bursts: [{ time: 0, count: 24, cycles: 3, interval: 1.2 }] },
-        shape: { type: 'box', size: [5.2, 0.12, 1.8], distribution: 'volume' },
-        initialize: {
-            lifetime: { min: 2, max: 4.2 },
-            direction: { min: [-0.12, 0.5, -0.1], max: [0.12, 1, 0.1] },
-            speed: { min: 0.15, max: 0.55 },
-            size: { min: 0.025, max: 0.075 }
-        },
-        modules: [
-            { type: 'wind', force: [0.16, 0.12, 0] },
-            { type: 'drag', coefficient: 0.08 },
+            { type: 'drag', coefficient: 0.25 },
             { type: 'size-over-lifetime', curve: emberSize },
-            {
-                type: 'color-over-lifetime',
-                gradient: new Particle.ParticleGradient([
-                    { time: 0, color: [1, 0.55, 0.08, 1] },
-                    { time: 0.7, color: [0.28, 0.62, 1, 0.62] },
-                    { time: 1, color: [0.08, 0.15, 0.4, 0] }
-                ])
-            }
+            { type: 'color-over-lifetime', gradient: fireColor }
         ],
         renderers: [
             {
                 type: 'sprite',
                 texture: discTexture,
-                blend: 'additive',
                 alignment: 'stretched',
-                stretchScale: 2.2,
+                stretchScale: 1.8,
+                blend: 'additive',
                 depthWrite: false,
-                renderOrder: 1
+                renderOrder: 3
             }
         ]
     },
-    [0, -1.26, -1.6],
-    1234
+    [0, -0.98, 0],
+    301
 );
 
 createSystem(
     {
-        name: 'aether-sphere',
-        capacity: 380,
+        name: 'golden-filaments',
+        capacity: 260,
         execution: 'cpu',
         prewarm: true,
-        emission: { rateOverTime: 82 },
-        shape: { type: 'sphere', radius: 1.22, thickness: 0.06, distribution: 'surface' },
+        emission: { rateOverTime: 78 },
+        shape: { type: 'point' },
         initialize: {
-            lifetime: { min: 2.4, max: 4.2 },
-            speed: 0.04,
-            size: { min: 0.02, max: 0.055 }
+            lifetime: { min: 1.4, max: 2.8 },
+            direction: { min: [-0.26, 0.8, -0.26], max: [0.26, 1, 0.26] },
+            speed: { min: 0.9, max: 1.8 },
+            size: { min: 0.016, max: 0.032 }
         },
         modules: [
-            { type: 'rotate-around-point', center: [0, 0, 0], axis: [0, 1, 0], angularSpeed: 0.32 },
-            { type: 'camera-fade', range: [2, 14] },
-            { type: 'screen-space-size', scale: 1.1 },
-            { type: 'alpha-over-lifetime', curve: growThenFade },
-            { type: 'custom-channel', name: 'aetherBand', valueType: 'float', value: 0.72 }
-        ],
-        renderers: [{ type: 'sprite', texture: discTexture, blend: 'additive', depthWrite: false }]
-    },
-    [0, 0.35, -0.4],
-    55
-);
-
-createSystem(
-    {
-        name: 'line-comets',
-        capacity: 180,
-        execution: 'cpu',
-        emission: { rateOverTime: 32 },
-        shape: { type: 'line', start: [-2.8, 0, 0], end: [2.8, 0, 0] },
-        initialize: {
-            lifetime: { min: 1.1, max: 2.1 },
-            direction: { min: [-0.08, 0.75, -0.08], max: [0.08, 1, 0.08] },
-            speed: { min: 0.55, max: 1.2 },
-            size: { min: 0.035, max: 0.08 }
-        },
-        modules: [
-            { type: 'limit-velocity', limit: 1.1, dampen: 0.2 },
-            { type: 'alpha-over-lifetime', curve: growThenFade },
-            { type: 'kill-distance', range: [0, 5.5] }
+            { type: 'gravity', force: [0, -0.38, 0] },
+            { type: 'orbital-force', center: [0, 0.5, 0], strength: 0.2, axis: [0, 1, 0] },
+            { type: 'size-over-lifetime', curve: emberSize },
+            { type: 'color-over-lifetime', gradient: fireColor }
         ],
         renderers: [
             {
                 type: 'sprite',
                 texture: sparkTexture,
-                blend: 'additive',
                 alignment: 'stretched',
-                stretchScale: 4
+                stretchScale: 10,
+                blend: 'additive',
+                depthWrite: false,
+                renderOrder: 4
             }
         ]
     },
-    [0, 1.72, -0.4],
+    [0, -0.72, 0],
+    191
+);
+
+createSystem(
+    {
+        name: 'oxidised-halo',
+        capacity: 520,
+        execution: 'cpu',
+        prewarm: true,
+        emission: { rateOverTime: 110 },
+        shape: { type: 'disc', radius: 1.03, distribution: 'surface' },
+        initialize: {
+            lifetime: { min: 2.8, max: 4.3 },
+            direction: [0, 1, 0],
+            speed: { min: 0.04, max: 0.2 },
+            size: { min: 0.012, max: 0.032 }
+        },
+        modules: [
+            { type: 'rotate-around-point', center: [0, 0, 0], axis: [0, 1, 0], angularSpeed: 0.18 },
+            { type: 'alpha-over-lifetime', curve: fade },
+            {
+                type: 'color-over-lifetime',
+                gradient: new Particle.ParticleGradient([
+                    { time: 0, color: [0.28, 0.67, 0.69, 0] },
+                    { time: 0.2, color: [0.35, 0.75, 0.73, 0.75] },
+                    { time: 0.7, color: [0.14, 0.35, 0.37, 0.4] },
+                    { time: 1, color: [0.1, 0.26, 0.29, 0] }
+                ])
+            }
+        ],
+        renderers: [{ type: 'sprite', texture: discTexture, blend: 'additive', depthWrite: false }]
+    },
+    [0, -0.99, 0],
+    77
+);
+
+const aureole = createSystem(
+    {
+        name: 'orbital-cinders',
+        capacity: 740,
+        execution: 'cpu',
+        prewarm: true,
+        emission: { rateOverTime: 185 },
+        shape: { type: 'torus', radius: 1.2, tubeRadius: 0.018, distribution: 'volume' },
+        initialize: {
+            lifetime: { min: 2.4, max: 3.8 },
+            speed: 0.008,
+            size: { min: 0.01, max: 0.026 },
+            color: { min: [0.75, 0.39, 0.12, 0.45], max: [1.2, 0.86, 0.46, 0.9] }
+        },
+        modules: [
+            { type: 'rotate-around-point', center: [0, 0, 0], axis: [0, 1, 0], angularSpeed: 0.34 },
+            { type: 'alpha-over-lifetime', curve: fade }
+        ],
+        renderers: [{ type: 'sprite', texture: discTexture, blend: 'additive', depthWrite: false }]
+    },
+    [0, 0.47, 0],
+    909
+);
+aureole.rotationZ = 18;
+aureole.rotationX = 18;
+
+createSystem(
+    {
+        name: 'suspended-ash',
+        capacity: 260,
+        execution: 'cpu',
+        prewarm: true,
+        emission: { rateOverTime: 30 },
+        shape: { type: 'box', size: [5.8, 4.4, 3], distribution: 'volume' },
+        initialize: {
+            lifetime: { min: 5, max: 8 },
+            direction: [0.12, 0.3, 0],
+            speed: { min: 0.02, max: 0.07 },
+            size: { min: 0.008, max: 0.026 },
+            color: { min: [0.3, 0.26, 0.19, 0.15], max: [0.68, 0.55, 0.34, 0.55] }
+        },
+        modules: [{ type: 'alpha-over-lifetime', curve: fade }],
+        renderers: [{ type: 'sprite', texture: discTexture, blend: 'additive', depthWrite: false }]
+    },
+    [0, 0.4, -0.8],
+    1234
+);
+
+createSystem(
+    {
+        name: 'aether-shell',
+        capacity: 340,
+        execution: 'cpu',
+        prewarm: true,
+        emission: { rateOverTime: 68 },
+        shape: { type: 'sphere', radius: 1.5, thickness: 0.015, distribution: 'surface' },
+        initialize: {
+            lifetime: { min: 3.2, max: 4.8 },
+            speed: 0.012,
+            size: { min: 0.008, max: 0.021 },
+            color: [0.5, 0.64, 0.62, 0.38]
+        },
+        modules: [
+            { type: 'rotate-around-point', center: [0, 0, 0], axis: [0, 1, 0], angularSpeed: 0.08 },
+            { type: 'alpha-over-lifetime', curve: fade }
+        ],
+        renderers: [{ type: 'sprite', texture: discTexture, blend: 'additive', depthWrite: false }]
+    },
+    [0, 0.45, 0],
+    55
+);
+
+createSystem(
+    {
+        name: 'rim-sparks',
+        capacity: 130,
+        execution: 'cpu',
+        prewarm: true,
+        emission: { rateOverTime: 34 },
+        shape: { type: 'line', start: [-0.55, 0, 0], end: [0.55, 0, 0] },
+        initialize: {
+            lifetime: { min: 0.65, max: 1.8 },
+            direction: { min: [-0.7, 0.55, -0.5], max: [0.7, 1, 0.5] },
+            speed: { min: 0.5, max: 0.9 },
+            size: { min: 0.035, max: 0.065 }
+        },
+        modules: [
+            { type: 'gravity', force: [0, -0.18, 0] },
+            { type: 'texture-sheet', mode: 'lifetime', rows: 4, columns: 4, cycles: 1 },
+            { type: 'size-over-lifetime', curve: emberSize },
+            { type: 'color-over-lifetime', gradient: fireColor }
+        ],
+        renderers: [{ type: 'sprite', texture: atlasTexture, blend: 'additive', depthWrite: false }]
+    },
+    [0, -0.95, 0],
     812
 );
 
 createSystem(
     {
-        name: 'hemisphere-mist',
-        capacity: 190,
+        name: 'heat-veil',
+        capacity: 120,
         execution: 'cpu',
         prewarm: true,
-        emission: { rateOverTime: 36 },
-        shape: {
-            type: 'hemisphere',
-            radius: 1.1,
-            thickness: 0.32,
-            distribution: 'volume',
-            arc: (Math.PI * 11) / 9
-        },
+        emission: { rateOverTime: 27 },
+        shape: { type: 'hemisphere', radius: 0.58, thickness: 0.4, distribution: 'volume' },
         initialize: {
-            lifetime: { min: 2.8, max: 4.4 },
-            speed: { min: 0.03, max: 0.16 },
-            size: { min: 0.28, max: 0.58 }
+            lifetime: { min: 2.2, max: 3.6 },
+            direction: [0, 1, 0],
+            speed: { min: 0.07, max: 0.2 },
+            size: { min: 0.2, max: 0.42 }
         },
         modules: [
-            { type: 'velocity-over-lifetime', velocity: [0.04, 0.08, -0.03] },
-            { type: 'size-over-lifetime', curve: growThenFade },
+            { type: 'velocity-over-lifetime', velocity: [0.03, 0.12, -0.02] },
+            { type: 'size-over-lifetime', curve: fade },
             {
                 type: 'color-over-lifetime',
                 gradient: new Particle.ParticleGradient([
-                    { time: 0, color: [0.18, 0.38, 0.8, 0] },
-                    { time: 0.3, color: [0.22, 0.5, 1, 0.2] },
-                    { time: 1, color: [0.5, 0.16, 0.8, 0] }
+                    { time: 0, color: [0.38, 0.18, 0.055, 0] },
+                    { time: 0.25, color: [0.48, 0.24, 0.09, 0.08] },
+                    { time: 1, color: [0.2, 0.16, 0.11, 0] }
                 ])
             }
         ],
@@ -420,15 +477,27 @@ createSystem(
             }
         ]
     },
-    [0, -0.75, -1.2],
+    [0, -0.7, 0],
     486
 );
 
-fire.onUpdate = deltaTime => {
-    fire.rotationY += deltaTime * 0.008;
+let elapsed = 0;
+base.onUpdate = deltaTime => {
+    elapsed += deltaTime * 0.001;
+    apparatus.rotationY = 12 + Math.sin(elapsed * 0.12) * 12;
+    innerHoop.rotationZ = -32 + Math.sin(elapsed * 0.18) * 7;
+    crucible.rotationY += deltaTime * 0.001;
 };
 
+const resizeComposition = (): void => {
+    const portrait = window.innerWidth < 700;
+    context.camera.fov = portrait ? 60 : 38;
+    context.orbitControls.setTarget(new Hilo3d.Vector3(portrait ? 0 : -0.45, 0.1, 0));
+};
+resizeComposition();
+window.addEventListener('resize', resizeComposition);
 document.body.dataset['particleExampleReady'] = 'true';
 installExampleDisposal(() => {
+    window.removeEventListener('resize', resizeComposition);
     context.dispose();
 });

--- a/examples/particle_gpu_nebula.html
+++ b/examples/particle_gpu_nebula.html
@@ -5,36 +5,30 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
             name="description"
-            content="A WebGPU Hilo3D particle nebula using stateful compute, stateless reconstruction, soft depth, scene collision, and GPU event routing."
+            content="Copper dust traces a dark celestial center. An interactive particle study with resident WebGPU simulation and absolute-age stellar dust."
         />
         <title>Hilo3D Particle GPU Nebula</title>
         <link rel="stylesheet" href="./example.css" />
         <link rel="stylesheet" href="./particle_showcase.css" />
     </head>
-    <body>
+    <body class="particle-gallery nebula-page">
         <div id="container"></div>
         <header class="particle-hero">
-            <div class="particle-kicker">Particle studies · 04 / WebGPU</div>
+            <div class="particle-kicker">Studies in motion · 05 / cosmos</div>
             <h1>Event Horizon</h1>
             <p>
-                A stateful compute storm folds into a stateless stellar shell. Soft depth, scene
-                collisions and resident event routing keep the entire spectacle on the GPU.
+                A dark center. A thousand burning orbits.<br />Light, held at the edge of silence.
             </p>
-            <div class="particle-chips">
-                <span>65K bodies</span><span>GPU stateful</span><span>stateless</span
-                ><span>soft depth</span><span>resident routing</span>
-            </div>
         </header>
-        <output class="particle-readout" id="particle-readout"
-            >GPU simulation resident no particle readback</output
-        >
-        <div class="particle-hint">WEBGPU · DRAG TO ORBIT THE EVENT HORIZON</div>
+        <output class="particle-readout" id="particle-readout">05 — EVENT HORIZON</output>
+        <div class="particle-hint">DRAG TO ORBIT · SCROLL TO EXPLORE</div>
         <nav class="particle-nav" aria-label="Particle example collection">
             <a href="./particle_elemental_forge.html">Elemental</a>
-            <a href="./particle_noise_fields.html">Noise</a>
-            <a href="./particle_orbital_weave.html">Topology</a>
-            <a href="./particle_collision_theatre.html">Interaction</a>
-            <a aria-current="page" href="./particle_gpu_nebula.html?backend=webgpu">GPU nebula</a>
+            <a href="./particle_noise_fields.html">Flow</a>
+            <a href="./particle_orbital_weave.html">Orbit</a>
+            <a href="./particle_collision_theatre.html">Impact</a>
+            <a aria-current="page" href="./particle_gpu_nebula.html?backend=webgpu">Horizon</a>
+            <a href="./compute_particles.html?backend=webgpu">Tides</a>
         </nav>
         <script type="module" src="./particle_gpu_nebula.ts"></script>
     </body>

--- a/examples/particle_gpu_nebula.ts
+++ b/examples/particle_gpu_nebula.ts
@@ -11,22 +11,23 @@ const testMode = new URLSearchParams(window.location.search).get('test') === '1'
 const stormCapacity = testMode ? 4_096 : 24_576;
 const coreCapacity = testMode ? 2_048 : 8_192;
 const sparkCapacity = testMode ? 2_048 : 8_192;
-const statelessCapacity = testMode ? 4_096 : 24_576;
+const statelessCapacity = testMode ? 2_048 : 8_192;
+const portrait = window.innerWidth < 720;
 
 const context = await createExampleContext({
     backend: 'webgpu',
-    camera: { fov: 43, near: 0.1, far: 120, x: 0, y: 1.5, z: 11.5 },
+    camera: { fov: 42, near: 0.1, far: 120, x: 0, y: 1.2, z: portrait ? 27 : 12.8 },
     stage: {
         renderPipeline: new Hilo3d.PostProcessRenderPipelineFactory({
-            bloom: { threshold: 0.78, knee: 0.52, intensity: 0.7, scatter: 0.72, maxLevels: 7 },
+            bloom: { threshold: 0.7, knee: 0.42, intensity: 0.48, scatter: 0.68, maxLevels: 6 },
             colorUber: {
-                exposure: -0.32,
-                contrast: 0.16,
-                saturation: 0.14,
-                temperature: -0.03,
-                tint: 0.04,
+                exposure: -0.12,
+                contrast: 0.12,
+                saturation: -0.08,
+                temperature: 0.035,
+                tint: 0,
                 toneMapping: 'pbr-neutral',
-                vignetteIntensity: 0.74,
+                vignetteIntensity: 0.5,
                 vignetteSmoothness: 0.52,
                 vignetteColor: new Hilo3d.Color(0.001, 0.002, 0.012, 0.78)
             },
@@ -34,42 +35,196 @@ const context = await createExampleContext({
         })
     },
     controls: {
-        target: new Hilo3d.Vector3(0, 0.2, 0),
+        target: new Hilo3d.Vector3(portrait ? 0 : -0.55, portrait ? 0.65 : 0.15, 0),
         minDistance: 6,
-        maxDistance: 20,
+        maxDistance: 36,
         minPolarAngle: 0.45,
         maxPolarAngle: 2.55
     }
 });
 const { stage, renderer, directionLight, ambientLight } = context;
 
-renderer.clearColor.set(0.001, 0.002, 0.009, 1);
-directionLight.amount = 3.4;
-directionLight.color.set(0.4, 0.68, 1, 1);
-ambientLight.amount = 0.18;
-ambientLight.color.set(0.32, 0.18, 0.72, 1);
+renderer.clearColor.set(0.0015, 0.0025, 0.005, 1);
+directionLight.amount = 0.4;
+directionLight.color.set(0.62, 0.72, 0.9, 1);
+ambientLight.amount = 0.08;
 
+// The opaque center is also the scene-depth collision surface for the resident dust.
 const horizon = new Hilo3d.Mesh({
-    y: 0.15,
-    geometry: new Hilo3d.SphereGeometry({ radius: 1.12, widthSegments: 48, heightSegments: 32 }),
-    material: new Hilo3d.PBRMaterial({
-        baseColor: new Hilo3d.Color(0.002, 0.003, 0.008),
-        metallic: 0.94,
-        roughness: 0.08
+    geometry: new Hilo3d.SphereGeometry({ radius: 1.16, widthSegments: 64, heightSegments: 48 }),
+    material: new Hilo3d.BasicMaterial({
+        diffuse: new Hilo3d.Color(0.0002, 0.0003, 0.0006),
+        lightType: 'NONE'
     })
 }).addTo(stage);
 
-new Hilo3d.PointLight({
-    x: -2.8,
-    y: 2.4,
-    z: 1.5,
-    amount: 24,
-    range: 10,
-    color: new Hilo3d.Color(0.12, 0.68, 1)
+const disk = new Hilo3d.Node({ rotationX: 23, rotationZ: -19 }).addTo(stage);
+
+// A procedural optical veil supplies continuous gas between the individual particles.
+// The ordinary material shader owns the managed texture's UV normalization.
+function createCelestialTexture(kind: 'disk' | 'photon'): Hilo3d.Texture<Uint8Array> {
+    const size = kind === 'disk' ? 1536 : 512;
+    const pixels = new Uint8Array(size * size * 4);
+    for (let y = 0; y < size; y += 1) {
+        for (let x = 0; x < size; x += 1) {
+            const nx = ((x + 0.5) / size) * 2 - 1;
+            const ny = ((y + 0.5) / size) * 2 - 1;
+            const radius = Math.hypot(nx, ny) * (kind === 'disk' ? 4.5 : 1.55);
+            const angle = Math.atan2(ny, nx);
+            let alpha: number;
+            let blueMix: number;
+            let brightness: number;
+            if (kind === 'disk') {
+                const inner = Math.min(1, Math.max(0, (radius - 1.2) / 0.22));
+                const outer = Math.pow(Math.max(0, 1 - Math.max(0, radius - 2.05) / 2.3), 1.7);
+                const spiral = angle + Math.log(Math.max(radius, 0.2)) * 5.5;
+                const billow = Math.sin(spiral * 3 + Math.sin(angle * 5) * 0.6) * 0.5 + 0.5;
+                const wisps =
+                    Math.sin(radius * 86 + angle * 6 + Math.sin(spiral * 7) * 1.6) * 0.5 + 0.5;
+                const fine =
+                    Math.sin(radius * 193 + angle * 11 + Math.cos(spiral * 5) * 2.5) * 0.5 + 0.5;
+                const asymmetry = 0.52 + 0.48 * Math.pow(Math.sin(angle + 0.7) * 0.5 + 0.5, 2);
+                alpha =
+                    inner *
+                    outer *
+                    asymmetry *
+                    (0.09 + billow * 0.34 + wisps * wisps * 0.22 + fine * 0.08);
+                blueMix = Math.max(0, Math.min(1, (radius - 2.15) / 1.7)) * 0.96;
+                brightness = 0.76 + billow * 0.24;
+            } else {
+                const distance = Math.abs(radius - 1.195);
+                alpha =
+                    Math.exp((-distance * distance) / 0.00024) * 0.95 +
+                    Math.exp((-distance * distance) / 0.006) * 0.16;
+                blueMix = Math.pow(Math.cos(angle - 0.5) * 0.5 + 0.5, 5) * 0.5;
+                brightness = 1;
+            }
+            const offset = (y * size + x) * 4;
+            pixels[offset] = Math.round((255 - blueMix * 160) * brightness);
+            pixels[offset + 1] = Math.round(
+                (kind === 'disk' ? 168 + blueMix * 16 : 216) * brightness
+            );
+            pixels[offset + 2] = Math.round(
+                kind === 'disk' ? 83 + blueMix * 145 : 155 + blueMix * 100
+            );
+            pixels[offset + 3] = Math.round(Math.min(1, alpha) * 255);
+        }
+    }
+    return new Hilo3d.Texture({
+        image: pixels,
+        width: size,
+        height: size,
+        internalFormat: Hilo3d.constants.RGBA8,
+        format: Hilo3d.constants.RGBA,
+        type: Hilo3d.constants.UNSIGNED_BYTE,
+        wrapS: Hilo3d.constants.CLAMP_TO_EDGE,
+        wrapT: Hilo3d.constants.CLAMP_TO_EDGE,
+        magFilter: Hilo3d.constants.LINEAR,
+        minFilter: Hilo3d.constants.LINEAR_MIPMAP_LINEAR
+    });
+}
+
+// Rotate the veil about the disk normal; keep the plane's fixed tilt on its child.
+const accretionFlow = new Hilo3d.Node().addTo(disk);
+new Hilo3d.Mesh({
+    rotationX: -90,
+    geometry: new Hilo3d.PlaneGeometry({ width: 9, height: 9 }),
+    material: new Hilo3d.BasicMaterial({
+        diffuse: createCelestialTexture('disk'),
+        lightType: 'NONE',
+        cullMode: 'none',
+        compositing: { mode: 'additive', premultiplied: false },
+        state: { depthWrite: false }
+    })
+}).addTo(accretionFlow);
+
+const photonRing = new Hilo3d.Mesh({
+    geometry: new Hilo3d.PlaneGeometry({ width: 3.1, height: 3.1 }),
+    material: new Hilo3d.BasicMaterial({
+        diffuse: createCelestialTexture('photon'),
+        lightType: 'NONE',
+        cullMode: 'none',
+        compositing: { mode: 'additive', premultiplied: false },
+        state: { depthWrite: false }
+    })
 }).addTo(stage);
+
+// Fine orbit filaments give the rotating dust a continuous, legible silhouette.
+function createOrbitFilaments(): Hilo3d.Geometry {
+    const vertices: number[] = [];
+    const colors: number[] = [];
+    const indices: number[] = [];
+    for (let lane = 0; lane < 22; lane += 1) {
+        const radius = 1.22 + Math.pow(lane / 21, 1.35) * 2.75;
+        const width = 0.002 + (1 - lane / 22) * 0.001;
+        const start = Math.sin(lane * 8.37) * Math.PI;
+        const span = 3.1 + (Math.sin(lane * 3.14) * 0.5 + 0.5) * 2.9;
+        for (let segment = 0; segment <= 256; segment += 1) {
+            const progress = segment / 256;
+            const angle = start + progress * span;
+            const ripple = Math.sin(angle * 3 + lane * 0.7) * 0.012;
+            const opacity =
+                Math.pow(Math.sin(progress * Math.PI), 0.6) * (0.035 + 0.06 * (1 - lane / 22));
+            for (let edge = -1; edge <= 1; edge += 2) {
+                const radial = radius + ripple + edge * width;
+                vertices.push(
+                    Math.cos(angle) * radial,
+                    Math.sin(angle * 2 + lane) * 0.008,
+                    Math.sin(angle) * radial
+                );
+                colors.push(1.4, 0.55 + (lane / 22) * 0.12, 0.17 + (lane / 22) * 0.15, opacity);
+            }
+            if (segment < 256) {
+                const vertex = (lane * 257 + segment) * 2;
+                indices.push(vertex, vertex + 1, vertex + 2, vertex + 1, vertex + 3, vertex + 2);
+            }
+        }
+    }
+    return new Hilo3d.Geometry({
+        vertices: new Hilo3d.GeometryData(new Float32Array(vertices), 3),
+        colors: new Hilo3d.GeometryData(new Float32Array(colors), 4),
+        indices: new Hilo3d.GeometryData(new Uint16Array(indices), 1)
+    });
+}
+
+new Hilo3d.Mesh({
+    geometry: createOrbitFilaments(),
+    material: new Hilo3d.BasicMaterial({
+        lightType: 'NONE',
+        cullMode: 'none',
+        compositing: { mode: 'alpha-blend', premultiplied: false },
+        state: { depthWrite: false }
+    })
+}).addTo(disk);
+
+// Sparse fixed stars keep the dark center and accretion disk as the visual focus.
+const starGeometry = new Hilo3d.Geometry();
+for (let index = 0; index < 380; index += 1) {
+    const random = (offset: number): number => {
+        const value = Math.sin(index * 127.1 + offset * 311.7) * 43758.5453;
+        return value - Math.floor(value);
+    };
+    const x = (random(1) - 0.5) * 44;
+    const y = (random(2) - 0.5) * 28;
+    const z = -12 - random(3) * 14;
+    const radius = 0.004 + Math.pow(random(4), 5) * 0.03;
+    starGeometry.addFace(
+        [x - radius, y - radius, z],
+        [x + radius, y - radius, z],
+        [x, y + radius, z]
+    );
+}
+new Hilo3d.Mesh({
+    geometry: starGeometry,
+    material: new Hilo3d.BasicMaterial({
+        lightType: 'NONE',
+        diffuse: new Hilo3d.Color(0.42, 0.48, 0.58)
+    })
+}).addTo(stage);
+
 const softTexture = createParticleTexture({ style: 'disc', size: 64 });
 const sparkTexture = createParticleTexture({ style: 'spark', size: 64 });
-const ringTexture = createParticleTexture({ style: 'ring', size: 64 });
+
 const fade = new Particle.ParticleCurve(
     [
         { time: 0, value: 0 },
@@ -101,32 +256,32 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
                     { time: 3.2, count: 768, cycles: 3, interval: 2.8 }
                 ]
             },
-            shape: { type: 'torus', radius: 2.2, tubeRadius: 0.52, distribution: 'volume' },
+            shape: { type: 'torus', radius: 2.45, tubeRadius: 0.52, distribution: 'volume' },
             initialize: {
                 lifetime: { min: 6, max: 10 },
                 direction: { min: [-0.12, -0.04, -0.12], max: [0.12, 0.18, 0.12] },
                 speed: { min: 0.08, max: 0.42 },
-                size: { min: 0.06, max: 0.16 },
+                size: { min: 0.012, max: 0.035 },
                 mass: { min: 0.6, max: 1.6 }
             },
             modules: [
                 {
                     type: 'vortex-force',
-                    center: [0, 0.1, 0],
-                    strength: { min: 0.28, max: 0.9 },
-                    axis: [0.08, 1, 0.04]
+                    center: [0, 0, 0],
+                    strength: { min: 0.14, max: 0.34 },
+                    axis: [0, 1, 0]
                 },
-                { type: 'point-attraction', point: [0, 0.15, 0], strength: 0.24 },
+                { type: 'point-attraction', point: [0, 0, 0], strength: 0.15 },
                 {
                     type: 'noise',
                     mode: 'force',
                     field: 'curl',
-                    strength: { min: [0.16, 0.08, 0.16], max: [0.72, 0.38, 0.72] },
-                    frequency: 1.35,
-                    octaves: 4,
+                    strength: { min: [0.05, 0.015, 0.05], max: [0.22, 0.055, 0.22] },
+                    frequency: 1.8,
+                    octaves: 3,
                     lacunarity: 2.1,
                     persistence: 0.52,
-                    scrollVelocity: [0.08, 0.14, -0.06],
+                    scrollVelocity: [0.025, 0.015, -0.02],
                     damping: 0.18,
                     seedOffset: 71
                 },
@@ -135,7 +290,7 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
                 {
                     type: 'collision',
                     colliders: [
-                        { type: 'sphere', center: [0, 0.15, 0], radius: 1.2 },
+                        { type: 'sphere', center: [0, 0, 0], radius: 1.2 },
                         { type: 'plane', normal: [0, 1, 0], offset: -1.2 }
                     ],
                     bounce: 0.58,
@@ -168,11 +323,11 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
                 {
                     type: 'color-over-lifetime',
                     gradient: new Particle.ParticleGradient([
-                        { time: 0, color: [0.14, 0.72, 1, 0] },
-                        { time: 0.12, color: [0.08, 0.9, 1, 0.82] },
-                        { time: 0.48, color: [0.34, 0.2, 1, 0.76] },
-                        { time: 0.78, color: [1, 0.12, 0.72, 0.62] },
-                        { time: 1, color: [1, 0.38, 0.08, 0] }
+                        { time: 0, color: [1, 0.72, 0.38, 0] },
+                        { time: 0.12, color: [1.25, 0.81, 0.45, 0.3] },
+                        { time: 0.48, color: [1.0, 0.45, 0.19, 0.22] },
+                        { time: 0.78, color: [0.6, 0.23, 0.1, 0.13] },
+                        { time: 1, color: [0.3, 0.08, 0.02, 0] }
                     ])
                 }
             ],
@@ -201,25 +356,25 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
                 rateOverTime: { min: 720, max: 960 },
                 bursts: [{ time: 0, count: 2_048 }]
             },
-            shape: { type: 'torus', radius: 1.72, tubeRadius: 0.34, distribution: 'volume' },
+            shape: { type: 'torus', radius: 1.35, tubeRadius: 0.075, distribution: 'volume' },
             initialize: {
                 lifetime: { min: 5.5, max: 8.5 },
                 direction: { min: [-0.04, -0.015, -0.04], max: [0.04, 0.04, 0.04] },
                 speed: { min: 0.02, max: 0.12 },
-                size: { min: 0.14, max: 0.32 }
+                size: { min: 0.018, max: 0.036 }
             },
             modules: [
                 {
                     type: 'vortex-force',
-                    center: [0, 0.15, 0],
-                    strength: { min: 0.18, max: 0.5 },
-                    axis: [0.04, 1, 0.02]
+                    center: [0, 0, 0],
+                    strength: { min: 0.025, max: 0.08 },
+                    axis: [0, 1, 0]
                 },
                 {
                     type: 'noise',
                     mode: 'force',
                     field: 'curl',
-                    strength: [0.22, 0.08, 0.22],
+                    strength: [0.025, 0.008, 0.025],
                     frequency: 1.7,
                     octaves: 3,
                     scrollVelocity: [0.035, 0.08, -0.025],
@@ -231,11 +386,11 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
                 {
                     type: 'color-over-lifetime',
                     gradient: new Particle.ParticleGradient([
-                        { time: 0, color: [0.16, 0.92, 1, 0] },
-                        { time: 0.12, color: [0.42, 1, 1, 1] },
-                        { time: 0.56, color: [0.28, 0.62, 1, 0.92] },
-                        { time: 0.82, color: [1, 0.18, 1, 0.78] },
-                        { time: 1, color: [1, 0.12, 0.48, 0] }
+                        { time: 0, color: [1.7, 1.15, 0.58, 0] },
+                        { time: 0.12, color: [1.6, 1.25, 0.72, 0.38] },
+                        { time: 0.56, color: [1.35, 0.76, 0.3, 0.3] },
+                        { time: 0.82, color: [0.8, 0.3, 0.12, 0.2] },
+                        { time: 1, color: [0.5, 0.12, 0.04, 0] }
                     ])
                 }
             ],
@@ -268,8 +423,8 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
                     type: 'color-over-lifetime',
                     gradient: new Particle.ParticleGradient([
                         { time: 0, color: [1, 0.9, 0.48, 1] },
-                        { time: 0.35, color: [0.22, 0.82, 1, 0.92] },
-                        { time: 1, color: [0.62, 0.08, 1, 0] }
+                        { time: 0.35, color: [1.2, 0.52, 0.18, 0.72] },
+                        { time: 1, color: [0.3, 0.08, 0.03, 0] }
                     ])
                 }
             ],
@@ -289,12 +444,11 @@ const gpuDefinition = Particle.ParticleSystemDefinition.create({
 });
 
 const resident = new Particle.ParticleSystem({
-    y: 0,
-    rotationX: 58,
+    scaleY: 0.18,
     definition: gpuDefinition,
     seed: 65_536,
     compilationEnvironment: { backend: 'webgpu', preferGPUAboveCapacity: 1_024 }
-}).addTo(stage);
+}).addTo(disk);
 resident.emit({ emitter: 'resident-nebula', count: testMode ? 768 : 6_144 });
 resident.emit({ emitter: 'luminous-core', count: testMode ? 512 : 4_096 });
 
@@ -308,27 +462,27 @@ const statelessDefinition = Particle.ParticleSystemDefinition.create({
             looping: true,
             prewarm: !testMode,
             bounds: { mode: 'manual', min: [-8, -6, -8], max: [8, 8, 8] },
-            emission: { rateOverTime: 2_400 },
+            emission: { rateOverTime: 900 },
             shape: {
                 type: 'torus',
-                radius: 3.55,
-                tubeRadius: 0.82,
-                thickness: 0.48,
+                radius: 3.2,
+                tubeRadius: 0.72,
+                thickness: 0.3,
                 distribution: 'volume'
             },
             initialize: {
                 lifetime: { min: 7.5, max: 10 },
                 direction: { min: [-0.08, -0.04, -0.08], max: [0.08, 0.04, 0.08] },
                 speed: { min: 0.03, max: 0.12 },
-                size: { min: 0.012, max: 0.045 }
+                size: { min: 0.014, max: 0.05 }
             },
             modules: [
-                { type: 'velocity-over-lifetime', velocity: [0, 0.025, 0] },
+                { type: 'velocity-over-lifetime', velocity: [0, 0.005, 0] },
                 {
                     type: 'noise',
                     mode: 'position-offset',
                     field: 'vector',
-                    strength: [0.22, 0.12, 0.22],
+                    strength: [0.24, 0.08, 0.24],
                     frequency: 0.72,
                     octaves: 2,
                     scrollVelocity: [0.015, 0.03, -0.02],
@@ -339,10 +493,10 @@ const statelessDefinition = Particle.ParticleSystemDefinition.create({
                 {
                     type: 'color-over-lifetime',
                     gradient: new Particle.ParticleGradient([
-                        { time: 0, color: [0.2, 0.65, 1, 0] },
-                        { time: 0.18, color: [0.22, 0.85, 1, 0.72] },
-                        { time: 0.65, color: [0.58, 0.28, 1, 0.6] },
-                        { time: 1, color: [1, 0.16, 0.58, 0] }
+                        { time: 0, color: [0.3, 0.5, 0.78, 0] },
+                        { time: 0.18, color: [0.24, 0.42, 0.66, 0.55] },
+                        { time: 0.65, color: [0.16, 0.28, 0.48, 0.35] },
+                        { time: 1, color: [0.09, 0.14, 0.22, 0] }
                     ])
                 },
                 { type: 'screen-space-size', scale: 0.86 }
@@ -350,7 +504,7 @@ const statelessDefinition = Particle.ParticleSystemDefinition.create({
             renderers: [
                 {
                     type: 'sprite',
-                    texture: ringTexture,
+                    texture: softTexture,
                     alignment: 'view',
                     blend: 'additive',
                     depthWrite: false,
@@ -363,31 +517,23 @@ const statelessDefinition = Particle.ParticleSystemDefinition.create({
 });
 
 const stateless = new Particle.ParticleSystem({
-    rotationX: 64,
+    scaleY: 0.3,
     definition: statelessDefinition,
     seed: 8008,
     compilationEnvironment: { backend: 'webgpu' }
-}).addTo(stage);
+}).addTo(disk);
 
 const readout = requireElement('#particle-readout', HTMLOutputElement);
 let nextReadoutUpdate = 0;
 horizon.onUpdate = deltaTime => {
-    horizon.rotationY += deltaTime * 0.008;
-    resident.rotationY += deltaTime * 0.0016;
-    stateless.rotationY -= deltaTime * 0.0006;
+    photonRing.quaternion.copy(context.camera.quaternion);
+    resident.rotationY += deltaTime * 0.0012;
+    accretionFlow.rotationY += deltaTime * 0.0007;
+    stateless.rotationY -= deltaTime * 0.0009;
     const now = performance.now();
     if (now < nextReadoutUpdate) return;
     nextReadoutUpdate = now + 500;
-    readout.textContent = [
-        'stateful GPU      40,960 cap',
-        'stateless GPU     24,576 cap',
-        'total             65,536 cap',
-        `draws             ${String(renderer.renderInfo.drawCount).padStart(6)}`,
-        `faces             ${String(renderer.renderInfo.faceCount).padStart(6)}`,
-        '',
-        'simulation + events remain resident',
-        'alive counts intentionally not read back'
-    ].join('\n');
+    readout.textContent = '05 — EVENT HORIZON\nCopper dust · glacial blue\nDrag to turn the orbit';
 };
 
 document.body.dataset['particleExampleReady'] = 'true';

--- a/examples/particle_noise_fields.html
+++ b/examples/particle_noise_fields.html
@@ -5,37 +5,39 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
             name="description"
-            content="Compare Hilo3D vector and curl particle noise as stateless position offsets and stateful forces."
+            content="Four live particle currents combine coherent emission, vector and curl noise, and soft granular wakes."
         />
         <title>Hilo3D Particle Noise Fields</title>
         <link rel="stylesheet" href="./example.css" />
         <link rel="stylesheet" href="./particle_showcase.css" />
     </head>
-    <body>
+    <body class="particle-gallery noise-page">
         <div id="container"></div>
         <header class="particle-hero">
-            <div class="particle-kicker">Particle studies · 02 / noise fields</div>
+            <div class="particle-kicker">Studies in motion · 02 / flow</div>
             <h1>Turbulence Atlas</h1>
-            <p>
-                Four living fields isolate vector and curl noise as absolute position offsets or
-                accumulated forces, revealing octave, frequency, scroll and damping behavior.
-            </p>
-            <div class="particle-chips">
-                <span>vector noise</span><span>curl noise</span><span>position-offset</span
-                ><span>force + damping</span><span>1–4 octaves</span>
-            </div>
+            <p>Invisible currents, traced in mineral light.</p>
         </header>
-        <div class="noise-label" style="left: 34%; top: 27%; color: #57e9ff">vector offset</div>
-        <div class="noise-label" style="left: 66%; top: 27%; color: #a45aff">curl offset</div>
-        <div class="noise-label" style="left: 34%; top: 67%; color: #ffb349">vector force</div>
-        <div class="noise-label" style="left: 66%; top: 67%; color: #ff4b92">curl force</div>
-        <div class="particle-hint">NOISE PARAMETERS ARE FIXED AND DETERMINISTIC</div>
+        <div class="noise-label noise-label--one">
+            <span>01 / VECTOR OFFSET</span><strong>Jade current</strong>
+        </div>
+        <div class="noise-label noise-label--two">
+            <span>02 / CURL OFFSET</span><strong>Glacial gyre</strong>
+        </div>
+        <div class="noise-label noise-label--three">
+            <span>03 / VECTOR FORCE</span><strong>Gilded drift</strong>
+        </div>
+        <div class="noise-label noise-label--four">
+            <span>04 / CURL FORCE</span><strong>Copper eddy</strong>
+        </div>
+        <div class="particle-hint">DRAG TO EXPLORE · FOUR STUDIES OF MOTION</div>
         <nav class="particle-nav" aria-label="Particle example collection">
             <a href="./particle_elemental_forge.html">Elemental</a>
-            <a aria-current="page" href="./particle_noise_fields.html">Noise</a>
-            <a href="./particle_orbital_weave.html">Topology</a>
-            <a href="./particle_collision_theatre.html">Interaction</a>
-            <a href="./particle_gpu_nebula.html?backend=webgpu">GPU nebula</a>
+            <a aria-current="page" href="./particle_noise_fields.html">Flow</a>
+            <a href="./particle_orbital_weave.html">Orbit</a>
+            <a href="./particle_collision_theatre.html">Impact</a>
+            <a href="./particle_gpu_nebula.html?backend=webgpu">Horizon</a>
+            <a href="./compute_particles.html?backend=webgpu">Tides</a>
         </nav>
         <script type="module" src="./particle_noise_fields.ts"></script>
     </body>

--- a/examples/particle_noise_fields.ts
+++ b/examples/particle_noise_fields.ts
@@ -1,202 +1,399 @@
 import * as Hilo3d from '../src/Hilo3d';
 import * as Particle from '@hilo/addon-particle';
 import { createExampleContext } from './shared/init';
-import {
-    addParticlePedestal,
-    createParticleTexture,
-    installExampleDisposal
-} from './shared/particleShowcase';
+import { installExampleDisposal } from './shared/particleShowcase';
 
 const context = await createExampleContext({
-    camera: { fov: 42, near: 0.1, far: 70, x: 0, y: 1.2, z: 10.2 },
+    camera: { fov: 38, near: 0.1, far: 70, x: 0, y: 0.15, z: 10.8 },
     stage: {
+        pixelRatio: 1.5,
         renderPipeline: new Hilo3d.PostProcessRenderPipelineFactory({
-            bloom: { threshold: 0.62, knee: 0.52, intensity: 0.7, scatter: 0.72, maxLevels: 6 },
+            bloom: { threshold: 0.74, knee: 0.4, intensity: 0.42, scatter: 0.6, maxLevels: 5 },
             colorUber: {
-                exposure: -0.22,
-                contrast: 0.14,
-                saturation: 0.12,
+                exposure: 0.06,
+                contrast: 0.08,
+                saturation: 0.02,
                 toneMapping: 'pbr-neutral',
-                vignetteIntensity: 0.68,
-                vignetteSmoothness: 0.54,
-                vignetteColor: new Hilo3d.Color(0.002, 0.003, 0.016, 0.72)
+                vignetteIntensity: 0.32,
+                vignetteSmoothness: 0.76,
+                vignetteColor: new Hilo3d.Color(0.008, 0.012, 0.016, 0.5)
             }
         })
     },
     controls: {
-        target: new Hilo3d.Vector3(0, 0.2, 0),
+        target: new Hilo3d.Vector3(0, 0.15, 0),
         minDistance: 8,
         maxDistance: 17,
-        minPolarAngle: 0.65,
-        maxPolarAngle: 2.1
+        minPolarAngle: 0.95,
+        maxPolarAngle: 2.05
     }
 });
-const { stage, renderer, directionLight, ambientLight } = context;
+const { stage, renderer } = context;
+renderer.clearColor.set(0.003, 0.008, 0.015, 1);
 
-renderer.clearColor.set(0.001, 0.004, 0.014, 1);
-directionLight.amount = 2.2;
-ambientLight.amount = 0.22;
-addParticlePedestal(stage, new Hilo3d.Color(0.022, 0.046, 0.11));
-
-const texture = createParticleTexture({ style: 'disc' });
-const spark = createParticleTexture({ style: 'spark' });
-const fade = new Particle.ParticleCurve(
-    [
-        { time: 0, value: 0 },
-        { time: 0.12, value: 1 },
-        { time: 0.82, value: 0.78 },
-        { time: 1, value: 0 }
-    ],
-    { interpolation: 'smooth' }
-);
-
-interface FieldParameters {
+/** Smooth grains and low-opacity gas have no hard heads or radial star rays. */
+function createFilamentTexture(soft = false): Hilo3d.Texture<Uint8Array> {
+    const size = 64;
+    const data = new Uint8Array(size * size * 4);
+    for (let y = 0; y < size; y += 1) {
+        for (let x = 0; x < size; x += 1) {
+            const u = ((x + 0.5) / size) * 2 - 1;
+            const v = ((y + 0.5) / size) * 2 - 1;
+            const radius = Math.hypot(u, v);
+            const alpha = Math.exp(-(u * u + v * v) * (soft ? 3 : 8)) * Math.max(0, 1 - radius);
+            const offset = (y * size + x) * 4;
+            data[offset] = 255;
+            data[offset + 1] = 255;
+            data[offset + 2] = 255;
+            data[offset + 3] = Math.round(alpha * 255);
+        }
+    }
+    return new Hilo3d.Texture({
+        image: data,
+        width: size,
+        height: size,
+        internalFormat: Hilo3d.constants.RGBA8,
+        format: Hilo3d.constants.RGBA,
+        type: Hilo3d.constants.UNSIGNED_BYTE,
+        wrapS: Hilo3d.constants.CLAMP_TO_EDGE,
+        wrapT: Hilo3d.constants.CLAMP_TO_EDGE,
+        minFilter: Hilo3d.constants.LINEAR,
+        magFilter: Hilo3d.constants.LINEAR
+    });
+}
+const texture = createFilamentTexture();
+const mistTexture = createFilamentTexture(true);
+interface Field {
     readonly name: string;
-    readonly position: readonly [number, number, number];
-    readonly execution: 'cpu' | 'stateless';
+    readonly position: Particle.ParticleVector3;
     readonly mode: 'position-offset' | 'force';
     readonly field: 'vector' | 'curl';
-    readonly color: readonly [number, number, number, number];
-    readonly strength: Particle.ParticleVector3;
-    readonly frequency: number;
-    readonly octaves: 1 | 2 | 3 | 4;
-    readonly scroll: Particle.ParticleVector3;
-    readonly damping?: number;
+    readonly color: Particle.ParticleColor;
 }
-
-const fields: readonly FieldParameters[] = [
+const fields: readonly Field[] = [
     {
-        name: 'vector-position',
-        position: [-2.25, 0.85, 0],
-        execution: 'stateless',
+        name: 'jade-current',
+        position: [-2.15, 1.15, 0],
         mode: 'position-offset',
         field: 'vector',
-        color: [0.08, 0.92, 1, 1],
-        strength: [0.75, 0.48, 0.34],
-        frequency: 1.1,
-        octaves: 2,
-        scroll: [0.12, 0.06, -0.04]
+        color: [0.14, 0.85, 0.65, 0.75]
     },
     {
-        name: 'curl-position',
-        position: [2.25, 0.85, 0],
-        execution: 'stateless',
+        name: 'glacial-gyre',
+        position: [2.15, 1.15, 0],
         mode: 'position-offset',
         field: 'curl',
-        color: [0.64, 0.2, 1, 1],
-        strength: [0.48, 0.72, 0.48],
-        frequency: 1.75,
-        octaves: 4,
-        scroll: [-0.08, 0.1, 0.05]
+        color: [0.22, 0.61, 1, 0.72]
     },
     {
-        name: 'vector-force',
-        position: [-2.25, -1.05, 0],
-        execution: 'cpu',
+        name: 'gilded-drift',
+        position: [-2.15, -1.25, 0],
         mode: 'force',
         field: 'vector',
-        color: [1, 0.58, 0.08, 1],
-        strength: [0.85, 0.44, 0.6],
-        frequency: 0.74,
-        octaves: 1,
-        scroll: [0.04, 0.16, 0]
+        color: [1, 0.56, 0.13, 0.72]
     },
     {
-        name: 'curl-force',
-        position: [2.25, -1.05, 0],
-        execution: 'cpu',
+        name: 'copper-eddy',
+        position: [2.15, -1.25, 0],
         mode: 'force',
         field: 'curl',
-        color: [1, 0.12, 0.48, 1],
-        strength: [0.92, 0.58, 0.92],
-        frequency: 1.32,
-        octaves: 3,
-        scroll: [0.09, 0.03, -0.07],
-        damping: 0.36
+        color: [1, 0.24, 0.15, 0.72]
     }
 ];
 
-const systems = fields.map((field, index) => {
-    const gradient = new Particle.ParticleGradient([
-        { time: 0, color: [1, 1, 1, 0] },
-        { time: 0.16, color: field.color },
-        { time: 0.72, color: [field.color[0] * 0.5, field.color[1] * 0.5, field.color[2], 0.72] },
-        { time: 1, color: [field.color[0] * 0.18, field.color[1] * 0.18, field.color[2] * 0.32, 0] }
-    ]);
+/** Deterministic emission samples form a fluid volume, never a rendered line mesh. */
+function pointOnCurrent(
+    study: number,
+    u: number,
+    lane: number,
+    depth: number
+): Particle.ParticleVector3 {
+    const t = u * Math.PI * 2;
+    if (study === 0) {
+        return [
+            (u - 0.5) * 3.15,
+            Math.sin(u * 5.8 - 0.8) * 0.37 + lane * (0.1 + Math.sin(u * Math.PI) * 0.45),
+            depth * 0.19 + Math.cos(u * 4.2) * 0.13
+        ];
+    }
+    if (study === 1) {
+        const radius = 0.64 + lane * 0.22 + Math.sin(t * 2.3) * 0.08;
+        return [
+            Math.cos(t) * radius * 1.65,
+            Math.sin(t) * radius * 0.72,
+            depth * 0.16 + Math.sin(t) * 0.16
+        ];
+    }
+    if (study === 2) {
+        return [
+            (u - 0.5) * 3.15,
+            Math.sin(u * 5.4 + 0.35) * 0.36 +
+                lane * (0.08 + Math.pow(Math.sin(u * Math.PI), 2) * 0.62),
+            depth * 0.17 + Math.sin(u * 7) * 0.13
+        ];
+    }
+    const angle = t * 1.1 - 0.8;
+    const radius = 0.12 + Math.pow(u, 0.7) * 0.93 + lane * (0.025 + u * 0.16);
+    return [
+        Math.cos(angle) * radius * 1.35,
+        Math.sin(angle) * radius * 0.7,
+        depth * 0.13 + Math.cos(angle) * 0.12
+    ];
+}
+function random(index: number, channel: number): number {
+    let value = (Math.imul(index + 19, 0x9e3779b1) ^ Math.imul(channel + 47, 0x85ebca6b)) >>> 0;
+    value ^= value >>> 16;
+    value = Math.imul(value, 0x7feb352d) >>> 0;
+    value ^= value >>> 15;
+    return (value >>> 0) / 0x1_0000_0000;
+}
+
+const studies = fields.map((field, index) => {
     const definition = Particle.ParticleSystemDefinition.create({
         emitters: [
             {
                 name: field.name,
-                capacity: 1_280,
-                execution: field.execution,
-                duration: 6,
-                looping: true,
-                prewarm: true,
-                bounds: { mode: 'manual', min: [-2, -2, -2], max: [2, 2, 2] },
-                emission: { rateOverTime: 210, bursts: [{ time: 0, count: 210 }] },
-                shape: { type: 'box', size: [1.4, 1.15, 0.55], distribution: 'volume' },
+                capacity: 5000,
+                fixedStep: 1 / 30,
+                execution: 'cpu',
+                simulationSpace: 'local',
+                bounds: { mode: 'manual', min: [-2.2, -1.1, -0.8], max: [2.2, 1.1, 0.8] },
                 initialize: {
-                    lifetime: { min: 3.8, max: 5.8 },
-                    direction: { min: [-0.08, -0.05, -0.08], max: [0.08, 0.12, 0.08] },
-                    speed: { min: 0.02, max: 0.16 },
-                    size: { min: 0.028, max: 0.078 }
+                    lifetime: { min: 1.35, max: 2.1 },
+                    size: { min: 0.02, max: 0.036 }
                 },
                 modules: [
                     {
                         type: 'noise',
                         mode: field.mode,
                         field: field.field,
-                        strength: field.strength,
-                        frequency: field.frequency,
-                        octaves: field.octaves,
-                        lacunarity: 2.05,
-                        persistence: 0.52,
-                        scrollVelocity: field.scroll,
-                        ...(field.damping === undefined ? {} : { damping: field.damping }),
-                        seedOffset: index * 37 + 11
+                        strength:
+                            field.mode === 'position-offset'
+                                ? [0.035, 0.045, 0.035]
+                                : [0.09, 0.1, 0.07],
+                        frequency: 1.25,
+                        octaves: 1,
+                        scrollVelocity: [0.13, 0.09, 0.08],
+                        seedOffset: index * 31
                     },
-                    ...(field.mode === 'force'
-                        ? ([
-                              { type: 'drag', coefficient: 0.16 },
-                              { type: 'limit-velocity', limit: 0.82, dampen: 0.22 }
-                          ] as const)
-                        : []),
-                    { type: 'size-over-lifetime', curve: fade },
-                    { type: 'color-over-lifetime', gradient },
-                    { type: 'screen-space-size', scale: 0.92 }
+                    { type: 'drag', coefficient: 0.12 },
+                    {
+                        type: 'size-over-lifetime',
+                        curve: new Particle.ParticleCurve([
+                            { time: 0, value: 0.7 },
+                            { time: 1, value: 1.3 }
+                        ])
+                    },
+                    {
+                        type: 'color-over-lifetime',
+                        gradient: new Particle.ParticleGradient([
+                            {
+                                time: 0,
+                                color: [
+                                    0.65 + field.color[0] * 0.35,
+                                    0.65 + field.color[1] * 0.35,
+                                    0.65 + field.color[2] * 0.35,
+                                    0
+                                ]
+                            },
+                            { time: 0.15, color: field.color },
+                            {
+                                time: 0.55,
+                                color: [
+                                    field.color[0] * 0.65,
+                                    field.color[1] * 0.72,
+                                    field.color[2] * 0.85,
+                                    0.4
+                                ]
+                            },
+                            {
+                                time: 1,
+                                color: [
+                                    field.color[0] * 0.35,
+                                    field.color[1] * 0.4,
+                                    field.color[2] * 0.65,
+                                    0
+                                ]
+                            }
+                        ])
+                    }
                 ],
                 renderers: [
                     {
                         type: 'sprite',
-                        texture: field.mode === 'force' ? spark : texture,
-                        alignment: field.mode === 'force' ? 'stretched' : 'view',
-                        stretchScale: field.mode === 'force' ? 2.8 : 1,
+                        texture,
+                        alignment: 'stretched',
+                        stretchScale: 2,
                         blend: 'additive',
                         depthWrite: false,
                         sort: 'none'
                     }
                 ]
+            },
+            {
+                // A small base opacity prevents a flash on birth; the gradient is a multiplier.
+                name: 'mist',
+                capacity: 1400,
+                execution: 'cpu',
+                fixedStep: 1 / 30,
+                bounds: { mode: 'manual', min: [-2.2, -1.1, -0.8], max: [2.2, 1.1, 0.8] },
+                initialize: {
+                    lifetime: { min: 1.4, max: 2 },
+                    size: { min: 0.08, max: 0.14 },
+                    color: [field.color[0], field.color[1], field.color[2], 0.03]
+                },
+                modules: [
+                    {
+                        type: 'size-over-lifetime',
+                        curve: new Particle.ParticleCurve([
+                            { time: 0, value: 0.6 },
+                            { time: 1, value: 1.4 }
+                        ])
+                    },
+                    {
+                        type: 'color-over-lifetime',
+                        gradient: new Particle.ParticleGradient([
+                            { time: 0, color: [1, 1, 1, 0] },
+                            {
+                                time: 0.22,
+                                color: [1, 1, 1, 1.4]
+                            },
+                            {
+                                time: 0.65,
+                                color: [1, 1, 1, 0.65]
+                            },
+                            { time: 1, color: [1, 1, 1, 0] }
+                        ])
+                    }
+                ],
+                renderers: [
+                    {
+                        type: 'sprite',
+                        texture: mistTexture,
+                        alignment: 'view',
+                        blend: 'additive',
+                        depthWrite: false,
+                        renderOrder: -1
+                    }
+                ]
             }
         ]
     });
-    return new Particle.ParticleSystem({
+    const system = new Particle.ParticleSystem({
+        definition,
+        seed: 401 + index * 73,
+        autoPlay: false,
         x: field.position[0],
         y: field.position[1],
-        z: field.position[2],
-        definition,
-        seed: 100 + index * 73
+        z: field.position[2]
     }).addTo(stage);
+    const samples: Readonly<Particle.ParticleSystemEmitCommand>[] = [];
+    for (let sample = 0; sample < 4096; sample += 1) {
+        const u = random(sample, index * 7);
+        const lane = (random(sample, 8) + random(sample, 9) + random(sample, 10) - 1.5) * 0.68;
+        const depth = random(sample, 11) * 2 - 1;
+        const point = pointOnCurrent(index, u, lane, depth);
+        const next = pointOnCurrent(index, u + 0.001, lane, depth);
+        const speed = 0.19 + random(sample, 12) * 0.17;
+        const dx = next[0] - point[0];
+        const dy = next[1] - point[1];
+        const dz = next[2] - point[2];
+        const scale = speed / Math.max(0.00001, Math.hypot(dx, dy, dz));
+        samples.push({
+            count: 1,
+            emitter: sample % 4 === 0 ? 'mist' : field.name,
+            position: point,
+            velocity: [dx * scale, dy * scale, dz * scale]
+        });
+    }
+    return { system, samples, cursor: 0, accumulator: 0 };
 });
 
-let elapsed = 0;
-stage.onUpdate = deltaTime => {
-    elapsed += deltaTime * 0.001;
-    systems.forEach((system, index) => {
-        system.rotationY = Math.sin(elapsed * (0.22 + index * 0.03) + index) * 8;
-    });
-};
+function advanceCurrent(seconds: number): void {
+    for (const study of studies) {
+        study.accumulator += seconds * 2100;
+        const count = Math.floor(study.accumulator);
+        study.accumulator -= count;
+        for (let index = 0; index < count; index += 1) {
+            const sample = study.samples[study.cursor];
+            if (sample) study.system.emit(sample);
+            study.cursor = (study.cursor + 1597) % study.samples.length;
+        }
+        study.system.simulate(seconds);
+    }
+}
+// Fixed-step warm-up fills the live currents without substituting static contour geometry.
+for (let frame = 0; frame < 63; frame += 1) advanceCurrent(1 / 30);
 
+const labelElements = document.querySelectorAll<HTMLElement>('.noise-label');
+const studyLabels = studies.map((study, index) => {
+    const element = labelElements[index];
+    if (!element) throw new Error('Each noise study requires a label');
+    return {
+        study: study.system,
+        element,
+        projected: new Hilo3d.Vector3(),
+        worldMatrix: new Hilo3d.Matrix4()
+    };
+});
+let viewportWidth = window.innerWidth;
+let viewportHeight = window.innerHeight;
+function updateStudyLabels(): void {
+    context.camera.updateViewProjectionMatrix();
+    for (const label of studyLabels) {
+        label.worldMatrix.multiply(stage.worldMatrix, label.study.matrix);
+        label.projected
+            .set(0, viewportWidth < 720 ? -0.7 : -0.88, 0)
+            .transformMat4(label.worldMatrix)
+            .transformMat4(context.camera.viewProjectionMatrix);
+        const x = (label.projected.x + 1) * viewportWidth * 0.5;
+        const y = (1 - label.projected.y) * viewportHeight * 0.5 + 20;
+        const visible =
+            label.projected.z > -1 &&
+            label.projected.z < 1 &&
+            x > 24 &&
+            x < viewportWidth - 24 &&
+            y > 24 &&
+            y < viewportHeight - 112;
+        label.element.style.visibility = visible ? 'visible' : 'hidden';
+        if (visible)
+            label.element.style.transform = `translate3d(${x.toFixed(1)}px, ${y.toFixed(1)}px, 0) translateX(-50%)`;
+    }
+}
+function fitStudies(): void {
+    viewportWidth = window.innerWidth;
+    viewportHeight = window.innerHeight;
+    const portrait = viewportWidth < 720 && viewportWidth < viewportHeight;
+    studies.forEach((study, index) => {
+        const field = fields[index];
+        if (!field) return;
+        study.system.position.set(
+            portrait ? 0 : field.position[0],
+            portrait ? 1.98 - index * 1.15 : field.position[1],
+            0
+        );
+        study.system.setScale(portrait ? 0.64 : 1);
+    });
+    context.orbitControls.setView(
+        new Hilo3d.Vector3(0, 0.15, portrait ? 9.8 : 10.8),
+        new Hilo3d.Vector3(0, 0.15, 0)
+    );
+}
+fitStudies();
+window.addEventListener('resize', fitStudies);
+let accumulator = 0;
+stage.onUpdate = deltaTime => {
+    accumulator += Math.min(deltaTime * 0.001, 0.1);
+    let steps = 0;
+    while (accumulator >= 1 / 30 && steps < 3) {
+        advanceCurrent(1 / 30);
+        accumulator -= 1 / 30;
+        steps += 1;
+    }
+    updateStudyLabels();
+};
 document.body.dataset['particleExampleReady'] = 'true';
 installExampleDisposal(() => {
+    window.removeEventListener('resize', fitStudies);
     context.dispose();
 });

--- a/examples/particle_orbital_weave.html
+++ b/examples/particle_orbital_weave.html
@@ -5,33 +5,27 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
             name="description"
-            content="Portable mesh, ribbon, and trail particle topology with scene lighting and orbital motion."
+            content="Two wandering comets shed luminous, living particle wakes through intersecting orbits."
         />
         <title>Hilo3D Particle Orbital Weave</title>
         <link rel="stylesheet" href="./example.css" />
         <link rel="stylesheet" href="./particle_showcase.css" />
     </head>
-    <body>
+    <body class="particle-gallery orbital-page">
         <div id="container"></div>
         <header class="particle-hero">
-            <div class="particle-kicker">Particle studies · 02 / topology</div>
+            <div class="particle-kicker">Studies in motion · 03 / orbit</div>
             <h1>Orbital Weave</h1>
-            <p>
-                Dense mesh buckets, luminous ribbons and velocity trails share one portable
-                simulation while preserving topology and bounded draw counts.
-            </p>
-            <div class="particle-chips">
-                <span>mesh buckets</span><span>ribbon + trail</span><span>Lambert lighting</span
-                ><span>ribbonId</span><span>motion vectors</span>
-            </div>
+            <p>Two wandering lights. A thousand traces left behind.</p>
         </header>
-        <div class="particle-hint">DRAG TO ORBIT · WATCH THE WEAVE REFORM</div>
+        <div class="particle-hint">DRAG TO ORBIT · FOLLOW THE COMETS</div>
         <nav class="particle-nav" aria-label="Particle example collection">
             <a href="./particle_elemental_forge.html">Elemental</a>
-            <a href="./particle_noise_fields.html">Noise</a>
-            <a aria-current="page" href="./particle_orbital_weave.html">Topology</a>
-            <a href="./particle_collision_theatre.html">Interaction</a>
-            <a href="./particle_gpu_nebula.html?backend=webgpu">GPU nebula</a>
+            <a href="./particle_noise_fields.html">Flow</a>
+            <a aria-current="page" href="./particle_orbital_weave.html">Orbit</a>
+            <a href="./particle_collision_theatre.html">Impact</a>
+            <a href="./particle_gpu_nebula.html?backend=webgpu">Horizon</a>
+            <a href="./compute_particles.html?backend=webgpu">Tides</a>
         </nav>
         <script type="module" src="./particle_orbital_weave.ts"></script>
     </body>

--- a/examples/particle_orbital_weave.ts
+++ b/examples/particle_orbital_weave.ts
@@ -4,309 +4,495 @@ import { createExampleContext } from './shared/init';
 import { createParticleTexture, installExampleDisposal } from './shared/particleShowcase';
 
 const context = await createExampleContext({
-    camera: { fov: 40, near: 0.1, far: 80, x: 0, y: 2, z: 10.8 },
+    autoStart: false,
+    camera: { fov: 36, near: 0.1, far: 80, x: 0, y: 0.2, z: 10.8 },
     stage: {
+        pixelRatio: 1.5,
         useInstanced: true,
         renderPipeline: new Hilo3d.PostProcessRenderPipelineFactory({
-            bloom: { threshold: 0.8, knee: 0.45, intensity: 0.5, scatter: 0.68, maxLevels: 6 },
+            bloom: { threshold: 1.25, knee: 0.4, intensity: 0.32, scatter: 0.6, maxLevels: 5 },
             colorUber: {
-                exposure: -0.24,
-                contrast: 0.12,
-                saturation: 0.1,
+                exposure: 0,
+                contrast: 0.06,
+                saturation: 0.04,
                 toneMapping: 'pbr-neutral',
-                vignetteIntensity: 0.62,
-                vignetteSmoothness: 0.56,
-                vignetteColor: new Hilo3d.Color(0.002, 0.006, 0.02, 0.68)
+                vignetteIntensity: 0.35,
+                vignetteSmoothness: 0.8,
+                vignetteColor: new Hilo3d.Color(0.002, 0.005, 0.018, 0.8)
             }
         })
     },
     controls: {
-        target: new Hilo3d.Vector3(0, 0.1, 0),
+        target: new Hilo3d.Vector3(0, 0, 0),
         minDistance: 6,
-        maxDistance: 16,
-        minPolarAngle: 0.55,
-        maxPolarAngle: 2.35
+        maxDistance: 28,
+        minPolarAngle: 0.5,
+        maxPolarAngle: 2.6
     }
 });
-const { stage, renderer, directionLight, ambientLight } = context;
+const { stage, renderer } = context;
+renderer.clearColor.set(0.002, 0.005, 0.011, 1);
 
-renderer.clearColor.set(0.002, 0.006, 0.018, 1);
-directionLight.amount = 4.6;
-directionLight.color.set(0.48, 0.82, 1, 1);
-directionLight.direction.set(-0.45, -1, -0.25);
-ambientLight.amount = 0.36;
-ambientLight.color.set(0.32, 0.22, 0.72, 1);
-
-new Hilo3d.PointLight({
-    x: -2.4,
-    y: 2.4,
-    z: 1.4,
-    amount: 16,
-    range: 9,
-    color: new Hilo3d.Color(0.18, 0.82, 1)
-}).addTo(stage);
-new Hilo3d.PointLight({
-    x: 2.7,
-    y: 0.5,
-    z: 0.5,
-    amount: 13,
-    range: 8,
-    color: new Hilo3d.Color(0.92, 0.2, 1)
-}).addTo(stage);
-
+const grainTexture = createParticleTexture({ style: 'disc', size: 32 });
+const sparkTexture = createParticleTexture({ style: 'spark', size: 32 });
 const ribbonTexture = createParticleTexture({ style: 'ribbon', size: 32 });
-const pulse = new Particle.ParticleCurve(
+
+const dustSize = new Particle.ParticleCurve(
     [
-        { time: 0, value: 0.12 },
-        { time: 0.18, value: 1 },
-        { time: 0.8, value: 0.72 },
+        { time: 0, value: 0.8 },
+        { time: 0.12, value: 1 },
+        { time: 0.62, value: 0.72 },
         { time: 1, value: 0 }
     ],
     { interpolation: 'smooth' }
 );
-const orbitColor = new Particle.ParticleGradient([
-    { time: 0, color: [0.12, 0.88, 1, 0.95] },
-    { time: 0.38, color: [0.24, 0.3, 1, 0.9] },
-    { time: 0.72, color: [0.88, 0.16, 1, 0.82] },
-    { time: 1, color: [1, 0.44, 0.18, 0] }
-]);
-
-const trailWidth = new Particle.ParticleCurve(
+const filamentSize = new Particle.ParticleCurve(
     [
-        { time: 0, value: 0.08 },
+        { time: 0, value: 0.75 },
         { time: 0.08, value: 1 },
-        { time: 0.78, value: 0.72 },
+        { time: 0.65, value: 0.25 },
         { time: 1, value: 0 }
     ],
     { interpolation: 'smooth' }
 );
 
-const weaveDefinition = Particle.ParticleSystemDefinition.create({
-    emitters: [
-        {
-            name: 'lit-orbit-meshes',
-            capacity: 240,
-            execution: 'cpu',
-            prewarm: true,
-            overflow: 'replace-oldest',
-            bounds: { mode: 'automatic' },
-            emission: { rateOverTime: 38, bursts: [{ time: 0, count: 80 }] },
-            shape: { type: 'torus', radius: 1.65, tubeRadius: 0.32, distribution: 'volume' },
-            initialize: {
-                lifetime: { min: 4.8, max: 7.4 },
-                direction: { min: [-0.1, -0.05, -0.1], max: [0.1, 0.05, 0.1] },
-                speed: { min: 0.04, max: 0.24 },
-                size: { min: 0.075, max: 0.18 },
-                rotation: { min: -3.14, max: 3.14 },
-                meshIndex: { min: 0, max: 1 }
-            },
-            modules: [
-                {
-                    type: 'rotate-around-point',
-                    center: [0, 0, 0],
-                    axis: [0.12, 1, 0.08],
-                    angularSpeed: { min: 0.34, max: 0.62 }
-                },
-                { type: 'conform-sphere', center: [0, 0, 0], radius: 1.8, strength: 1.1 },
-                {
-                    type: 'orbital-force',
-                    center: [0, 0, 0],
-                    strength: { min: 0.12, max: 0.42 },
-                    axis: [0, 1, 0]
-                },
-                { type: 'drag', coefficient: 0.16 },
-                {
-                    type: 'rotation-over-lifetime',
-                    curve: new Particle.ParticleCurve([
-                        { time: 0, value: 0 },
-                        { time: 1, value: 6.28 }
-                    ]),
-                    cycles: 2
-                },
-                { type: 'size-over-lifetime', curve: pulse },
-                { type: 'color-over-lifetime', gradient: orbitColor }
-            ],
-            renderers: [
-                {
-                    type: 'mesh',
-                    meshes: [
-                        {
-                            geometry: new Hilo3d.BoxGeometry({
-                                width: 0.7,
-                                height: 0.7,
-                                depth: 0.7
-                            })
-                        },
-                        {
-                            geometry: new Hilo3d.SphereGeometry({
-                                radius: 0.45,
-                                widthSegments: 12,
-                                heightSegments: 8
-                            })
-                        }
-                    ],
-                    orientation: 'velocity',
-                    coverage: 'opaque',
-                    lighting: 'lambert',
-                    depthTest: true,
-                    depthWrite: true,
-                    motionVectors: true,
-                    renderOrder: 0
-                }
-            ]
-        }
-    ]
-});
+function cometGradient(warm: boolean, alpha = 1): Particle.ParticleGradient {
+    return new Particle.ParticleGradient(
+        warm
+            ? [
+                  { time: 0, color: [3.6, 2.5, 1.65, alpha] },
+                  { time: 0.05, color: [2, 0.93, 0.42, alpha * 0.95] },
+                  { time: 0.24, color: [1.3, 0.35, 0.17, alpha * 0.86] },
+                  { time: 0.6, color: [0.66, 0.14, 0.15, alpha * 0.42] },
+                  { time: 1, color: [0.19, 0.07, 0.14, 0] }
+              ]
+            : [
+                  { time: 0, color: [3.8, 4.5, 5, alpha] },
+                  { time: 0.04, color: [0.85, 2, 2.6, alpha * 0.95] },
+                  { time: 0.24, color: [0.22, 1.08, 1.5, alpha * 0.82] },
+                  { time: 0.6, color: [0.12, 0.43, 0.78, alpha * 0.46] },
+                  { time: 1, color: [0.09, 0.12, 0.34, 0] }
+              ]
+    );
+}
 
-const weave = new Particle.ParticleSystem({
-    y: 0.25,
-    definition: weaveDefinition,
-    seed: 2026
-}).addTo(stage);
-
-function createOrbitPathDefinition(
-    name: string,
-    type: 'ribbon' | 'trail',
-    gradient: Particle.ParticleGradient,
-    facing: 'view' | 'world-up'
-): Particle.ParticleSystemDefinition {
-    return Particle.ParticleSystemDefinition.create({
+/** Every visible tail sample is born at the moving comet and ages in world space. */
+function createComet(warm: boolean): Particle.ParticleSystem {
+    const lifetime = warm ? 8 : 10;
+    const density = warm ? 0.64 : 1;
+    const gradient = cometGradient(warm);
+    const definition = Particle.ParticleSystemDefinition.create({
         emitters: [
             {
-                name,
-                capacity: 220,
+                name: 'dust-wake',
+                capacity: Math.ceil(1200 * density * lifetime),
                 execution: 'cpu',
                 simulationSpace: 'world',
-                duration: 12,
-                looping: true,
                 fixedStep: 1 / 60,
                 bounds: { mode: 'dynamic' },
-                emission: { rateOverTime: 56 },
+                emission: { rateOverTime: 840 * density },
+                shape: { type: 'sphere', radius: warm ? 0.016 : 0.022, distribution: 'volume' },
                 initialize: {
-                    lifetime: 3.35,
-                    speed: 0,
-                    size: 0.09,
-                    ribbonId: 0
+                    lifetime: { min: lifetime * 0.68, max: lifetime },
+                    speed: { min: 0.02, max: warm ? 0.095 : 0.14 },
+                    size: { min: 0.014, max: 0.036 },
+                    rotation: { min: -Math.PI, max: Math.PI }
                 },
                 modules: [
-                    { type: 'size-over-lifetime', curve: trailWidth },
+                    { type: 'drag', coefficient: 0.11 },
+                    {
+                        type: 'noise',
+                        field: 'vector',
+                        mode: 'force',
+                        strength: [0.018, 0.018, 0.018],
+                        frequency: 1.2,
+                        octaves: 1,
+                        scrollVelocity: [0.04, 0.03, 0],
+                        seedOffset: warm ? 45 : 18
+                    },
+                    { type: 'size-over-lifetime', curve: dustSize },
                     { type: 'color-over-lifetime', gradient }
                 ],
                 renderers: [
                     {
-                        type,
+                        type: 'sprite',
+                        texture: grainTexture,
+                        blend: 'additive',
+                        depthWrite: false,
+                        renderOrder: 3
+                    }
+                ]
+            },
+            {
+                name: 'ion-mist',
+                capacity: Math.ceil(320 * density * lifetime),
+                execution: 'cpu',
+                simulationSpace: 'world',
+                bounds: { mode: 'dynamic' },
+                emission: { rateOverTime: 280 * density },
+                shape: { type: 'sphere', radius: 0.025, distribution: 'volume' },
+                initialize: {
+                    lifetime: { min: lifetime * 0.5, max: lifetime },
+                    speed: { min: 0.012, max: 0.065 },
+                    size: { min: 0.065, max: 0.11 }
+                },
+                modules: [
+                    { type: 'drag', coefficient: 0.12 },
+                    { type: 'size-over-lifetime', curve: dustSize },
+                    { type: 'color-over-lifetime', gradient: cometGradient(warm, 0.035) }
+                ],
+                renderers: [
+                    {
+                        type: 'sprite',
+                        texture: grainTexture,
+                        blend: 'additive',
+                        depthWrite: false,
+                        renderOrder: 1
+                    }
+                ]
+            },
+            {
+                name: 'escaping-grains',
+                capacity: warm ? 420 : 700,
+                execution: 'cpu',
+                simulationSpace: 'world',
+                bounds: { mode: 'dynamic' },
+                emission: { rateOverTime: warm ? 55 : 88 },
+                shape: { type: 'sphere', radius: 0.04, distribution: 'volume' },
+                initialize: {
+                    lifetime: { min: 3.5, max: 7 },
+                    speed: { min: 0.15, max: 0.38 },
+                    size: { min: 0.014, max: 0.034 }
+                },
+                modules: [
+                    { type: 'drag', coefficient: 0.13 },
+                    { type: 'size-over-lifetime', curve: dustSize },
+                    { type: 'color-over-lifetime', gradient: cometGradient(warm, 0.72) }
+                ],
+                renderers: [
+                    {
+                        type: 'sprite',
+                        texture: sparkTexture,
+                        blend: 'additive',
+                        depthWrite: false,
+                        renderOrder: 4
+                    }
+                ]
+            },
+            {
+                name: warm ? 'ember-ribbon' : 'ion-trail',
+                capacity: 800,
+                execution: 'cpu',
+                simulationSpace: 'world',
+                fixedStep: 1 / 60,
+                bounds: { mode: 'dynamic' },
+                emission: { rateOverTime: 72 },
+                initialize: { lifetime: lifetime * 0.9, speed: 0, size: 0.012, ribbonId: 0 },
+                modules: [
+                    { type: 'size-over-lifetime', curve: filamentSize },
+                    { type: 'color-over-lifetime', gradient: cometGradient(warm, 0.4) }
+                ],
+                renderers: [
+                    {
+                        type: warm ? 'ribbon' : 'trail',
                         texture: ribbonTexture,
                         coverage: 'transparent',
                         blend: 'additive',
-                        facing,
-                        widthScale: type === 'trail' ? 0.82 : 1.05,
+                        facing: 'view',
+                        widthScale: 1,
                         uvMode: 'repeat',
-                        tilesPerUnit: 3.6,
+                        tilesPerUnit: 2,
                         depthWrite: false,
-                        renderOrder: type === 'trail' ? 3 : 2
+                        renderOrder: 2
+                    }
+                ]
+            },
+            {
+                name: 'solid-micrometeors',
+                capacity: 128,
+                execution: 'cpu',
+                simulationSpace: 'world',
+                bounds: { mode: 'dynamic' },
+                emission: { rateOverTime: 24 },
+                shape: { type: 'sphere', radius: 0.025, distribution: 'volume' },
+                initialize: {
+                    lifetime: { min: 2, max: 4 },
+                    speed: { min: 0.025, max: 0.1 },
+                    size: { min: 0.024, max: 0.052 },
+                    meshIndex: { min: 0, max: 1 }
+                },
+                modules: [
+                    { type: 'size-over-lifetime', curve: dustSize },
+                    { type: 'color-over-lifetime', gradient }
+                ],
+                renderers: [
+                    {
+                        type: 'mesh',
+                        meshes: [
+                            {
+                                geometry: new Hilo3d.SphereGeometry({
+                                    radius: 0.22,
+                                    widthSegments: 8,
+                                    heightSegments: 6
+                                })
+                            },
+                            {
+                                geometry: new Hilo3d.SphereGeometry({
+                                    radius: 0.3,
+                                    widthSegments: 10,
+                                    heightSegments: 8
+                                })
+                            }
+                        ],
+                        orientation: 'velocity',
+                        coverage: 'opaque',
+                        lighting: 'lambert',
+                        depthWrite: true,
+                        motionVectors: true,
+                        renderOrder: 0
+                    }
+                ]
+            },
+            {
+                name: 'comet-heart',
+                capacity: 48,
+                execution: 'cpu',
+                simulationSpace: 'world',
+                bounds: { mode: 'dynamic' },
+                emission: { rateOverTime: 120 },
+                shape: { type: 'sphere', radius: 0.012, distribution: 'volume' },
+                initialize: {
+                    lifetime: { min: 0.055, max: 0.12 },
+                    speed: { min: 0.01, max: 0.025 },
+                    size: { min: 0.045, max: 0.065 }
+                },
+                modules: [
+                    { type: 'size-over-lifetime', curve: filamentSize },
+                    { type: 'color-over-lifetime', gradient }
+                ],
+                renderers: [
+                    {
+                        type: 'sprite',
+                        texture: grainTexture,
+                        blend: 'additive',
+                        depthWrite: false,
+                        renderOrder: 5
                     }
                 ]
             }
         ]
     });
+    return new Particle.ParticleSystem({ definition, seed: warm ? 405 : 404, autoPlay: false });
 }
 
-const cyanPath = new Particle.ParticleSystem({
-    definition: createOrbitPathDefinition(
-        'cyan-trail',
-        'trail',
-        new Particle.ParticleGradient([
-            { time: 0, color: [0.75, 1, 1, 1] },
-            { time: 0.32, color: [0.04, 0.82, 1, 0.9] },
-            { time: 1, color: [0.02, 0.18, 1, 0] }
-        ]),
-        'view'
-    ),
-    seed: 404
-}).addTo(stage);
-const magentaPath = new Particle.ParticleSystem({
-    definition: createOrbitPathDefinition(
-        'magenta-ribbon',
-        'ribbon',
-        new Particle.ParticleGradient([
-            { time: 0, color: [1, 0.9, 1, 1] },
-            { time: 0.35, color: [1, 0.08, 0.72, 0.88] },
-            { time: 1, color: [0.25, 0.03, 0.8, 0] }
-        ]),
-        'world-up'
-    ),
-    seed: 405
-}).addTo(stage);
-const amberPath = new Particle.ParticleSystem({
-    definition: createOrbitPathDefinition(
-        'amber-trail',
-        'trail',
-        new Particle.ParticleGradient([
-            { time: 0, color: [1, 1, 0.82, 1] },
-            { time: 0.3, color: [1, 0.44, 0.06, 0.9] },
-            { time: 1, color: [0.76, 0.04, 0.2, 0] }
-        ]),
-        'view'
-    ),
-    seed: 406
-}).addTo(stage);
+interface OrbitTracer {
+    readonly system: Particle.ParticleSystem;
+    readonly radiusX: number;
+    readonly radiusY: number;
+    readonly tilt: number;
+    readonly depth: number;
+    readonly speed: number;
+    readonly phase: number;
+}
 
-const core = new Hilo3d.Mesh({
-    y: 0.25,
-    geometry: new Hilo3d.SphereGeometry({ radius: 0.72, widthSegments: 36, heightSegments: 24 }),
-    material: new Hilo3d.PBRMaterial({
-        baseColor: new Hilo3d.Color(0.012, 0.026, 0.08),
-        metallic: 0.92,
-        roughness: 0.12,
-        emissionFactor: new Hilo3d.Color(0.006, 0.04, 0.16)
-    })
-}).addTo(stage);
-const coreWire = new Hilo3d.Mesh({
-    y: 0.25,
-    rotationX: 17,
-    rotationY: 31,
-    geometry: new Hilo3d.SphereGeometry({
-        radius: 0.745,
-        widthSegments: 22,
-        heightSegments: 14
-    }),
-    material: new Hilo3d.BasicMaterial({
-        lightType: 'NONE',
-        diffuse: new Hilo3d.Color(0.38, 1.15, 2.6),
-        compositing: { mode: 'alpha-blend', premultiplied: true },
-        opacity: 0.32,
-        state: { wireframe: true, depthWrite: false }
-    }),
-    castShadows: false,
-    receiveShadows: false
-}).addTo(stage);
+const tracerWidth = new Particle.ParticleCurve(
+    [
+        { time: 0, value: 0.75 },
+        { time: 0.07, value: 1 },
+        { time: 0.45, value: 0.88 },
+        { time: 0.8, value: 0.35 },
+        { time: 1, value: 0 }
+    ],
+    { interpolation: 'smooth' }
+);
 
-let pathTime = 0;
-core.onUpdate = deltaTime => {
-    pathTime += deltaTime * 0.001;
-    core.rotationY += deltaTime * 0.014;
-    core.rotationX += deltaTime * 0.006;
-    coreWire.rotationY -= deltaTime * 0.018;
-    coreWire.rotationX += deltaTime * 0.009;
-    weave.rotationY += deltaTime * 0.003;
-    cyanPath.position.set(
-        Math.cos(pathTime * 1.05) * 2.75,
-        0.25 + Math.sin(pathTime * 2.1) * 0.75,
-        Math.sin(pathTime * 1.05) * 1.65
+/** A separately moving light draws one continuous, finite-lived particle ribbon. */
+function createOrbitTracer(
+    name: string,
+    type: 'ribbon' | 'trail',
+    color: readonly [number, number, number],
+    lifetime: number,
+    width: number,
+    seed: number
+): Particle.ParticleSystem {
+    const gradient = new Particle.ParticleGradient([
+        { time: 0, color: [color[0] * 1.5, color[1] * 1.5, color[2] * 1.5, 1] },
+        { time: 0.12, color: [color[0], color[1], color[2], 0.95] },
+        { time: 0.55, color: [color[0] * 0.85, color[1] * 0.85, color[2] * 0.85, 0.85] },
+        { time: 0.85, color: [color[0] * 0.5, color[1] * 0.5, color[2] * 0.5, 0.45] },
+        { time: 1, color: [color[0] * 0.3, color[1] * 0.3, color[2] * 0.3, 0] }
+    ]);
+    return new Particle.ParticleSystem({
+        seed,
+        autoPlay: false,
+        definition: Particle.ParticleSystemDefinition.create({
+            emitters: [
+                {
+                    name,
+                    capacity: Math.ceil(lifetime * 100),
+                    execution: 'cpu',
+                    simulationSpace: 'world',
+                    fixedStep: 1 / 60,
+                    bounds: { mode: 'dynamic' },
+                    emission: { rateOverTime: 90 },
+                    initialize: { lifetime, speed: 0, size: width, ribbonId: 0 },
+                    modules: [
+                        { type: 'size-over-lifetime', curve: tracerWidth },
+                        { type: 'color-over-lifetime', gradient }
+                    ],
+                    renderers: [
+                        {
+                            type,
+                            texture: ribbonTexture,
+                            coverage: 'transparent',
+                            blend: 'additive',
+                            facing: 'view',
+                            widthScale: 1,
+                            uvMode: 'repeat',
+                            tilesPerUnit: 2,
+                            depthWrite: false,
+                            renderOrder: 6
+                        }
+                    ]
+                },
+                {
+                    name: `${name}-head`,
+                    capacity: 16,
+                    execution: 'cpu',
+                    simulationSpace: 'world',
+                    bounds: { mode: 'dynamic' },
+                    emission: { rateOverTime: 90 },
+                    initialize: { lifetime: 0.065, speed: 0, size: width * 1.5 },
+                    modules: [
+                        { type: 'size-over-lifetime', curve: filamentSize },
+                        { type: 'color-over-lifetime', gradient }
+                    ],
+                    renderers: [
+                        {
+                            type: 'sprite',
+                            texture: grainTexture,
+                            blend: 'additive',
+                            depthWrite: false,
+                            renderOrder: 7
+                        }
+                    ]
+                }
+            ]
+        })
+    });
+}
+
+const tracers: readonly OrbitTracer[] = [
+    {
+        system: createOrbitTracer('silver-ribbon', 'ribbon', [2.1, 2.4, 2.7], 7.2, 0.048, 1401),
+        radiusX: 3,
+        radiusY: 0.92,
+        tilt: -0.28,
+        depth: 1.45,
+        speed: -0.5,
+        phase: 1.2
+    },
+    {
+        system: createOrbitTracer(
+            'champagne-ribbon',
+            'ribbon',
+            [2.4, 1.75, 0.95],
+            5.6,
+            0.046,
+            1402
+        ),
+        radiusX: 1.22,
+        radiusY: 2.25,
+        tilt: 0.4,
+        depth: 1.1,
+        speed: 0.61,
+        phase: 0.5
+    },
+    {
+        system: createOrbitTracer('aqua-trail', 'trail', [0.45, 1.8, 2.1], 4.8, 0.052, 1403),
+        radiusX: 2.45,
+        radiusY: 1.13,
+        tilt: 0.6,
+        depth: 1.65,
+        speed: -0.73,
+        phase: 2.2
+    }
+];
+
+function positionTracers(time: number): void {
+    for (const tracer of tracers) {
+        const angle = time * tracer.speed + tracer.phase;
+        const x = Math.cos(angle) * tracer.radiusX;
+        const y = Math.sin(angle) * tracer.radiusY;
+        const cosine = Math.cos(tracer.tilt);
+        const sine = Math.sin(tracer.tilt);
+        tracer.system.position.set(
+            x * cosine - y * sine,
+            x * sine + y * cosine,
+            Math.sin(angle + 0.65) * tracer.depth
+        );
+    }
+}
+
+const motion = new Hilo3d.Node().addTo(stage);
+const blueComet = createComet(false);
+const emberComet = createComet(true);
+
+/** Different inclinations and orbital periods keep the two wakes from forming a fixed ring. */
+function positionComets(time: number): void {
+    const blueAngle = time * 0.37 + 0.5;
+    const blueX = Math.cos(blueAngle) * 2.6;
+    const blueY = Math.sin(blueAngle) * 1.65;
+    blueComet.position.set(
+        blueX * 0.94 - blueY * 0.34 + 0.2,
+        blueX * 0.34 + blueY * 0.94,
+        Math.sin(blueAngle + 0.7) * 1.1
     );
-    magentaPath.position.set(
-        Math.cos(pathTime * 0.82 + 2.1) * 2.35,
-        0.25 + Math.sin(pathTime * 1.64 + 0.7) * 1.35,
-        Math.sin(pathTime * 0.82 + 2.1) * 2.15
+    const emberAngle = time * 0.43 + 3.1;
+    const emberX = Math.cos(emberAngle) * 1.9;
+    const emberY = Math.sin(emberAngle) * 1.45;
+    emberComet.position.set(
+        emberX * 0.72 + emberY * 0.69 - 0.35,
+        -emberX * 0.69 + emberY * 0.72 - 0.1,
+        Math.cos(emberAngle + 0.3) * 1.8
     );
-    amberPath.position.set(
-        Math.cos(pathTime * 1.28 + 4.2) * 1.95,
-        0.25 + Math.sin(pathTime * 2.56 + 1.4) * 1.05,
-        Math.sin(pathTime * 1.28 + 4.2) * 2.55
-    );
+}
+
+// Rehearse the actual emitters along their paths, so the first frame already has a living wake.
+let orbitTime = 7;
+for (let frame = 0; frame < 600; frame += 1) {
+    const sampleTime = orbitTime - 10 + frame / 60;
+    positionComets(sampleTime);
+    positionTracers(sampleTime);
+    for (const tracer of tracers) tracer.system.simulate(1 / 60);
+    blueComet.simulate(1 / 60);
+    emberComet.simulate(1 / 60);
+}
+positionComets(orbitTime);
+positionTracers(orbitTime);
+for (const tracer of tracers) tracer.system.addTo(stage).play();
+blueComet.addTo(stage).play();
+emberComet.addTo(stage).play();
+motion.onUpdate = deltaTime => {
+    // Match the emitters' eight fixed-step catch-up budget, including slow browser frames.
+    orbitTime += Math.min(deltaTime * 0.001, 8 / 60);
+    positionComets(orbitTime);
+    positionTracers(orbitTime);
 };
 
+function fitOrbit(): void {
+    const aspect = window.innerWidth / window.innerHeight;
+    const distance = Math.max(10.8, 10.8 / Math.max(0.4, aspect));
+    context.orbitControls.setView(
+        new Hilo3d.Vector3(0, 0.2, distance),
+        new Hilo3d.Vector3(0, 0, 0)
+    );
+}
+fitOrbit();
+window.addEventListener('resize', fitOrbit);
+context.ticker.start();
 document.body.dataset['particleExampleReady'] = 'true';
 installExampleDisposal(() => {
+    window.removeEventListener('resize', fitOrbit);
     context.dispose();
 });

--- a/examples/particle_showcase.css
+++ b/examples/particle_showcase.css
@@ -1,439 +1,269 @@
 :root {
     color-scheme: dark;
-    font-family:
-        Inter,
-        ui-sans-serif,
-        system-ui,
-        -apple-system,
-        BlinkMacSystemFont,
-        'Segoe UI',
-        sans-serif;
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+    --particle-ink: #ece7dd;
+    --particle-muted: #9a9993;
+    --particle-accent: #cfac79;
+    --particle-line: rgb(205 190 161 / 18%);
 }
 
 body {
-    background: #02040c;
-    color: #f4f7ff;
+    background: #080b10;
+    color: var(--particle-ink);
 }
-
+.particle-gallery::after {
+    position: fixed;
+    z-index: 99990;
+    inset: 18px;
+    border: 1px solid rgb(205 190 161 / 9%);
+    pointer-events: none;
+    content: '';
+}
+.particle-gallery .hilo3dStats {
+    display: none;
+}
 .particle-hero {
     position: fixed;
     z-index: 100000;
-    top: 22px;
-    right: 24px;
-    width: min(390px, calc(100vw - 48px));
+    top: 42px;
+    left: 42px;
+    width: 280px;
     pointer-events: none;
 }
-
 .particle-kicker {
-    color: #7fe9ff;
-    font-size: 10px;
-    font-weight: 750;
-    letter-spacing: 0.18em;
+    color: var(--particle-accent);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    line-height: 1.6;
     text-transform: uppercase;
 }
-
 .particle-hero h1 {
-    margin: 7px 0 6px;
-    font-size: clamp(24px, 4vw, 46px);
-    font-weight: 650;
-    letter-spacing: -0.045em;
-    line-height: 0.96;
-    text-shadow: 0 4px 30px rgba(0, 0, 0, 0.55);
+    margin: 17px 0 15px;
+    font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
+    font-size: clamp(42px, 4.4vw, 66px);
+    font-weight: 400;
+    letter-spacing: -0.055em;
+    line-height: 0.94;
+    text-wrap: balance;
 }
-
+.particle-hero h1 span {
+    display: block;
+}
 .particle-hero p {
+    max-width: 248px;
     margin: 0;
-    color: rgba(230, 239, 255, 0.7);
-    font-size: 12px;
-    line-height: 1.55;
+    color: var(--particle-muted);
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.8;
+    text-wrap: pretty;
 }
-
 .particle-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin-top: 12px;
+    display: none;
 }
-
-.particle-chips span,
-.particle-nav a,
-.particle-controls button {
-    border: 1px solid rgba(150, 210, 255, 0.18);
-    border-radius: 999px;
-    background: rgba(8, 17, 35, 0.58);
-    box-shadow: inset 0 1px rgba(255, 255, 255, 0.06);
-    color: rgba(230, 245, 255, 0.82);
-    font-size: 10px;
-    line-height: 1;
-    text-decoration: none;
-    backdrop-filter: blur(14px);
-}
-
-.particle-chips span {
-    padding: 7px 9px;
-}
-
 .particle-nav {
     position: fixed;
     z-index: 100005;
-    right: 24px;
-    bottom: 22px;
+    right: 42px;
+    bottom: 33px;
+    left: 42px;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     justify-content: flex-end;
-    gap: 7px;
-    max-width: min(620px, calc(100vw - 48px));
+    gap: 24px;
+    padding-top: 18px;
+    border-top: 1px solid var(--particle-line);
+    counter-reset: study;
 }
-
+.particle-nav::before {
+    margin-right: auto;
+    color: #8b8880;
+    font-size: 9px;
+    letter-spacing: 0.18em;
+    content: 'HILO3D / STUDIES IN MOTION';
+}
 .particle-nav a {
-    padding: 9px 12px;
-    pointer-events: auto;
-    transition:
-        border-color 160ms ease,
-        background 160ms ease,
-        transform 160ms ease;
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+    padding: 6px 0;
+    color: #92928d;
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    text-decoration: none;
+    transition: color 180ms ease;
+    counter-increment: study;
 }
-
+.particle-nav a::before {
+    color: #656966;
+    font-family: ui-monospace, monospace;
+    font-size: 8px;
+    content: '0' counter(study);
+}
 .particle-nav a:hover,
-.particle-nav a[aria-current='page'] {
-    border-color: rgba(109, 231, 255, 0.72);
-    background: rgba(23, 82, 112, 0.62);
-    transform: translateY(-1px);
+.particle-nav a[aria-current='page'],
+.particle-nav a[aria-current='page']::before {
+    color: var(--particle-accent);
 }
-
+.particle-nav a:focus-visible,
+.particle-controls button:focus-visible {
+    outline: 1px solid var(--particle-accent);
+    outline-offset: 6px;
+}
 .particle-controls {
     position: fixed;
     z-index: 100005;
-    left: 22px;
-    bottom: 22px;
+    bottom: 94px;
+    left: 42px;
     display: flex;
     gap: 8px;
 }
-
 .particle-controls button {
-    padding: 10px 13px;
+    padding: 10px 15px;
+    border: 1px solid var(--particle-line);
+    border-radius: 2px;
+    background: rgb(14 17 21 / 75%);
+    color: #c3beb3;
+    font: inherit;
+    font-size: 9px;
+    letter-spacing: 0.1em;
     cursor: pointer;
+    backdrop-filter: blur(12px);
+    transition:
+        color 180ms ease,
+        border-color 180ms ease;
 }
-
+.particle-controls button:first-child {
+    border-color: rgb(207 172 121 / 45%);
+    color: var(--particle-accent);
+}
 .particle-controls button:hover {
-    border-color: rgba(255, 183, 93, 0.7);
-    background: rgba(94, 48, 20, 0.7);
+    border-color: var(--particle-accent);
+    color: #fff9ec;
 }
-
 .particle-readout {
     position: fixed;
     z-index: 100002;
-    right: 24px;
-    top: 205px;
-    min-width: 188px;
-    padding: 12px 14px;
-    border: 1px solid rgba(124, 206, 255, 0.14);
-    border-radius: 12px;
-    background: rgba(4, 10, 24, 0.62);
-    color: rgba(210, 233, 255, 0.76);
+    top: 46px;
+    right: 42px;
+    padding: 6px 0 6px 16px;
+    border-left: 1px solid var(--particle-line);
+    color: #989c99;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 10px;
-    line-height: 1.65;
+    font-size: 9px;
+    line-height: 1.9;
     white-space: pre;
-    backdrop-filter: blur(14px);
     pointer-events: none;
 }
-
 .particle-hint {
     position: fixed;
     z-index: 100000;
-    left: 50%;
-    bottom: 24px;
-    transform: translateX(-50%);
-    color: rgba(219, 235, 255, 0.48);
-    font-size: 10px;
-    letter-spacing: 0.08em;
+    bottom: 95px;
+    left: 42px;
+    color: #818780;
+    font-size: 8px;
+    letter-spacing: 0.15em;
+    line-height: 1.8;
     pointer-events: none;
 }
-
-.particle-legend {
-    top: 132px;
-    right: auto;
-    left: 22px;
-    border-color: rgba(126, 220, 255, 0.2);
-    color: rgba(224, 241, 255, 0.82);
-}
-
-.particle-legend span {
-    display: block;
-}
-
 .noise-label {
     position: fixed;
     z-index: 100001;
-    transform: translate(-50%, -50%);
-    color: rgba(221, 240, 255, 0.62);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 9px;
-    letter-spacing: 0.08em;
-    text-shadow: 0 2px 12px #000;
-    text-transform: uppercase;
+    left: 0;
+    top: 0;
+    text-align: center;
+    color: var(--particle-accent);
     pointer-events: none;
 }
-
-.noise-label::before {
-    display: inline-block;
-    width: 5px;
-    height: 5px;
-    margin-right: 7px;
-    border-radius: 50%;
-    background: currentColor;
-    box-shadow: 0 0 12px currentColor;
-    content: '';
-}
-
-.collision-theatre-page {
-    --theatre-ink: #f0eae1;
-    --theatre-muted: rgba(211, 202, 191, 0.58);
-    --theatre-line: rgba(202, 153, 96, 0.2);
-    --theatre-glass: rgba(18, 15, 18, 0.62);
-    background:
-        radial-gradient(circle at 24% 30%, rgba(91, 73, 64, 0.13), transparent 40%),
-        radial-gradient(circle at 80% 58%, rgba(55, 63, 82, 0.1), transparent 38%), #0d0b0e;
-}
-
-.collision-theatre-page::before,
-.collision-theatre-page::after {
-    position: fixed;
-    z-index: 99990;
-    inset: 0;
-    pointer-events: none;
-    content: '';
-}
-
-.collision-theatre-page::before {
-    background:
-        radial-gradient(circle at 50% 42%, transparent 28%, rgba(0, 0, 0, 0.18) 82%),
-        linear-gradient(110deg, rgba(255, 225, 193, 0.018), transparent 34%);
-}
-
-.collision-theatre-page::after {
-    inset: 18px;
-    border: 1px solid rgba(216, 166, 108, 0.09);
-    border-radius: 2px;
-    box-shadow: inset 0 0 100px rgba(12, 8, 10, 0.12);
-}
-
-.collision-theatre-page .particle-hero {
-    top: 42px;
-    right: auto;
-    left: 48px;
-    width: min(330px, calc(100vw - 96px));
-}
-
-.collision-theatre-page .particle-kicker {
-    color: rgba(211, 159, 101, 0.78);
-    font-family: 'Avenir Next', Inter, sans-serif;
-    font-size: 8px;
-    font-weight: 620;
-    letter-spacing: 0.26em;
-}
-
-.collision-theatre-page .particle-hero h1 {
-    margin: 12px 0 12px;
-    color: var(--theatre-ink);
-    font-family: 'Iowan Old Style', Baskerville, 'Times New Roman', serif;
-    font-size: clamp(38px, 4.5vw, 66px);
-    font-weight: 400;
-    letter-spacing: -0.055em;
-    line-height: 0.82;
-}
-
-.collision-theatre-page .particle-hero h1 span {
+.noise-label span {
     display: block;
-    margin-bottom: 7px;
-    color: rgba(218, 205, 191, 0.54);
-    font-family: 'Avenir Next', Inter, sans-serif;
-    font-size: 0.22em;
-    font-weight: 580;
-    letter-spacing: 0.42em;
-    line-height: 1;
-    text-transform: uppercase;
-}
-
-.collision-theatre-page .particle-hero p {
-    max-width: 290px;
-    color: var(--theatre-muted);
-    font-family: 'Avenir Next', Inter, sans-serif;
-    font-size: 10px;
-    line-height: 1.7;
-}
-
-.collision-theatre-page .particle-readout {
-    top: 44px;
-    right: 48px;
-    min-width: 166px;
-    padding: 34px 0 8px 17px;
-    border: 0;
-    border-left: 1px solid var(--theatre-line);
-    border-radius: 0;
-    background: transparent;
-    box-shadow: none;
-    color: rgba(205, 197, 187, 0.58);
+    color: #939d9c;
+    font-family: ui-monospace, monospace;
     font-size: 8px;
-    line-height: 1.56;
-    backdrop-filter: none;
-}
-
-.collision-theatre-page .particle-readout::before {
-    position: absolute;
-    top: 7px;
-    right: 0;
-    left: 17px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid rgba(202, 153, 96, 0.1);
-    color: rgba(211, 159, 101, 0.68);
-    font-family: 'Avenir Next', Inter, sans-serif;
-    font-size: 7px;
-    font-weight: 620;
-    letter-spacing: 0.24em;
-    content: 'IMPACT REGISTER';
-}
-
-.collision-theatre-page .hilo3dStats {
-    display: none;
-}
-
-.collision-theatre-page .particle-controls {
-    left: 48px;
-    bottom: 42px;
-    align-items: center;
-}
-
-.collision-theatre-page .particle-controls button {
-    border-color: rgba(208, 189, 169, 0.14);
-    border-radius: 2px;
-    background: rgba(23, 19, 22, 0.62);
-    color: rgba(218, 207, 194, 0.62);
-    font-family: 'Avenir Next', Inter, sans-serif;
-    font-size: 7px;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    transition:
-        border-color 180ms ease,
-        background 180ms ease,
-        color 180ms ease,
-        transform 180ms ease;
-}
-
-.collision-theatre-page .particle-controls button:first-child {
-    padding: 11px 17px;
-    border-color: rgba(211, 159, 101, 0.42);
-    background: rgba(104, 67, 43, 0.42);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.16);
-    color: rgba(244, 226, 205, 0.88);
-}
-
-.collision-theatre-page .particle-controls button:hover {
-    border-color: rgba(222, 171, 112, 0.7);
-    background: rgba(111, 72, 47, 0.72);
-    color: #fff8ee;
-    transform: translateY(-2px);
-}
-
-.collision-theatre-page .particle-nav {
-    right: 48px;
-    bottom: 42px;
-    gap: 2px;
-}
-
-.collision-theatre-page .particle-nav a {
-    padding: 7px 9px;
-    border-color: transparent;
-    border-radius: 2px;
-    background: transparent;
-    color: rgba(197, 187, 176, 0.4);
-    font-family: 'Avenir Next', Inter, sans-serif;
-    font-size: 7px;
     letter-spacing: 0.12em;
-    text-transform: uppercase;
-    backdrop-filter: none;
 }
-
-.collision-theatre-page .particle-nav a:hover,
-.collision-theatre-page .particle-nav a[aria-current='page'] {
-    border-color: rgba(211, 159, 101, 0.18);
-    background: rgba(75, 53, 39, 0.26);
-    color: rgba(235, 213, 187, 0.86);
+.noise-label strong {
+    display: block;
+    margin-top: 7px;
+    font-family: 'Iowan Old Style', Palatino, Georgia, serif;
+    font-size: 20px;
+    font-weight: 400;
 }
-
+.noise-page,
+.orbital-page {
+    --particle-accent: #adc6c3;
+}
+.nebula-page {
+    --particle-accent: #d9b387;
+}
 @media (prefers-reduced-motion: reduce) {
-    .collision-theatre-page .particle-controls button,
-    .collision-theatre-page .particle-nav a {
+    .particle-nav a,
+    .particle-controls button {
         transition: none;
     }
 }
-
-@media (max-width: 720px) {
-    .hilo3dStats {
+@media (max-width: 1000px) {
+    .particle-nav {
+        justify-content: space-between;
+        gap: 14px;
+    }
+    .particle-nav::before {
         display: none;
+    }
+}
+@media (max-width: 720px) {
+    .particle-gallery::after {
+        inset: 10px;
     }
     .particle-hero {
-        top: 16px;
-        right: 16px;
-        width: calc(100vw - 32px);
+        top: 28px;
+        left: 26px;
+        width: calc(100vw - 52px);
     }
-    .particle-hero p {
-        max-width: 88%;
+    .particle-kicker {
+        font-size: 8px;
     }
-    .particle-chips span:nth-child(n + 5) {
-        display: none;
-    }
-    .particle-nav {
-        right: 16px;
-        bottom: 16px;
-        max-width: calc(100vw - 32px);
-    }
-    .particle-nav a {
-        padding: 8px 9px;
-    }
-    .particle-controls {
-        left: 16px;
-        bottom: 72px;
-    }
-    .particle-readout {
-        display: none;
-    }
-    .particle-hint {
-        display: none;
-    }
-    .particle-legend,
-    .noise-label {
-        display: none;
-    }
-    .collision-theatre-page::after {
-        inset: 8px;
-        border-radius: 12px;
-    }
-    .collision-theatre-page .particle-hero {
-        top: 24px;
-        right: 22px;
-        left: 22px;
-        width: auto;
-    }
-    .collision-theatre-page .particle-hero h1 {
+    .particle-hero h1 {
+        margin: 12px 0;
+        max-width: 300px;
         font-size: 42px;
     }
-    .collision-theatre-page .particle-hero p {
-        max-width: 280px;
+    .particle-hero p {
+        max-width: 260px;
+        font-size: 10px;
     }
-    .collision-theatre-page .particle-controls {
-        bottom: 58px;
-        left: 22px;
+    .particle-nav {
+        right: 26px;
+        bottom: 26px;
+        left: 26px;
+        gap: 10px;
+        padding-top: 14px;
     }
-    .collision-theatre-page .particle-nav {
-        right: 18px;
-        bottom: 14px;
-        left: 18px;
-        justify-content: center;
+    .particle-nav a {
+        flex-direction: column;
+        gap: 8px;
+        font-size: 9px;
+        letter-spacing: 0;
     }
-    .collision-theatre-page .particle-nav a {
-        padding: 7px 6px;
+    .particle-controls {
+        bottom: 95px;
+        left: 26px;
+    }
+    .particle-controls button {
+        padding: 10px 12px;
+    }
+    .particle-readout,
+    .noise-label strong {
+        display: none;
+    }
+    .noise-label span {
+        font-size: 7px;
+    }
+    .particle-hint {
+        bottom: 98px;
+        left: 26px;
         font-size: 7px;
     }
 }

--- a/examples/shared/catalog.ts
+++ b/examples/shared/catalog.ts
@@ -116,7 +116,7 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'gtao_acceptance_lab.html': 'GTAO Acceptance Lab',
     'temporal_aa_observatory.html': 'Temporal Observatory — Signals in Deep Time',
     'compute_eclipse_shrine.html': 'Eclipse Shrine — WebGPU Compute Installation',
-    'compute_particles.html': 'Hilo3D Compute Particle Field',
+    'compute_particles.html': 'Luminous Tides — Interactive Particle Landscape',
     'compute_raytracing.html': 'Hilo3D Crystal Compute Path Tracer',
     '2d_sprite_animation.html': '2D Moon Moth Animation',
     '2d_sorting_town.html': '2D Sorting Town',
@@ -137,10 +137,10 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'physics/rapier_character.html': 'Clockwork courier — Character Controller',
     'physics/rapier_bridge.html': 'Suspension atelier — Loads & Constraints',
     'cascaded_shadows.html': 'Little Sunshine — Toy Shadow Garden',
-    'particle_elemental_forge.html': 'Elemental Forge — Particle Fundamentals',
-    'particle_noise_fields.html': 'Turbulence Atlas — Particle Noise Fields',
-    'particle_orbital_weave.html': 'Orbital Weave — Meshes, Ribbons & Trails',
-    'particle_collision_theatre.html': 'Collision Theatre — Particle Interaction',
+    'particle_elemental_forge.html': 'Elemental Forge — Molten Light',
+    'particle_noise_fields.html': 'Turbulence Atlas — Mineral Currents',
+    'particle_orbital_weave.html': 'Orbital Weave — A Choreography of Light',
+    'particle_collision_theatre.html': 'Collision Theatre — Falling Light',
     'particle_gpu_nebula.html': 'Event Horizon — WebGPU Particle Nebula'
 });
 
@@ -225,15 +225,15 @@ const DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = Object.freeze({
     'cascaded_shadows.html':
         'Explore a rounded plastic toy town with a windmill, lighthouse and miniature train. Compare single-map and four-cascade shadows at the same shadow-texel budget.',
     'particle_elemental_forge.html':
-        'Compare every analytic emission shape through elemental sprite effects with lifetime curves, gradients, SubUV animation, alignments, blending, and sorting.',
+        'Molten light rises through a brass instrument: eight emission shapes, fine embers, cold mineral dust, and a calibrated circular plinth.',
     'particle_noise_fields.html':
-        'Read vector and curl noise side by side as stateless position offsets and stateful forces with explicit octave, frequency, scroll, and damping profiles.',
+        'Fine grains and soft mist flow through four mineral currents, with coherent particle velocities, vector and curl noise, and gradual dissolution.',
     'particle_orbital_weave.html':
-        'Orbit lit mesh buckets, topology-preserving ribbons, and velocity trails driven by shared portable particle simulation.',
+        'Two comets shed granular wakes while three luminous ribbon and trail systems follow independent inclinations, directions, and periods.',
     'particle_collision_theatre.html':
-        'Launch particles through plane, sphere, box, and capsule colliders with triggers, bounded events, typed channels, and resident sub-emitters.',
+        'Release a shower of light onto four polished surfaces. Real particle collisions scatter sparks within a quiet architectural frame.',
     'particle_gpu_nebula.html':
-        'Fold 65,536 stateful and stateless bodies around soft scene depth with compute simulation, collision, sorting, and GPU-resident event routing.'
+        'A copper accretion disk surrounds a dark core, with glacial dust, WebGPU simulation and resident event routing, plus portable stateless stars.'
 });
 
 const FEATURED_PATHS = new Set([

--- a/test/ui/examples.spec.ts
+++ b/test/ui/examples.spec.ts
@@ -953,10 +953,11 @@ test.describe('examples using the generic release gate', () => {
                 examplePath === 'pbr2.html' ||
                 examplePath === 'ground_truth_ambient_occlusion.html' ||
                 examplePath === 'particle_gpu_nebula.html' ||
+                examplePath === 'particle_noise_fields.html' ||
                 examplePath === 'particle_orbital_weave.html'
             ) {
-                // The HDR material grid and multi-pass GTAO gallery are intentionally expensive
-                // under CI SwiftShader.
+                // HDR material/particle galleries and multi-pass GTAO require extra time for
+                // software rendering under CI SwiftShader.
                 test.slow();
             }
             await installRenderHealthProbe(page);


### PR DESCRIPTION
## Summary

Redesign the five particle-addon exhibits around readable motion and distinct compositions: a brass elemental forge, four coherent noise currents, orbiting comets with three independent ribbon/trail paths, a lighter collision theatre, and a copper/blue accretion disk. Refine particle sizes, emission, lifetime fades, lighting and bloom, with responsive framing and projected flow captions.

Unify the collection's gallery styling and navigation, including the Luminous Tides compute page, and update the catalog and documented feature coverage. Engine APIs, shader sources, the specialized compute simulation, and backend support remain unchanged: the four portable exhibits support WebGL2 and WebGPU; Event Horizon and Luminous Tides require WebGPU. Event Horizon's stateless stars retain CPU reconstruction.

Rebased onto `origin/dev` at `7fcae7f8` without conflicts. Give Flow the existing slow-case time budget used by other heavy galleries under SwiftShader; all graphics-health and presentation assertions remain intact.

## Validation

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check:modernity`
- [x] `npm run docs:check`
- [x] `npm run test:ui:contract` — 26 tests passed.
- [x] Targeted particle browser and compute interaction coverage: 11 cases passed in the full targeted run; Flow initially exceeded the default 30-second WebGL2 timeout. Both Flow backend cases passed after applying the existing slow-case budget (21.8s WebGL2, 7.7s WebGPU). All 12 related cases are verified across these runs.
- [ ] I ran `npm run test:browser` locally and all browser GPU tests passed.

Desktop/mobile visual inspection and sustained animation checks were performed on WebGL2/WebGPU during authoring. Full `test:browser`, `validate`, package/API and performance suites were not run; this change has no public API or engine implementation changes.
