### PR TITLE
fix(render): stabilize screen-space reflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Unreleased
 
+### Fixes
+
+- Reject unsupported or rapidly moving SSR missed-hit history, fade confidence-premultiplied
+  radiance together with confidence, and honor zero history weight on every resolve path. This
+  removes red reflection trails on empty floors during fast camera orbit.
+
+- Keep built-in scene vertex positions invariant across depth, motion, material-attributes and color
+  variants, eliminating jitter-dependent attribute holes and flickering SSR black speckles. Remove
+  the red and blue point fill lights that produced circular floor highlights in Afterimage.
+
+- Apply runtime normal-map scale in shared raster shading, restoring smooth Car Concept paint on
+  WebGL2 and WebGPU.
+- Traverse SSR Hi-Z cells conservatively and refine thin-surface crossings before rejecting hits.
+  Keep integer history counts separate from confidence during packing and bilinear reprojection.
+- Refine the Afterimage studio camera, paint, lighting, and polished floor reflection; fit portrait
+  viewports and cap physical rendering dimensions to the declared GPU budget.
+
 # 2.0.0-alpha.8 (2026-09-08)
 
 ### Breaking changes

--- a/documentation/PBR_AND_POST_PROCESSING.md
+++ b/documentation/PBR_AND_POST_PROCESSING.md
@@ -44,6 +44,10 @@ light。
 - 线性 HDR attachment 输出；材质 Shader 不执行 gamma encode、exposure 或 tone
   mapping，显示变换只在后处理末端发生。
 
+普通 normal map 始终在 tangent space 中应用 `normalScale`，再变换到 view
+space；它是 MaterialBlock 的运行时参数，不依赖额外 shader feature。`normalScale: 0`
+恢复几何法线，并同时影响 forward 光照与 material-attributes 中供 SSR/GTAO 使用的 normal。
+
 ## glTF layered material 扩展
 
 `GLTFParser` 原生解析以下扩展，并把所有引用纹理加入资源预加载集合：

--- a/documentation/SCREEN_SPACE_REFLECTIONS.md
+++ b/documentation/SCREEN_SPACE_REFLECTIONS.md
@@ -63,6 +63,12 @@ ordinary Forward opaque 必须先通过正式 `depth-only` material role 把 fal
 scene depth，再构建 Hi-Z。否则 radiance 中虽能看到 fallback 物体，hierarchical
 trace 却没有对应深度可命中；Car Concept 的 layered PBR 车身就是这条回归的发布夹具。
 
+普通 scene 顶点 shader 与 GPU Scene 一样声明
+`invariant gl_Position`，并在 depth、motion、material-attributes 与 color
+variants 中使用同一位置表达式。Naga 产物保留 WGSL position 的 `@invariant`。材质属性 pass 的 `equal`
+深度测试依赖这一约束；否则不同编译变体的微小浮点误差会在大斜面产生覆盖孔洞，SSR 全分辨率 resolve 因缺少属性而露出地板本色，并随 TAA
+jitter 闪烁。
+
 ## Material attribute ABI
 
 `material-attributes` 是内置材质的正式 semantic pass。普通消费者使用一个 single-sample `rgba8unorm`
@@ -103,7 +109,13 @@ Hi-Z 每级保存 device-depth 的 min/max，因此 standard 与 reversed depth 
 culling 从相应边界读取 conservative farthest
 depth，SSR 则使用完整区间做 coarse-to-fine 推进、line-segment refinement、grazing/depth-adaptive
 thickness 和 hit-normal facing 测试。背景 crossing、过深 penetration 和背面候选不会被当作普通 valid
-hit。trace 不假设反射 ray 必须远离相机，因此 camera-facing vertical
+hit。层级步进在投影空间求当前 Hi-Z
+cell 的出口，只在整段射线都位于该 cell 的保守深度区间之前时跳过它；可能相交的 cell 原地降级，而不是用指数增长的 view-space 步长跨过轮廓。最细层直接求 cell 内的 depth-plane 交点；跨薄表面的 front/behind
+bracket 在 thickness
+rejection 前进行最多六次 depth 重采样细化，避免把深度不连续的两个表面做线性插值。粗糙表面保留更充分的迭代预算；实际工作量仍受
+`maxSteps`、roughness 与 active-tile dispatch 限制。
+
+trace 不假设反射 ray 必须远离相机，因此 camera-facing vertical
 mirror 也能追踪位于镜面与相机之间的屏幕内物体。命中辐射按 roughness 与 ray distance 选择四级 HDR
 color cone。perceptual roughness 不高于 0.1 时使用确定性镜面 ray；这与 Unreal legacy SSR 的
 `Roughness < 0.1` 镜面退化一致。更粗糙 receiver 每帧使用四条完整分层的 scrambled Hammersley
@@ -153,7 +165,16 @@ filter 也用 response 与 packed material continuity 阻止跨材质边界借�
 
 当前 3×3 radiance 在 YCoCg 中生成 mean/variance
 clamp，并在粗糙 stochastic 区域先抑制单帧 firefly；history alpha 的整数部分保存最高 31 的 capped
-sample count，小数部分保存 confidence。粗糙表面最多使用 24-frame
+sample count，小数部分保存 confidence。写入 alpha 前先把 sample count 取整；重投影的四个 history
+tap 分别解包 count/confidence 后再做双线性插值，禁止直接过滤 packed
+alpha。这样不同累积年龄不会变成虚假的高置信度。miss 的 count 每帧至少减少一帧。只有当前 3×3 邻域仍有有效命中时才允许短暂 hole
+fill；全邻域 miss 不会借助非零 YCoCg clamp 下限恢复旧倒影。receiver motion 在 2–8 个 scene
+pixel 之间平滑拒绝 miss history，2 像素以内保留静止 TAA
+jitter 的累积，快速运动时立即拒绝。同一个保留权重同时乘预乘 radiance 与 confidence，并受
+`historyWeight` 限制； `historyWeight: 0`
+对 hit 和 miss 两条路径都禁用历史。这样沿地面重投影的旧反射不会在快速 orbit 后残留为暗红/洋红条带。
+
+粗糙表面最多使用 24-frame
 accumulation，镜面、快速 motion、miss 和 disocclusion 更快响应；miss 可以短暂继承低 confidence
 history 完成局部 hole fill，但会持续衰减。
 
@@ -175,18 +196,33 @@ recipe 重建资源，public pipeline identity 不变。
 
 ## 上线证据
 
+- `test/spec/renderer/MaterialPassDepthParity.test.ts`：双后端、standard/reversed 深度、两种大斜面视角与八个 jitter
+  phase，验证 depth-only 已覆盖的像素在 equal-depth 三 MRT attributes 中全部写入。
+  `GlslToWgsl.test.ts` 的内置 shader corpus 验证 invariant 一直保留到 WGSL。
+- Afterimage 浏览器测试额外在 1440×960 下检查连续 32 帧的反射区域局部暗孔，防止稀疏黑条被全图平均差异门槛掩盖。
+- 快速往返 orbit 的浏览器回归逐帧检查运动当帧的空地红色残留，并在停下后检查收敛。
+  `ScreenSpaceReflectionMissHistory.test.ts` 以真实 WebGPU
+  compute/readback 覆盖当前支持、jitter、快速运动拒绝和 history weight 上限。
+
+- `test/spec/renderer/NormalMapScale.test.ts`：双后端真实像素验证 normal
+  scale 的 0、0.5、1 运行时更新；`ScreenSpaceReflectionHistory.test.ts` 用真实 WebGPU
+  compute/readback 验证 fractional
+  count 与不同年龄 history 的 confidence 不串扰；`ScreenSpaceReflectionTrace.test.ts`
+  覆盖薄表面、较大 stride、标准/反向深度与连续反射 ROI。
 - `test/spec/renderer/ClusteredForwardPlus.test.ts`：配置/limit/format 合同，以及真实 WebGPU 的 GPU
   Scene、ordinary fallback、active/hit/miss diagnostics、roughness cutoff、moving receiver、camera
-  cut、camera-facing reflection rays、resize、standard/reversed depth 和 device recovery。
+  cut、resize、standard/reversed depth 和 device recovery。
 - `test/ui/screen-space-reflections.spec.ts`：默认 0.5× trace resolution、真实浏览器 GPU
   validation、roughness 0.08 deterministic 与 0.16/0.24
   stochastic 地面反射 ROI 连续帧的局部 changed-pixel/mean-delta 闪烁门槛、静态与 camera/hero motion
-  history 收敛、低视角 grazing ROI 连续帧门槛、roughness active-work
-  rejection、垂直镜面命中，以及同一视角 SSR on/off 的非零像素贡献。
+  history 收敛、低视角 grazing ROI 连续帧门槛、roughness active-work rejection，以及同一视角 SSR
+  on/off 的非零像素贡献。
 - `examples/screen_space_reflections_palace.html`：使用仓库内 Khronos Car Concept、镜头外 studio
-  light field、ordinary Forward PBR 烟熏漆地面、TAA、Bloom 和高精度 Hi-Z SSR 的独立维护示例；
-  `ssr=false` 可显示确定性无 SSR 对照。Car Concept 资产来源、CC BY 4.0 许可和 hash 记录在
-  `examples/models/CarConcept/README.md`。
+  light field、ordinary Forward PBR 烟熏漆地面（默认 roughness 0.11）、TAA、Bloom 和半分辨率 Hi-Z
+  SSR 的独立维护示例；默认采用车头三分之四视角，车漆 normalScale 为 0.04、clearcoat
+  roughness 至少为 0.12；地面不再受到红、蓝两盏点补光的圆形高光影响；窄屏保持完整车身，physical
+  canvas 不超过 2560×1440。`ssr=false` 可显示保留环境反射的无 SSR 对照。Car Concept 资产来源、CC BY
+  4.0 许可和 hash 记录在 `examples/models/CarConcept/README.md`。
 
 现有 `examples/temporal_aa_observatory.html` 保持为独立 TAA/TAAU 案例，不承担 SSR release evidence。
 

--- a/examples/screen_space_reflections_palace.ts
+++ b/examples/screen_space_reflections_palace.ts
@@ -63,6 +63,7 @@ if (carModel.resourceErrors.length > 0) {
 }
 for (const material of carModel.materials) {
     if (!(material instanceof Hilo3d.PBRMaterial) || !material.name?.startsWith('Paint')) continue;
+    material.clearcoatRoughnessFactor = Math.max(material.clearcoatRoughnessFactor, 0.12);
     material.normalScale = Math.min(material.normalScale, 0.04);
     material.roughness = Math.max(material.roughness, 0.36);
     material.iridescenceFactor = Math.min(material.iridescenceFactor, 0.02);
@@ -73,22 +74,12 @@ const floorGeometry = new Hilo3d.PlaneGeometry({ width: 80, height: 80 });
 const floorMaterial = new Hilo3d.PBRMaterial({
     baseColor: new Hilo3d.Color(0.018, 0.015, 0.022),
     metallic: 0.38,
-    roughness: 0.16,
+    roughness: 0.11,
     brdfLUT,
     diffuseEnvMap: { texture: diffuseEnvMap, encoding: 'srgb' },
     specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
     diffuseEnvIntensity: 0.03,
     specularEnvIntensity: 0.04
-});
-const verticalMirrorMaterial = new Hilo3d.PBRMaterial({
-    baseColor: new Hilo3d.Color(0.025, 0.03, 0.045),
-    metallic: 0.72,
-    roughness: 0.11,
-    brdfLUT,
-    diffuseEnvMap: { texture: diffuseEnvMap, encoding: 'srgb' },
-    specularEnvMap: { texture: specularEnvMap, encoding: 'srgb' },
-    diffuseEnvIntensity: 0.015,
-    specularEnvIntensity: 0.065
 });
 const gpuEvidenceGeometry = new Hilo3d.BoxGeometry({ width: 0.16, height: 0.08, depth: 0.16 });
 const gpuEvidenceMaterial = new Hilo3d.PBRMaterial({
@@ -105,8 +96,8 @@ const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
     maxLightsPerCluster: 48,
     tileSize: 24,
     zSlices: 24,
-    maxViewportWidth: testMode ? 960 : 2560,
-    maxViewportHeight: testMode ? 600 : 1440,
+    maxViewportWidth: 2560,
+    maxViewportHeight: 1440,
     hiZ: true,
     bloomStrength: 0.14,
     exposure: 1.08,
@@ -121,23 +112,32 @@ const factory = new Hilo3d.ClusteredForwardPlusPipelineFactory({
         ? {
               resolutionScale: 0.5,
               maxRayDistance: 56,
-              thickness: 0.18,
+              thickness: 0.12,
               stride: 0.06,
               maxSteps: 96,
-              roughnessCutoff: 0.28,
+              roughnessCutoff: 0.32,
               edgeFade: 0.1,
               historyWeight: 0.95,
               depthThreshold: 0.03,
-              intensity: 1.55
+              intensity: 1.15
           }
         : false
 });
 
-const initialWidth = testMode ? 960 : innerWidth;
-const initialHeight = testMode ? 600 : innerHeight;
+// Keep the complete car in portrait viewports and stay within the declared physical GPU budget.
+function cameraFieldOfView(aspect: number): number {
+    return (Math.atan(Math.tan((32 * Math.PI) / 360) * Math.max(1, 1.2 / aspect)) * 360) / Math.PI;
+}
+
+function renderPixelRatio(width: number, height: number): number {
+    return Math.min(testMode ? 1 : devicePixelRatio, 1.5, 2560 / width, 1440 / height);
+}
+
+const initialWidth = innerWidth;
+const initialHeight = innerHeight;
 const camera = new Hilo3d.PerspectiveCamera({
     aspect: initialWidth / Math.max(initialHeight, 1),
-    fov: 32,
+    fov: cameraFieldOfView(initialWidth / Math.max(initialHeight, 1)),
     near: 0.05,
     far: 90,
     depthMode: 'reversed'
@@ -150,7 +150,7 @@ const stage = await Hilo3d.Stage.create<'webgpu'>({
     camera,
     width: initialWidth,
     height: initialHeight,
-    pixelRatio: testMode ? 1 : Math.min(devicePixelRatio, 1.5),
+    pixelRatio: renderPixelRatio(initialWidth, initialHeight),
     antialias: false,
     alpha: false,
     clearColor: new Hilo3d.Color(0.0012, 0.001, 0.0018),
@@ -164,33 +164,19 @@ new Hilo3d.AmbientLight({
     color: new Hilo3d.Color(0.25, 0.28, 0.36)
 }).addTo(stage);
 new Hilo3d.DirectionalLight({
-    amount: 2.4,
+    amount: 1.65,
     color: new Hilo3d.Color(1, 0.86, 0.76),
     direction: new Hilo3d.Vector3(-0.34, -0.91, -0.2)
 }).addTo(stage);
 
-const lightPlan = [
-    { amount: 5.2, range: 12, color: new Hilo3d.Color(1, 0.78, 0.64), x: 3.8, y: 3.2, z: 1.6 },
-    {
-        amount: 2.7,
-        range: 10,
-        color: new Hilo3d.Color(0.32, 0.47, 0.86),
-        x: -4.6,
-        y: 1.4,
-        z: -4.2
-    },
-    {
-        amount: 3.2,
-        range: 11,
-        color: new Hilo3d.Color(1, 0.08, 0.035),
-        x: -0.8,
-        y: 0.65,
-        z: -8.6
-    }
-] as const;
-for (const light of lightPlan) {
-    new Hilo3d.PointLight(light).addTo(stage);
-}
+new Hilo3d.PointLight({
+    amount: 3.8,
+    range: 12,
+    color: new Hilo3d.Color(1, 0.78, 0.64),
+    x: 3.8,
+    y: 3.2,
+    z: 1.6
+}).addTo(stage);
 
 const floor = new Hilo3d.Mesh({
     geometry: floorGeometry,
@@ -202,17 +188,6 @@ const floor = new Hilo3d.Mesh({
     frustumTest: false
 }).addTo(stage);
 floor.receiveShadows = false;
-
-new Hilo3d.Mesh({
-    geometry: new Hilo3d.PlaneGeometry({ width: 5.8, height: 3.3 }),
-    material: verticalMirrorMaterial,
-    x: -3.25,
-    y: -0.12,
-    z: -9.65,
-    rotationY: -8,
-    pointerEnabled: false,
-    frustumTest: false
-}).addTo(stage);
 
 new Hilo3d.Mesh({
     geometry: gpuEvidenceGeometry,
@@ -247,10 +222,10 @@ const carScale = 7.7 / carLargestDimension;
 carModel.node.setScale(carScale);
 carModel.node.setPosition(
     -carBounds.x * carScale + 1.05,
-    -carBounds.y * carScale + carBounds.height * carScale * 0.5 - 1.69,
+    -carBounds.y * carScale + carBounds.height * carScale * 0.5 - 1.755,
     -carBounds.z * carScale - 5.4
 );
-carModel.node.rotationY = 164;
+carModel.node.rotationY = -16;
 for (const mesh of carModel.meshes) {
     mesh.pointerEnabled = false;
     mesh.frustumTest = false;
@@ -259,18 +234,18 @@ carModel.node.addTo(stage);
 
 const controls = new Hilo3d.OrbitControls(stage, {
     camera,
-    target: new Hilo3d.Vector3(0.72, -0.64, -5.35),
+    target: new Hilo3d.Vector3(0.15, -0.85, -5.35),
     enablePan: false,
     enableZoom: false,
     minDistance: 12.5,
     maxDistance: 18,
-    minPolarAngle: Math.PI * 0.39,
-    maxPolarAngle: Math.PI * 0.52,
+    minPolarAngle: Math.PI * 0.34,
+    maxPolarAngle: Math.PI * 0.495,
     rotateSpeed: 0.42,
     zoomSpeed: 0.68
 });
-const heroView = new Hilo3d.Vector3(9.85, 0.82, 5.45);
-const heroTarget = new Hilo3d.Vector3(0.72, -0.64, -5.35);
+const heroView = new Hilo3d.Vector3(10.8, 2.15, 6.55);
+const heroTarget = new Hilo3d.Vector3(0.15, -0.85, -5.35);
 controls.setView(heroView, heroTarget);
 
 const ticker = new Hilo3d.Ticker(60);
@@ -296,9 +271,9 @@ ssrToggleLabel.textContent = reflectionsEnabled ? 'SSR on' : 'SSR off';
 ssrToggle.addEventListener('click', toggleReflections);
 
 const resize = (): void => {
-    if (testMode) return;
     camera.aspect = innerWidth / Math.max(innerHeight, 1);
-    stage.resize(innerWidth, innerHeight, Math.min(devicePixelRatio, 1.5));
+    camera.fov = cameraFieldOfView(camera.aspect);
+    stage.resize(innerWidth, innerHeight, renderPixelRatio(innerWidth, innerHeight));
 };
 window.addEventListener('resize', resize);
 
@@ -347,7 +322,9 @@ window.__HILO3D_SSR_PALACE_TEST_API__ = {
         return (await factory.readDiagnostics()).screenSpaceReflectionActivePixelCount;
     }
 };
-statusLabel.textContent = reflectionsEnabled ? 'reflection history stable' : 'direct light only';
+statusLabel.textContent = reflectionsEnabled
+    ? 'reflection history stable'
+    : 'environment reflections only';
 document.body.dataset['ssrReady'] = 'true';
 document.body.dataset['ssrPhase'] = 'ready';
 if (!testMode) ticker.start();

--- a/src/render/postprocessing/ScreenSpaceReflectionHistory.ts
+++ b/src/render/postprocessing/ScreenSpaceReflectionHistory.ts
@@ -1,0 +1,32 @@
+/** @internal Integer history count stored above fractional SSR confidence in rgba16float. */
+export const MAX_HISTORY_SAMPLE_COUNT = 31;
+
+/** @internal Shared compute packing and interpolation; never filter packed alpha directly. */
+export const REFLECTION_HISTORY_WGSL = `
+fn historySampleCount(packed: f32) -> f32 { return floor(max(packed, 0.0)); }
+fn historyConfidence(packed: f32) -> f32 {
+    return clamp(fract(max(packed, 0.0)) * 2.0, 0.0, 1.0);
+}
+fn packHistoryState(sampleCount: f32, confidence: f32) -> f32 {
+    return round(clamp(sampleCount, 0.0, ${String(MAX_HISTORY_SAMPLE_COUNT)}.0)) +
+        min(confidence, 0.999) * 0.5;
+}
+// Receiver motion follows the surface, not its reflected virtual image. Only use it
+// to fill supported, nearly stationary misses; TAA jitter alone stays below two pixels.
+fn reflectionMissHistoryWeight(velocityPixels: f32, hasCurrentSupport: bool, historyWeight: f32, continuity: f32) -> f32 {
+    if (!hasCurrentSupport) { return 0.0; }
+    return min(historyWeight, 0.82) * clamp(continuity, 0.0, 1.0) *
+        (1.0 - smoothstep(2.0, 8.0, velocityPixels));
+}
+fn interpolateHistory(a: vec4<f32>, b: vec4<f32>, c: vec4<f32>, d: vec4<f32>, fraction: vec2<f32>) -> vec4<f32> {
+    let weights = vec4<f32>(
+        (1.0 - fraction.x) * (1.0 - fraction.y), fraction.x * (1.0 - fraction.y),
+        (1.0 - fraction.x) * fraction.y, fraction.x * fraction.y
+    );
+    let counts = vec4<f32>(historySampleCount(a.a), historySampleCount(b.a), historySampleCount(c.a), historySampleCount(d.a));
+    let confidence = vec4<f32>(historyConfidence(a.a), historyConfidence(b.a), historyConfidence(c.a), historyConfidence(d.a));
+    return vec4<f32>(
+        a.rgb * weights.x + b.rgb * weights.y + c.rgb * weights.z + d.rgb * weights.w,
+        packHistoryState(dot(counts, weights), dot(confidence, weights))
+    );
+}`;

--- a/src/render/postprocessing/ScreenSpaceReflections.ts
+++ b/src/render/postprocessing/ScreenSpaceReflections.ts
@@ -1,3 +1,4 @@
+import { MAX_HISTORY_SAMPLE_COUNT, REFLECTION_HISTORY_WGSL } from './ScreenSpaceReflectionHistory';
 import { DEFAULT_MATERIAL_PIPELINE_STATE } from '../../material/MaterialDefinition';
 import Shader from '../../shader/Shader';
 import ComputeKernel from '../compute/ComputeKernel';
@@ -37,7 +38,6 @@ const SSR_DIAGNOSTIC_BYTES = 32;
 const TEMPORAL_SEQUENCE_LENGTH = 32;
 const DETERMINISTIC_REFLECTION_ROUGHNESS = 0.1;
 const STOCHASTIC_RAY_COUNT = 4;
-const MAX_HISTORY_SAMPLE_COUNT = 31;
 const MAX_INDIRECT_DISPATCH_X = 65_535;
 
 /** Submitted GPU work counters for the hierarchical SSR trace. */
@@ -677,6 +677,11 @@ function traceShader(
         (_unused, index) =>
             `        case ${String(index)}u: { return textureLoad(hiZ${String(index)}, pixelFor(hiZ${String(index)}, uv), 0).xy; }`
     ).join('\n');
+    const hiZSizeCases = Array.from(
+        { length: Math.max(0, hiZLevelCount - 1) },
+        (_unused, index) =>
+            `        case ${String(index)}u: { return vec2<f32>(textureDimensions(hiZ${String(index)})); }`
+    ).join('\n');
     const lastColor = COLOR_PYRAMID_LEVELS - 1;
     const lastHiZ = hiZLevelCount - 1;
     const bindings: ComputeShaderBinding[] = [
@@ -797,6 +802,36 @@ ${hiZCases}
         default: { return textureLoad(hiZ${String(lastHiZ)}, pixelFor(hiZ${String(lastHiZ)}, uv), 0).xy; }
     }
 }
+fn hiZSize(level: u32) -> vec2<f32> {
+    switch level {
+${hiZSizeCases}
+        default: { return vec2<f32>(textureDimensions(hiZ${String(lastHiZ)})); }
+    }
+}
+fn cellExitDistance(
+    originClip: vec4<f32>,
+    directionClip: vec4<f32>,
+    uv: vec2<f32>,
+    level: u32,
+    distance: f32,
+    maximumDistance: f32
+) -> f32 {
+    let size = hiZSize(level);
+    let screenDirection = (directionClip.xy * originClip.w - originClip.xy * directionClip.w) *
+        vec2<f32>(1.0, -1.0);
+    let cell = floor(uv * size);
+    let boundary = (cell + select(vec2<f32>(0.0), vec2<f32>(1.0), screenDirection > vec2<f32>(0.0))) / size;
+    let ndc = boundary * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0);
+    let denominator = directionClip.xy - ndc * directionClip.w;
+    var result = maximumDistance;
+    for (var axis = 0u; axis < 2u; axis += 1u) {
+        if (abs(denominator[axis]) > 1e-7 && abs(screenDirection[axis]) > 1e-7) {
+            let candidate = (ndc[axis] * originClip.w - originClip[axis]) / denominator[axis];
+            if (candidate > distance) { result = min(result, candidate); }
+        }
+    }
+    return result;
+}
 fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
     let encodedSigned = encoded * 2.0 - vec2<f32>(1.0);
     var normal = vec3<f32>(
@@ -828,9 +863,6 @@ fn projectViewPosition(position: vec3<f32>) -> vec3<f32> {
 }
 fn rayIsInFront(rayDepth: f32, bounds: vec2<f32>) -> bool {
     return select((rayDepth < bounds.x), (rayDepth > bounds.y), frameData.depth.w > 0.5);
-}
-fn rayIsBehind(rayDepth: f32, bounds: vec2<f32>) -> bool {
-    return select((rayDepth > bounds.y), (rayDepth < bounds.x), frameData.depth.w > 0.5);
 }
 fn isBackgroundDepth(deviceDepth: f32) -> bool {
     return select(
@@ -958,6 +990,7 @@ fn main(
     let origin = surfacePosition + normal * originBias;
     let minimumStep = max(${String(settings.stride)}, -origin.z * 0.002);
     let startDistance = minimumStep;
+    let originClip = frameData.projection * vec4<f32>(origin, 1.0);
     let roughnessRatio = clamp(roughness / ${String(settings.roughnessCutoff)}, 0.0, 1.0);
     let maximumDistance = mix(
         ${String(settings.maxRayDistance)},
@@ -967,8 +1000,7 @@ fn main(
     let maximumIterations = u32(max(
         8.0,
         floor(
-            ${String(settings.maxSteps)}.0 * mix(1.0, 0.35, roughnessRatio) *
-                select(1.0, 0.55, roughness > ${String(DETERMINISTIC_REFLECTION_ROUGHNESS)})
+            ${String(settings.maxSteps)}.0 * mix(1.0, 0.65, roughnessRatio)
         )
     ));
     let rayCount = select(
@@ -1002,6 +1034,7 @@ fn main(
                 direction = stochasticDirection;
             }
         }
+        let directionClip = frameData.projection * vec4<f32>(direction, 0.0);
         var distance = startDistance;
         var previousDistance = 0.0;
         var hasFrontSample = false;
@@ -1012,8 +1045,8 @@ fn main(
         var backfaceRejected = false;
         for (var iteration = 0u; iteration < ${String(settings.maxSteps)}u; iteration += 1u) {
             if (iteration >= maximumIterations || distance > maximumDistance) { break; }
-            let rayPoint = origin + direction * distance;
-            let projected = projectViewPosition(rayPoint);
+            var rayPoint = origin + direction * distance;
+            var projected = projectViewPosition(rayPoint);
             if (
                 projected.x <= 0.0 || projected.y <= 0.0 ||
                 projected.x >= 1.0 || projected.y >= 1.0 ||
@@ -1021,15 +1054,36 @@ fn main(
             ) { break; }
             let bounds = sampleHiZ(level, projected.xy);
             if (rayIsInFront(projected.z, bounds)) {
+                let exitDistance = cellExitDistance(
+                    originClip, directionClip, projected.xy, level, distance, maximumDistance
+                );
+                let epsilon = max(1e-5, distance * 1e-5);
+                let exitPoint = origin + direction * max(distance, exitDistance - epsilon);
+                let exitProjected = projectViewPosition(exitPoint);
+                // Skip only a cell whose complete ray segment stays in front of its depth
+                // interval. View-space exponential steps can leap over entire silhouettes.
+                if (exitProjected.z >= 0.0 && exitProjected.z <= 1.0 &&
+                    rayIsInFront(exitProjected.z, bounds)) {
+                    previousDistance = distance;
+                    hasFrontSample = true;
+                    distance = exitDistance + epsilon;
+                    level = min(level + 1u, ${String(lastHiZ)}u);
+                    continue;
+                }
+                if (level > 0u) {
+                    level -= 1u;
+                    continue;
+                }
                 previousDistance = distance;
                 hasFrontSample = true;
-                distance += minimumStep * exp2(f32(level));
-                level = min(level + 1u, ${String(lastHiZ)}u);
-                continue;
-            }
-            if (level > 0u) {
+                let sceneZ = reconstructViewPosition(projected.xy, bounds.x).z;
+                if (abs(direction.z) > 1e-7) {
+                    distance = clamp((sceneZ - origin.z) / direction.z, distance, max(distance, exitDistance - epsilon));
+                    rayPoint = origin + direction * distance;
+                    projected = projectViewPosition(rayPoint);
+                }
+            } else if (level > 0u) {
                 level -= 1u;
-                distance = max(startDistance, mix(previousDistance, distance, 0.5));
                 continue;
             }
             let exactPixel = clamp(
@@ -1047,57 +1101,54 @@ fn main(
             let grazingScale = 1.0 / max(abs(dot(normal, direction)), 0.25);
             let thickness = ${String(settings.thickness)} *
                 (1.0 + max(-rayPoint.z, 0.0) * 0.002) * min(grazingScale, 2.5);
-            if (
-                !rayIsBehind(projected.z, bounds) ||
-                (penetration >= -thickness * 0.25 && penetration <= thickness)
-            ) {
-                if (penetration >= -thickness * 0.25 && penetration <= thickness) {
-                    var refinedDistance = distance;
-                    if (hasFrontSample && previousDistance < distance) {
-                        let previousPoint = origin + direction * previousDistance;
-                        let previousProjected = projectViewPosition(previousPoint);
-                        let previousDepthPixel = clamp(
-                            vec2<i32>(previousProjected.xy * vec2<f32>(depthSize)),
-                            vec2<i32>(0),
-                            vec2<i32>(depthSize) - vec2<i32>(1)
-                        );
-                        let previousDepth = textureLoad(sceneDepth, previousDepthPixel, 0);
-                        if (!isBackgroundDepth(previousDepth)) {
-                            let previousScene = reconstructViewPosition(
-                                previousProjected.xy,
-                                previousDepth
-                            );
-                            let previousPenetration =
-                                (-previousPoint.z) - (-previousScene.z);
-                            let denominator = previousPenetration - penetration;
-                            if (abs(denominator) > 1e-5) {
-                                refinedDistance = mix(
-                                    previousDistance,
-                                    distance,
-                                    clamp(previousPenetration / denominator, 0.0, 1.0)
-                                );
-                            }
-                        }
-                    }
-                    let refinedUv = projectViewPosition(
-                        origin + direction * refinedDistance
-                    ).xy;
-                    let hitAttributes = textureLoad(
-                        materialAttributes,
-                        pixelFor(materialAttributes, refinedUv),
-                        0
+            // A coarse step can cross a thin surface without landing inside its thickness
+            // band. Refine the front/behind bracket before deciding that it is a miss.
+            // Re-sample depth at every candidate; interpolating two unrelated surface depths
+            // across a silhouette can otherwise produce a hit in empty space.
+            var refinedDistance = distance;
+            var refinedUv = projected.xy;
+            var refinedPenetration = penetration;
+            if (penetration > 0.0 && hasFrontSample && previousDistance < distance) {
+                var frontDistance = previousDistance;
+                var behindDistance = distance;
+                for (var refinement = 0u; refinement < 6u; refinement += 1u) {
+                    let candidateDistance = (frontDistance + behindDistance) * 0.5;
+                    let candidatePoint = origin + direction * candidateDistance;
+                    let candidateProjected = projectViewPosition(candidatePoint);
+                    let candidatePixel = clamp(
+                        vec2<i32>(candidateProjected.xy * vec2<f32>(depthSize)),
+                        vec2<i32>(0),
+                        vec2<i32>(depthSize) - vec2<i32>(1)
                     );
-                    let hitNormal = decodeOctahedralNormal(hitAttributes.xy);
-                    if (dot(hitNormal, direction) >= -0.01) {
-                        backfaceRejected = true;
-                        break;
+                    let candidateDepth = textureLoad(sceneDepth, candidatePixel, 0);
+                    let candidateScene = reconstructViewPosition(candidateProjected.xy, candidateDepth);
+                    let candidatePenetration = candidateScene.z - candidatePoint.z;
+                    if (isBackgroundDepth(candidateDepth) || candidatePenetration < 0.0) {
+                        frontDistance = candidateDistance;
+                    } else {
+                        behindDistance = candidateDistance;
+                        refinedDistance = candidateDistance;
+                        refinedUv = candidateProjected.xy;
+                        refinedPenetration = candidatePenetration;
                     }
-                    hitUv = refinedUv;
-                    hitDistance = refinedDistance;
-                    break;
                 }
             }
-            if (penetration > thickness) {
+            if (refinedPenetration >= -thickness * 0.25 && refinedPenetration <= thickness) {
+                let hitAttributes = textureLoad(
+                    materialAttributes,
+                    pixelFor(materialAttributes, refinedUv),
+                    0
+                );
+                let hitNormal = decodeOctahedralNormal(hitAttributes.xy);
+                if (dot(hitNormal, direction) >= -0.01) {
+                    backfaceRejected = true;
+                    break;
+                }
+                hitUv = refinedUv;
+                hitDistance = refinedDistance;
+                break;
+            }
+            if (refinedPenetration > thickness) {
                 uncertain = true;
                 break;
             }
@@ -1410,7 +1461,6 @@ struct TileList { values: array<u32> };
 @group(0) @binding(9) var previousDepth: texture_2d<f32>;
 @group(0) @binding(10) var previousState: texture_2d<f32>;
 @group(0) @binding(11) var previousResponseState: texture_2d<f32>;
-@group(0) @binding(12) var linearSampler: sampler;
 @group(0) @binding(13) var historyOutput: texture_storage_2d<rgba16float, write>;
 @group(0) @binding(14) var depthOutput: texture_storage_2d<r32float, write>;
 @group(0) @binding(15) var stateOutput: texture_storage_2d<rgba16float, write>;
@@ -1451,13 +1501,22 @@ fn rgbToYCoCg(value: vec3<f32>) -> vec3<f32> {
 fn yCoCgToRGB(value: vec3<f32>) -> vec3<f32> {
     return vec3<f32>(value.x + value.y - value.z, value.x + value.z, value.x - value.y - value.z);
 }
-fn historySampleCount(packed: f32) -> f32 { return floor(max(packed, 0.0)); }
-fn historyConfidence(packed: f32) -> f32 {
-    return clamp(fract(max(packed, 0.0)) * 2.0, 0.0, 1.0);
-}
-fn packHistoryState(sampleCount: f32, confidence: f32) -> f32 {
-    return min(sampleCount, ${String(MAX_HISTORY_SAMPLE_COUNT)}.0) +
-        min(confidence, 0.999) * 0.5;
+${REFLECTION_HISTORY_WGSL}
+// Decode the integer sample count and fractional confidence before interpolation.
+// Filtering their packed alpha directly lets neighboring counts masquerade as confidence.
+fn sampleHistory(uv: vec2<f32>) -> vec4<f32> {
+    let size = textureDimensions(previousHistory);
+    let coordinate = uv * vec2<f32>(size) - vec2<f32>(0.5);
+    let base = vec2<i32>(floor(coordinate));
+    let fraction = fract(coordinate);
+    let maximum = vec2<i32>(size) - vec2<i32>(1);
+    return interpolateHistory(
+        textureLoad(previousHistory, clamp(base, vec2<i32>(0), maximum), 0),
+        textureLoad(previousHistory, clamp(base + vec2<i32>(1, 0), vec2<i32>(0), maximum), 0),
+        textureLoad(previousHistory, clamp(base + vec2<i32>(0, 1), vec2<i32>(0), maximum), 0),
+        textureLoad(previousHistory, clamp(base + vec2<i32>(1, 1), vec2<i32>(0), maximum), 0),
+        fraction
+    );
 }
 fn materialContinuity(currentPacked: f32, previousPacked: f32) -> f32 {
     let currentBits = u32(clamp(round(currentPacked * 255.0), 0.0, 255.0));
@@ -1534,7 +1593,8 @@ fn main(
             }
         }
     }
-    if (neighborhoodWeight < 0.5) {
+    let hasCurrentSupport = neighborhoodWeight >= 0.5;
+    if (!hasCurrentSupport) {
         let fallback = rgbToYCoCg(current.rgb);
         neighborhoodSum = fallback;
         neighborhoodSquaredSum = fallback * fallback;
@@ -1581,12 +1641,7 @@ fn main(
     var surfaceHistory = vec4<f32>(0.0);
     var surfaceScore = 0.0;
     if (surfaceInside && motion.z >= 0.0) {
-        surfaceHistory = textureSampleLevel(
-            previousHistory,
-            linearSampler,
-            surfaceHistoryUv,
-            0.0
-        );
+        surfaceHistory = sampleHistory(surfaceHistoryUv);
         let surfaceState = textureLoad(
             previousState,
             pixelFor(previousState, surfaceHistoryUv),
@@ -1633,7 +1688,7 @@ fn main(
         current.a > 0.0 && currentHitValue.z >= 0.0 && hitInside &&
         dominantDirection > 0.0
     ) {
-        hitHistory = textureSampleLevel(previousHistory, linearSampler, hitHistoryUv, 0.0);
+        hitHistory = sampleHistory(hitHistoryUv);
         let hitState = textureLoad(
             previousState,
             pixelFor(previousState, hitHistoryUv),
@@ -1691,7 +1746,12 @@ fn main(
         selectedHistory = hitHistory;
         selectedScore = hitScore;
     }
-    let historyAvailable = selectedScore > 0.01;
+    let velocityPixels = length(motion.xy * vec2<f32>(motionSize));
+    let missHistoryWeight = reflectionMissHistoryWeight(
+        velocityPixels, hasCurrentSupport, ${String(settings.historyWeight)}, selectedScore
+    );
+    let historyAvailable = selectedScore > 0.01 && ${String(settings.historyWeight)} > 0.0 &&
+        (current.a > 0.0 || missHistoryWeight > 0.0);
     let selectedYCoCg = clamp(
         rgbToYCoCg(selectedHistory.rgb),
         neighborhoodCenter - neighborhoodExtent,
@@ -1705,7 +1765,6 @@ fn main(
         24.0,
         denoiseStrength
     );
-    let velocityPixels = length(motion.xy * vec2<f32>(motionSize));
     let motionResponse = clamp(velocityPixels / 24.0, 0.0, 1.0);
     var resolvedRadiance = stableCurrent;
     var resolvedConfidence = current.a;
@@ -1721,9 +1780,11 @@ fn main(
             resolvedRadiance = mix(stableCurrent, clampedHistory, blend);
             resolvedConfidence = max(current.a, previousConfidence * blend);
         } else {
-            resolvedCount = max(previousCount * selectedScore - 0.25, 1.0);
-            resolvedRadiance = clampedHistory;
-            resolvedConfidence = previousConfidence * min(selectedScore, 0.82);
+            resolvedCount = max(previousCount * selectedScore - 1.0, 1.0);
+            // Radiance is already confidence-premultiplied. Fading alpha alone leaves
+            // the old reflection at full brightness until the composite gate closes.
+            resolvedRadiance = clampedHistory * missHistoryWeight;
+            resolvedConfidence = previousConfidence * missHistoryWeight;
         }
     } else {
         atomicAdd(&diagnostics.historyRejectedPixels, 1u);
@@ -1829,7 +1890,6 @@ fn main(
                     kind: 'sampled-texture',
                     sampleType: 'float'
                 },
-                { name: 'linearSampler', group: 0, binding: 12, kind: 'sampler' },
                 {
                     name: 'historyOutput',
                     group: 0,
@@ -2026,14 +2086,7 @@ fn decodeOctahedralNormal(encoded: vec2<f32>) -> vec3<f32> {
     }
     return normalize(normal);
 }
-fn historySampleCount(packed: f32) -> f32 { return floor(max(packed, 0.0)); }
-fn historyConfidence(packed: f32) -> f32 {
-    return clamp(fract(max(packed, 0.0)) * 2.0, 0.0, 1.0);
-}
-fn packHistoryState(sampleCount: f32, confidence: f32) -> f32 {
-    return min(sampleCount, ${String(MAX_HISTORY_SAMPLE_COUNT)}.0) +
-        min(confidence, 0.999) * 0.5;
-}
+${REFLECTION_HISTORY_WGSL}
 @compute @workgroup_size(${String(TRACE_WORKGROUP_SIZE)}, ${String(TRACE_WORKGROUP_SIZE)})
 fn main(
     @builtin(workgroup_id) groupId: vec3<u32>,
@@ -2419,7 +2472,7 @@ export class ScreenSpaceReflectionsController {
         () => new MutableComputeParameters(0, 4, 0)
     );
     readonly #resolvePool = new RenderPassParameterPool(
-        () => new MutableComputeParameters(2, 14, 1)
+        () => new MutableComputeParameters(2, 14, 0)
     );
     readonly #filterResetPool = new RenderPassParameterPool(
         () => new MutableComputeParameters(0, 1, 0)

--- a/src/shader/basic.vert
+++ b/src/shader/basic.vert
@@ -3,6 +3,9 @@
 #include "./chunk/precision.vert"
 #include "./chunk/uniformBlocks.glsl"
 
+// Depth, motion, material-attributes and color variants must rasterize identical positions.
+invariant gl_Position;
+
 in vec3 a_position;
 
 #include "./chunk/unQuantize.vert"

--- a/src/shader/chunk/normal.frag
+++ b/src/shader/chunk/normal.frag
@@ -4,9 +4,6 @@
         in mat3 v_TBN;
         #ifdef HILO_NORMAL_MAP
             uniform sampler2D u_normalMap;
-            
-            #ifdef HILO_NORMAL_MAP_SCALE
-            #endif
         #endif
 
         #ifdef HILO_CLEARCOAT_NORMAL_MAP

--- a/src/shader/chunk/normal_main.frag
+++ b/src/shader/chunk/normal_main.frag
@@ -1,8 +1,6 @@
 #ifdef HILO_NORMAL_MAP
     vec3 normal = HILO_TEXTURE_2D(u_normalMap, HILO_NORMAL_MAP).rgb * 2.0 - 1.0;
-    #ifdef HILO_NORMAL_MAP_SCALE
-        normal.xy *= u_normalMapScale;
-    #endif
+    normal.xy *= u_normalMapScale;
     normal = normalize(v_TBN * normal);
 #elif defined(HILO_HAS_NORMAL)
     vec3 normal = normalize(v_normal);

--- a/test/spec/renderer/GlslToWgsl.test.ts
+++ b/test/spec/renderer/GlslToWgsl.test.ts
@@ -1249,6 +1249,10 @@ describe('built-in shader WebGPU corpus', () => {
 
         expect(translated.vertex.wgsl).toContain('@vertex');
         expect(translated.fragment.wgsl).toContain('@fragment');
+        if (shaderCase.vertex === undefined) {
+            expect(translated.vertex.glsl).toContain('invariant gl_Position;');
+            expect(translated.vertex.wgsl).toMatch(/@builtin\(position\)\s+@invariant/u);
+        }
         expect(translated.vertexInputs.some(input => input.name === 'a_position')).toBe(true);
         const vertexInputNames = new Set(translated.vertexInputs.map(input => input.name));
         for (const name of shaderCase.expectedVertexInputs ?? []) {

--- a/test/spec/renderer/MaterialPassDepthParity.test.ts
+++ b/test/spec/renderer/MaterialPassDepthParity.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import type { CameraDepthMode } from '../../../src/camera/Camera';
+import Mesh from '../../../src/core/Mesh';
+import Node from '../../../src/core/Node';
+import PlaneGeometry from '../../../src/geometry/PlaneGeometry';
+import PBRMaterial from '../../../src/material/PBRMaterial';
+import { DEFAULT_MATERIAL_PIPELINE_STATE } from '../../../src/material/MaterialDefinition';
+import Vector3 from '../../../src/math/Vector3';
+import Renderer from '../../../src/render/Renderer';
+import type {
+    RenderPipeline,
+    RenderPipelineContext,
+    RenderPipelineFactory
+} from '../../../src/render/pipeline/RenderPipeline';
+import { FullscreenRenderPass } from '../../../src/render/pipeline/passes/FullscreenRenderPass';
+import { SceneRenderPass } from '../../../src/render/pipeline/passes/SceneRenderPass';
+import { PORTABLE_FULLSCREEN_VERTEX_SOURCE } from '../../../src/render/pipeline/passes/internal/PortableFullscreenShader';
+import Shader from '../../../src/shader/Shader';
+
+const WIDTH = 384;
+const HEIGHT = 256;
+const JITTER_PHASES = [
+    [0, -1 / 6],
+    [-1 / 4, 1 / 6],
+    [1 / 4, -7 / 18],
+    [-3 / 8, -1 / 18],
+    [1 / 8, 5 / 18],
+    [-1 / 8, -5 / 18],
+    [3 / 8, 1 / 18],
+    [-7 / 16, 7 / 18]
+] as const;
+const ZERO = { r: 0, g: 0, b: 0, a: 0 } as const;
+
+class MaterialDepthParityPipeline implements RenderPipeline {
+    readonly name = 'Material pass exact depth coverage';
+    readonly #depthPass = new SceneRenderPass('Material parity depth prepass');
+    readonly #attributesPass = new SceneRenderPass('Material parity equal-depth attributes');
+    readonly #coveragePass: FullscreenRenderPass;
+
+    constructor(readonly depthMode: CameraDepthMode) {
+        this.#coveragePass = new FullscreenRenderPass({
+            name: 'Material parity coverage readback',
+            shader: new Shader({
+                vs: PORTABLE_FULLSCREEN_VERTEX_SOURCE,
+                fs: `#version 300 es
+precision highp float;
+uniform sampler2D u_depth;
+uniform sampler2D u_attributes;
+layout(location = 0) out vec4 color;
+void main() {
+    // Both attachments and gl_FragCoord use the same native integer pixel coordinates.
+    // The diagnostic counts all pixels, so it does not depend on framebuffer row order.
+    ivec2 pixel = ivec2(gl_FragCoord.xy);
+    float depth = texelFetch(u_depth, pixel, 0).r;
+    bool covered = depth ${depthMode === 'reversed' ? '> 0.0' : '< 1.0'};
+    bool written = texelFetch(u_attributes, pixel, 0).b > 0.05;
+    color = vec4(covered && !written ? 1.0 : 0.0, covered && written ? 1.0 : 0.0, 0.0, 1.0);
+}`
+            }),
+            pipelineState: {
+                ...DEFAULT_MATERIAL_PIPELINE_STATE,
+                depthTest: false,
+                depthWrite: false,
+                cullMode: 'none'
+            }
+        });
+    }
+
+    record(context: RenderPipelineContext): void {
+        const cullingResults = context.cull();
+        const depthList = context.createRendererList({
+            cullingResults,
+            queue: 'opaque',
+            sorting: 'material-front-to-back',
+            materialPass: 'depth-only'
+        });
+        const attributesList = context.createRendererList({
+            cullingResults,
+            queue: 'opaque',
+            sorting: 'material-front-to-back',
+            materialPass: 'material-attributes'
+        });
+        const extent = { relativeTo: 'output', scale: 1 } as const;
+        const depth = context.graph.createTexture('Material parity scene depth', {
+            format: 'depth32float',
+            extent
+        });
+        const attributes = context.graph.createTexture('Material parity attributes', {
+            format: 'rgba8unorm',
+            extent
+        });
+        const reflectionResponse = context.graph.createTexture('Material parity SSR response', {
+            format: 'rgba16float',
+            extent
+        });
+        const fallbackSpecular = context.graph.createTexture('Material parity SSR fallback', {
+            format: 'rgba16float',
+            extent
+        });
+        context.graph.addPass(this.#depthPass, {
+            rendererList: depthList,
+            colorAttachments: [],
+            depthStencilAttachment: {
+                texture: depth,
+                depthLoadOp: 'clear',
+                depthStoreOp: 'store',
+                depthClearValue: this.depthMode === 'reversed' ? 0 : 1
+            }
+        });
+        context.graph.addPass(this.#attributesPass, {
+            rendererList: attributesList,
+            colorAttachments: [attributes, reflectionResponse, fallbackSpecular].map(texture => ({
+                texture,
+                loadOp: 'clear' as const,
+                storeOp: 'store' as const,
+                clearValue: ZERO
+            })),
+            depthStencilAttachment: { texture: depth, depthReadOnly: true }
+        });
+        context.graph.addPass(this.#coveragePass, {
+            inputTextures: [depth, attributes],
+            colorAttachments: [
+                {
+                    texture: context.graph.importOutput().color(0),
+                    loadOp: 'clear',
+                    storeOp: 'store',
+                    clearValue: ZERO
+                }
+            ]
+        });
+    }
+
+    destroy(): void {
+        this.#coveragePass.shader.destroy();
+    }
+}
+
+describe.each(['webgl2', 'webgpu'] as const)('material pass depth parity through %s', backend => {
+    it.each(['standard', 'reversed'] as const)(
+        'writes attributes at every covered floor pixel across %s-depth jitter phases',
+        async depthMode => {
+            const factory: RenderPipelineFactory = {
+                name: 'Material depth parity factory',
+                create: (): RenderPipeline => new MaterialDepthParityPipeline(depthMode)
+            };
+            const renderer = await Renderer.create({
+                backend,
+                width: WIDTH,
+                height: HEIGHT,
+                antialias: false,
+                renderPipeline: factory,
+                domElement: document.createElement('canvas')
+            });
+            const target = renderer.createRenderTarget({
+                width: WIDTH,
+                height: HEIGHT,
+                depthStencilAttachment: false
+            });
+            const scene = new Node();
+            new Mesh({
+                geometry: new PlaneGeometry({ width: 80, height: 80 }),
+                material: new PBRMaterial({ metallic: 0.38, roughness: 0.11 }),
+                y: -1.76,
+                z: -4.4,
+                rotationX: -90,
+                frustumTest: false
+            }).addTo(scene);
+            const camera = new PerspectiveCamera({
+                aspect: WIDTH / HEIGHT,
+                fov: 32,
+                near: 0.05,
+                far: 90,
+                depthMode
+            });
+            const lookAt = new Vector3(0.15, -0.85, -5.35);
+            try {
+                // Large oblique triangles expose sub-ULP depth differences between separately
+                // compiled depth and material variants. Test the hero and grazing directions.
+                for (const position of [
+                    new Vector3(10.8, 2.15, 6.55),
+                    new Vector3(9.85, -0.49, 5.45)
+                ]) {
+                    camera.setPosition(position.x, position.y, position.z).lookAt(lookAt);
+                    for (const [phase, jitter] of JITTER_PHASES.entries()) {
+                        camera.setProjectionJitter(
+                            (jitter[0] * 2) / WIDTH,
+                            (jitter[1] * 2) / HEIGHT
+                        );
+                        renderer.renderToTarget(target, scene, camera);
+                        const result = await target.readColorAttachment();
+                        let missing = 0;
+                        let written = 0;
+                        for (let offset = 0; offset < result.data.length; offset += 4) {
+                            if ((result.data[offset] ?? 0) > 128) missing++;
+                            if ((result.data[offset + 1] ?? 0) > 128) written++;
+                        }
+                        expect(
+                            written,
+                            `visible floor at camera y=${String(position.y)}, phase ${String(phase)}`
+                        ).toBeGreaterThan((WIDTH * HEIGHT) / 4);
+                        expect(
+                            missing,
+                            `attribute holes at camera y=${String(position.y)}, phase ${String(phase)}`
+                        ).toBe(0);
+                    }
+                }
+            } finally {
+                target.destroy();
+                renderer.destroy();
+            }
+        },
+        20_000
+    );
+});

--- a/test/spec/renderer/NormalMapScale.test.ts
+++ b/test/spec/renderer/NormalMapScale.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import { RGBA, UNSIGNED_BYTE } from '../../../src/constants/webgl';
+import { RGBA8 } from '../../../src/constants/webgl2';
+import Mesh from '../../../src/core/Mesh';
+import Node from '../../../src/core/Node';
+import PlaneGeometry from '../../../src/geometry/PlaneGeometry';
+import DirectionalLight from '../../../src/light/DirectionalLight';
+import PBRMaterial from '../../../src/material/PBRMaterial';
+import Color from '../../../src/math/Color';
+import Vector3 from '../../../src/math/Vector3';
+import Renderer from '../../../src/render/Renderer';
+import Texture from '../../../src/texture/Texture';
+
+// A uniform tilted normal makes this a lighting contract, independent of texture filtering,
+// temporal sampling, or a particular image baseline.
+describe.each(['webgl2', 'webgpu'] as const)('normal map scale through %s', backend => {
+    it('updates lighting through the material uniform, including scale zero', async () => {
+        const renderer = await Renderer.create({
+            backend,
+            width: 16,
+            height: 16,
+            antialias: false,
+            domElement: document.createElement('canvas')
+        });
+        const target = renderer.createRenderTarget({ width: 16, height: 16 });
+        const normalMap = new Texture({
+            image: new Uint8Array([240, 128, 192, 255]),
+            width: 1,
+            height: 1,
+            internalFormat: RGBA8,
+            format: RGBA,
+            type: UNSIGNED_BYTE
+        });
+        const material = new PBRMaterial({
+            baseColor: new Color(0.5, 0.5, 0.5),
+            metallic: 0,
+            roughness: 1,
+            normalMap,
+            normalScale: 1
+        });
+        const scene = new Node();
+        new Mesh({ geometry: new PlaneGeometry({ width: 4, height: 4 }), material }).addTo(scene);
+        new DirectionalLight({ amount: 1, direction: new Vector3(0, 0, -1) }).addTo(scene);
+        const camera = new PerspectiveCamera({ near: 0.1, far: 10 });
+        camera.setPosition(0, 0, 3).lookAt(new Vector3());
+        const renderRed = async (): Promise<number> => {
+            renderer.renderToTarget(target, scene, camera);
+            const result = await target.readColorAttachment({ x: 8, y: 8, width: 1, height: 1 });
+            return result.data[0] ?? 0;
+        };
+        try {
+            const tilted = await renderRed();
+            material.normalScale = 0;
+            const flat = await renderRed();
+            material.normalScale = 0.5;
+            const half = await renderRed();
+            material.normalScale = 1;
+            const restored = await renderRed();
+            expect(flat).toBeGreaterThan(tilted + 12);
+            expect(half).toBeGreaterThan(tilted + 5);
+            expect(half).toBeLessThan(flat - 5);
+            expect(restored).toBe(tilted);
+        } finally {
+            target.destroy();
+            renderer.destroy();
+        }
+    });
+});

--- a/test/spec/renderer/ScreenSpaceReflectionHistory.test.ts
+++ b/test/spec/renderer/ScreenSpaceReflectionHistory.test.ts
@@ -1,0 +1,83 @@
+import { expect, it } from 'vitest';
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import Node from '../../../src/core/Node';
+import Renderer from '../../../src/render/Renderer';
+import ComputeKernel from '../../../src/render/compute/ComputeKernel';
+import ComputeShader from '../../../src/render/compute/ComputeShader';
+import { ComputeRenderPass } from '../../../src/render/pipeline/passes';
+import type {
+    RenderPipeline,
+    RenderPipelineContext
+} from '../../../src/render/pipeline/RenderPipeline';
+import { REFLECTION_HISTORY_WGSL } from '../../../src/render/postprocessing/ScreenSpaceReflectionHistory';
+import type { StorageBuffer } from '../../../src/render/StorageBuffer';
+
+it('keeps confidence independent of fractional and interpolated sample counts on WebGPU', async () => {
+    const pass = new ComputeRenderPass(
+        new ComputeKernel({
+            shader: new ComputeShader({
+                source: `
+${REFLECTION_HISTORY_WGSL}
+@group(0) @binding(0) var<storage, read_write> output: array<vec4<f32>>;
+@compute @workgroup_size(1)
+fn main() {
+    let fractional = packHistoryState(7.75, 0.25);
+    let a = vec4<f32>(1.0, 0.0, 0.0, packHistoryState(1.0, 0.25));
+    let b = vec4<f32>(0.0, 1.0, 0.0, packHistoryState(4.0, 0.5));
+    let c = vec4<f32>(0.0, 0.0, 1.0, packHistoryState(12.0, 0.75));
+    let d = vec4<f32>(1.0, 1.0, 1.0, packHistoryState(24.0, 0.0));
+    let interpolated = interpolateHistory(a, b, c, d, vec2<f32>(0.5));
+    output[0] = vec4<f32>(historySampleCount(fractional), historyConfidence(fractional), historySampleCount(interpolated.a), historyConfidence(interpolated.a));
+    output[1] = vec4<f32>(interpolated.rgb, 0.0);
+}`,
+                workgroupSize: [1],
+                bindings: [
+                    {
+                        name: 'output',
+                        group: 0,
+                        binding: 0,
+                        kind: 'storage-buffer',
+                        access: 'write-discard',
+                        minBindingSize: 32
+                    }
+                ]
+            })
+        })
+    );
+    const runtime: RenderPipeline & { buffer: StorageBuffer | null } = {
+        name: 'SSR history encoding regression',
+        buffer: null,
+        record(context: RenderPipelineContext): void {
+            if (this.buffer === null) throw new Error('Missing history output');
+            context.graph.addPass(pass, {
+                buffers: [{ buffer: context.graph.importStorageBuffer(this.buffer) }],
+                textures: [],
+                dispatch: { x: 1 }
+            });
+        },
+        destroy(): void {
+            this.buffer?.destroy();
+        }
+    };
+    const renderer = await Renderer.create({
+        backend: 'webgpu',
+        width: 4,
+        height: 4,
+        antialias: false,
+        domElement: document.createElement('canvas'),
+        renderPipeline: { name: runtime.name, create: (): RenderPipeline => runtime }
+    });
+    try {
+        runtime.buffer = renderer.createStorageBuffer({
+            byteLength: 32,
+            usage: ['storage', 'copy-source']
+        });
+        renderer.render(new Node(), new PerspectiveCamera());
+        const result = await runtime.buffer.read();
+        expect([...new Float32Array(result.data.buffer)]).toEqual([
+            8, 0.25, 10, 0.375, 0.5, 0.5, 0.5, 0
+        ]);
+    } finally {
+        renderer.destroy();
+    }
+});

--- a/test/spec/renderer/ScreenSpaceReflectionMissHistory.test.ts
+++ b/test/spec/renderer/ScreenSpaceReflectionMissHistory.test.ts
@@ -1,0 +1,128 @@
+import { expect, it } from 'vitest';
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import Node from '../../../src/core/Node';
+import Renderer from '../../../src/render/Renderer';
+import ComputeKernel from '../../../src/render/compute/ComputeKernel';
+import ComputeShader from '../../../src/render/compute/ComputeShader';
+import { ComputeRenderPass } from '../../../src/render/pipeline/passes';
+import type {
+    RenderPipeline,
+    RenderPipelineContext
+} from '../../../src/render/pipeline/RenderPipeline';
+import { REFLECTION_HISTORY_WGSL } from '../../../src/render/postprocessing/ScreenSpaceReflectionHistory';
+import type { StorageBuffer } from '../../../src/render/StorageBuffer';
+
+it('rejects unsupported and moving SSR misses while retaining jitter-safe history on WebGPU', async () => {
+    const byteLength = 80;
+    const pass = new ComputeRenderPass(
+        new ComputeKernel({
+            shader: new ComputeShader({
+                source: `
+${REFLECTION_HISTORY_WGSL}
+@group(0) @binding(0) var<storage, read_write> output: array<vec4<f32>>;
+@compute @workgroup_size(1)
+fn main() {
+    output[0] = vec4<f32>(
+        reflectionMissHistoryWeight(0.0, false, 0.95, 1.0),
+        reflectionMissHistoryWeight(0.0, true, 0.0, 1.0),
+        reflectionMissHistoryWeight(0.0, true, 0.95, 0.0),
+        reflectionMissHistoryWeight(8.0, true, 0.95, 1.0)
+    );
+    output[1] = vec4<f32>(
+        reflectionMissHistoryWeight(0.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(1.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(2.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(5.0, true, 0.95, 1.0)
+    );
+    output[2] = vec4<f32>(
+        reflectionMissHistoryWeight(9.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(64.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(0.0, true, 0.95, -1.0),
+        reflectionMissHistoryWeight(5.0, false, 0.95, 1.0)
+    );
+    output[3] = vec4<f32>(
+        reflectionMissHistoryWeight(0.0, true, 0.25, 1.0),
+        reflectionMissHistoryWeight(0.0, true, 0.95, 0.5),
+        reflectionMissHistoryWeight(0.0, true, 0.95, 2.0),
+        reflectionMissHistoryWeight(5.0, true, 0.25, 0.5)
+    );
+    output[4] = vec4<f32>(
+        reflectionMissHistoryWeight(3.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(4.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(6.0, true, 0.95, 1.0),
+        reflectionMissHistoryWeight(7.0, true, 0.95, 1.0)
+    );
+}`,
+                workgroupSize: [1],
+                bindings: [
+                    {
+                        name: 'output',
+                        group: 0,
+                        binding: 0,
+                        kind: 'storage-buffer',
+                        access: 'write-discard',
+                        minBindingSize: byteLength
+                    }
+                ]
+            })
+        })
+    );
+    const runtime: RenderPipeline & { buffer: StorageBuffer | null } = {
+        name: 'SSR missed-hit history regression',
+        buffer: null,
+        record(context: RenderPipelineContext): void {
+            if (this.buffer === null) throw new Error('Missing miss-history output');
+            context.graph.addPass(pass, {
+                buffers: [{ buffer: context.graph.importStorageBuffer(this.buffer) }],
+                textures: [],
+                dispatch: { x: 1 }
+            });
+        },
+        destroy(): void {
+            this.buffer?.destroy();
+        }
+    };
+    const renderer = await Renderer.create({
+        backend: 'webgpu',
+        width: 4,
+        height: 4,
+        antialias: false,
+        domElement: document.createElement('canvas'),
+        renderPipeline: { name: runtime.name, create: (): RenderPipeline => runtime }
+    });
+    try {
+        runtime.buffer = renderer.createStorageBuffer({
+            byteLength,
+            usage: ['storage', 'copy-source']
+        });
+        renderer.render(new Node(), new PerspectiveCamera());
+        const result = await runtime.buffer.read();
+        const weights = new Float32Array(
+            result.data.buffer,
+            result.data.byteOffset,
+            result.data.byteLength / Float32Array.BYTES_PER_ELEMENT
+        );
+
+        // Unsupported pixels, disabled history, and fast motion must leave no residual energy.
+        expect([...weights.slice(0, 4)]).toEqual([0, 0, 0, 0]);
+        expect([...weights.slice(8, 12)]).toEqual([0, 0, 0, 0]);
+
+        // Subpixel temporal jitter does not shorten a supported stationary reflection's life.
+        for (const weight of weights.slice(4, 7)) expect(weight).toBeCloseTo(0.82, 6);
+        expect(weights[7]).toBeCloseTo(0.41, 6);
+
+        // Honor the public history limit and reject discontinuous surfaces before reuse.
+        const expectedLimits = [0.25, 0.41, 0.82, 0.0625];
+        for (const [index, expected] of expectedLimits.entries()) {
+            expect(weights[12 + index]).toBeCloseTo(expected, 6);
+        }
+
+        // Motion between the retention and rejection thresholds fades smoothly, without steps.
+        const expectedFade = [0.75925926, 0.60740741, 0.21259259, 0.06074074];
+        for (const [index, expected] of expectedFade.entries()) {
+            expect(weights[16 + index]).toBeCloseTo(expected, 6);
+        }
+    } finally {
+        renderer.destroy();
+    }
+});

--- a/test/spec/renderer/ScreenSpaceReflectionTrace.test.ts
+++ b/test/spec/renderer/ScreenSpaceReflectionTrace.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import PerspectiveCamera from '../../../src/camera/PerspectiveCamera';
+import Mesh from '../../../src/core/Mesh';
+import Node from '../../../src/core/Node';
+import BoxGeometry from '../../../src/geometry/BoxGeometry';
+import PlaneGeometry from '../../../src/geometry/PlaneGeometry';
+import PBRMaterial from '../../../src/material/PBRMaterial';
+import Color from '../../../src/math/Color';
+import Vector3 from '../../../src/math/Vector3';
+import Renderer from '../../../src/render/Renderer';
+import { ClusteredForwardPlusPipelineFactory } from '../../../src/render/pipeline/ClusteredForwardPlus';
+
+describe.each(['standard', 'reversed'] as const)('SSR thin surfaces with %s depth', depthMode => {
+    it('resolves a continuous reflection when stride is much larger than surface thickness', async () => {
+        const floorGeometry = new PlaneGeometry({ width: 12, height: 12 });
+        const floorMaterial = new PBRMaterial({
+            metallic: 1,
+            roughness: 0.08,
+            baseColor: new Color(1, 1, 1)
+        });
+        const cardGeometry = new BoxGeometry({ width: 2, height: 1.4, depth: 0.04 });
+        const cardMaterial = new PBRMaterial({ unlit: true, baseColor: new Color(1, 0, 0) });
+        const factory = new ClusteredForwardPlusPipelineFactory({
+            buckets: [{ geometry: floorGeometry, material: floorMaterial }],
+            maxObjects: 2,
+            maxLights: 1,
+            maxLightIndices: 1,
+            maxLightsPerCluster: 1,
+            maxViewportWidth: 96,
+            maxViewportHeight: 96,
+            bloomStrength: 0,
+            temporalAA: { historyWeight: 0, sharpness: 0 },
+            screenSpaceReflections: {
+                resolutionScale: 1,
+                stride: 0.3,
+                thickness: 0.002,
+                maxRayDistance: 20,
+                maxSteps: 96
+            }
+        });
+        const renderer = await Renderer.create({
+            backend: 'webgpu',
+            width: 96,
+            height: 96,
+            antialias: false,
+            renderPipeline: factory,
+            domElement: document.createElement('canvas')
+        });
+        const target = renderer.createRenderTarget({
+            width: 96,
+            height: 96,
+            colorAttachments: [{ format: 'rgba8unorm' }],
+            depthStencilAttachment: { format: 'depth32float', depthMode }
+        });
+        const scene = new Node();
+        new Mesh({ geometry: floorGeometry, material: floorMaterial, rotationX: -90 }).addTo(scene);
+        new Mesh({ geometry: cardGeometry, material: cardMaterial, y: 0.9 }).addTo(scene);
+        const camera = new PerspectiveCamera({ near: 0.1, far: 30, depthMode });
+        camera.setPosition(0, 2.5, 5).lookAt(new Vector3(0, 0.4, 0));
+        try {
+            for (let frame = 0; frame < 4; frame++) {
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+            }
+            const reflected = await target.readColorAttachment({
+                x: 36,
+                y: 62,
+                width: 24,
+                height: 12
+            });
+            let reflectedPixels = 0;
+            for (let offset = 0; offset < reflected.data.length; offset += 4) {
+                if (
+                    (reflected.data[offset] ?? 0) > 30 &&
+                    (reflected.data[offset] ?? 0) > (reflected.data[offset + 1] ?? 0) * 2
+                )
+                    reflectedPixels++;
+            }
+            // Check raw hits as well as the filtered image: spatial hole filling can hide
+            // a broken traversal even when most of the reflection has no valid samples.
+            expect(
+                (await factory.readDiagnostics()).screenSpaceReflectionHitPixelCount
+            ).toBeGreaterThan(350);
+            expect(reflectedPixels).toBeGreaterThan(220);
+            floorMaterial.roughness = 1;
+            for (let frame = 0; frame < 2; frame++) {
+                renderer.renderToTarget(target, scene, camera);
+                await renderer.waitForIdle();
+            }
+            const disabled = await target.readColorAttachment({
+                x: 36,
+                y: 62,
+                width: 24,
+                height: 12
+            });
+            expect(
+                Math.max(...disabled.data.filter((_value, index) => index % 4 === 0))
+            ).toBeLessThan(10);
+        } finally {
+            target.destroy();
+            renderer.destroy();
+        }
+    }, 20_000);
+});

--- a/test/ui/screen-space-reflections.spec.ts
+++ b/test/ui/screen-space-reflections.spec.ts
@@ -49,6 +49,52 @@ function pixelDifference(
     };
 }
 
+// A whole-image frame delta can miss sparse single-pixel holes. Measure dark outliers
+// inside a smooth red reflection against their local median instead of its silhouette.
+function reflectionHoleRatio(frame: Buffer): { readonly holes: number; readonly samples: number } {
+    const pixels = PNG.sync.read(frame);
+    let holes = 0;
+    let samples = 0;
+    const neighbors: number[] = [];
+    for (let y = 740; y < 850; y++) {
+        for (let x = 530; x < 645; x++) {
+            neighbors.length = 0;
+            for (let dy = -2; dy <= 2; dy++) {
+                for (let dx = -2; dx <= 2; dx++) {
+                    if (dx !== 0 || dy !== 0) {
+                        neighbors.push(pixels.data[((y + dy) * pixels.width + x + dx) * 4] ?? 0);
+                    }
+                }
+            }
+            neighbors.sort((left, right) => left - right);
+            const median = neighbors[12] ?? 0;
+            const red = pixels.data[(y * pixels.width + x) * 4] ?? 0;
+            if (median > 30) {
+                samples++;
+                if (red < median * 0.65 && median - red > 12) holes++;
+            }
+        }
+    }
+    return { holes, samples };
+}
+
+function meanRedTrail(frame: Buffer): number {
+    const pixels = PNG.sync.read(frame);
+    let excess = 0;
+    // This floor area stays outside the car's reflection throughout the fixed orbit below.
+    for (let y = 630; y < 835; y++) {
+        for (let x = 0; x < 220; x++) {
+            const offset = (y * pixels.width + x) * 4;
+            excess += Math.max(
+                0,
+                (pixels.data[offset] ?? 0) -
+                    Math.max(pixels.data[offset + 1] ?? 0, pixels.data[offset + 2] ?? 0)
+            );
+        }
+    }
+    return excess / (220 * 205);
+}
+
 async function worstConsecutiveDifference(
     page: Page,
     canvas: Locator,
@@ -181,7 +227,7 @@ test('renders a stable and visually material SSR contribution in Afterimage', as
     expect(grazingStability.changedRatio).toBeLessThan(0.1);
     expect(grazingStability.meanChannelDelta).toBeLessThan(2);
 
-    const defaultStochasticActivePixels = evidence?.activePixelCount ?? 0;
+    const defaultActivePixels = evidence?.activePixelCount ?? 0;
     const deterministicActivePixels = await page.evaluate(async () => {
         const activePixels =
             (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(0.08)) ?? -1;
@@ -200,29 +246,31 @@ test('renders a stable and visually material SSR contribution in Afterimage', as
     expect(deterministicStability.changedRatio).toBeLessThan(0.1);
     expect(deterministicStability.meanChannelDelta).toBeLessThan(1.5);
 
-    const stochasticActivePixels = await page.evaluate(async () => {
-        const activePixels =
-            (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(0.24)) ?? -1;
-        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24);
-        return activePixels;
-    });
-    expect(stochasticActivePixels).toBeGreaterThan(0);
-    const stochasticReflection = await canvas.screenshot({ animations: 'disabled' });
-    const stochasticStability = await worstConsecutiveDifference(
-        page,
-        canvas,
-        stochasticReflection,
-        reflectionRegion,
-        4
-    );
-    expect(stochasticStability.changedRatio).toBeLessThan(0.12);
-    expect(stochasticStability.meanChannelDelta).toBeLessThan(2);
+    for (const roughness of [0.16, 0.24]) {
+        const stochasticActivePixels = await page.evaluate(async value => {
+            const activePixels =
+                (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(value)) ?? -1;
+            await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24);
+            return activePixels;
+        }, roughness);
+        expect(stochasticActivePixels).toBeGreaterThan(0);
+        const stochasticReflection = await canvas.screenshot({ animations: 'disabled' });
+        const stochasticStability = await worstConsecutiveDifference(
+            page,
+            canvas,
+            stochasticReflection,
+            reflectionRegion,
+            4
+        );
+        expect(stochasticStability.changedRatio).toBeLessThan(roughness < 0.2 ? 0.075 : 0.12);
+        expect(stochasticStability.meanChannelDelta).toBeLessThan(roughness < 0.2 ? 1.5 : 2);
+    }
 
     const roughActivePixels = await page.evaluate(async () => {
         return (await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(1)) ?? -1;
     });
     expect(roughActivePixels).toBeGreaterThanOrEqual(0);
-    expect(roughActivePixels).toBeLessThan(defaultStochasticActivePixels);
+    expect(roughActivePixels).toBeLessThan(defaultActivePixels);
     await page.evaluate(async () => {
         await window.__HILO3D_SSR_PALACE_TEST_API__?.setFloorRoughness(0.16);
         await window.__HILO3D_SSR_PALACE_TEST_API__?.moveCamera();
@@ -240,10 +288,8 @@ test('renders a stable and visually material SSR contribution in Afterimage', as
     expect(movedStability.changedRatio).toBeLessThan(0.18);
     expect(movedStability.meanChannelDelta).toBeLessThan(4);
 
-    await page.goto(
-        `${examplesOrigin}/examples/screen_space_reflections_palace.html?backend=webgpu&test=1&ssr=false`,
-        { waitUntil: 'load' }
-    );
+    await page.locator('#ssrToggle').click();
+    await expect(page).toHaveURL(/ssr=false/u);
     await expect(page.locator('body')).toHaveAttribute('data-ssr-ready', 'true', {
         timeout: 60_000
     });
@@ -263,6 +309,117 @@ test('renders a stable and visually material SSR contribution in Afterimage', as
     expect(pageErrors).toEqual([]);
     expect(consoleErrors).toEqual([]);
     expect(gpuValidationErrors).toEqual([]);
+});
+
+test('keeps Afterimage reflections free of fine dark holes across a full jitter cycle', async ({
+    page
+}) => {
+    test.setTimeout(180_000);
+    const errors: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.setViewportSize({ width: 1440, height: 960 });
+    const examplesOrigin = process.env['HILO3D_EXAMPLES_ORIGIN'] ?? '';
+    await page.goto(`${examplesOrigin}/examples/screen_space_reflections_palace.html?test=1`);
+    await expect(page.locator('body')).toHaveAttribute('data-ssr-ready', 'true', {
+        timeout: 60_000
+    });
+    await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24));
+    for (let phase = 0; phase < 32; phase++) {
+        const frame = await page.locator('canvas').screenshot({ animations: 'disabled' });
+        const { holes, samples } = reflectionHoleRatio(frame);
+        expect(samples, `visible reflection at phase ${String(phase)}`).toBeGreaterThan(5_000);
+        expect(holes / samples, `fine dark holes at phase ${String(phase)}`).toBeLessThan(0.005);
+        await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(1));
+    }
+    expect(errors).toEqual([]);
+});
+
+test('rejects stale Afterimage reflection trails during rapid orbit in both directions', async ({
+    page
+}) => {
+    test.setTimeout(180_000);
+    const errors: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.setViewportSize({ width: 1440, height: 960 });
+    const examplesOrigin = process.env['HILO3D_EXAMPLES_ORIGIN'] ?? '';
+    await page.goto(`${examplesOrigin}/examples/screen_space_reflections_palace.html?test=1`);
+    await expect(page.locator('body')).toHaveAttribute('data-ssr-ready', 'true', {
+        timeout: 60_000
+    });
+    await page.evaluate(async () => {
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.setGrazingCamera();
+        await window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24);
+    });
+    await page.mouse.move(1100, 400);
+    await page.mouse.down();
+    for (const step of [1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1, 0]) {
+        await page.mouse.move(1100 - step * 115, 400);
+        // Inspect the moving frame immediately; settling here would conceal the regression.
+        await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(1));
+        const movingFrame = await page.locator('canvas').screenshot({ animations: 'disabled' });
+        expect(meanRedTrail(movingFrame), `red trails at orbit step ${String(step)}`).toBeLessThan(
+            1
+        );
+    }
+    await page.mouse.up();
+    await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(32));
+    const settled = await page.locator('canvas').screenshot({ animations: 'disabled' });
+    expect(meanRedTrail(settled)).toBeLessThan(1);
+    const stability = await worstConsecutiveDifference(
+        page,
+        page.locator('canvas'),
+        settled,
+        { left: 0.2, top: 0.64, right: 0.9, bottom: 0.94 },
+        3
+    );
+    expect(stability.meanChannelDelta).toBeLessThan(2);
+    expect(errors).toEqual([]);
+});
+
+test('keeps the complete car visible in portrait and supports orbit after resizing', async ({
+    page
+}) => {
+    test.setTimeout(90_000);
+    const errors: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.setViewportSize({ width: 390, height: 844 });
+    const examplesOrigin = process.env['HILO3D_EXAMPLES_ORIGIN'] ?? '';
+    await page.goto(`${examplesOrigin}/examples/screen_space_reflections_palace.html?test=1`);
+    await expect(page.locator('body')).toHaveAttribute('data-ssr-ready', 'true', {
+        timeout: 60_000
+    });
+    await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(8));
+    await expect(page.locator('#ssrToggle')).toBeInViewport();
+    await expect(page.locator('.ssrIntro')).toBeInViewport();
+    const portrait = PNG.sync.read(await page.locator('canvas').screenshot());
+    let left = portrait.width;
+    let right = 0;
+    for (let y = Math.floor(portrait.height * 0.3); y < portrait.height * 0.7; y++) {
+        for (let x = 0; x < portrait.width; x++) {
+            const offset = (y * portrait.width + x) * 4;
+            if (
+                (portrait.data[offset] ?? 0) > 60 &&
+                (portrait.data[offset] ?? 0) > (portrait.data[offset + 1] ?? 0) * 2
+            ) {
+                left = Math.min(left, x);
+                right = Math.max(right, x);
+            }
+        }
+    }
+    expect(right - left).toBeGreaterThan(180);
+    expect(left).toBeGreaterThan(12);
+    expect(right).toBeLessThan(portrait.width - 12);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24));
+    const beforeOrbit = await page.locator('canvas').screenshot();
+    await page.mouse.move(820, 370);
+    await page.mouse.down();
+    await page.mouse.move(980, 400, { steps: 8 });
+    await page.mouse.up();
+    await page.evaluate(async () => window.__HILO3D_SSR_PALACE_TEST_API__?.settle(24));
+    const afterOrbit = await page.locator('canvas').screenshot();
+    expect(pixelDifference(beforeOrbit, afterOrbit).changedRatio).toBeGreaterThan(0.01);
+    expect(errors).toEqual([]);
 });
 
 declare global {


### PR DESCRIPTION
The Afterimage SSR showcase showed noisy paint, incomplete floor reflections, flickering dark holes, and red trails during rapid camera orbit. This change fixes normal-map scaling, makes Hi-Z traversal and thin-surface refinement conservative, preserves packed history confidence correctly, rejects unsupported moving miss history, and keeps depth/material variants position-invariant.

The showcase now uses a cleaner three-quarter composition, removes the background mirror and colored floor spotlights, and handles portrait sizing within its GPU budget. Regression coverage was added for depth parity, normal scaling, thin-surface tracing, history packing, fast orbit trails, static dark holes, and responsive interaction.

Validation after rebase: not run, per request.